### PR TITLE
LLVM: Do not pre-allocate integer variables

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4885,19 +4885,6 @@ public:
             builder->SetCurrentDebugLocation(nullptr);
             debug_emit_loc(x);
         }
-        // there maybe a possibility that nested function has an array variable
-        // whose dimension depends on variable present in this program / function
-        // thereby visit all integer variables and declare those:
-        for(auto &item: x.m_symtab->get_scope()) {
-            ASR::symbol_t* sym = item.second;
-            if ( is_a<ASR::Variable_t>(*sym) ) {
-                ASR::Variable_t* v = down_cast<ASR::Variable_t>(sym);
-                uint32_t debug_arg_count = 0;
-                if ( ASR::is_a<ASR::Integer_t>(*v->m_type) ) {
-                    process_Variable(sym, x, debug_arg_count);
-                }
-            }
-        }
 
         // Generate code for nested subroutines and functions first:
         for (auto &item : x.m_symtab->get_scope()) {

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "2f7dbc0f9edeb4b44e1b9c9c0be1bbefc98b5bcb7331d46ef77345d3",
+    "stdout_hash": "34af77d0203164a32bc4988906c38316993731a4d38bff5f79b17c60",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -11,7 +11,6 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %arr = alloca %array*, align 8
   store %array* null, %array** %arr, align 8
@@ -31,7 +30,7 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
   store i32* null, i32** %9, align 8
   store %array* %arr_desc, %array** %arr, align 8
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %10 = load %array*, %array** %arr, align 8
   %11 = ptrtoint %array* %10 to i64
   %12 = icmp eq i64 %11, 0
@@ -70,70 +69,70 @@ ifcont:                                           ; preds = %merge_allocated
   %26 = call i8* @_lfortran_malloc(i64 4)
   %27 = bitcast i8* %26 to i32*
   store i32* %27, i32** %25, align 8
-  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont11, %ifcont
-  %28 = load i32, i32* %i1, align 4
+loop.head:                                        ; preds = %ifcont10, %ifcont
+  %28 = load i32, i32* %i, align 4
   %29 = add i32 %28, 1
   %30 = icmp sle i32 %29, 1000000
   br i1 %30, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %31 = load i32, i32* %i1, align 4
+  %31 = load i32, i32* %i, align 4
   %32 = add i32 %31, 1
-  store i32 %32, i32* %i1, align 4
+  store i32 %32, i32* %i, align 4
   %33 = load %array*, %array** %arr, align 8
   %34 = ptrtoint %array* %33 to i64
   %35 = icmp eq i64 %34, 0
-  br i1 %35, label %merge_allocated3, label %check_data2
+  br i1 %35, label %merge_allocated2, label %check_data1
 
-check_data2:                                      ; preds = %loop.body
+check_data1:                                      ; preds = %loop.body
   %36 = getelementptr %array, %array* %33, i32 0, i32 0
   %37 = load i32*, i32** %36, align 8
   %38 = ptrtoint i32* %37 to i64
   %39 = icmp ne i64 %38, 0
-  br label %merge_allocated3
+  br label %merge_allocated2
 
-merge_allocated3:                                 ; preds = %check_data2, %loop.body
-  %is_allocated4 = phi i1 [ false, %loop.body ], [ %39, %check_data2 ]
-  br i1 %is_allocated4, label %then5, label %else
+merge_allocated2:                                 ; preds = %check_data1, %loop.body
+  %is_allocated3 = phi i1 [ false, %loop.body ], [ %39, %check_data1 ]
+  br i1 %is_allocated3, label %then4, label %else
 
-then5:                                            ; preds = %merge_allocated3
+then4:                                            ; preds = %merge_allocated2
   %40 = getelementptr %array, %array* %33, i32 0, i32 0
   %41 = load i32*, i32** %40, align 8
   %42 = bitcast i32* %41 to i8*
   call void @_lfortran_free(i8* %42)
   %43 = getelementptr %array, %array* %33, i32 0, i32 0
   store i32* null, i32** %43, align 8
-  br label %ifcont6
+  br label %ifcont5
 
-else:                                             ; preds = %merge_allocated3
-  br label %ifcont6
+else:                                             ; preds = %merge_allocated2
+  br label %ifcont5
 
-ifcont6:                                          ; preds = %else, %then5
+ifcont5:                                          ; preds = %else, %then4
   %44 = load %array*, %array** %arr, align 8
   %45 = ptrtoint %array* %44 to i64
   %46 = icmp eq i64 %45, 0
-  br i1 %46, label %merge_allocated8, label %check_data7
+  br i1 %46, label %merge_allocated7, label %check_data6
 
-check_data7:                                      ; preds = %ifcont6
+check_data6:                                      ; preds = %ifcont5
   %47 = getelementptr %array, %array* %44, i32 0, i32 0
   %48 = load i32*, i32** %47, align 8
   %49 = ptrtoint i32* %48 to i64
   %50 = icmp ne i64 %49, 0
-  br label %merge_allocated8
+  br label %merge_allocated7
 
-merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %50, %check_data7 ]
-  br i1 %is_allocated9, label %then10, label %ifcont11
+merge_allocated7:                                 ; preds = %check_data6, %ifcont5
+  %is_allocated8 = phi i1 [ false, %ifcont5 ], [ %50, %check_data6 ]
+  br i1 %is_allocated8, label %then9, label %ifcont10
 
-then10:                                           ; preds = %merge_allocated8
+then9:                                            ; preds = %merge_allocated7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([92 x i8], [92 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont11:                                         ; preds = %merge_allocated8
+ifcont10:                                         ; preds = %merge_allocated7
   %51 = load %array*, %array** %arr, align 8
   %52 = getelementptr %array, %array* %51, i32 0, i32 1
   store i32 0, i32* %52, align 4

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "425cb9d8f972c930fbefeb6578a5dcea5b401e81ec3fe8b87bec966b",
+    "stdout_hash": "14d4c80ac3b06f9ba58eab9120ce4b2158cfd346ccd0d482bccbaa0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -133,8 +133,6 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %r = alloca i32, align 4
-  %stat = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca %array*, align 8
   store %array* null, %array** %c, align 8
@@ -154,9 +152,9 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
   store i32* null, i32** %9, align 8
   store %array* %arr_desc, %array** %c, align 8
-  %r1 = alloca i32, align 4
-  %stat2 = alloca i32, align 4
-  store i32 1, i32* %stat2, align 4
+  %r = alloca i32, align 4
+  %stat = alloca i32, align 4
+  store i32 1, i32* %stat, align 4
   %10 = load %array*, %array** %c, align 8
   %11 = ptrtoint %array* %10 to i64
   %12 = icmp eq i64 %11, 0
@@ -209,43 +207,43 @@ ifcont:                                           ; preds = %merge_allocated
   %34 = call i8* @_lfortran_malloc(i64 108)
   %35 = bitcast i8* %34 to i32*
   store i32* %35, i32** %33, align 8
-  store i32 0, i32* %stat2, align 4
-  %36 = load i32, i32* %stat2, align 4
+  store i32 0, i32* %stat, align 4
+  %36 = load i32, i32* %stat, align 4
   %37 = icmp ne i32 %36, 0
-  br i1 %37, label %then3, label %else
+  br i1 %37, label %then1, label %else
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont4
+  br label %ifcont2
 
 else:                                             ; preds = %ifcont
-  br label %ifcont4
+  br label %ifcont2
 
-ifcont4:                                          ; preds = %else, %then3
+ifcont2:                                          ; preds = %else, %then1
   %38 = load %array*, %array** %c, align 8
   %39 = ptrtoint %array* %38 to i64
   %40 = icmp eq i64 %39, 0
-  br i1 %40, label %merge_allocated6, label %check_data5
+  br i1 %40, label %merge_allocated4, label %check_data3
 
-check_data5:                                      ; preds = %ifcont4
+check_data3:                                      ; preds = %ifcont2
   %41 = getelementptr %array, %array* %38, i32 0, i32 0
   %42 = load i32*, i32** %41, align 8
   %43 = ptrtoint i32* %42 to i64
   %44 = icmp ne i64 %43, 0
-  br label %merge_allocated6
+  br label %merge_allocated4
 
-merge_allocated6:                                 ; preds = %check_data5, %ifcont4
-  %is_allocated7 = phi i1 [ false, %ifcont4 ], [ %44, %check_data5 ]
-  %45 = xor i1 %is_allocated7, true
-  br i1 %45, label %then8, label %ifcont9
+merge_allocated4:                                 ; preds = %check_data3, %ifcont2
+  %is_allocated5 = phi i1 [ false, %ifcont2 ], [ %44, %check_data3 ]
+  %45 = xor i1 %is_allocated5, true
+  br i1 %45, label %then6, label %ifcont7
 
-then8:                                            ; preds = %merge_allocated6
+then6:                                            ; preds = %merge_allocated4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont9:                                          ; preds = %merge_allocated6
+ifcont7:                                          ; preds = %merge_allocated4
   %46 = getelementptr %array, %array* %38, i32 0, i32 2
   %47 = load %dimension_descriptor*, %dimension_descriptor** %46, align 8
   %48 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %47, i32 0
@@ -259,14 +257,14 @@ ifcont9:                                          ; preds = %merge_allocated6
   %56 = icmp slt i32 1, %50
   %57 = icmp sgt i32 1, %55
   %58 = or i1 %56, %57
-  br i1 %58, label %then10, label %ifcont11
+  br i1 %58, label %then8, label %ifcont9
 
-then10:                                           ; preds = %ifcont9
+then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 1, i32 1, i32 %50, i32 %55)
   call void @exit(i32 1)
   unreachable
 
-ifcont11:                                         ; preds = %ifcont9
+ifcont9:                                          ; preds = %ifcont7
   %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 0
   %60 = load i32, i32* %59, align 4
   %61 = mul i32 %60, %53
@@ -282,14 +280,14 @@ ifcont11:                                         ; preds = %ifcont9
   %71 = icmp slt i32 1, %65
   %72 = icmp sgt i32 1, %70
   %73 = or i1 %71, %72
-  br i1 %73, label %then12, label %ifcont13
+  br i1 %73, label %then10, label %ifcont11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i32 1, i32 2, i32 %65, i32 %70)
   call void @exit(i32 1)
   unreachable
 
-ifcont13:                                         ; preds = %ifcont11
+ifcont11:                                         ; preds = %ifcont9
   %74 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 0
   %75 = load i32, i32* %74, align 4
   %76 = mul i32 %75, %68
@@ -305,14 +303,14 @@ ifcont13:                                         ; preds = %ifcont11
   %86 = icmp slt i32 1, %80
   %87 = icmp sgt i32 1, %85
   %88 = or i1 %86, %87
-  br i1 %88, label %then14, label %ifcont15
+  br i1 %88, label %then12, label %ifcont13
 
-then14:                                           ; preds = %ifcont13
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @98, i32 0, i32 0), i32 1, i32 3, i32 %80, i32 %85)
   call void @exit(i32 1)
   unreachable
 
-ifcont15:                                         ; preds = %ifcont13
+ifcont13:                                         ; preds = %ifcont11
   %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %78, i32 0, i32 0
   %90 = load i32, i32* %89, align 4
   %91 = mul i32 %90, %83
@@ -327,58 +325,58 @@ ifcont15:                                         ; preds = %ifcont13
   %99 = load %array*, %array** %c, align 8
   %100 = ptrtoint %array* %99 to i64
   %101 = icmp eq i64 %100, 0
-  br i1 %101, label %merge_allocated17, label %check_data16
+  br i1 %101, label %merge_allocated15, label %check_data14
 
-check_data16:                                     ; preds = %ifcont15
+check_data14:                                     ; preds = %ifcont13
   %102 = getelementptr %array, %array* %99, i32 0, i32 0
   %103 = load i32*, i32** %102, align 8
   %104 = ptrtoint i32* %103 to i64
   %105 = icmp ne i64 %104, 0
-  br label %merge_allocated17
+  br label %merge_allocated15
 
-merge_allocated17:                                ; preds = %check_data16, %ifcont15
-  %is_allocated18 = phi i1 [ false, %ifcont15 ], [ %105, %check_data16 ]
-  br i1 %is_allocated18, label %then19, label %else20
+merge_allocated15:                                ; preds = %check_data14, %ifcont13
+  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %105, %check_data14 ]
+  br i1 %is_allocated16, label %then17, label %else18
 
-then19:                                           ; preds = %merge_allocated17
+then17:                                           ; preds = %merge_allocated15
   %106 = getelementptr %array, %array* %99, i32 0, i32 0
   %107 = load i32*, i32** %106, align 8
   %108 = bitcast i32* %107 to i8*
   call void @_lfortran_free(i8* %108)
   %109 = getelementptr %array, %array* %99, i32 0, i32 0
   store i32* null, i32** %109, align 8
-  br label %ifcont21
+  br label %ifcont19
 
-else20:                                           ; preds = %merge_allocated17
-  br label %ifcont21
+else18:                                           ; preds = %merge_allocated15
+  br label %ifcont19
 
-ifcont21:                                         ; preds = %else20, %then19
+ifcont19:                                         ; preds = %else18, %then17
   call void @h(%array** %c)
   %110 = call i32 @g(%array** %c)
-  store i32 %110, i32* %r1, align 4
+  store i32 %110, i32* %r, align 4
   %111 = load %array*, %array** %c, align 8
   %112 = ptrtoint %array* %111 to i64
   %113 = icmp eq i64 %112, 0
-  br i1 %113, label %merge_allocated23, label %check_data22
+  br i1 %113, label %merge_allocated21, label %check_data20
 
-check_data22:                                     ; preds = %ifcont21
+check_data20:                                     ; preds = %ifcont19
   %114 = getelementptr %array, %array* %111, i32 0, i32 0
   %115 = load i32*, i32** %114, align 8
   %116 = ptrtoint i32* %115 to i64
   %117 = icmp ne i64 %116, 0
-  br label %merge_allocated23
+  br label %merge_allocated21
 
-merge_allocated23:                                ; preds = %check_data22, %ifcont21
-  %is_allocated24 = phi i1 [ false, %ifcont21 ], [ %117, %check_data22 ]
-  %118 = xor i1 %is_allocated24, true
-  br i1 %118, label %then25, label %ifcont26
+merge_allocated21:                                ; preds = %check_data20, %ifcont19
+  %is_allocated22 = phi i1 [ false, %ifcont19 ], [ %117, %check_data20 ]
+  %118 = xor i1 %is_allocated22, true
+  br i1 %118, label %then23, label %ifcont24
 
-then25:                                           ; preds = %merge_allocated23
+then23:                                           ; preds = %merge_allocated21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont26:                                         ; preds = %merge_allocated23
+ifcont24:                                         ; preds = %merge_allocated21
   %119 = getelementptr %array, %array* %111, i32 0, i32 2
   %120 = load %dimension_descriptor*, %dimension_descriptor** %119, align 8
   %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 0
@@ -392,14 +390,14 @@ ifcont26:                                         ; preds = %merge_allocated23
   %129 = icmp slt i32 1, %123
   %130 = icmp sgt i32 1, %128
   %131 = or i1 %129, %130
-  br i1 %131, label %then27, label %ifcont28
+  br i1 %131, label %then25, label %ifcont26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i32 1, i32 1, i32 %123, i32 %128)
   call void @exit(i32 1)
   unreachable
 
-ifcont28:                                         ; preds = %ifcont26
+ifcont26:                                         ; preds = %ifcont24
   %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
   %133 = load i32, i32* %132, align 4
   %134 = mul i32 %133, %126
@@ -415,14 +413,14 @@ ifcont28:                                         ; preds = %ifcont26
   %144 = icmp slt i32 1, %138
   %145 = icmp sgt i32 1, %143
   %146 = or i1 %144, %145
-  br i1 %146, label %then29, label %ifcont30
+  br i1 %146, label %then27, label %ifcont28
 
-then29:                                           ; preds = %ifcont28
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 1, i32 2, i32 %138, i32 %143)
   call void @exit(i32 1)
   unreachable
 
-ifcont30:                                         ; preds = %ifcont28
+ifcont28:                                         ; preds = %ifcont26
   %147 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 0
   %148 = load i32, i32* %147, align 4
   %149 = mul i32 %148, %141
@@ -438,14 +436,14 @@ ifcont30:                                         ; preds = %ifcont28
   %159 = icmp slt i32 1, %153
   %160 = icmp sgt i32 1, %158
   %161 = or i1 %159, %160
-  br i1 %161, label %then31, label %ifcont32
+  br i1 %161, label %then29, label %ifcont30
 
-then31:                                           ; preds = %ifcont30
+then29:                                           ; preds = %ifcont28
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 1, i32 3, i32 %153, i32 %158)
   call void @exit(i32 1)
   unreachable
 
-ifcont32:                                         ; preds = %ifcont30
+ifcont30:                                         ; preds = %ifcont28
   %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 0
   %163 = load i32, i32* %162, align 4
   %164 = mul i32 %163, %156
@@ -458,41 +456,41 @@ ifcont32:                                         ; preds = %ifcont30
   %171 = getelementptr inbounds i32, i32* %170, i32 %168
   %172 = load i32, i32* %171, align 4
   %173 = icmp ne i32 %172, 8
-  br i1 %173, label %then33, label %else34
+  br i1 %173, label %then31, label %else32
 
-then33:                                           ; preds = %ifcont32
+then31:                                           ; preds = %ifcont30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont35
+  br label %ifcont33
 
-else34:                                           ; preds = %ifcont32
-  br label %ifcont35
+else32:                                           ; preds = %ifcont30
+  br label %ifcont33
 
-ifcont35:                                         ; preds = %else34, %then33
+ifcont33:                                         ; preds = %else32, %then31
   %174 = alloca i64, align 8
   %175 = load %array*, %array** %c, align 8
   %176 = ptrtoint %array* %175 to i64
   %177 = icmp eq i64 %176, 0
-  br i1 %177, label %merge_allocated37, label %check_data36
+  br i1 %177, label %merge_allocated35, label %check_data34
 
-check_data36:                                     ; preds = %ifcont35
+check_data34:                                     ; preds = %ifcont33
   %178 = getelementptr %array, %array* %175, i32 0, i32 0
   %179 = load i32*, i32** %178, align 8
   %180 = ptrtoint i32* %179 to i64
   %181 = icmp ne i64 %180, 0
-  br label %merge_allocated37
+  br label %merge_allocated35
 
-merge_allocated37:                                ; preds = %check_data36, %ifcont35
-  %is_allocated38 = phi i1 [ false, %ifcont35 ], [ %181, %check_data36 ]
-  %182 = xor i1 %is_allocated38, true
-  br i1 %182, label %then39, label %ifcont40
+merge_allocated35:                                ; preds = %check_data34, %ifcont33
+  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %181, %check_data34 ]
+  %182 = xor i1 %is_allocated36, true
+  br i1 %182, label %then37, label %ifcont38
 
-then39:                                           ; preds = %merge_allocated37
+then37:                                           ; preds = %merge_allocated35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([101 x i8], [101 x i8]* @112, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @111, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont40:                                         ; preds = %merge_allocated37
+ifcont38:                                         ; preds = %merge_allocated35
   %183 = getelementptr %array, %array* %175, i32 0, i32 2
   %184 = load %dimension_descriptor*, %dimension_descriptor** %183, align 8
   %185 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 0
@@ -506,14 +504,14 @@ ifcont40:                                         ; preds = %merge_allocated37
   %193 = icmp slt i32 1, %187
   %194 = icmp sgt i32 1, %192
   %195 = or i1 %193, %194
-  br i1 %195, label %then41, label %ifcont42
+  br i1 %195, label %then39, label %ifcont40
 
-then41:                                           ; preds = %ifcont40
+then39:                                           ; preds = %ifcont38
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @113, i32 0, i32 0), i32 1, i32 1, i32 %187, i32 %192)
   call void @exit(i32 1)
   unreachable
 
-ifcont42:                                         ; preds = %ifcont40
+ifcont40:                                         ; preds = %ifcont38
   %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 0
   %197 = load i32, i32* %196, align 4
   %198 = mul i32 %197, %190
@@ -529,14 +527,14 @@ ifcont42:                                         ; preds = %ifcont40
   %208 = icmp slt i32 1, %202
   %209 = icmp sgt i32 1, %207
   %210 = or i1 %208, %209
-  br i1 %210, label %then43, label %ifcont44
+  br i1 %210, label %then41, label %ifcont42
 
-then43:                                           ; preds = %ifcont42
+then41:                                           ; preds = %ifcont40
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @116, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i32 1, i32 2, i32 %202, i32 %207)
   call void @exit(i32 1)
   unreachable
 
-ifcont44:                                         ; preds = %ifcont42
+ifcont42:                                         ; preds = %ifcont40
   %211 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 0
   %212 = load i32, i32* %211, align 4
   %213 = mul i32 %212, %205
@@ -552,14 +550,14 @@ ifcont44:                                         ; preds = %ifcont42
   %223 = icmp slt i32 1, %217
   %224 = icmp sgt i32 1, %222
   %225 = or i1 %223, %224
-  br i1 %225, label %then45, label %ifcont46
+  br i1 %225, label %then43, label %ifcont44
 
-then45:                                           ; preds = %ifcont44
+then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @117, i32 0, i32 0), i32 1, i32 3, i32 %217, i32 %222)
   call void @exit(i32 1)
   unreachable
 
-ifcont46:                                         ; preds = %ifcont44
+ifcont44:                                         ; preds = %ifcont42
   %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 0
   %227 = load i32, i32* %226, align 4
   %228 = mul i32 %227, %220
@@ -589,11 +587,11 @@ ifcont46:                                         ; preds = %ifcont44
   %247 = icmp eq i8* %238, null
   br i1 %247, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont46
+free_nonnull:                                     ; preds = %ifcont44
   call void @_lfortran_free(i8* %238)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont46
+free_done:                                        ; preds = %free_nonnull, %ifcont44
   call void @_lpython_free_argv()
   br label %return
 
@@ -608,14 +606,14 @@ Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_a
   %249 = getelementptr %array, %array* %248, i32 0, i32 0
   %250 = load i32*, i32** %249, align 8
   %251 = icmp eq i32* %250, null
-  br i1 %251, label %free_done48, label %free_nonnull47
+  br i1 %251, label %free_done46, label %free_nonnull45
 
-free_nonnull47:                                   ; preds = %Finalize_Variable_c
+free_nonnull45:                                   ; preds = %Finalize_Variable_c
   %252 = bitcast i32* %250 to i8*
   call void @_lfortran_free(i8* %252)
-  br label %free_done48
+  br label %free_done46
 
-free_done48:                                      ; preds = %free_nonnull47, %Finalize_Variable_c
+free_done46:                                      ; preds = %free_nonnull45, %Finalize_Variable_c
   ret i32 0
 }
 

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "86dfd5e80e6bfadf8a5e931bbcb422607bf9549b26300b9068651240",
+    "stdout_hash": "0f4a2e903ff80171710ddc441b88f37a813820f0005f8124a79c4983",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -75,25 +75,24 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x i32], align 4
   %b = alloca [4 x i32], align 4
-  %i1 = alloca i32, align 4
-  store i32 0, i32* %i1, align 4
+  %i = alloca i32, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i1, align 4
-  %7 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %i, align 4
+  %7 = load i32, i32* %i, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
@@ -109,92 +108,92 @@ then:                                             ; preds = %loop.body
 
 ifcont:                                           ; preds = %loop.body
   %14 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %10
-  %15 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %i, align 4
   %16 = add i32 %15, 10
   store i32 %16, i32* %14, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 false, label %then2, label %ifcont3
+  br i1 false, label %then1, label %ifcont2
 
-then2:                                            ; preds = %loop.end
+then1:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([176 x i8], [176 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont3:                                          ; preds = %loop.end
+ifcont2:                                          ; preds = %loop.end
   %17 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %18 = load i32, i32* %17, align 4
   %19 = icmp ne i32 %18, 11
-  br i1 %19, label %then4, label %else
+  br i1 %19, label %then3, label %else
 
-then4:                                            ; preds = %ifcont3
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont4
 
-else:                                             ; preds = %ifcont3
-  br label %ifcont5
+else:                                             ; preds = %ifcont2
+  br label %ifcont4
 
-ifcont5:                                          ; preds = %else, %then4
-  br i1 false, label %then6, label %ifcont7
+ifcont4:                                          ; preds = %else, %then3
+  br i1 false, label %then5, label %ifcont6
 
-then6:                                            ; preds = %ifcont5
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([176 x i8], [176 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 2, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont7:                                          ; preds = %ifcont5
+ifcont6:                                          ; preds = %ifcont4
   %20 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 1
   %21 = load i32, i32* %20, align 4
   %22 = icmp ne i32 %21, 12
-  br i1 %22, label %then8, label %else9
+  br i1 %22, label %then7, label %else8
 
-then8:                                            ; preds = %ifcont7
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont10
+  br label %ifcont9
 
-else9:                                            ; preds = %ifcont7
-  br label %ifcont10
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont10:                                         ; preds = %else9, %then8
-  br i1 false, label %then11, label %ifcont12
+ifcont9:                                          ; preds = %else8, %then7
+  br i1 false, label %then10, label %ifcont11
 
-then11:                                           ; preds = %ifcont10
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([176 x i8], [176 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 3, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont12:                                         ; preds = %ifcont10
+ifcont11:                                         ; preds = %ifcont9
   %23 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 2
   %24 = load i32, i32* %23, align 4
   %25 = icmp ne i32 %24, 13
-  br i1 %25, label %then13, label %else14
+  br i1 %25, label %then12, label %else13
 
-then13:                                           ; preds = %ifcont12
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont14
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont15:                                         ; preds = %else14, %then13
-  store i32 10, i32* %i1, align 4
-  br label %loop.head16
+ifcont14:                                         ; preds = %else13, %then12
+  store i32 10, i32* %i, align 4
+  br label %loop.head15
 
-loop.head16:                                      ; preds = %ifcont19, %ifcont15
-  %26 = load i32, i32* %i1, align 4
+loop.head15:                                      ; preds = %ifcont18, %ifcont14
+  %26 = load i32, i32* %i, align 4
   %27 = add i32 %26, 1
   %28 = icmp sle i32 %27, 14
-  br i1 %28, label %loop.body17, label %loop.end20
+  br i1 %28, label %loop.body16, label %loop.end19
 
-loop.body17:                                      ; preds = %loop.head16
-  %29 = load i32, i32* %i1, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %29 = load i32, i32* %i, align 4
   %30 = add i32 %29, 1
-  store i32 %30, i32* %i1, align 4
-  %31 = load i32, i32* %i1, align 4
+  store i32 %30, i32* %i, align 4
+  %31 = load i32, i32* %i, align 4
   %32 = sub i32 %31, 10
   %33 = sub i32 %32, 1
   %34 = mul i32 1, %33
@@ -202,346 +201,346 @@ loop.body17:                                      ; preds = %loop.head16
   %36 = icmp slt i32 %32, 1
   %37 = icmp sgt i32 %32, 4
   %38 = or i1 %36, %37
-  br i1 %38, label %then18, label %ifcont19
+  br i1 %38, label %then17, label %ifcont18
 
-then18:                                           ; preds = %loop.body17
+then17:                                           ; preds = %loop.body16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 %32, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont19:                                         ; preds = %loop.body17
+ifcont18:                                         ; preds = %loop.body16
   %39 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %35
-  %40 = load i32, i32* %i1, align 4
+  %40 = load i32, i32* %i, align 4
   store i32 %40, i32* %39, align 4
-  br label %loop.head16
+  br label %loop.head15
 
-loop.end20:                                       ; preds = %loop.head16
-  br i1 false, label %then21, label %ifcont22
+loop.end19:                                       ; preds = %loop.head15
+  br i1 false, label %then20, label %ifcont21
 
-then21:                                           ; preds = %loop.end20
+then20:                                           ; preds = %loop.end19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont22:                                         ; preds = %loop.end20
+ifcont21:                                         ; preds = %loop.end19
   %41 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %42 = load i32, i32* %41, align 4
   %43 = icmp ne i32 %42, 11
-  br i1 %43, label %then23, label %else24
+  br i1 %43, label %then22, label %else23
 
-then23:                                           ; preds = %ifcont22
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont25
+  br label %ifcont24
 
-else24:                                           ; preds = %ifcont22
-  br label %ifcont25
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont25:                                         ; preds = %else24, %then23
-  br i1 false, label %then26, label %ifcont27
+ifcont24:                                         ; preds = %else23, %then22
+  br i1 false, label %then25, label %ifcont26
 
-then26:                                           ; preds = %ifcont25
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont27:                                         ; preds = %ifcont25
+ifcont26:                                         ; preds = %ifcont24
   %44 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %45 = load i32, i32* %44, align 4
   %46 = icmp ne i32 %45, 12
-  br i1 %46, label %then28, label %else29
+  br i1 %46, label %then27, label %else28
 
-then28:                                           ; preds = %ifcont27
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont29
 
-else29:                                           ; preds = %ifcont27
-  br label %ifcont30
+else28:                                           ; preds = %ifcont26
+  br label %ifcont29
 
-ifcont30:                                         ; preds = %else29, %then28
-  br i1 false, label %then31, label %ifcont32
+ifcont29:                                         ; preds = %else28, %then27
+  br i1 false, label %then30, label %ifcont31
 
-then31:                                           ; preds = %ifcont30
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont32:                                         ; preds = %ifcont30
+ifcont31:                                         ; preds = %ifcont29
   %47 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %48 = load i32, i32* %47, align 4
   %49 = icmp ne i32 %48, 13
-  br i1 %49, label %then33, label %else34
+  br i1 %49, label %then32, label %else33
 
-then33:                                           ; preds = %ifcont32
+then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont35
+  br label %ifcont34
 
-else34:                                           ; preds = %ifcont32
-  br label %ifcont35
+else33:                                           ; preds = %ifcont31
+  br label %ifcont34
 
-ifcont35:                                         ; preds = %else34, %then33
-  br i1 false, label %then36, label %ifcont37
+ifcont34:                                         ; preds = %else33, %then32
+  br i1 false, label %then35, label %ifcont36
 
-then36:                                           ; preds = %ifcont35
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont37:                                         ; preds = %ifcont35
+ifcont36:                                         ; preds = %ifcont34
   %50 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %51 = load i32, i32* %50, align 4
   %52 = icmp ne i32 %51, 14
-  br i1 %52, label %then38, label %else39
+  br i1 %52, label %then37, label %else38
 
-then38:                                           ; preds = %ifcont37
+then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont40
+  br label %ifcont39
 
-else39:                                           ; preds = %ifcont37
-  br label %ifcont40
+else38:                                           ; preds = %ifcont36
+  br label %ifcont39
 
-ifcont40:                                         ; preds = %else39, %then38
-  store i32 0, i32* %i1, align 4
-  br label %loop.head41
+ifcont39:                                         ; preds = %else38, %then37
+  store i32 0, i32* %i, align 4
+  br label %loop.head40
 
-loop.head41:                                      ; preds = %ifcont46, %ifcont40
-  %53 = load i32, i32* %i1, align 4
+loop.head40:                                      ; preds = %ifcont45, %ifcont39
+  %53 = load i32, i32* %i, align 4
   %54 = add i32 %53, 1
   %55 = icmp sle i32 %54, 3
-  br i1 %55, label %loop.body42, label %loop.end47
+  br i1 %55, label %loop.body41, label %loop.end46
 
-loop.body42:                                      ; preds = %loop.head41
-  %56 = load i32, i32* %i1, align 4
+loop.body41:                                      ; preds = %loop.head40
+  %56 = load i32, i32* %i, align 4
   %57 = add i32 %56, 1
-  store i32 %57, i32* %i1, align 4
-  %58 = load i32, i32* %i1, align 4
+  store i32 %57, i32* %i, align 4
+  %58 = load i32, i32* %i, align 4
   %59 = sub i32 %58, 1
   %60 = mul i32 1, %59
   %61 = add i32 0, %60
   %62 = icmp slt i32 %58, 1
   %63 = icmp sgt i32 %58, 4
   %64 = or i1 %62, %63
-  br i1 %64, label %then43, label %ifcont44
+  br i1 %64, label %then42, label %ifcont43
 
-then43:                                           ; preds = %loop.body42
+then42:                                           ; preds = %loop.body41
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 %58, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont44:                                         ; preds = %loop.body42
+ifcont43:                                         ; preds = %loop.body41
   %65 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %61
-  %66 = load i32, i32* %i1, align 4
+  %66 = load i32, i32* %i, align 4
   %67 = sub i32 %66, 1
   %68 = mul i32 1, %67
   %69 = add i32 0, %68
   %70 = icmp slt i32 %66, 1
   %71 = icmp sgt i32 %66, 3
   %72 = or i1 %70, %71
-  br i1 %72, label %then45, label %ifcont46
+  br i1 %72, label %then44, label %ifcont45
 
-then45:                                           ; preds = %ifcont44
+then44:                                           ; preds = %ifcont43
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 %66, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont46:                                         ; preds = %ifcont44
+ifcont45:                                         ; preds = %ifcont43
   %73 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %69
   %74 = load i32, i32* %73, align 4
   %75 = sub i32 %74, 10
   store i32 %75, i32* %65, align 4
-  br label %loop.head41
+  br label %loop.head40
 
-loop.end47:                                       ; preds = %loop.head41
-  br i1 false, label %then48, label %ifcont49
+loop.end46:                                       ; preds = %loop.head40
+  br i1 false, label %then47, label %ifcont48
 
-then48:                                           ; preds = %loop.end47
+then47:                                           ; preds = %loop.end46
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont49:                                         ; preds = %loop.end47
+ifcont48:                                         ; preds = %loop.end46
   %76 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %77 = load i32, i32* %76, align 4
   %78 = icmp ne i32 %77, 1
-  br i1 %78, label %then50, label %else51
+  br i1 %78, label %then49, label %else50
 
-then50:                                           ; preds = %ifcont49
+then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont52
+  br label %ifcont51
 
-else51:                                           ; preds = %ifcont49
-  br label %ifcont52
+else50:                                           ; preds = %ifcont48
+  br label %ifcont51
 
-ifcont52:                                         ; preds = %else51, %then50
-  br i1 false, label %then53, label %ifcont54
+ifcont51:                                         ; preds = %else50, %then49
+  br i1 false, label %then52, label %ifcont53
 
-then53:                                           ; preds = %ifcont52
+then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont54:                                         ; preds = %ifcont52
+ifcont53:                                         ; preds = %ifcont51
   %79 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %80 = load i32, i32* %79, align 4
   %81 = icmp ne i32 %80, 2
-  br i1 %81, label %then55, label %else56
+  br i1 %81, label %then54, label %else55
 
-then55:                                           ; preds = %ifcont54
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont57
+  br label %ifcont56
 
-else56:                                           ; preds = %ifcont54
-  br label %ifcont57
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont57:                                         ; preds = %else56, %then55
-  br i1 false, label %then58, label %ifcont59
+ifcont56:                                         ; preds = %else55, %then54
+  br i1 false, label %then57, label %ifcont58
 
-then58:                                           ; preds = %ifcont57
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont59:                                         ; preds = %ifcont57
+ifcont58:                                         ; preds = %ifcont56
   %82 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %83 = load i32, i32* %82, align 4
   %84 = icmp ne i32 %83, 3
-  br i1 %84, label %then60, label %else61
+  br i1 %84, label %then59, label %else60
 
-then60:                                           ; preds = %ifcont59
+then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont62
+  br label %ifcont61
 
-else61:                                           ; preds = %ifcont59
-  br label %ifcont62
+else60:                                           ; preds = %ifcont58
+  br label %ifcont61
 
-ifcont62:                                         ; preds = %else61, %then60
-  br i1 false, label %then63, label %ifcont64
+ifcont61:                                         ; preds = %else60, %then59
+  br i1 false, label %then62, label %ifcont63
 
-then63:                                           ; preds = %ifcont62
+then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont64:                                         ; preds = %ifcont62
+ifcont63:                                         ; preds = %ifcont61
   %85 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  br i1 false, label %then65, label %ifcont66
+  br i1 false, label %then64, label %ifcont65
 
-then65:                                           ; preds = %ifcont64
+then64:                                           ; preds = %ifcont63
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont66:                                         ; preds = %ifcont64
+ifcont65:                                         ; preds = %ifcont63
   %86 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %87 = load i32, i32* %86, align 4
-  br i1 false, label %then67, label %ifcont68
+  br i1 false, label %then66, label %ifcont67
 
-then67:                                           ; preds = %ifcont66
+then66:                                           ; preds = %ifcont65
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont68:                                         ; preds = %ifcont66
+ifcont67:                                         ; preds = %ifcont65
   %88 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %89 = load i32, i32* %88, align 4
   %90 = add i32 %87, %89
-  br i1 false, label %then69, label %ifcont70
+  br i1 false, label %then68, label %ifcont69
 
-then69:                                           ; preds = %ifcont68
+then68:                                           ; preds = %ifcont67
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont70:                                         ; preds = %ifcont68
+ifcont69:                                         ; preds = %ifcont67
   %91 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %92 = load i32, i32* %91, align 4
   %93 = add i32 %90, %92
-  br i1 false, label %then71, label %ifcont72
+  br i1 false, label %then70, label %ifcont71
 
-then71:                                           ; preds = %ifcont70
+then70:                                           ; preds = %ifcont69
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont72:                                         ; preds = %ifcont70
+ifcont71:                                         ; preds = %ifcont69
   %94 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %95 = load i32, i32* %94, align 4
   %96 = add i32 %93, %95
   store i32 %96, i32* %85, align 4
-  br i1 false, label %then73, label %ifcont74
+  br i1 false, label %then72, label %ifcont73
 
-then73:                                           ; preds = %ifcont72
+then72:                                           ; preds = %ifcont71
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont74:                                         ; preds = %ifcont72
+ifcont73:                                         ; preds = %ifcont71
   %97 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %98 = load i32, i32* %97, align 4
   %99 = icmp ne i32 %98, 17
-  br i1 %99, label %then75, label %else76
+  br i1 %99, label %then74, label %else75
 
-then75:                                           ; preds = %ifcont74
+then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont77
+  br label %ifcont76
 
-else76:                                           ; preds = %ifcont74
-  br label %ifcont77
+else75:                                           ; preds = %ifcont73
+  br label %ifcont76
 
-ifcont77:                                         ; preds = %else76, %then75
-  br i1 false, label %then78, label %ifcont79
+ifcont76:                                         ; preds = %else75, %then74
+  br i1 false, label %then77, label %ifcont78
 
-then78:                                           ; preds = %ifcont77
+then77:                                           ; preds = %ifcont76
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont79:                                         ; preds = %ifcont77
+ifcont78:                                         ; preds = %ifcont76
   %100 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  br i1 false, label %then80, label %ifcont81
+  br i1 false, label %then79, label %ifcont80
 
-then80:                                           ; preds = %ifcont79
+then79:                                           ; preds = %ifcont78
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont81:                                         ; preds = %ifcont79
+ifcont80:                                         ; preds = %ifcont78
   %101 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %102 = load i32, i32* %101, align 4
   store i32 %102, i32* %100, align 4
-  br i1 false, label %then82, label %ifcont83
+  br i1 false, label %then81, label %ifcont82
 
-then82:                                           ; preds = %ifcont81
+then81:                                           ; preds = %ifcont80
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([177 x i8], [177 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont83:                                         ; preds = %ifcont81
+ifcont82:                                         ; preds = %ifcont80
   %103 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %104 = load i32, i32* %103, align 4
   %105 = icmp ne i32 %104, 11
-  br i1 %105, label %then84, label %else85
+  br i1 %105, label %then83, label %else84
 
-then84:                                           ; preds = %ifcont83
+then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont86
+  br label %ifcont85
 
-else85:                                           ; preds = %ifcont83
-  br label %ifcont86
+else84:                                           ; preds = %ifcont82
+  br label %ifcont85
 
-ifcont86:                                         ; preds = %else85, %then84
+ifcont85:                                         ; preds = %else84, %then83
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont86
+return:                                           ; preds = %ifcont85
   br label %FINALIZE_SYMTABLE_arrays_01
 
 FINALIZE_SYMTABLE_arrays_01:                      ; preds = %return

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "50828923554dae966347412245f7bf57a97e9f38e4e84521fd5086fa",
+    "stdout_hash": "7885759604f1e9c1038b78b5a59e7454034e55d937a6e688e7092a33",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -105,28 +105,26 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x %complex_4], align 8
   %b = alloca [4 x %complex_4], align 8
   %c = alloca [4 x %complex_4], align 8
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 0, i32* %i1, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i1, align 4
-  %7 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %i, align 4
+  %7 = load i32, i32* %i, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
@@ -142,7 +140,7 @@ then:                                             ; preds = %loop.body
 
 ifcont:                                           ; preds = %loop.body
   %14 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 %10
-  %15 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %i, align 4
   %16 = add i32 %15, 10
   %17 = sitofp i32 %16 to float
   %18 = insertvalue %complex_4 undef, float %17, 0
@@ -151,14 +149,14 @@ ifcont:                                           ; preds = %loop.body
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 false, label %then3, label %ifcont4
+  br i1 false, label %then1, label %ifcont2
 
-then3:                                            ; preds = %loop.end
+then1:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([184 x i8], [184 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont4:                                          ; preds = %loop.end
+ifcont2:                                          ; preds = %loop.end
   %20 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 0
   %21 = load %complex_4, %complex_4* %20, align 1
   %22 = extractvalue %complex_4 %21, 0
@@ -166,25 +164,25 @@ ifcont4:                                          ; preds = %loop.end
   %24 = fcmp one float %22, 1.100000e+01
   %25 = fcmp one float %23, 0.000000e+00
   %26 = or i1 %24, %25
-  br i1 %26, label %then5, label %else
+  br i1 %26, label %then3, label %else
 
-then5:                                            ; preds = %ifcont4
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont4
 
-else:                                             ; preds = %ifcont4
-  br label %ifcont6
+else:                                             ; preds = %ifcont2
+  br label %ifcont4
 
-ifcont6:                                          ; preds = %else, %then5
-  br i1 false, label %then7, label %ifcont8
+ifcont4:                                          ; preds = %else, %then3
+  br i1 false, label %then5, label %ifcont6
 
-then7:                                            ; preds = %ifcont6
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([184 x i8], [184 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 2, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont8:                                          ; preds = %ifcont6
+ifcont6:                                          ; preds = %ifcont4
   %27 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 1
   %28 = load %complex_4, %complex_4* %27, align 1
   %29 = extractvalue %complex_4 %28, 0
@@ -192,25 +190,25 @@ ifcont8:                                          ; preds = %ifcont6
   %31 = fcmp one float %29, 1.200000e+01
   %32 = fcmp one float %30, 0.000000e+00
   %33 = or i1 %31, %32
-  br i1 %33, label %then9, label %else10
+  br i1 %33, label %then7, label %else8
 
-then9:                                            ; preds = %ifcont8
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %ifcont8
-  br label %ifcont11
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
-  br i1 false, label %then12, label %ifcont13
+ifcont9:                                          ; preds = %else8, %then7
+  br i1 false, label %then10, label %ifcont11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 3, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont13:                                         ; preds = %ifcont11
+ifcont11:                                         ; preds = %ifcont9
   %34 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 2
   %35 = load %complex_4, %complex_4* %34, align 1
   %36 = extractvalue %complex_4 %35, 0
@@ -218,31 +216,31 @@ ifcont13:                                         ; preds = %ifcont11
   %38 = fcmp one float %36, 1.300000e+01
   %39 = fcmp one float %37, 0.000000e+00
   %40 = or i1 %38, %39
-  br i1 %40, label %then14, label %else15
+  br i1 %40, label %then12, label %else13
 
-then14:                                           ; preds = %ifcont13
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont16
+  br label %ifcont14
 
-else15:                                           ; preds = %ifcont13
-  br label %ifcont16
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont16:                                         ; preds = %else15, %then14
-  store i32 10, i32* %i1, align 4
-  br label %loop.head17
+ifcont14:                                         ; preds = %else13, %then12
+  store i32 10, i32* %i, align 4
+  br label %loop.head15
 
-loop.head17:                                      ; preds = %ifcont20, %ifcont16
-  %41 = load i32, i32* %i1, align 4
+loop.head15:                                      ; preds = %ifcont18, %ifcont14
+  %41 = load i32, i32* %i, align 4
   %42 = add i32 %41, 1
   %43 = icmp sle i32 %42, 14
-  br i1 %43, label %loop.body18, label %loop.end21
+  br i1 %43, label %loop.body16, label %loop.end19
 
-loop.body18:                                      ; preds = %loop.head17
-  %44 = load i32, i32* %i1, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %44 = load i32, i32* %i, align 4
   %45 = add i32 %44, 1
-  store i32 %45, i32* %i1, align 4
-  %46 = load i32, i32* %i1, align 4
+  store i32 %45, i32* %i, align 4
+  %46 = load i32, i32* %i, align 4
   %47 = sub i32 %46, 10
   %48 = sub i32 %47, 1
   %49 = mul i32 1, %48
@@ -250,31 +248,31 @@ loop.body18:                                      ; preds = %loop.head17
   %51 = icmp slt i32 %47, 1
   %52 = icmp sgt i32 %47, 4
   %53 = or i1 %51, %52
-  br i1 %53, label %then19, label %ifcont20
+  br i1 %53, label %then17, label %ifcont18
 
-then19:                                           ; preds = %loop.body18
+then17:                                           ; preds = %loop.body16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 %47, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont20:                                         ; preds = %loop.body18
+ifcont18:                                         ; preds = %loop.body16
   %54 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 %50
-  %55 = load i32, i32* %i1, align 4
+  %55 = load i32, i32* %i, align 4
   %56 = sitofp i32 %55 to float
   %57 = insertvalue %complex_4 undef, float %56, 0
   %58 = insertvalue %complex_4 %57, float 0.000000e+00, 1
   store %complex_4 %58, %complex_4* %54, align 1
-  br label %loop.head17
+  br label %loop.head15
 
-loop.end21:                                       ; preds = %loop.head17
-  br i1 false, label %then22, label %ifcont23
+loop.end19:                                       ; preds = %loop.head15
+  br i1 false, label %then20, label %ifcont21
 
-then22:                                           ; preds = %loop.end21
+then20:                                           ; preds = %loop.end19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont23:                                         ; preds = %loop.end21
+ifcont21:                                         ; preds = %loop.end19
   %59 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %60 = load %complex_4, %complex_4* %59, align 1
   %61 = extractvalue %complex_4 %60, 0
@@ -282,25 +280,25 @@ ifcont23:                                         ; preds = %loop.end21
   %63 = fcmp one float %61, 1.100000e+01
   %64 = fcmp one float %62, 0.000000e+00
   %65 = or i1 %63, %64
-  br i1 %65, label %then24, label %else25
+  br i1 %65, label %then22, label %else23
 
-then24:                                           ; preds = %ifcont23
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %ifcont23
-  br label %ifcont26
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %then24
-  br i1 false, label %then27, label %ifcont28
+ifcont24:                                         ; preds = %else23, %then22
+  br i1 false, label %then25, label %ifcont26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont28:                                         ; preds = %ifcont26
+ifcont26:                                         ; preds = %ifcont24
   %66 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 1
   %67 = load %complex_4, %complex_4* %66, align 1
   %68 = extractvalue %complex_4 %67, 0
@@ -308,25 +306,25 @@ ifcont28:                                         ; preds = %ifcont26
   %70 = fcmp one float %68, 1.200000e+01
   %71 = fcmp one float %69, 0.000000e+00
   %72 = or i1 %70, %71
-  br i1 %72, label %then29, label %else30
+  br i1 %72, label %then27, label %else28
 
-then29:                                           ; preds = %ifcont28
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont31
+  br label %ifcont29
 
-else30:                                           ; preds = %ifcont28
-  br label %ifcont31
+else28:                                           ; preds = %ifcont26
+  br label %ifcont29
 
-ifcont31:                                         ; preds = %else30, %then29
-  br i1 false, label %then32, label %ifcont33
+ifcont29:                                         ; preds = %else28, %then27
+  br i1 false, label %then30, label %ifcont31
 
-then32:                                           ; preds = %ifcont31
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont33:                                         ; preds = %ifcont31
+ifcont31:                                         ; preds = %ifcont29
   %73 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 2
   %74 = load %complex_4, %complex_4* %73, align 1
   %75 = extractvalue %complex_4 %74, 0
@@ -334,25 +332,25 @@ ifcont33:                                         ; preds = %ifcont31
   %77 = fcmp one float %75, 1.300000e+01
   %78 = fcmp one float %76, 0.000000e+00
   %79 = or i1 %77, %78
-  br i1 %79, label %then34, label %else35
+  br i1 %79, label %then32, label %else33
 
-then34:                                           ; preds = %ifcont33
+then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont34
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else33:                                           ; preds = %ifcont31
+  br label %ifcont34
 
-ifcont36:                                         ; preds = %else35, %then34
-  br i1 false, label %then37, label %ifcont38
+ifcont34:                                         ; preds = %else33, %then32
+  br i1 false, label %then35, label %ifcont36
 
-then37:                                           ; preds = %ifcont36
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont38:                                         ; preds = %ifcont36
+ifcont36:                                         ; preds = %ifcont34
   %80 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %81 = load %complex_4, %complex_4* %80, align 1
   %82 = extractvalue %complex_4 %81, 0
@@ -360,61 +358,61 @@ ifcont38:                                         ; preds = %ifcont36
   %84 = fcmp one float %82, 1.400000e+01
   %85 = fcmp one float %83, 0.000000e+00
   %86 = or i1 %84, %85
-  br i1 %86, label %then39, label %else40
+  br i1 %86, label %then37, label %else38
 
-then39:                                           ; preds = %ifcont38
+then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont41
+  br label %ifcont39
 
-else40:                                           ; preds = %ifcont38
-  br label %ifcont41
+else38:                                           ; preds = %ifcont36
+  br label %ifcont39
 
-ifcont41:                                         ; preds = %else40, %then39
-  store i32 0, i32* %i1, align 4
-  br label %loop.head42
+ifcont39:                                         ; preds = %else38, %then37
+  store i32 0, i32* %i, align 4
+  br label %loop.head40
 
-loop.head42:                                      ; preds = %ifcont47, %ifcont41
-  %87 = load i32, i32* %i1, align 4
+loop.head40:                                      ; preds = %ifcont45, %ifcont39
+  %87 = load i32, i32* %i, align 4
   %88 = add i32 %87, 1
   %89 = icmp sle i32 %88, 3
-  br i1 %89, label %loop.body43, label %loop.end48
+  br i1 %89, label %loop.body41, label %loop.end46
 
-loop.body43:                                      ; preds = %loop.head42
-  %90 = load i32, i32* %i1, align 4
+loop.body41:                                      ; preds = %loop.head40
+  %90 = load i32, i32* %i, align 4
   %91 = add i32 %90, 1
-  store i32 %91, i32* %i1, align 4
-  %92 = load i32, i32* %i1, align 4
+  store i32 %91, i32* %i, align 4
+  %92 = load i32, i32* %i, align 4
   %93 = sub i32 %92, 1
   %94 = mul i32 1, %93
   %95 = add i32 0, %94
   %96 = icmp slt i32 %92, 1
   %97 = icmp sgt i32 %92, 4
   %98 = or i1 %96, %97
-  br i1 %98, label %then44, label %ifcont45
+  br i1 %98, label %then42, label %ifcont43
 
-then44:                                           ; preds = %loop.body43
+then42:                                           ; preds = %loop.body41
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 %92, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont45:                                         ; preds = %loop.body43
+ifcont43:                                         ; preds = %loop.body41
   %99 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 %95
-  %100 = load i32, i32* %i1, align 4
+  %100 = load i32, i32* %i, align 4
   %101 = sub i32 %100, 1
   %102 = mul i32 1, %101
   %103 = add i32 0, %102
   %104 = icmp slt i32 %100, 1
   %105 = icmp sgt i32 %100, 3
   %106 = or i1 %104, %105
-  br i1 %106, label %then46, label %ifcont47
+  br i1 %106, label %then44, label %ifcont45
 
-then46:                                           ; preds = %ifcont45
+then44:                                           ; preds = %ifcont43
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 %100, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont47:                                         ; preds = %ifcont45
+ifcont45:                                         ; preds = %ifcont43
   %107 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 %103
   %108 = load %complex_4, %complex_4* %107, align 1
   %109 = extractvalue %complex_4 %108, 0
@@ -424,17 +422,17 @@ ifcont47:                                         ; preds = %ifcont45
   %113 = insertvalue %complex_4 undef, float %111, 0
   %114 = insertvalue %complex_4 %113, float %112, 1
   store %complex_4 %114, %complex_4* %99, align 1
-  br label %loop.head42
+  br label %loop.head40
 
-loop.end48:                                       ; preds = %loop.head42
-  br i1 false, label %then49, label %ifcont50
+loop.end46:                                       ; preds = %loop.head40
+  br i1 false, label %then47, label %ifcont48
 
-then49:                                           ; preds = %loop.end48
+then47:                                           ; preds = %loop.end46
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont50:                                         ; preds = %loop.end48
+ifcont48:                                         ; preds = %loop.end46
   %115 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %116 = load %complex_4, %complex_4* %115, align 1
   %117 = extractvalue %complex_4 %116, 0
@@ -442,25 +440,25 @@ ifcont50:                                         ; preds = %loop.end48
   %119 = fcmp one float %117, 1.000000e+00
   %120 = fcmp one float %118, 0.000000e+00
   %121 = or i1 %119, %120
-  br i1 %121, label %then51, label %else52
+  br i1 %121, label %then49, label %else50
 
-then51:                                           ; preds = %ifcont50
+then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont53
+  br label %ifcont51
 
-else52:                                           ; preds = %ifcont50
-  br label %ifcont53
+else50:                                           ; preds = %ifcont48
+  br label %ifcont51
 
-ifcont53:                                         ; preds = %else52, %then51
-  br i1 false, label %then54, label %ifcont55
+ifcont51:                                         ; preds = %else50, %then49
+  br i1 false, label %then52, label %ifcont53
 
-then54:                                           ; preds = %ifcont53
+then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont55:                                         ; preds = %ifcont53
+ifcont53:                                         ; preds = %ifcont51
   %122 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 1
   %123 = load %complex_4, %complex_4* %122, align 1
   %124 = extractvalue %complex_4 %123, 0
@@ -468,25 +466,25 @@ ifcont55:                                         ; preds = %ifcont53
   %126 = fcmp one float %124, 2.000000e+00
   %127 = fcmp one float %125, 0.000000e+00
   %128 = or i1 %126, %127
-  br i1 %128, label %then56, label %else57
+  br i1 %128, label %then54, label %else55
 
-then56:                                           ; preds = %ifcont55
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont58
+  br label %ifcont56
 
-else57:                                           ; preds = %ifcont55
-  br label %ifcont58
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont58:                                         ; preds = %else57, %then56
-  br i1 false, label %then59, label %ifcont60
+ifcont56:                                         ; preds = %else55, %then54
+  br i1 false, label %then57, label %ifcont58
 
-then59:                                           ; preds = %ifcont58
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont60:                                         ; preds = %ifcont58
+ifcont58:                                         ; preds = %ifcont56
   %129 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 2
   %130 = load %complex_4, %complex_4* %129, align 1
   %131 = extractvalue %complex_4 %130, 0
@@ -494,44 +492,44 @@ ifcont60:                                         ; preds = %ifcont58
   %133 = fcmp one float %131, 3.000000e+00
   %134 = fcmp one float %132, 0.000000e+00
   %135 = or i1 %133, %134
-  br i1 %135, label %then61, label %else62
+  br i1 %135, label %then59, label %else60
 
-then61:                                           ; preds = %ifcont60
+then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont63
+  br label %ifcont61
 
-else62:                                           ; preds = %ifcont60
-  br label %ifcont63
+else60:                                           ; preds = %ifcont58
+  br label %ifcont61
 
-ifcont63:                                         ; preds = %else62, %then61
-  br i1 false, label %then64, label %ifcont65
+ifcont61:                                         ; preds = %else60, %then59
+  br i1 false, label %then62, label %ifcont63
 
-then64:                                           ; preds = %ifcont63
+then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont65:                                         ; preds = %ifcont63
+ifcont63:                                         ; preds = %ifcont61
   %136 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
-  br i1 false, label %then66, label %ifcont67
+  br i1 false, label %then64, label %ifcont65
 
-then66:                                           ; preds = %ifcont65
+then64:                                           ; preds = %ifcont63
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont67:                                         ; preds = %ifcont65
+ifcont65:                                         ; preds = %ifcont63
   %137 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 0
   %138 = load %complex_4, %complex_4* %137, align 1
-  br i1 false, label %then68, label %ifcont69
+  br i1 false, label %then66, label %ifcont67
 
-then68:                                           ; preds = %ifcont67
+then66:                                           ; preds = %ifcont65
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont69:                                         ; preds = %ifcont67
+ifcont67:                                         ; preds = %ifcont65
   %139 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 1
   %140 = load %complex_4, %complex_4* %139, align 1
   %141 = extractvalue %complex_4 %138, 0
@@ -542,14 +540,14 @@ ifcont69:                                         ; preds = %ifcont67
   %146 = fadd float %142, %144
   %147 = insertvalue %complex_4 undef, float %145, 0
   %148 = insertvalue %complex_4 %147, float %146, 1
-  br i1 false, label %then70, label %ifcont71
+  br i1 false, label %then68, label %ifcont69
 
-then70:                                           ; preds = %ifcont69
+then68:                                           ; preds = %ifcont67
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont71:                                         ; preds = %ifcont69
+ifcont69:                                         ; preds = %ifcont67
   %149 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 2
   %150 = load %complex_4, %complex_4* %149, align 1
   %151 = extractvalue %complex_4 %148, 0
@@ -560,14 +558,14 @@ ifcont71:                                         ; preds = %ifcont69
   %156 = fadd float %152, %154
   %157 = insertvalue %complex_4 undef, float %155, 0
   %158 = insertvalue %complex_4 %157, float %156, 1
-  br i1 false, label %then72, label %ifcont73
+  br i1 false, label %then70, label %ifcont71
 
-then72:                                           ; preds = %ifcont71
+then70:                                           ; preds = %ifcont69
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont73:                                         ; preds = %ifcont71
+ifcont71:                                         ; preds = %ifcont69
   %159 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 0
   %160 = load %complex_4, %complex_4* %159, align 1
   %161 = extractvalue %complex_4 %158, 0
@@ -579,14 +577,14 @@ ifcont73:                                         ; preds = %ifcont71
   %167 = insertvalue %complex_4 undef, float %165, 0
   %168 = insertvalue %complex_4 %167, float %166, 1
   store %complex_4 %168, %complex_4* %136, align 1
-  br i1 false, label %then74, label %ifcont75
+  br i1 false, label %then72, label %ifcont73
 
-then74:                                           ; preds = %ifcont73
+then72:                                           ; preds = %ifcont71
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont75:                                         ; preds = %ifcont73
+ifcont73:                                         ; preds = %ifcont71
   %169 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %170 = load %complex_4, %complex_4* %169, align 1
   %171 = extractvalue %complex_4 %170, 0
@@ -594,45 +592,45 @@ ifcont75:                                         ; preds = %ifcont73
   %173 = fcmp one float %171, 1.700000e+01
   %174 = fcmp one float %172, 0.000000e+00
   %175 = or i1 %173, %174
-  br i1 %175, label %then76, label %else77
+  br i1 %175, label %then74, label %else75
 
-then76:                                           ; preds = %ifcont75
+then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont78
+  br label %ifcont76
 
-else77:                                           ; preds = %ifcont75
-  br label %ifcont78
+else75:                                           ; preds = %ifcont73
+  br label %ifcont76
 
-ifcont78:                                         ; preds = %else77, %then76
-  br i1 false, label %then79, label %ifcont80
+ifcont76:                                         ; preds = %else75, %then74
+  br i1 false, label %then77, label %ifcont78
 
-then79:                                           ; preds = %ifcont78
+then77:                                           ; preds = %ifcont76
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont80:                                         ; preds = %ifcont78
+ifcont78:                                         ; preds = %ifcont76
   %176 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
-  br i1 false, label %then81, label %ifcont82
+  br i1 false, label %then79, label %ifcont80
 
-then81:                                           ; preds = %ifcont80
+then79:                                           ; preds = %ifcont78
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont82:                                         ; preds = %ifcont80
+ifcont80:                                         ; preds = %ifcont78
   %177 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i32 0
   %178 = load %complex_4, %complex_4* %177, align 1
   store %complex_4 %178, %complex_4* %176, align 1
-  br i1 false, label %then83, label %ifcont84
+  br i1 false, label %then81, label %ifcont82
 
-then83:                                           ; preds = %ifcont82
+then81:                                           ; preds = %ifcont80
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont84:                                         ; preds = %ifcont82
+ifcont82:                                         ; preds = %ifcont80
   %179 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i32 3
   %180 = load %complex_4, %complex_4* %179, align 1
   %181 = extractvalue %complex_4 %180, 0
@@ -640,104 +638,104 @@ ifcont84:                                         ; preds = %ifcont82
   %183 = fcmp one float %181, 1.100000e+01
   %184 = fcmp one float %182, 0.000000e+00
   %185 = or i1 %183, %184
-  br i1 %185, label %then85, label %else86
+  br i1 %185, label %then83, label %else84
 
-then85:                                           ; preds = %ifcont84
+then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont87
+  br label %ifcont85
 
-else86:                                           ; preds = %ifcont84
-  br label %ifcont87
+else84:                                           ; preds = %ifcont82
+  br label %ifcont85
 
-ifcont87:                                         ; preds = %else86, %then85
-  store i32 0, i32* %i1, align 4
-  br label %loop.head88
+ifcont85:                                         ; preds = %else84, %then83
+  store i32 0, i32* %i, align 4
+  br label %loop.head86
 
-loop.head88:                                      ; preds = %loop.end96, %ifcont87
-  %186 = load i32, i32* %i1, align 4
+loop.head86:                                      ; preds = %loop.end94, %ifcont85
+  %186 = load i32, i32* %i, align 4
   %187 = add i32 %186, 1
   %188 = icmp sle i32 %187, 2
-  br i1 %188, label %loop.body89, label %loop.end97
+  br i1 %188, label %loop.body87, label %loop.end95
 
-loop.body89:                                      ; preds = %loop.head88
-  %189 = load i32, i32* %i1, align 4
+loop.body87:                                      ; preds = %loop.head86
+  %189 = load i32, i32* %i, align 4
   %190 = add i32 %189, 1
-  store i32 %190, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head90
+  store i32 %190, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head88
 
-loop.head90:                                      ; preds = %ifcont95, %loop.body89
-  %191 = load i32, i32* %j2, align 4
+loop.head88:                                      ; preds = %ifcont93, %loop.body87
+  %191 = load i32, i32* %j, align 4
   %192 = add i32 %191, 1
   %193 = icmp sle i32 %192, 2
-  br i1 %193, label %loop.body91, label %loop.end96
+  br i1 %193, label %loop.body89, label %loop.end94
 
-loop.body91:                                      ; preds = %loop.head90
-  %194 = load i32, i32* %j2, align 4
+loop.body89:                                      ; preds = %loop.head88
+  %194 = load i32, i32* %j, align 4
   %195 = add i32 %194, 1
-  store i32 %195, i32* %j2, align 4
-  %196 = load i32, i32* %i1, align 4
-  %197 = load i32, i32* %j2, align 4
+  store i32 %195, i32* %j, align 4
+  %196 = load i32, i32* %i, align 4
+  %197 = load i32, i32* %j, align 4
   %198 = sub i32 %196, 1
   %199 = mul i32 1, %198
   %200 = add i32 0, %199
   %201 = icmp slt i32 %196, 1
   %202 = icmp sgt i32 %196, 2
   %203 = or i1 %201, %202
-  br i1 %203, label %then92, label %ifcont93
+  br i1 %203, label %then90, label %ifcont91
 
-then92:                                           ; preds = %loop.body91
+then90:                                           ; preds = %loop.body89
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i32 %196, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont93:                                         ; preds = %loop.body91
+ifcont91:                                         ; preds = %loop.body89
   %204 = sub i32 %197, 1
   %205 = mul i32 2, %204
   %206 = add i32 %200, %205
   %207 = icmp slt i32 %197, 1
   %208 = icmp sgt i32 %197, 2
   %209 = or i1 %207, %208
-  br i1 %209, label %then94, label %ifcont95
+  br i1 %209, label %then92, label %ifcont93
 
-then94:                                           ; preds = %ifcont93
+then92:                                           ; preds = %ifcont91
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 %197, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont95:                                         ; preds = %ifcont93
+ifcont93:                                         ; preds = %ifcont91
   %210 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 %206
-  %211 = load i32, i32* %i1, align 4
-  %212 = load i32, i32* %j2, align 4
+  %211 = load i32, i32* %i, align 4
+  %212 = load i32, i32* %j, align 4
   %213 = add i32 %211, %212
   %214 = add i32 %213, 10
   %215 = sitofp i32 %214 to float
   %216 = insertvalue %complex_4 undef, float %215, 0
   %217 = insertvalue %complex_4 %216, float 0.000000e+00, 1
   store %complex_4 %217, %complex_4* %210, align 1
-  br label %loop.head90
-
-loop.end96:                                       ; preds = %loop.head90
   br label %loop.head88
 
-loop.end97:                                       ; preds = %loop.head88
-  br i1 false, label %then98, label %ifcont99
+loop.end94:                                       ; preds = %loop.head88
+  br label %loop.head86
 
-then98:                                           ; preds = %loop.end97
+loop.end95:                                       ; preds = %loop.head86
+  br i1 false, label %then96, label %ifcont97
+
+then96:                                           ; preds = %loop.end95
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont99:                                         ; preds = %loop.end97
-  br i1 false, label %then100, label %ifcont101
+ifcont97:                                         ; preds = %loop.end95
+  br i1 false, label %then98, label %ifcont99
 
-then100:                                          ; preds = %ifcont99
+then98:                                           ; preds = %ifcont97
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont101:                                        ; preds = %ifcont99
+ifcont99:                                         ; preds = %ifcont97
   %218 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 0
   %219 = load %complex_4, %complex_4* %218, align 1
   %220 = extractvalue %complex_4 %219, 0
@@ -745,33 +743,33 @@ ifcont101:                                        ; preds = %ifcont99
   %222 = fcmp one float %220, 1.200000e+01
   %223 = fcmp one float %221, 0.000000e+00
   %224 = or i1 %222, %223
-  br i1 %224, label %then102, label %else103
+  br i1 %224, label %then100, label %else101
 
-then102:                                          ; preds = %ifcont101
+then100:                                          ; preds = %ifcont99
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont104
+  br label %ifcont102
 
-else103:                                          ; preds = %ifcont101
-  br label %ifcont104
+else101:                                          ; preds = %ifcont99
+  br label %ifcont102
 
-ifcont104:                                        ; preds = %else103, %then102
-  br i1 false, label %then105, label %ifcont106
+ifcont102:                                        ; preds = %else101, %then100
+  br i1 false, label %then103, label %ifcont104
 
-then105:                                          ; preds = %ifcont104
+then103:                                          ; preds = %ifcont102
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont106:                                        ; preds = %ifcont104
-  br i1 false, label %then107, label %ifcont108
+ifcont104:                                        ; preds = %ifcont102
+  br i1 false, label %then105, label %ifcont106
 
-then107:                                          ; preds = %ifcont106
+then105:                                          ; preds = %ifcont104
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont108:                                        ; preds = %ifcont106
+ifcont106:                                        ; preds = %ifcont104
   %225 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 2
   %226 = load %complex_4, %complex_4* %225, align 1
   %227 = extractvalue %complex_4 %226, 0
@@ -779,33 +777,33 @@ ifcont108:                                        ; preds = %ifcont106
   %229 = fcmp one float %227, 1.300000e+01
   %230 = fcmp one float %228, 0.000000e+00
   %231 = or i1 %229, %230
-  br i1 %231, label %then109, label %else110
+  br i1 %231, label %then107, label %else108
 
-then109:                                          ; preds = %ifcont108
+then107:                                          ; preds = %ifcont106
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont111
+  br label %ifcont109
 
-else110:                                          ; preds = %ifcont108
-  br label %ifcont111
+else108:                                          ; preds = %ifcont106
+  br label %ifcont109
 
-ifcont111:                                        ; preds = %else110, %then109
-  br i1 false, label %then112, label %ifcont113
+ifcont109:                                        ; preds = %else108, %then107
+  br i1 false, label %then110, label %ifcont111
 
-then112:                                          ; preds = %ifcont111
+then110:                                          ; preds = %ifcont109
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont113:                                        ; preds = %ifcont111
-  br i1 false, label %then114, label %ifcont115
+ifcont111:                                        ; preds = %ifcont109
+  br i1 false, label %then112, label %ifcont113
 
-then114:                                          ; preds = %ifcont113
+then112:                                          ; preds = %ifcont111
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont115:                                        ; preds = %ifcont113
+ifcont113:                                        ; preds = %ifcont111
   %232 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 1
   %233 = load %complex_4, %complex_4* %232, align 1
   %234 = extractvalue %complex_4 %233, 0
@@ -813,33 +811,33 @@ ifcont115:                                        ; preds = %ifcont113
   %236 = fcmp one float %234, 1.300000e+01
   %237 = fcmp one float %235, 0.000000e+00
   %238 = or i1 %236, %237
-  br i1 %238, label %then116, label %else117
+  br i1 %238, label %then114, label %else115
 
-then116:                                          ; preds = %ifcont115
+then114:                                          ; preds = %ifcont113
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont118
+  br label %ifcont116
 
-else117:                                          ; preds = %ifcont115
-  br label %ifcont118
+else115:                                          ; preds = %ifcont113
+  br label %ifcont116
 
-ifcont118:                                        ; preds = %else117, %then116
-  br i1 false, label %then119, label %ifcont120
+ifcont116:                                        ; preds = %else115, %then114
+  br i1 false, label %then117, label %ifcont118
 
-then119:                                          ; preds = %ifcont118
+then117:                                          ; preds = %ifcont116
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont120:                                        ; preds = %ifcont118
-  br i1 false, label %then121, label %ifcont122
+ifcont118:                                        ; preds = %ifcont116
+  br i1 false, label %then119, label %ifcont120
 
-then121:                                          ; preds = %ifcont120
+then119:                                          ; preds = %ifcont118
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont122:                                        ; preds = %ifcont120
+ifcont120:                                        ; preds = %ifcont118
   %239 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i32 3
   %240 = load %complex_4, %complex_4* %239, align 1
   %241 = extractvalue %complex_4 %240, 0
@@ -847,21 +845,21 @@ ifcont122:                                        ; preds = %ifcont120
   %243 = fcmp one float %241, 1.400000e+01
   %244 = fcmp one float %242, 0.000000e+00
   %245 = or i1 %243, %244
-  br i1 %245, label %then123, label %else124
+  br i1 %245, label %then121, label %else122
 
-then123:                                          ; preds = %ifcont122
+then121:                                          ; preds = %ifcont120
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont125
+  br label %ifcont123
 
-else124:                                          ; preds = %ifcont122
-  br label %ifcont125
+else122:                                          ; preds = %ifcont120
+  br label %ifcont123
 
-ifcont125:                                        ; preds = %else124, %then123
+ifcont123:                                        ; preds = %else122, %then121
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont125
+return:                                           ; preds = %ifcont123
   br label %FINALIZE_SYMTABLE_arrays_01_complex
 
 FINALIZE_SYMTABLE_arrays_01_complex:              ; preds = %return

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "863b2b5a174d43d60fa3f13651963dc2388d259c0469fdbf9b36d47a",
+    "stdout_hash": "c3d13e474bcbcb72e9c216759b51b520988991a26d225fa2e8f6e241",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -115,14 +115,12 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x i8], align 1
   %b = alloca [4 x i8], align 1
   %c = alloca [4 x i8], align 1
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
   br i1 false, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
@@ -133,36 +131,36 @@ then:                                             ; preds = %.entry
 ifcont:                                           ; preds = %.entry
   %2 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 0
   store i8 1, i8* %2, align 1
-  store i32 1, i32* %i1, align 4
+  store i32 1, i32* %i, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont6, %ifcont
-  %3 = load i32, i32* %i1, align 4
+loop.head:                                        ; preds = %ifcont4, %ifcont
+  %3 = load i32, i32* %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 3
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i1, align 4
+  %6 = load i32, i32* %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i1, align 4
-  %8 = load i32, i32* %i1, align 4
+  store i32 %7, i32* %i, align 4
+  %8 = load i32, i32* %i, align 4
   %9 = sub i32 %8, 1
   %10 = mul i32 1, %9
   %11 = add i32 0, %10
   %12 = icmp slt i32 %8, 1
   %13 = icmp sgt i32 %8, 3
   %14 = or i1 %12, %13
-  br i1 %14, label %then3, label %ifcont4
+  br i1 %14, label %then1, label %ifcont2
 
-then3:                                            ; preds = %loop.body
+then1:                                            ; preds = %loop.body
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([184 x i8], [184 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 %8, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont4:                                          ; preds = %loop.body
+ifcont2:                                          ; preds = %loop.body
   %15 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 %11
-  %16 = load i32, i32* %i1, align 4
+  %16 = load i32, i32* %i, align 4
   %17 = sub i32 %16, 1
   %18 = sub i32 %17, 1
   %19 = mul i32 1, %18
@@ -170,14 +168,14 @@ ifcont4:                                          ; preds = %loop.body
   %21 = icmp slt i32 %17, 1
   %22 = icmp sgt i32 %17, 3
   %23 = or i1 %21, %22
-  br i1 %23, label %then5, label %ifcont6
+  br i1 %23, label %then3, label %ifcont4
 
-then5:                                            ; preds = %ifcont4
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 %17, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont6:                                          ; preds = %ifcont4
+ifcont4:                                          ; preds = %ifcont2
   %24 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 %20
   %25 = load i8, i8* %24, align 1
   %26 = icmp ne i8 %25, 0
@@ -187,98 +185,98 @@ ifcont6:                                          ; preds = %ifcont4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 false, label %then7, label %ifcont8
+  br i1 false, label %then5, label %ifcont6
 
-then7:                                            ; preds = %loop.end
+then5:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont8:                                          ; preds = %loop.end
+ifcont6:                                          ; preds = %loop.end
   %29 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 0
   %30 = load i8, i8* %29, align 1
   %31 = icmp ne i8 %30, 0
   %32 = xor i1 %31, true
-  br i1 %32, label %then9, label %else
+  br i1 %32, label %then7, label %else
 
-then9:                                            ; preds = %ifcont8
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont10
+  br label %ifcont8
 
-else:                                             ; preds = %ifcont8
-  br label %ifcont10
+else:                                             ; preds = %ifcont6
+  br label %ifcont8
 
-ifcont10:                                         ; preds = %else, %then9
-  br i1 false, label %then11, label %ifcont12
+ifcont8:                                          ; preds = %else, %then7
+  br i1 false, label %then9, label %ifcont10
 
-then11:                                           ; preds = %ifcont10
+then9:                                            ; preds = %ifcont8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 2, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont12:                                         ; preds = %ifcont10
+ifcont10:                                         ; preds = %ifcont8
   %33 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 1
   %34 = load i8, i8* %33, align 1
   %35 = icmp ne i8 %34, 0
-  br i1 %35, label %then13, label %else14
+  br i1 %35, label %then11, label %else12
 
-then13:                                           ; preds = %ifcont12
+then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont15
+  br label %ifcont13
 
-else14:                                           ; preds = %ifcont12
-  br label %ifcont15
+else12:                                           ; preds = %ifcont10
+  br label %ifcont13
 
-ifcont15:                                         ; preds = %else14, %then13
-  br i1 false, label %then16, label %ifcont17
+ifcont13:                                         ; preds = %else12, %then11
+  br i1 false, label %then14, label %ifcont15
 
-then16:                                           ; preds = %ifcont15
+then14:                                           ; preds = %ifcont13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 3, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont17:                                         ; preds = %ifcont15
+ifcont15:                                         ; preds = %ifcont13
   %36 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 2
   %37 = load i8, i8* %36, align 1
   %38 = icmp ne i8 %37, 0
   %39 = xor i1 %38, true
-  br i1 %39, label %then18, label %else19
+  br i1 %39, label %then16, label %else17
 
-then18:                                           ; preds = %ifcont17
+then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else19:                                           ; preds = %ifcont17
-  br label %ifcont20
+else17:                                           ; preds = %ifcont15
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %else19, %then18
-  br i1 false, label %then21, label %ifcont22
+ifcont18:                                         ; preds = %else17, %then16
+  br i1 false, label %then19, label %ifcont20
 
-then21:                                           ; preds = %ifcont20
+then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont22:                                         ; preds = %ifcont20
+ifcont20:                                         ; preds = %ifcont18
   %40 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 0
   store i8 0, i8* %40, align 1
-  store i32 11, i32* %i1, align 4
-  br label %loop.head23
+  store i32 11, i32* %i, align 4
+  br label %loop.head21
 
-loop.head23:                                      ; preds = %ifcont28, %ifcont22
-  %41 = load i32, i32* %i1, align 4
+loop.head21:                                      ; preds = %ifcont26, %ifcont20
+  %41 = load i32, i32* %i, align 4
   %42 = add i32 %41, 1
   %43 = icmp sle i32 %42, 14
-  br i1 %43, label %loop.body24, label %loop.end29
+  br i1 %43, label %loop.body22, label %loop.end27
 
-loop.body24:                                      ; preds = %loop.head23
-  %44 = load i32, i32* %i1, align 4
+loop.body22:                                      ; preds = %loop.head21
+  %44 = load i32, i32* %i, align 4
   %45 = add i32 %44, 1
-  store i32 %45, i32* %i1, align 4
-  %46 = load i32, i32* %i1, align 4
+  store i32 %45, i32* %i, align 4
+  %46 = load i32, i32* %i, align 4
   %47 = sub i32 %46, 10
   %48 = sub i32 %47, 1
   %49 = mul i32 1, %48
@@ -286,16 +284,16 @@ loop.body24:                                      ; preds = %loop.head23
   %51 = icmp slt i32 %47, 1
   %52 = icmp sgt i32 %47, 4
   %53 = or i1 %51, %52
-  br i1 %53, label %then25, label %ifcont26
+  br i1 %53, label %then23, label %ifcont24
 
-then25:                                           ; preds = %loop.body24
+then23:                                           ; preds = %loop.body22
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 %47, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont26:                                         ; preds = %loop.body24
+ifcont24:                                         ; preds = %loop.body22
   %54 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 %50
-  %55 = load i32, i32* %i1, align 4
+  %55 = load i32, i32* %i, align 4
   %56 = sub i32 %55, 10
   %57 = sub i32 %56, 1
   %58 = sub i32 %57, 1
@@ -304,157 +302,157 @@ ifcont26:                                         ; preds = %loop.body24
   %61 = icmp slt i32 %57, 1
   %62 = icmp sgt i32 %57, 4
   %63 = or i1 %61, %62
-  br i1 %63, label %then27, label %ifcont28
+  br i1 %63, label %then25, label %ifcont26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 %57, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont28:                                         ; preds = %ifcont26
+ifcont26:                                         ; preds = %ifcont24
   %64 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 %60
   %65 = load i8, i8* %64, align 1
   %66 = icmp ne i8 %65, 0
   %67 = xor i1 %66, true
   %68 = zext i1 %67 to i8
   store i8 %68, i8* %54, align 1
-  br label %loop.head23
+  br label %loop.head21
 
-loop.end29:                                       ; preds = %loop.head23
-  br i1 false, label %then30, label %ifcont31
+loop.end27:                                       ; preds = %loop.head21
+  br i1 false, label %then28, label %ifcont29
 
-then30:                                           ; preds = %loop.end29
+then28:                                           ; preds = %loop.end27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont31:                                         ; preds = %loop.end29
+ifcont29:                                         ; preds = %loop.end27
   %69 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 0
   %70 = load i8, i8* %69, align 1
   %71 = icmp ne i8 %70, 0
-  br i1 %71, label %then32, label %else33
+  br i1 %71, label %then30, label %else31
 
-then32:                                           ; preds = %ifcont31
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont34
+  br label %ifcont32
 
-else33:                                           ; preds = %ifcont31
-  br label %ifcont34
+else31:                                           ; preds = %ifcont29
+  br label %ifcont32
 
-ifcont34:                                         ; preds = %else33, %then32
-  br i1 false, label %then35, label %ifcont36
+ifcont32:                                         ; preds = %else31, %then30
+  br i1 false, label %then33, label %ifcont34
 
-then35:                                           ; preds = %ifcont34
+then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont36:                                         ; preds = %ifcont34
+ifcont34:                                         ; preds = %ifcont32
   %72 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 1
   %73 = load i8, i8* %72, align 1
   %74 = icmp ne i8 %73, 0
   %75 = xor i1 %74, true
-  br i1 %75, label %then37, label %else38
+  br i1 %75, label %then35, label %else36
 
-then37:                                           ; preds = %ifcont36
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont39
+  br label %ifcont37
 
-else38:                                           ; preds = %ifcont36
-  br label %ifcont39
+else36:                                           ; preds = %ifcont34
+  br label %ifcont37
 
-ifcont39:                                         ; preds = %else38, %then37
-  br i1 false, label %then40, label %ifcont41
+ifcont37:                                         ; preds = %else36, %then35
+  br i1 false, label %then38, label %ifcont39
 
-then40:                                           ; preds = %ifcont39
+then38:                                           ; preds = %ifcont37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont41:                                         ; preds = %ifcont39
+ifcont39:                                         ; preds = %ifcont37
   %76 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 2
   %77 = load i8, i8* %76, align 1
   %78 = icmp ne i8 %77, 0
-  br i1 %78, label %then42, label %else43
+  br i1 %78, label %then40, label %else41
 
-then42:                                           ; preds = %ifcont41
+then40:                                           ; preds = %ifcont39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont44
+  br label %ifcont42
 
-else43:                                           ; preds = %ifcont41
-  br label %ifcont44
+else41:                                           ; preds = %ifcont39
+  br label %ifcont42
 
-ifcont44:                                         ; preds = %else43, %then42
-  br i1 false, label %then45, label %ifcont46
+ifcont42:                                         ; preds = %else41, %then40
+  br i1 false, label %then43, label %ifcont44
 
-then45:                                           ; preds = %ifcont44
+then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont46:                                         ; preds = %ifcont44
+ifcont44:                                         ; preds = %ifcont42
   %79 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 3
   %80 = load i8, i8* %79, align 1
   %81 = icmp ne i8 %80, 0
   %82 = xor i1 %81, true
-  br i1 %82, label %then47, label %else48
+  br i1 %82, label %then45, label %else46
 
-then47:                                           ; preds = %ifcont46
+then45:                                           ; preds = %ifcont44
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont49
+  br label %ifcont47
 
-else48:                                           ; preds = %ifcont46
-  br label %ifcont49
+else46:                                           ; preds = %ifcont44
+  br label %ifcont47
 
-ifcont49:                                         ; preds = %else48, %then47
-  store i32 0, i32* %i1, align 4
-  br label %loop.head50
+ifcont47:                                         ; preds = %else46, %then45
+  store i32 0, i32* %i, align 4
+  br label %loop.head48
 
-loop.head50:                                      ; preds = %ifcont55, %ifcont49
-  %83 = load i32, i32* %i1, align 4
+loop.head48:                                      ; preds = %ifcont53, %ifcont47
+  %83 = load i32, i32* %i, align 4
   %84 = add i32 %83, 1
   %85 = icmp sle i32 %84, 3
-  br i1 %85, label %loop.body51, label %loop.end56
+  br i1 %85, label %loop.body49, label %loop.end54
 
-loop.body51:                                      ; preds = %loop.head50
-  %86 = load i32, i32* %i1, align 4
+loop.body49:                                      ; preds = %loop.head48
+  %86 = load i32, i32* %i, align 4
   %87 = add i32 %86, 1
-  store i32 %87, i32* %i1, align 4
-  %88 = load i32, i32* %i1, align 4
+  store i32 %87, i32* %i, align 4
+  %88 = load i32, i32* %i, align 4
   %89 = sub i32 %88, 1
   %90 = mul i32 1, %89
   %91 = add i32 0, %90
   %92 = icmp slt i32 %88, 1
   %93 = icmp sgt i32 %88, 4
   %94 = or i1 %92, %93
-  br i1 %94, label %then52, label %ifcont53
+  br i1 %94, label %then50, label %ifcont51
 
-then52:                                           ; preds = %loop.body51
+then50:                                           ; preds = %loop.body49
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 %88, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont53:                                         ; preds = %loop.body51
+ifcont51:                                         ; preds = %loop.body49
   %95 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 %91
-  %96 = load i32, i32* %i1, align 4
+  %96 = load i32, i32* %i, align 4
   %97 = sub i32 %96, 1
   %98 = mul i32 1, %97
   %99 = add i32 0, %98
   %100 = icmp slt i32 %96, 1
   %101 = icmp sgt i32 %96, 3
   %102 = or i1 %100, %101
-  br i1 %102, label %then54, label %ifcont55
+  br i1 %102, label %then52, label %ifcont53
 
-then54:                                           ; preds = %ifcont53
+then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 %96, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont55:                                         ; preds = %ifcont53
+ifcont53:                                         ; preds = %ifcont51
   %103 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 %99
   %104 = load i8, i8* %103, align 1
   %105 = icmp ne i8 %104, 0
@@ -462,129 +460,129 @@ ifcont55:                                         ; preds = %ifcont53
   %107 = select i1 %106, i1 %105, i1 false
   %108 = zext i1 %107 to i8
   store i8 %108, i8* %95, align 1
-  br label %loop.head50
+  br label %loop.head48
 
-loop.end56:                                       ; preds = %loop.head50
-  br i1 false, label %then57, label %ifcont58
+loop.end54:                                       ; preds = %loop.head48
+  br i1 false, label %then55, label %ifcont56
 
-then57:                                           ; preds = %loop.end56
+then55:                                           ; preds = %loop.end54
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont58:                                         ; preds = %loop.end56
+ifcont56:                                         ; preds = %loop.end54
   %109 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 0
   %110 = load i8, i8* %109, align 1
   %111 = icmp ne i8 %110, 0
-  br i1 %111, label %then59, label %else60
+  br i1 %111, label %then57, label %else58
 
-then59:                                           ; preds = %ifcont58
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont61
+  br label %ifcont59
 
-else60:                                           ; preds = %ifcont58
-  br label %ifcont61
+else58:                                           ; preds = %ifcont56
+  br label %ifcont59
 
-ifcont61:                                         ; preds = %else60, %then59
-  br i1 false, label %then62, label %ifcont63
+ifcont59:                                         ; preds = %else58, %then57
+  br i1 false, label %then60, label %ifcont61
 
-then62:                                           ; preds = %ifcont61
+then60:                                           ; preds = %ifcont59
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont63:                                         ; preds = %ifcont61
+ifcont61:                                         ; preds = %ifcont59
   %112 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 1
   %113 = load i8, i8* %112, align 1
   %114 = icmp ne i8 %113, 0
-  br i1 %114, label %then64, label %else65
+  br i1 %114, label %then62, label %else63
 
-then64:                                           ; preds = %ifcont63
+then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont66
+  br label %ifcont64
 
-else65:                                           ; preds = %ifcont63
-  br label %ifcont66
+else63:                                           ; preds = %ifcont61
+  br label %ifcont64
 
-ifcont66:                                         ; preds = %else65, %then64
-  br i1 false, label %then67, label %ifcont68
+ifcont64:                                         ; preds = %else63, %then62
+  br i1 false, label %then65, label %ifcont66
 
-then67:                                           ; preds = %ifcont66
+then65:                                           ; preds = %ifcont64
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont68:                                         ; preds = %ifcont66
+ifcont66:                                         ; preds = %ifcont64
   %115 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 2
   %116 = load i8, i8* %115, align 1
   %117 = icmp ne i8 %116, 0
-  br i1 %117, label %then69, label %else70
+  br i1 %117, label %then67, label %else68
 
-then69:                                           ; preds = %ifcont68
+then67:                                           ; preds = %ifcont66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont71
+  br label %ifcont69
 
-else70:                                           ; preds = %ifcont68
-  br label %ifcont71
+else68:                                           ; preds = %ifcont66
+  br label %ifcont69
 
-ifcont71:                                         ; preds = %else70, %then69
-  br i1 false, label %then72, label %ifcont73
+ifcont69:                                         ; preds = %else68, %then67
+  br i1 false, label %then70, label %ifcont71
 
-then72:                                           ; preds = %ifcont71
+then70:                                           ; preds = %ifcont69
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont73:                                         ; preds = %ifcont71
+ifcont71:                                         ; preds = %ifcont69
   %118 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 3
-  br i1 false, label %then74, label %ifcont75
+  br i1 false, label %then72, label %ifcont73
 
-then74:                                           ; preds = %ifcont73
+then72:                                           ; preds = %ifcont71
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont75:                                         ; preds = %ifcont73
+ifcont73:                                         ; preds = %ifcont71
   %119 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 0
   %120 = load i8, i8* %119, align 1
   %121 = icmp ne i8 %120, 0
-  br i1 false, label %then76, label %ifcont77
+  br i1 false, label %then74, label %ifcont75
 
-then76:                                           ; preds = %ifcont75
+then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont77:                                         ; preds = %ifcont75
+ifcont75:                                         ; preds = %ifcont73
   %122 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 1
   %123 = load i8, i8* %122, align 1
   %124 = icmp ne i8 %123, 0
   %125 = icmp eq i1 %121, false
   %126 = select i1 %125, i1 %124, i1 %121
-  br i1 false, label %then78, label %ifcont79
+  br i1 false, label %then76, label %ifcont77
 
-then78:                                           ; preds = %ifcont77
+then76:                                           ; preds = %ifcont75
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont79:                                         ; preds = %ifcont77
+ifcont77:                                         ; preds = %ifcont75
   %127 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 2
   %128 = load i8, i8* %127, align 1
   %129 = icmp ne i8 %128, 0
   %130 = icmp eq i1 %126, false
   %131 = select i1 %130, i1 %129, i1 %126
-  br i1 false, label %then80, label %ifcont81
+  br i1 false, label %then78, label %ifcont79
 
-then80:                                           ; preds = %ifcont79
+then78:                                           ; preds = %ifcont77
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont81:                                         ; preds = %ifcont79
+ifcont79:                                         ; preds = %ifcont77
   %132 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 0
   %133 = load i8, i8* %132, align 1
   %134 = icmp ne i8 %133, 0
@@ -592,315 +590,315 @@ ifcont81:                                         ; preds = %ifcont79
   %136 = select i1 %135, i1 %134, i1 %131
   %137 = zext i1 %136 to i8
   store i8 %137, i8* %118, align 1
-  br i1 false, label %then82, label %ifcont83
+  br i1 false, label %then80, label %ifcont81
 
-then82:                                           ; preds = %ifcont81
+then80:                                           ; preds = %ifcont79
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont83:                                         ; preds = %ifcont81
+ifcont81:                                         ; preds = %ifcont79
   %138 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 3
   %139 = load i8, i8* %138, align 1
   %140 = icmp ne i8 %139, 0
   %141 = xor i1 %140, true
-  br i1 %141, label %then84, label %else85
+  br i1 %141, label %then82, label %else83
 
-then84:                                           ; preds = %ifcont83
+then82:                                           ; preds = %ifcont81
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont86
+  br label %ifcont84
 
-else85:                                           ; preds = %ifcont83
-  br label %ifcont86
+else83:                                           ; preds = %ifcont81
+  br label %ifcont84
 
-ifcont86:                                         ; preds = %else85, %then84
-  br i1 false, label %then87, label %ifcont88
+ifcont84:                                         ; preds = %else83, %then82
+  br i1 false, label %then85, label %ifcont86
 
-then87:                                           ; preds = %ifcont86
+then85:                                           ; preds = %ifcont84
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont88:                                         ; preds = %ifcont86
+ifcont86:                                         ; preds = %ifcont84
   %142 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 3
-  br i1 false, label %then89, label %ifcont90
+  br i1 false, label %then87, label %ifcont88
 
-then89:                                           ; preds = %ifcont88
+then87:                                           ; preds = %ifcont86
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont90:                                         ; preds = %ifcont88
+ifcont88:                                         ; preds = %ifcont86
   %143 = getelementptr [3 x i8], [3 x i8]* %a, i32 0, i32 0
   %144 = load i8, i8* %143, align 1
   %145 = icmp ne i8 %144, 0
   %146 = zext i1 %145 to i8
   store i8 %146, i8* %142, align 1
-  br i1 false, label %then91, label %ifcont92
+  br i1 false, label %then89, label %ifcont90
 
-then91:                                           ; preds = %ifcont90
+then89:                                           ; preds = %ifcont88
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont92:                                         ; preds = %ifcont90
+ifcont90:                                         ; preds = %ifcont88
   %147 = getelementptr [4 x i8], [4 x i8]* %b, i32 0, i32 3
   %148 = load i8, i8* %147, align 1
   %149 = icmp ne i8 %148, 0
   %150 = xor i1 %149, true
-  br i1 %150, label %then93, label %else94
+  br i1 %150, label %then91, label %else92
 
-then93:                                           ; preds = %ifcont92
+then91:                                           ; preds = %ifcont90
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont95
+  br label %ifcont93
 
-else94:                                           ; preds = %ifcont92
-  br label %ifcont95
+else92:                                           ; preds = %ifcont90
+  br label %ifcont93
 
-ifcont95:                                         ; preds = %else94, %then93
-  store i32 0, i32* %i1, align 4
-  br label %loop.head96
+ifcont93:                                         ; preds = %else92, %then91
+  store i32 0, i32* %i, align 4
+  br label %loop.head94
 
-loop.head96:                                      ; preds = %loop.end111, %ifcont95
-  %151 = load i32, i32* %i1, align 4
+loop.head94:                                      ; preds = %loop.end109, %ifcont93
+  %151 = load i32, i32* %i, align 4
   %152 = add i32 %151, 1
   %153 = icmp sle i32 %152, 2
-  br i1 %153, label %loop.body97, label %loop.end112
+  br i1 %153, label %loop.body95, label %loop.end110
 
-loop.body97:                                      ; preds = %loop.head96
-  %154 = load i32, i32* %i1, align 4
+loop.body95:                                      ; preds = %loop.head94
+  %154 = load i32, i32* %i, align 4
   %155 = add i32 %154, 1
-  store i32 %155, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head98
+  store i32 %155, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head96
 
-loop.head98:                                      ; preds = %ifcont110, %loop.body97
-  %156 = load i32, i32* %j2, align 4
+loop.head96:                                      ; preds = %ifcont108, %loop.body95
+  %156 = load i32, i32* %j, align 4
   %157 = add i32 %156, 1
   %158 = icmp sle i32 %157, 2
-  br i1 %158, label %loop.body99, label %loop.end111
+  br i1 %158, label %loop.body97, label %loop.end109
 
-loop.body99:                                      ; preds = %loop.head98
-  %159 = load i32, i32* %j2, align 4
+loop.body97:                                      ; preds = %loop.head96
+  %159 = load i32, i32* %j, align 4
   %160 = add i32 %159, 1
-  store i32 %160, i32* %j2, align 4
-  %161 = load i32, i32* %i1, align 4
-  %162 = load i32, i32* %j2, align 4
+  store i32 %160, i32* %j, align 4
+  %161 = load i32, i32* %i, align 4
+  %162 = load i32, i32* %j, align 4
   %163 = add i32 %161, %162
-  %164 = load i32, i32* %i1, align 4
-  %165 = load i32, i32* %j2, align 4
+  %164 = load i32, i32* %i, align 4
+  %165 = load i32, i32* %j, align 4
   %166 = add i32 %164, %165
   %167 = sdiv i32 %166, 2
   %168 = mul i32 2, %167
   %169 = sub i32 %163, %168
   %170 = icmp eq i32 %169, 1
-  br i1 %170, label %then100, label %else105
+  br i1 %170, label %then98, label %else103
 
-then100:                                          ; preds = %loop.body99
-  %171 = load i32, i32* %i1, align 4
-  %172 = load i32, i32* %j2, align 4
+then98:                                           ; preds = %loop.body97
+  %171 = load i32, i32* %i, align 4
+  %172 = load i32, i32* %j, align 4
   %173 = sub i32 %171, 1
   %174 = mul i32 1, %173
   %175 = add i32 0, %174
   %176 = icmp slt i32 %171, 1
   %177 = icmp sgt i32 %171, 2
   %178 = or i1 %176, %177
-  br i1 %178, label %then101, label %ifcont102
+  br i1 %178, label %then99, label %ifcont100
 
-then101:                                          ; preds = %then100
+then99:                                           ; preds = %then98
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0), i32 %171, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont102:                                        ; preds = %then100
+ifcont100:                                        ; preds = %then98
   %179 = sub i32 %172, 1
   %180 = mul i32 2, %179
   %181 = add i32 %175, %180
   %182 = icmp slt i32 %172, 1
   %183 = icmp sgt i32 %172, 2
   %184 = or i1 %182, %183
-  br i1 %184, label %then103, label %ifcont104
+  br i1 %184, label %then101, label %ifcont102
 
-then103:                                          ; preds = %ifcont102
+then101:                                          ; preds = %ifcont100
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i32 %172, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont104:                                        ; preds = %ifcont102
+ifcont102:                                        ; preds = %ifcont100
   %185 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 %181
   store i8 1, i8* %185, align 1
-  br label %ifcont110
+  br label %ifcont108
 
-else105:                                          ; preds = %loop.body99
-  %186 = load i32, i32* %i1, align 4
-  %187 = load i32, i32* %j2, align 4
+else103:                                          ; preds = %loop.body97
+  %186 = load i32, i32* %i, align 4
+  %187 = load i32, i32* %j, align 4
   %188 = sub i32 %186, 1
   %189 = mul i32 1, %188
   %190 = add i32 0, %189
   %191 = icmp slt i32 %186, 1
   %192 = icmp sgt i32 %186, 2
   %193 = or i1 %191, %192
-  br i1 %193, label %then106, label %ifcont107
+  br i1 %193, label %then104, label %ifcont105
 
-then106:                                          ; preds = %else105
+then104:                                          ; preds = %else103
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 %186, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont107:                                        ; preds = %else105
+ifcont105:                                        ; preds = %else103
   %194 = sub i32 %187, 1
   %195 = mul i32 2, %194
   %196 = add i32 %190, %195
   %197 = icmp slt i32 %187, 1
   %198 = icmp sgt i32 %187, 2
   %199 = or i1 %197, %198
-  br i1 %199, label %then108, label %ifcont109
+  br i1 %199, label %then106, label %ifcont107
 
-then108:                                          ; preds = %ifcont107
+then106:                                          ; preds = %ifcont105
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i32 %187, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont109:                                        ; preds = %ifcont107
+ifcont107:                                        ; preds = %ifcont105
   %200 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 %196
   store i8 0, i8* %200, align 1
-  br label %ifcont110
+  br label %ifcont108
 
-ifcont110:                                        ; preds = %ifcont109, %ifcont104
-  br label %loop.head98
-
-loop.end111:                                      ; preds = %loop.head98
+ifcont108:                                        ; preds = %ifcont107, %ifcont102
   br label %loop.head96
 
-loop.end112:                                      ; preds = %loop.head96
-  br i1 false, label %then113, label %ifcont114
+loop.end109:                                      ; preds = %loop.head96
+  br label %loop.head94
 
-then113:                                          ; preds = %loop.end112
+loop.end110:                                      ; preds = %loop.head94
+  br i1 false, label %then111, label %ifcont112
+
+then111:                                          ; preds = %loop.end110
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont114:                                        ; preds = %loop.end112
-  br i1 false, label %then115, label %ifcont116
+ifcont112:                                        ; preds = %loop.end110
+  br i1 false, label %then113, label %ifcont114
 
-then115:                                          ; preds = %ifcont114
+then113:                                          ; preds = %ifcont112
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont116:                                        ; preds = %ifcont114
+ifcont114:                                        ; preds = %ifcont112
   %201 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 0
   %202 = load i8, i8* %201, align 1
   %203 = icmp ne i8 %202, 0
-  br i1 %203, label %then117, label %else118
+  br i1 %203, label %then115, label %else116
 
-then117:                                          ; preds = %ifcont116
+then115:                                          ; preds = %ifcont114
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont119
+  br label %ifcont117
 
-else118:                                          ; preds = %ifcont116
-  br label %ifcont119
+else116:                                          ; preds = %ifcont114
+  br label %ifcont117
 
-ifcont119:                                        ; preds = %else118, %then117
-  br i1 false, label %then120, label %ifcont121
+ifcont117:                                        ; preds = %else116, %then115
+  br i1 false, label %then118, label %ifcont119
 
-then120:                                          ; preds = %ifcont119
+then118:                                          ; preds = %ifcont117
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont121:                                        ; preds = %ifcont119
-  br i1 false, label %then122, label %ifcont123
+ifcont119:                                        ; preds = %ifcont117
+  br i1 false, label %then120, label %ifcont121
 
-then122:                                          ; preds = %ifcont121
+then120:                                          ; preds = %ifcont119
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont123:                                        ; preds = %ifcont121
+ifcont121:                                        ; preds = %ifcont119
   %204 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 2
   %205 = load i8, i8* %204, align 1
   %206 = icmp ne i8 %205, 0
   %207 = xor i1 %206, true
-  br i1 %207, label %then124, label %else125
+  br i1 %207, label %then122, label %else123
 
-then124:                                          ; preds = %ifcont123
+then122:                                          ; preds = %ifcont121
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont126
+  br label %ifcont124
 
-else125:                                          ; preds = %ifcont123
-  br label %ifcont126
+else123:                                          ; preds = %ifcont121
+  br label %ifcont124
 
-ifcont126:                                        ; preds = %else125, %then124
-  br i1 false, label %then127, label %ifcont128
+ifcont124:                                        ; preds = %else123, %then122
+  br i1 false, label %then125, label %ifcont126
 
-then127:                                          ; preds = %ifcont126
+then125:                                          ; preds = %ifcont124
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @98, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont128:                                        ; preds = %ifcont126
-  br i1 false, label %then129, label %ifcont130
+ifcont126:                                        ; preds = %ifcont124
+  br i1 false, label %then127, label %ifcont128
 
-then129:                                          ; preds = %ifcont128
+then127:                                          ; preds = %ifcont126
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([186 x i8], [186 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont130:                                        ; preds = %ifcont128
+ifcont128:                                        ; preds = %ifcont126
   %208 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 1
   %209 = load i8, i8* %208, align 1
   %210 = icmp ne i8 %209, 0
   %211 = xor i1 %210, true
-  br i1 %211, label %then131, label %else132
+  br i1 %211, label %then129, label %else130
 
-then131:                                          ; preds = %ifcont130
+then129:                                          ; preds = %ifcont128
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont133
+  br label %ifcont131
 
-else132:                                          ; preds = %ifcont130
-  br label %ifcont133
+else130:                                          ; preds = %ifcont128
+  br label %ifcont131
 
-ifcont133:                                        ; preds = %else132, %then131
-  br i1 false, label %then134, label %ifcont135
+ifcont131:                                        ; preds = %else130, %then129
+  br i1 false, label %then132, label %ifcont133
 
-then134:                                          ; preds = %ifcont133
+then132:                                          ; preds = %ifcont131
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont135:                                        ; preds = %ifcont133
-  br i1 false, label %then136, label %ifcont137
+ifcont133:                                        ; preds = %ifcont131
+  br i1 false, label %then134, label %ifcont135
 
-then136:                                          ; preds = %ifcont135
+then134:                                          ; preds = %ifcont133
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([185 x i8], [185 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont137:                                        ; preds = %ifcont135
+ifcont135:                                        ; preds = %ifcont133
   %212 = getelementptr [4 x i8], [4 x i8]* %c, i32 0, i32 3
   %213 = load i8, i8* %212, align 1
   %214 = icmp ne i8 %213, 0
-  br i1 %214, label %then138, label %else139
+  br i1 %214, label %then136, label %else137
 
-then138:                                          ; preds = %ifcont137
+then136:                                          ; preds = %ifcont135
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont140
+  br label %ifcont138
 
-else139:                                          ; preds = %ifcont137
-  br label %ifcont140
+else137:                                          ; preds = %ifcont135
+  br label %ifcont138
 
-ifcont140:                                        ; preds = %else139, %then138
+ifcont138:                                        ; preds = %else137, %then136
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont140
+return:                                           ; preds = %ifcont138
   br label %FINALIZE_SYMTABLE_arrays_01_logical
 
 FINALIZE_SYMTABLE_arrays_01_logical:              ; preds = %return

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "162957e70f0257d590a4fc9a0bb11a015ad7347c9dce1dcc9894b7be",
+    "stdout_hash": "b176ecfd9eea8c75b004d5ae364429748cdd16d34c5ed442211994ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -103,28 +103,26 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
-  %j = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x double], align 8
   %b = alloca [4 x double], align 8
   %c = alloca [4 x double], align 8
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 0, i32* %i1, align 4
+  %i = alloca i32, align 4
+  %j = alloca i32, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 3
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i1, align 4
-  %7 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %i, align 4
+  %7 = load i32, i32* %i, align 4
   %8 = sub i32 %7, 1
   %9 = mul i32 1, %8
   %10 = add i32 0, %9
@@ -140,93 +138,93 @@ then:                                             ; preds = %loop.body
 
 ifcont:                                           ; preds = %loop.body
   %14 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 %10
-  %15 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %i, align 4
   %16 = add i32 %15, 10
   %17 = sitofp i32 %16 to double
   store double %17, double* %14, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 false, label %then3, label %ifcont4
+  br i1 false, label %then1, label %ifcont2
 
-then3:                                            ; preds = %loop.end
+then1:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([181 x i8], [181 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont4:                                          ; preds = %loop.end
+ifcont2:                                          ; preds = %loop.end
   %18 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 0
   %19 = load double, double* %18, align 8
   %20 = fcmp une double %19, 1.100000e+01
-  br i1 %20, label %then5, label %else
+  br i1 %20, label %then3, label %else
 
-then5:                                            ; preds = %ifcont4
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont4
 
-else:                                             ; preds = %ifcont4
-  br label %ifcont6
+else:                                             ; preds = %ifcont2
+  br label %ifcont4
 
-ifcont6:                                          ; preds = %else, %then5
-  br i1 false, label %then7, label %ifcont8
+ifcont4:                                          ; preds = %else, %then3
+  br i1 false, label %then5, label %ifcont6
 
-then7:                                            ; preds = %ifcont6
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([181 x i8], [181 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 2, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont8:                                          ; preds = %ifcont6
+ifcont6:                                          ; preds = %ifcont4
   %21 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 1
   %22 = load double, double* %21, align 8
   %23 = fcmp une double %22, 1.200000e+01
-  br i1 %23, label %then9, label %else10
+  br i1 %23, label %then7, label %else8
 
-then9:                                            ; preds = %ifcont8
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %ifcont8
-  br label %ifcont11
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
-  br i1 false, label %then12, label %ifcont13
+ifcont9:                                          ; preds = %else8, %then7
+  br i1 false, label %then10, label %ifcont11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 3, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont13:                                         ; preds = %ifcont11
+ifcont11:                                         ; preds = %ifcont9
   %24 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 2
   %25 = load double, double* %24, align 8
   %26 = fcmp une double %25, 1.300000e+01
-  br i1 %26, label %then14, label %else15
+  br i1 %26, label %then12, label %else13
 
-then14:                                           ; preds = %ifcont13
+then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont16
+  br label %ifcont14
 
-else15:                                           ; preds = %ifcont13
-  br label %ifcont16
+else13:                                           ; preds = %ifcont11
+  br label %ifcont14
 
-ifcont16:                                         ; preds = %else15, %then14
-  store i32 10, i32* %i1, align 4
-  br label %loop.head17
+ifcont14:                                         ; preds = %else13, %then12
+  store i32 10, i32* %i, align 4
+  br label %loop.head15
 
-loop.head17:                                      ; preds = %ifcont20, %ifcont16
-  %27 = load i32, i32* %i1, align 4
+loop.head15:                                      ; preds = %ifcont18, %ifcont14
+  %27 = load i32, i32* %i, align 4
   %28 = add i32 %27, 1
   %29 = icmp sle i32 %28, 14
-  br i1 %29, label %loop.body18, label %loop.end21
+  br i1 %29, label %loop.body16, label %loop.end19
 
-loop.body18:                                      ; preds = %loop.head17
-  %30 = load i32, i32* %i1, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %30 = load i32, i32* %i, align 4
   %31 = add i32 %30, 1
-  store i32 %31, i32* %i1, align 4
-  %32 = load i32, i32* %i1, align 4
+  store i32 %31, i32* %i, align 4
+  %32 = load i32, i32* %i, align 4
   %33 = sub i32 %32, 10
   %34 = sub i32 %33, 1
   %35 = mul i32 1, %34
@@ -234,536 +232,536 @@ loop.body18:                                      ; preds = %loop.head17
   %37 = icmp slt i32 %33, 1
   %38 = icmp sgt i32 %33, 4
   %39 = or i1 %37, %38
-  br i1 %39, label %then19, label %ifcont20
+  br i1 %39, label %then17, label %ifcont18
 
-then19:                                           ; preds = %loop.body18
+then17:                                           ; preds = %loop.body16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 %33, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont20:                                         ; preds = %loop.body18
+ifcont18:                                         ; preds = %loop.body16
   %40 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 %36
-  %41 = load i32, i32* %i1, align 4
+  %41 = load i32, i32* %i, align 4
   %42 = sitofp i32 %41 to double
   store double %42, double* %40, align 8
-  br label %loop.head17
+  br label %loop.head15
 
-loop.end21:                                       ; preds = %loop.head17
-  br i1 false, label %then22, label %ifcont23
+loop.end19:                                       ; preds = %loop.head15
+  br i1 false, label %then20, label %ifcont21
 
-then22:                                           ; preds = %loop.end21
+then20:                                           ; preds = %loop.end19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont23:                                         ; preds = %loop.end21
+ifcont21:                                         ; preds = %loop.end19
   %43 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %44 = load double, double* %43, align 8
   %45 = fcmp une double %44, 1.100000e+01
-  br i1 %45, label %then24, label %else25
+  br i1 %45, label %then22, label %else23
 
-then24:                                           ; preds = %ifcont23
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %ifcont23
-  br label %ifcont26
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %then24
-  br i1 false, label %then27, label %ifcont28
+ifcont24:                                         ; preds = %else23, %then22
+  br i1 false, label %then25, label %ifcont26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont28:                                         ; preds = %ifcont26
+ifcont26:                                         ; preds = %ifcont24
   %46 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 1
   %47 = load double, double* %46, align 8
   %48 = fcmp une double %47, 1.200000e+01
-  br i1 %48, label %then29, label %else30
+  br i1 %48, label %then27, label %else28
 
-then29:                                           ; preds = %ifcont28
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont31
+  br label %ifcont29
 
-else30:                                           ; preds = %ifcont28
-  br label %ifcont31
+else28:                                           ; preds = %ifcont26
+  br label %ifcont29
 
-ifcont31:                                         ; preds = %else30, %then29
-  br i1 false, label %then32, label %ifcont33
+ifcont29:                                         ; preds = %else28, %then27
+  br i1 false, label %then30, label %ifcont31
 
-then32:                                           ; preds = %ifcont31
+then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont33:                                         ; preds = %ifcont31
+ifcont31:                                         ; preds = %ifcont29
   %49 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 2
   %50 = load double, double* %49, align 8
   %51 = fcmp une double %50, 1.300000e+01
-  br i1 %51, label %then34, label %else35
+  br i1 %51, label %then32, label %else33
 
-then34:                                           ; preds = %ifcont33
+then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont36
+  br label %ifcont34
 
-else35:                                           ; preds = %ifcont33
-  br label %ifcont36
+else33:                                           ; preds = %ifcont31
+  br label %ifcont34
 
-ifcont36:                                         ; preds = %else35, %then34
-  br i1 false, label %then37, label %ifcont38
+ifcont34:                                         ; preds = %else33, %then32
+  br i1 false, label %then35, label %ifcont36
 
-then37:                                           ; preds = %ifcont36
+then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont38:                                         ; preds = %ifcont36
+ifcont36:                                         ; preds = %ifcont34
   %52 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %53 = load double, double* %52, align 8
   %54 = fcmp une double %53, 1.400000e+01
-  br i1 %54, label %then39, label %else40
+  br i1 %54, label %then37, label %else38
 
-then39:                                           ; preds = %ifcont38
+then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont41
+  br label %ifcont39
 
-else40:                                           ; preds = %ifcont38
-  br label %ifcont41
+else38:                                           ; preds = %ifcont36
+  br label %ifcont39
 
-ifcont41:                                         ; preds = %else40, %then39
-  store i32 0, i32* %i1, align 4
-  br label %loop.head42
+ifcont39:                                         ; preds = %else38, %then37
+  store i32 0, i32* %i, align 4
+  br label %loop.head40
 
-loop.head42:                                      ; preds = %ifcont47, %ifcont41
-  %55 = load i32, i32* %i1, align 4
+loop.head40:                                      ; preds = %ifcont45, %ifcont39
+  %55 = load i32, i32* %i, align 4
   %56 = add i32 %55, 1
   %57 = icmp sle i32 %56, 3
-  br i1 %57, label %loop.body43, label %loop.end48
+  br i1 %57, label %loop.body41, label %loop.end46
 
-loop.body43:                                      ; preds = %loop.head42
-  %58 = load i32, i32* %i1, align 4
+loop.body41:                                      ; preds = %loop.head40
+  %58 = load i32, i32* %i, align 4
   %59 = add i32 %58, 1
-  store i32 %59, i32* %i1, align 4
-  %60 = load i32, i32* %i1, align 4
+  store i32 %59, i32* %i, align 4
+  %60 = load i32, i32* %i, align 4
   %61 = sub i32 %60, 1
   %62 = mul i32 1, %61
   %63 = add i32 0, %62
   %64 = icmp slt i32 %60, 1
   %65 = icmp sgt i32 %60, 4
   %66 = or i1 %64, %65
-  br i1 %66, label %then44, label %ifcont45
+  br i1 %66, label %then42, label %ifcont43
 
-then44:                                           ; preds = %loop.body43
+then42:                                           ; preds = %loop.body41
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 %60, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont45:                                         ; preds = %loop.body43
+ifcont43:                                         ; preds = %loop.body41
   %67 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 %63
-  %68 = load i32, i32* %i1, align 4
+  %68 = load i32, i32* %i, align 4
   %69 = sub i32 %68, 1
   %70 = mul i32 1, %69
   %71 = add i32 0, %70
   %72 = icmp slt i32 %68, 1
   %73 = icmp sgt i32 %68, 3
   %74 = or i1 %72, %73
-  br i1 %74, label %then46, label %ifcont47
+  br i1 %74, label %then44, label %ifcont45
 
-then46:                                           ; preds = %ifcont45
+then44:                                           ; preds = %ifcont43
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 %68, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont47:                                         ; preds = %ifcont45
+ifcont45:                                         ; preds = %ifcont43
   %75 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 %71
   %76 = load double, double* %75, align 8
   %77 = fsub double %76, 1.000000e+01
   store double %77, double* %67, align 8
-  br label %loop.head42
+  br label %loop.head40
 
-loop.end48:                                       ; preds = %loop.head42
-  br i1 false, label %then49, label %ifcont50
+loop.end46:                                       ; preds = %loop.head40
+  br i1 false, label %then47, label %ifcont48
 
-then49:                                           ; preds = %loop.end48
+then47:                                           ; preds = %loop.end46
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont50:                                         ; preds = %loop.end48
+ifcont48:                                         ; preds = %loop.end46
   %78 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %79 = load double, double* %78, align 8
   %80 = fcmp une double %79, 1.000000e+00
-  br i1 %80, label %then51, label %else52
+  br i1 %80, label %then49, label %else50
 
-then51:                                           ; preds = %ifcont50
+then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont53
+  br label %ifcont51
 
-else52:                                           ; preds = %ifcont50
-  br label %ifcont53
+else50:                                           ; preds = %ifcont48
+  br label %ifcont51
 
-ifcont53:                                         ; preds = %else52, %then51
-  br i1 false, label %then54, label %ifcont55
+ifcont51:                                         ; preds = %else50, %then49
+  br i1 false, label %then52, label %ifcont53
 
-then54:                                           ; preds = %ifcont53
+then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont55:                                         ; preds = %ifcont53
+ifcont53:                                         ; preds = %ifcont51
   %81 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 1
   %82 = load double, double* %81, align 8
   %83 = fcmp une double %82, 2.000000e+00
-  br i1 %83, label %then56, label %else57
+  br i1 %83, label %then54, label %else55
 
-then56:                                           ; preds = %ifcont55
+then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont58
+  br label %ifcont56
 
-else57:                                           ; preds = %ifcont55
-  br label %ifcont58
+else55:                                           ; preds = %ifcont53
+  br label %ifcont56
 
-ifcont58:                                         ; preds = %else57, %then56
-  br i1 false, label %then59, label %ifcont60
+ifcont56:                                         ; preds = %else55, %then54
+  br i1 false, label %then57, label %ifcont58
 
-then59:                                           ; preds = %ifcont58
+then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont60:                                         ; preds = %ifcont58
+ifcont58:                                         ; preds = %ifcont56
   %84 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 2
   %85 = load double, double* %84, align 8
   %86 = fcmp une double %85, 3.000000e+00
-  br i1 %86, label %then61, label %else62
+  br i1 %86, label %then59, label %else60
 
-then61:                                           ; preds = %ifcont60
+then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont63
+  br label %ifcont61
 
-else62:                                           ; preds = %ifcont60
-  br label %ifcont63
+else60:                                           ; preds = %ifcont58
+  br label %ifcont61
 
-ifcont63:                                         ; preds = %else62, %then61
-  br i1 false, label %then64, label %ifcont65
+ifcont61:                                         ; preds = %else60, %then59
+  br i1 false, label %then62, label %ifcont63
 
-then64:                                           ; preds = %ifcont63
+then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont65:                                         ; preds = %ifcont63
+ifcont63:                                         ; preds = %ifcont61
   %87 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
-  br i1 false, label %then66, label %ifcont67
+  br i1 false, label %then64, label %ifcont65
 
-then66:                                           ; preds = %ifcont65
+then64:                                           ; preds = %ifcont63
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont67:                                         ; preds = %ifcont65
+ifcont65:                                         ; preds = %ifcont63
   %88 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 0
   %89 = load double, double* %88, align 8
-  br i1 false, label %then68, label %ifcont69
+  br i1 false, label %then66, label %ifcont67
 
-then68:                                           ; preds = %ifcont67
+then66:                                           ; preds = %ifcont65
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont69:                                         ; preds = %ifcont67
+ifcont67:                                         ; preds = %ifcont65
   %90 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 1
   %91 = load double, double* %90, align 8
   %92 = fadd double %89, %91
-  br i1 false, label %then70, label %ifcont71
+  br i1 false, label %then68, label %ifcont69
 
-then70:                                           ; preds = %ifcont69
+then68:                                           ; preds = %ifcont67
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont71:                                         ; preds = %ifcont69
+ifcont69:                                         ; preds = %ifcont67
   %93 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 2
   %94 = load double, double* %93, align 8
   %95 = fadd double %92, %94
-  br i1 false, label %then72, label %ifcont73
+  br i1 false, label %then70, label %ifcont71
 
-then72:                                           ; preds = %ifcont71
+then70:                                           ; preds = %ifcont69
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont73:                                         ; preds = %ifcont71
+ifcont71:                                         ; preds = %ifcont69
   %96 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 0
   %97 = load double, double* %96, align 8
   %98 = fadd double %95, %97
   store double %98, double* %87, align 8
-  br i1 false, label %then74, label %ifcont75
+  br i1 false, label %then72, label %ifcont73
 
-then74:                                           ; preds = %ifcont73
+then72:                                           ; preds = %ifcont71
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont75:                                         ; preds = %ifcont73
+ifcont73:                                         ; preds = %ifcont71
   %99 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %100 = load double, double* %99, align 8
   %101 = fcmp une double %100, 1.700000e+01
-  br i1 %101, label %then76, label %else77
+  br i1 %101, label %then74, label %else75
 
-then76:                                           ; preds = %ifcont75
+then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont78
+  br label %ifcont76
 
-else77:                                           ; preds = %ifcont75
-  br label %ifcont78
+else75:                                           ; preds = %ifcont73
+  br label %ifcont76
 
-ifcont78:                                         ; preds = %else77, %then76
-  br i1 false, label %then79, label %ifcont80
+ifcont76:                                         ; preds = %else75, %then74
+  br i1 false, label %then77, label %ifcont78
 
-then79:                                           ; preds = %ifcont78
+then77:                                           ; preds = %ifcont76
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont80:                                         ; preds = %ifcont78
+ifcont78:                                         ; preds = %ifcont76
   %102 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
-  br i1 false, label %then81, label %ifcont82
+  br i1 false, label %then79, label %ifcont80
 
-then81:                                           ; preds = %ifcont80
+then79:                                           ; preds = %ifcont78
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont82:                                         ; preds = %ifcont80
+ifcont80:                                         ; preds = %ifcont78
   %103 = getelementptr [3 x double], [3 x double]* %a, i32 0, i32 0
   %104 = load double, double* %103, align 8
   store double %104, double* %102, align 8
-  br i1 false, label %then83, label %ifcont84
+  br i1 false, label %then81, label %ifcont82
 
-then83:                                           ; preds = %ifcont82
+then81:                                           ; preds = %ifcont80
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont84:                                         ; preds = %ifcont82
+ifcont82:                                         ; preds = %ifcont80
   %105 = getelementptr [4 x double], [4 x double]* %b, i32 0, i32 3
   %106 = load double, double* %105, align 8
   %107 = fcmp une double %106, 1.100000e+01
-  br i1 %107, label %then85, label %else86
+  br i1 %107, label %then83, label %else84
 
-then85:                                           ; preds = %ifcont84
+then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont87
+  br label %ifcont85
 
-else86:                                           ; preds = %ifcont84
-  br label %ifcont87
+else84:                                           ; preds = %ifcont82
+  br label %ifcont85
 
-ifcont87:                                         ; preds = %else86, %then85
-  store i32 0, i32* %i1, align 4
-  br label %loop.head88
+ifcont85:                                         ; preds = %else84, %then83
+  store i32 0, i32* %i, align 4
+  br label %loop.head86
 
-loop.head88:                                      ; preds = %loop.end96, %ifcont87
-  %108 = load i32, i32* %i1, align 4
+loop.head86:                                      ; preds = %loop.end94, %ifcont85
+  %108 = load i32, i32* %i, align 4
   %109 = add i32 %108, 1
   %110 = icmp sle i32 %109, 2
-  br i1 %110, label %loop.body89, label %loop.end97
+  br i1 %110, label %loop.body87, label %loop.end95
 
-loop.body89:                                      ; preds = %loop.head88
-  %111 = load i32, i32* %i1, align 4
+loop.body87:                                      ; preds = %loop.head86
+  %111 = load i32, i32* %i, align 4
   %112 = add i32 %111, 1
-  store i32 %112, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head90
+  store i32 %112, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head88
 
-loop.head90:                                      ; preds = %ifcont95, %loop.body89
-  %113 = load i32, i32* %j2, align 4
+loop.head88:                                      ; preds = %ifcont93, %loop.body87
+  %113 = load i32, i32* %j, align 4
   %114 = add i32 %113, 1
   %115 = icmp sle i32 %114, 2
-  br i1 %115, label %loop.body91, label %loop.end96
+  br i1 %115, label %loop.body89, label %loop.end94
 
-loop.body91:                                      ; preds = %loop.head90
-  %116 = load i32, i32* %j2, align 4
+loop.body89:                                      ; preds = %loop.head88
+  %116 = load i32, i32* %j, align 4
   %117 = add i32 %116, 1
-  store i32 %117, i32* %j2, align 4
-  %118 = load i32, i32* %i1, align 4
-  %119 = load i32, i32* %j2, align 4
+  store i32 %117, i32* %j, align 4
+  %118 = load i32, i32* %i, align 4
+  %119 = load i32, i32* %j, align 4
   %120 = sub i32 %118, 1
   %121 = mul i32 1, %120
   %122 = add i32 0, %121
   %123 = icmp slt i32 %118, 1
   %124 = icmp sgt i32 %118, 2
   %125 = or i1 %123, %124
-  br i1 %125, label %then92, label %ifcont93
+  br i1 %125, label %then90, label %ifcont91
 
-then92:                                           ; preds = %loop.body91
+then90:                                           ; preds = %loop.body89
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i32 %118, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont93:                                         ; preds = %loop.body91
+ifcont91:                                         ; preds = %loop.body89
   %126 = sub i32 %119, 1
   %127 = mul i32 2, %126
   %128 = add i32 %122, %127
   %129 = icmp slt i32 %119, 1
   %130 = icmp sgt i32 %119, 2
   %131 = or i1 %129, %130
-  br i1 %131, label %then94, label %ifcont95
+  br i1 %131, label %then92, label %ifcont93
 
-then94:                                           ; preds = %ifcont93
+then92:                                           ; preds = %ifcont91
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 %119, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont95:                                         ; preds = %ifcont93
+ifcont93:                                         ; preds = %ifcont91
   %132 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 %128
-  %133 = load i32, i32* %i1, align 4
-  %134 = load i32, i32* %j2, align 4
+  %133 = load i32, i32* %i, align 4
+  %134 = load i32, i32* %j, align 4
   %135 = add i32 %133, %134
   %136 = add i32 %135, 10
   %137 = sitofp i32 %136 to double
   store double %137, double* %132, align 8
-  br label %loop.head90
-
-loop.end96:                                       ; preds = %loop.head90
   br label %loop.head88
 
-loop.end97:                                       ; preds = %loop.head88
-  br i1 false, label %then98, label %ifcont99
+loop.end94:                                       ; preds = %loop.head88
+  br label %loop.head86
 
-then98:                                           ; preds = %loop.end97
+loop.end95:                                       ; preds = %loop.head86
+  br i1 false, label %then96, label %ifcont97
+
+then96:                                           ; preds = %loop.end95
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont99:                                         ; preds = %loop.end97
-  br i1 false, label %then100, label %ifcont101
+ifcont97:                                         ; preds = %loop.end95
+  br i1 false, label %then98, label %ifcont99
 
-then100:                                          ; preds = %ifcont99
+then98:                                           ; preds = %ifcont97
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont101:                                        ; preds = %ifcont99
+ifcont99:                                         ; preds = %ifcont97
   %138 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 0
   %139 = load double, double* %138, align 8
   %140 = fcmp une double %139, 1.200000e+01
-  br i1 %140, label %then102, label %else103
+  br i1 %140, label %then100, label %else101
 
-then102:                                          ; preds = %ifcont101
+then100:                                          ; preds = %ifcont99
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont104
+  br label %ifcont102
 
-else103:                                          ; preds = %ifcont101
-  br label %ifcont104
+else101:                                          ; preds = %ifcont99
+  br label %ifcont102
 
-ifcont104:                                        ; preds = %else103, %then102
-  br i1 false, label %then105, label %ifcont106
+ifcont102:                                        ; preds = %else101, %then100
+  br i1 false, label %then103, label %ifcont104
 
-then105:                                          ; preds = %ifcont104
+then103:                                          ; preds = %ifcont102
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont106:                                        ; preds = %ifcont104
-  br i1 false, label %then107, label %ifcont108
+ifcont104:                                        ; preds = %ifcont102
+  br i1 false, label %then105, label %ifcont106
 
-then107:                                          ; preds = %ifcont106
+then105:                                          ; preds = %ifcont104
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont108:                                        ; preds = %ifcont106
+ifcont106:                                        ; preds = %ifcont104
   %141 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 2
   %142 = load double, double* %141, align 8
   %143 = fcmp une double %142, 1.300000e+01
-  br i1 %143, label %then109, label %else110
+  br i1 %143, label %then107, label %else108
 
-then109:                                          ; preds = %ifcont108
+then107:                                          ; preds = %ifcont106
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont111
+  br label %ifcont109
 
-else110:                                          ; preds = %ifcont108
-  br label %ifcont111
+else108:                                          ; preds = %ifcont106
+  br label %ifcont109
 
-ifcont111:                                        ; preds = %else110, %then109
-  br i1 false, label %then112, label %ifcont113
+ifcont109:                                        ; preds = %else108, %then107
+  br i1 false, label %then110, label %ifcont111
 
-then112:                                          ; preds = %ifcont111
+then110:                                          ; preds = %ifcont109
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont113:                                        ; preds = %ifcont111
-  br i1 false, label %then114, label %ifcont115
+ifcont111:                                        ; preds = %ifcont109
+  br i1 false, label %then112, label %ifcont113
 
-then114:                                          ; preds = %ifcont113
+then112:                                          ; preds = %ifcont111
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i32 1, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont115:                                        ; preds = %ifcont113
+ifcont113:                                        ; preds = %ifcont111
   %144 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 1
   %145 = load double, double* %144, align 8
   %146 = fcmp une double %145, 1.300000e+01
-  br i1 %146, label %then116, label %else117
+  br i1 %146, label %then114, label %else115
 
-then116:                                          ; preds = %ifcont115
+then114:                                          ; preds = %ifcont113
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont118
+  br label %ifcont116
 
-else117:                                          ; preds = %ifcont115
-  br label %ifcont118
+else115:                                          ; preds = %ifcont113
+  br label %ifcont116
 
-ifcont118:                                        ; preds = %else117, %then116
-  br i1 false, label %then119, label %ifcont120
+ifcont116:                                        ; preds = %else115, %then114
+  br i1 false, label %then117, label %ifcont118
 
-then119:                                          ; preds = %ifcont118
+then117:                                          ; preds = %ifcont116
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @93, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont120:                                        ; preds = %ifcont118
-  br i1 false, label %then121, label %ifcont122
+ifcont118:                                        ; preds = %ifcont116
+  br i1 false, label %then119, label %ifcont120
 
-then121:                                          ; preds = %ifcont120
+then119:                                          ; preds = %ifcont118
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @94, i32 0, i32 0), i32 2, i32 2, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
-ifcont122:                                        ; preds = %ifcont120
+ifcont120:                                        ; preds = %ifcont118
   %147 = getelementptr [4 x double], [4 x double]* %c, i32 0, i32 3
   %148 = load double, double* %147, align 8
   %149 = fcmp une double %148, 1.400000e+01
-  br i1 %149, label %then123, label %else124
+  br i1 %149, label %then121, label %else122
 
-then123:                                          ; preds = %ifcont122
+then121:                                          ; preds = %ifcont120
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @97, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont125
+  br label %ifcont123
 
-else124:                                          ; preds = %ifcont122
-  br label %ifcont125
+else122:                                          ; preds = %ifcont120
+  br label %ifcont123
 
-ifcont125:                                        ; preds = %else124, %then123
+ifcont123:                                        ; preds = %else122, %then121
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont125
+return:                                           ; preds = %ifcont123
   br label %FINALIZE_SYMTABLE_arrays_01_real
 
 FINALIZE_SYMTABLE_arrays_01_real:                 ; preds = %return

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "7ad4449bf18a772aad45f37737ff9a573646c08915a977e5d41597f6",
+    "stdout_hash": "a6ef5c34ff7bf58132535e5fa8730abf0feae9153d0d433dad790f36",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -79,18 +79,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
-  %size_a = alloca i32, align 4
-  %size_b = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [3 x i32], align 4
   %b = alloca [4 x i32], align 4
-  %i1 = alloca i32, align 4
-  %size_a2 = alloca i32, align 4
-  %size_b3 = alloca i32, align 4
-  store i32 3, i32* %size_a2, align 4
-  store i32 4, i32* %size_b3, align 4
-  %2 = load i32, i32* %size_a2, align 4
+  %i = alloca i32, align 4
+  %size_a = alloca i32, align 4
+  %size_b = alloca i32, align 4
+  store i32 3, i32* %size_a, align 4
+  store i32 4, i32* %size_b, align 4
+  %2 = load i32, i32* %size_a, align 4
   %3 = icmp ne i32 %2, 3
   br i1 %3, label %then, label %else
 
@@ -103,137 +100,137 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %4 = load i32, i32* %size_b3, align 4
+  %4 = load i32, i32* %size_b, align 4
   %5 = icmp ne i32 %4, 4
-  br i1 %5, label %then4, label %else5
+  br i1 %5, label %then1, label %else2
 
-then4:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont6
+  br label %ifcont3
 
-else5:                                            ; preds = %ifcont
-  br label %ifcont6
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont6:                                          ; preds = %else5, %then4
-  store i32 0, i32* %i1, align 4
+ifcont3:                                          ; preds = %else2, %then1
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont8, %ifcont6
-  %6 = load i32, i32* %i1, align 4
+loop.head:                                        ; preds = %ifcont5, %ifcont3
+  %6 = load i32, i32* %i, align 4
   %7 = add i32 %6, 1
-  %8 = load i32, i32* %size_a2, align 4
+  %8 = load i32, i32* %size_a, align 4
   %9 = icmp sle i32 %7, %8
   br i1 %9, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %10 = load i32, i32* %i1, align 4
+  %10 = load i32, i32* %i, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %i1, align 4
-  %12 = load i32, i32* %i1, align 4
+  store i32 %11, i32* %i, align 4
+  %12 = load i32, i32* %i, align 4
   %13 = sub i32 %12, 1
   %14 = mul i32 1, %13
   %15 = add i32 0, %14
   %16 = icmp slt i32 %12, 1
   %17 = icmp sgt i32 %12, 3
   %18 = or i1 %16, %17
-  br i1 %18, label %then7, label %ifcont8
+  br i1 %18, label %then4, label %ifcont5
 
-then7:                                            ; preds = %loop.body
+then4:                                            ; preds = %loop.body
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 %12, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont8:                                          ; preds = %loop.body
+ifcont5:                                          ; preds = %loop.body
   %19 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %15
-  %20 = load i32, i32* %i1, align 4
+  %20 = load i32, i32* %i, align 4
   %21 = add i32 %20, 10
   store i32 %21, i32* %19, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  br i1 false, label %then9, label %ifcont10
+  br i1 false, label %then6, label %ifcont7
 
-then9:                                            ; preds = %loop.end
+then6:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont10:                                         ; preds = %loop.end
+ifcont7:                                          ; preds = %loop.end
   %22 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %23 = load i32, i32* %22, align 4
   %24 = icmp ne i32 %23, 11
-  br i1 %24, label %then11, label %else12
+  br i1 %24, label %then8, label %else9
 
-then11:                                           ; preds = %ifcont10
+then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont13
+  br label %ifcont10
 
-else12:                                           ; preds = %ifcont10
-  br label %ifcont13
+else9:                                            ; preds = %ifcont7
+  br label %ifcont10
 
-ifcont13:                                         ; preds = %else12, %then11
-  br i1 false, label %then14, label %ifcont15
+ifcont10:                                         ; preds = %else9, %then8
+  br i1 false, label %then11, label %ifcont12
 
-then14:                                           ; preds = %ifcont13
+then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 2, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont15:                                         ; preds = %ifcont13
+ifcont12:                                         ; preds = %ifcont10
   %25 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 1
   %26 = load i32, i32* %25, align 4
   %27 = icmp ne i32 %26, 12
-  br i1 %27, label %then16, label %else17
+  br i1 %27, label %then13, label %else14
 
-then16:                                           ; preds = %ifcont15
+then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont15
 
-else17:                                           ; preds = %ifcont15
-  br label %ifcont18
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
 
-ifcont18:                                         ; preds = %else17, %then16
-  br i1 false, label %then19, label %ifcont20
+ifcont15:                                         ; preds = %else14, %then13
+  br i1 false, label %then16, label %ifcont17
 
-then19:                                           ; preds = %ifcont18
+then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 3, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont20:                                         ; preds = %ifcont18
+ifcont17:                                         ; preds = %ifcont15
   %28 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 2
   %29 = load i32, i32* %28, align 4
   %30 = icmp ne i32 %29, 13
-  br i1 %30, label %then21, label %else22
+  br i1 %30, label %then18, label %else19
 
-then21:                                           ; preds = %ifcont20
+then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont23
+  br label %ifcont20
 
-else22:                                           ; preds = %ifcont20
-  br label %ifcont23
+else19:                                           ; preds = %ifcont17
+  br label %ifcont20
 
-ifcont23:                                         ; preds = %else22, %then21
-  store i32 10, i32* %i1, align 4
-  br label %loop.head24
+ifcont20:                                         ; preds = %else19, %then18
+  store i32 10, i32* %i, align 4
+  br label %loop.head21
 
-loop.head24:                                      ; preds = %ifcont27, %ifcont23
-  %31 = load i32, i32* %i1, align 4
+loop.head21:                                      ; preds = %ifcont24, %ifcont20
+  %31 = load i32, i32* %i, align 4
   %32 = add i32 %31, 1
-  %33 = load i32, i32* %size_b3, align 4
+  %33 = load i32, i32* %size_b, align 4
   %34 = add i32 10, %33
   %35 = icmp sle i32 %32, %34
-  br i1 %35, label %loop.body25, label %loop.end28
+  br i1 %35, label %loop.body22, label %loop.end25
 
-loop.body25:                                      ; preds = %loop.head24
-  %36 = load i32, i32* %i1, align 4
+loop.body22:                                      ; preds = %loop.head21
+  %36 = load i32, i32* %i, align 4
   %37 = add i32 %36, 1
-  store i32 %37, i32* %i1, align 4
-  %38 = load i32, i32* %i1, align 4
+  store i32 %37, i32* %i, align 4
+  %38 = load i32, i32* %i, align 4
   %39 = sub i32 %38, 10
   %40 = sub i32 %39, 1
   %41 = mul i32 1, %40
@@ -241,347 +238,347 @@ loop.body25:                                      ; preds = %loop.head24
   %43 = icmp slt i32 %39, 1
   %44 = icmp sgt i32 %39, 4
   %45 = or i1 %43, %44
-  br i1 %45, label %then26, label %ifcont27
+  br i1 %45, label %then23, label %ifcont24
 
-then26:                                           ; preds = %loop.body25
+then23:                                           ; preds = %loop.body22
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 %39, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont27:                                         ; preds = %loop.body25
+ifcont24:                                         ; preds = %loop.body22
   %46 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %42
-  %47 = load i32, i32* %i1, align 4
+  %47 = load i32, i32* %i, align 4
   store i32 %47, i32* %46, align 4
-  br label %loop.head24
+  br label %loop.head21
 
-loop.end28:                                       ; preds = %loop.head24
-  br i1 false, label %then29, label %ifcont30
+loop.end25:                                       ; preds = %loop.head21
+  br i1 false, label %then26, label %ifcont27
 
-then29:                                           ; preds = %loop.end28
+then26:                                           ; preds = %loop.end25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont30:                                         ; preds = %loop.end28
+ifcont27:                                         ; preds = %loop.end25
   %48 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %49 = load i32, i32* %48, align 4
   %50 = icmp ne i32 %49, 11
-  br i1 %50, label %then31, label %else32
+  br i1 %50, label %then28, label %else29
 
-then31:                                           ; preds = %ifcont30
+then28:                                           ; preds = %ifcont27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont30
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else29:                                           ; preds = %ifcont27
+  br label %ifcont30
 
-ifcont33:                                         ; preds = %else32, %then31
-  br i1 false, label %then34, label %ifcont35
+ifcont30:                                         ; preds = %else29, %then28
+  br i1 false, label %then31, label %ifcont32
 
-then34:                                           ; preds = %ifcont33
+then31:                                           ; preds = %ifcont30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont35:                                         ; preds = %ifcont33
+ifcont32:                                         ; preds = %ifcont30
   %51 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %52 = load i32, i32* %51, align 4
   %53 = icmp ne i32 %52, 12
-  br i1 %53, label %then36, label %else37
+  br i1 %53, label %then33, label %else34
 
-then36:                                           ; preds = %ifcont35
+then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont38
+  br label %ifcont35
 
-else37:                                           ; preds = %ifcont35
-  br label %ifcont38
+else34:                                           ; preds = %ifcont32
+  br label %ifcont35
 
-ifcont38:                                         ; preds = %else37, %then36
-  br i1 false, label %then39, label %ifcont40
+ifcont35:                                         ; preds = %else34, %then33
+  br i1 false, label %then36, label %ifcont37
 
-then39:                                           ; preds = %ifcont38
+then36:                                           ; preds = %ifcont35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont40:                                         ; preds = %ifcont38
+ifcont37:                                         ; preds = %ifcont35
   %54 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %55 = load i32, i32* %54, align 4
   %56 = icmp ne i32 %55, 13
-  br i1 %56, label %then41, label %else42
+  br i1 %56, label %then38, label %else39
 
-then41:                                           ; preds = %ifcont40
+then38:                                           ; preds = %ifcont37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont43
+  br label %ifcont40
 
-else42:                                           ; preds = %ifcont40
-  br label %ifcont43
+else39:                                           ; preds = %ifcont37
+  br label %ifcont40
 
-ifcont43:                                         ; preds = %else42, %then41
-  br i1 false, label %then44, label %ifcont45
+ifcont40:                                         ; preds = %else39, %then38
+  br i1 false, label %then41, label %ifcont42
 
-then44:                                           ; preds = %ifcont43
+then41:                                           ; preds = %ifcont40
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont45:                                         ; preds = %ifcont43
+ifcont42:                                         ; preds = %ifcont40
   %57 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %58 = load i32, i32* %57, align 4
   %59 = icmp ne i32 %58, 14
-  br i1 %59, label %then46, label %else47
+  br i1 %59, label %then43, label %else44
 
-then46:                                           ; preds = %ifcont45
+then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont48
+  br label %ifcont45
 
-else47:                                           ; preds = %ifcont45
-  br label %ifcont48
+else44:                                           ; preds = %ifcont42
+  br label %ifcont45
 
-ifcont48:                                         ; preds = %else47, %then46
-  store i32 0, i32* %i1, align 4
-  br label %loop.head49
+ifcont45:                                         ; preds = %else44, %then43
+  store i32 0, i32* %i, align 4
+  br label %loop.head46
 
-loop.head49:                                      ; preds = %ifcont54, %ifcont48
-  %60 = load i32, i32* %i1, align 4
+loop.head46:                                      ; preds = %ifcont51, %ifcont45
+  %60 = load i32, i32* %i, align 4
   %61 = add i32 %60, 1
-  %62 = load i32, i32* %size_a2, align 4
+  %62 = load i32, i32* %size_a, align 4
   %63 = icmp sle i32 %61, %62
-  br i1 %63, label %loop.body50, label %loop.end55
+  br i1 %63, label %loop.body47, label %loop.end52
 
-loop.body50:                                      ; preds = %loop.head49
-  %64 = load i32, i32* %i1, align 4
+loop.body47:                                      ; preds = %loop.head46
+  %64 = load i32, i32* %i, align 4
   %65 = add i32 %64, 1
-  store i32 %65, i32* %i1, align 4
-  %66 = load i32, i32* %i1, align 4
+  store i32 %65, i32* %i, align 4
+  %66 = load i32, i32* %i, align 4
   %67 = sub i32 %66, 1
   %68 = mul i32 1, %67
   %69 = add i32 0, %68
   %70 = icmp slt i32 %66, 1
   %71 = icmp sgt i32 %66, 4
   %72 = or i1 %70, %71
-  br i1 %72, label %then51, label %ifcont52
+  br i1 %72, label %then48, label %ifcont49
 
-then51:                                           ; preds = %loop.body50
+then48:                                           ; preds = %loop.body47
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 %66, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont52:                                         ; preds = %loop.body50
+ifcont49:                                         ; preds = %loop.body47
   %73 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 %69
-  %74 = load i32, i32* %i1, align 4
+  %74 = load i32, i32* %i, align 4
   %75 = sub i32 %74, 1
   %76 = mul i32 1, %75
   %77 = add i32 0, %76
   %78 = icmp slt i32 %74, 1
   %79 = icmp sgt i32 %74, 3
   %80 = or i1 %78, %79
-  br i1 %80, label %then53, label %ifcont54
+  br i1 %80, label %then50, label %ifcont51
 
-then53:                                           ; preds = %ifcont52
+then50:                                           ; preds = %ifcont49
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 %74, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont54:                                         ; preds = %ifcont52
+ifcont51:                                         ; preds = %ifcont49
   %81 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 %77
   %82 = load i32, i32* %81, align 4
   %83 = sub i32 %82, 10
   store i32 %83, i32* %73, align 4
-  br label %loop.head49
+  br label %loop.head46
 
-loop.end55:                                       ; preds = %loop.head49
-  br i1 false, label %then56, label %ifcont57
+loop.end52:                                       ; preds = %loop.head46
+  br i1 false, label %then53, label %ifcont54
 
-then56:                                           ; preds = %loop.end55
+then53:                                           ; preds = %loop.end52
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont57:                                         ; preds = %loop.end55
+ifcont54:                                         ; preds = %loop.end52
   %84 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %85 = load i32, i32* %84, align 4
   %86 = icmp ne i32 %85, 1
-  br i1 %86, label %then58, label %else59
+  br i1 %86, label %then55, label %else56
 
-then58:                                           ; preds = %ifcont57
+then55:                                           ; preds = %ifcont54
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont60
+  br label %ifcont57
 
-else59:                                           ; preds = %ifcont57
-  br label %ifcont60
+else56:                                           ; preds = %ifcont54
+  br label %ifcont57
 
-ifcont60:                                         ; preds = %else59, %then58
-  br i1 false, label %then61, label %ifcont62
+ifcont57:                                         ; preds = %else56, %then55
+  br i1 false, label %then58, label %ifcont59
 
-then61:                                           ; preds = %ifcont60
+then58:                                           ; preds = %ifcont57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont62:                                         ; preds = %ifcont60
+ifcont59:                                         ; preds = %ifcont57
   %87 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %88 = load i32, i32* %87, align 4
   %89 = icmp ne i32 %88, 2
-  br i1 %89, label %then63, label %else64
+  br i1 %89, label %then60, label %else61
 
-then63:                                           ; preds = %ifcont62
+then60:                                           ; preds = %ifcont59
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont65
+  br label %ifcont62
 
-else64:                                           ; preds = %ifcont62
-  br label %ifcont65
+else61:                                           ; preds = %ifcont59
+  br label %ifcont62
 
-ifcont65:                                         ; preds = %else64, %then63
-  br i1 false, label %then66, label %ifcont67
+ifcont62:                                         ; preds = %else61, %then60
+  br i1 false, label %then63, label %ifcont64
 
-then66:                                           ; preds = %ifcont65
+then63:                                           ; preds = %ifcont62
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont67:                                         ; preds = %ifcont65
+ifcont64:                                         ; preds = %ifcont62
   %90 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %91 = load i32, i32* %90, align 4
   %92 = icmp ne i32 %91, 3
-  br i1 %92, label %then68, label %else69
+  br i1 %92, label %then65, label %else66
 
-then68:                                           ; preds = %ifcont67
+then65:                                           ; preds = %ifcont64
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont70
+  br label %ifcont67
 
-else69:                                           ; preds = %ifcont67
-  br label %ifcont70
+else66:                                           ; preds = %ifcont64
+  br label %ifcont67
 
-ifcont70:                                         ; preds = %else69, %then68
-  br i1 false, label %then71, label %ifcont72
+ifcont67:                                         ; preds = %else66, %then65
+  br i1 false, label %then68, label %ifcont69
 
-then71:                                           ; preds = %ifcont70
+then68:                                           ; preds = %ifcont67
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont72:                                         ; preds = %ifcont70
+ifcont69:                                         ; preds = %ifcont67
   %93 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  br i1 false, label %then73, label %ifcont74
+  br i1 false, label %then70, label %ifcont71
 
-then73:                                           ; preds = %ifcont72
+then70:                                           ; preds = %ifcont69
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 1, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont74:                                         ; preds = %ifcont72
+ifcont71:                                         ; preds = %ifcont69
   %94 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 0
   %95 = load i32, i32* %94, align 4
-  br i1 false, label %then75, label %ifcont76
+  br i1 false, label %then72, label %ifcont73
 
-then75:                                           ; preds = %ifcont74
+then72:                                           ; preds = %ifcont71
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 2, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont76:                                         ; preds = %ifcont74
+ifcont73:                                         ; preds = %ifcont71
   %96 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 1
   %97 = load i32, i32* %96, align 4
   %98 = add i32 %95, %97
-  br i1 false, label %then77, label %ifcont78
+  br i1 false, label %then74, label %ifcont75
 
-then77:                                           ; preds = %ifcont76
+then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i32 3, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont78:                                         ; preds = %ifcont76
+ifcont75:                                         ; preds = %ifcont73
   %99 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 2
   %100 = load i32, i32* %99, align 4
   %101 = add i32 %98, %100
-  br i1 false, label %then79, label %ifcont80
+  br i1 false, label %then76, label %ifcont77
 
-then79:                                           ; preds = %ifcont78
+then76:                                           ; preds = %ifcont75
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([183 x i8], [183 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont80:                                         ; preds = %ifcont78
+ifcont77:                                         ; preds = %ifcont75
   %102 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %103 = load i32, i32* %102, align 4
   %104 = add i32 %101, %103
   store i32 %104, i32* %93, align 4
-  br i1 false, label %then81, label %ifcont82
+  br i1 false, label %then78, label %ifcont79
 
-then81:                                           ; preds = %ifcont80
+then78:                                           ; preds = %ifcont77
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont82:                                         ; preds = %ifcont80
+ifcont79:                                         ; preds = %ifcont77
   %105 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %106 = load i32, i32* %105, align 4
   %107 = icmp ne i32 %106, 17
-  br i1 %107, label %then83, label %else84
+  br i1 %107, label %then80, label %else81
 
-then83:                                           ; preds = %ifcont82
+then80:                                           ; preds = %ifcont79
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont85
+  br label %ifcont82
 
-else84:                                           ; preds = %ifcont82
-  br label %ifcont85
+else81:                                           ; preds = %ifcont79
+  br label %ifcont82
 
-ifcont85:                                         ; preds = %else84, %then83
-  br i1 false, label %then86, label %ifcont87
+ifcont82:                                         ; preds = %else81, %then80
+  br i1 false, label %then83, label %ifcont84
 
-then86:                                           ; preds = %ifcont85
+then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont87:                                         ; preds = %ifcont85
+ifcont84:                                         ; preds = %ifcont82
   %108 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
-  br i1 false, label %then88, label %ifcont89
+  br i1 false, label %then85, label %ifcont86
 
-then88:                                           ; preds = %ifcont87
+then85:                                           ; preds = %ifcont84
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0), i32 1, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont89:                                         ; preds = %ifcont87
+ifcont86:                                         ; preds = %ifcont84
   %109 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i32 0
   %110 = load i32, i32* %109, align 4
   store i32 %110, i32* %108, align 4
-  br i1 false, label %then90, label %ifcont91
+  br i1 false, label %then87, label %ifcont88
 
-then90:                                           ; preds = %ifcont89
+then87:                                           ; preds = %ifcont86
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([182 x i8], [182 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i32 4, i32 1, i32 1, i32 4)
   call void @exit(i32 1)
   unreachable
 
-ifcont91:                                         ; preds = %ifcont89
+ifcont88:                                         ; preds = %ifcont86
   %111 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i32 3
   %112 = load i32, i32* %111, align 4
   %113 = icmp ne i32 %112, 11
-  br i1 %113, label %then92, label %else93
+  br i1 %113, label %then89, label %else90
 
-then92:                                           ; preds = %ifcont91
+then89:                                           ; preds = %ifcont88
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont94
+  br label %ifcont91
 
-else93:                                           ; preds = %ifcont91
-  br label %ifcont94
+else90:                                           ; preds = %ifcont88
+  br label %ifcont91
 
-ifcont94:                                         ; preds = %else93, %then92
+ifcont91:                                         ; preds = %else90, %then89
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont94
+return:                                           ; preds = %ifcont91
   br label %FINALIZE_SYMTABLE_arrays_01
 
 FINALIZE_SYMTABLE_arrays_01:                      ; preds = %return

--- a/tests/reference/llvm-arrays_101-8ed52ae.json
+++ b/tests/reference/llvm-arrays_101-8ed52ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_101-8ed52ae.stdout",
-    "stdout_hash": "d4801695a68fa4fc043182a77af12f8b9b0d8020d891c5e0ac4cca7d",
+    "stdout_hash": "9bab2360a85d1f2a375ea74932a0a92d81f3cdd1823a2a2bd451de96",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_101-8ed52ae.stdout
+++ b/tests/reference/llvm-arrays_101-8ed52ae.stdout
@@ -45,19 +45,16 @@ FINALIZE_SYMTABLE__lcompilers_real_i32:           ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %array_bound42 = alloca i32, align 4
-  %array_bound37 = alloca i32, align 4
-  %array_bound16 = alloca i32, align 4
-  %array_bound11 = alloca i32, align 4
-  %array_bound5 = alloca i32, align 4
+  %array_bound38 = alloca i32, align 4
+  %array_bound33 = alloca i32, align 4
+  %array_bound12 = alloca i32, align 4
+  %array_bound7 = alloca i32, align 4
+  %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__libasr_index_0_ = alloca i32, align 4
   %__libasr_index_0_1 = alloca i32, align 4
   %i = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__libasr_index_0_2 = alloca i32, align 4
-  %__libasr_index_0_13 = alloca i32, align 4
-  %i4 = alloca i32, align 4
   %2 = call i8* @_lfortran_malloc(i64 8000)
   %3 = bitcast i8* %2 to [2000 x float]*
   %small_arr = alloca [100 x float], align 4
@@ -74,236 +71,236 @@ else:                                             ; preds = %.entry
 ifcont:                                           ; preds = %else, %then
   %4 = load i32, i32* %array_bound, align 4
   %5 = sub i32 %4, 1
-  store i32 %5, i32* %__libasr_index_0_2, align 4
+  store i32 %5, i32* %__libasr_index_0_, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont10, %ifcont
-  %6 = load i32, i32* %__libasr_index_0_2, align 4
+loop.head:                                        ; preds = %ifcont6, %ifcont
+  %6 = load i32, i32* %__libasr_index_0_, align 4
   %7 = add i32 %6, 1
-  br i1 true, label %then6, label %else7
+  br i1 true, label %then2, label %else3
 
-then6:                                            ; preds = %loop.head
-  store i32 100, i32* %array_bound5, align 4
-  br label %ifcont8
+then2:                                            ; preds = %loop.head
+  store i32 100, i32* %array_bound1, align 4
+  br label %ifcont4
 
-else7:                                            ; preds = %loop.head
-  br label %ifcont8
+else3:                                            ; preds = %loop.head
+  br label %ifcont4
 
-ifcont8:                                          ; preds = %else7, %then6
-  %8 = load i32, i32* %array_bound5, align 4
+ifcont4:                                          ; preds = %else3, %then2
+  %8 = load i32, i32* %array_bound1, align 4
   %9 = icmp sle i32 %7, %8
   br i1 %9, label %loop.body, label %loop.end
 
-loop.body:                                        ; preds = %ifcont8
-  %10 = load i32, i32* %__libasr_index_0_2, align 4
+loop.body:                                        ; preds = %ifcont4
+  %10 = load i32, i32* %__libasr_index_0_, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %__libasr_index_0_2, align 4
-  %12 = load i32, i32* %__libasr_index_0_2, align 4
+  store i32 %11, i32* %__libasr_index_0_, align 4
+  %12 = load i32, i32* %__libasr_index_0_, align 4
   %13 = sub i32 %12, 1
   %14 = mul i32 1, %13
   %15 = add i32 0, %14
   %16 = icmp slt i32 %12, 1
   %17 = icmp sgt i32 %12, 100
   %18 = or i1 %16, %17
-  br i1 %18, label %then9, label %ifcont10
+  br i1 %18, label %then5, label %ifcont6
 
-then9:                                            ; preds = %loop.body
+then5:                                            ; preds = %loop.body
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @0, i32 0, i32 0), i32 %12, i32 1, i32 1, i32 100)
   call void @exit(i32 1)
   unreachable
 
-ifcont10:                                         ; preds = %loop.body
+ifcont6:                                          ; preds = %loop.body
   %19 = getelementptr [100 x float], [100 x float]* %small_arr, i32 0, i32 %15
   store float 1.000000e+00, float* %19, align 4
   br label %loop.head
 
-loop.end:                                         ; preds = %ifcont8
-  br i1 true, label %then12, label %else13
+loop.end:                                         ; preds = %ifcont4
+  br i1 true, label %then8, label %else9
 
-then12:                                           ; preds = %loop.end
-  store i32 1, i32* %array_bound11, align 4
-  br label %ifcont14
+then8:                                            ; preds = %loop.end
+  store i32 1, i32* %array_bound7, align 4
+  br label %ifcont10
 
-else13:                                           ; preds = %loop.end
-  br label %ifcont14
+else9:                                            ; preds = %loop.end
+  br label %ifcont10
 
-ifcont14:                                         ; preds = %else13, %then12
-  %20 = load i32, i32* %array_bound11, align 4
+ifcont10:                                         ; preds = %else9, %then8
+  %20 = load i32, i32* %array_bound7, align 4
   %21 = sub i32 %20, 1
-  store i32 %21, i32* %__libasr_index_0_13, align 4
-  br label %loop.head15
+  store i32 %21, i32* %__libasr_index_0_1, align 4
+  br label %loop.head11
 
-loop.head15:                                      ; preds = %ifcont22, %ifcont14
-  %22 = load i32, i32* %__libasr_index_0_13, align 4
+loop.head11:                                      ; preds = %ifcont18, %ifcont10
+  %22 = load i32, i32* %__libasr_index_0_1, align 4
   %23 = add i32 %22, 1
-  br i1 true, label %then17, label %else18
+  br i1 true, label %then13, label %else14
 
-then17:                                           ; preds = %loop.head15
-  store i32 2000, i32* %array_bound16, align 4
-  br label %ifcont19
+then13:                                           ; preds = %loop.head11
+  store i32 2000, i32* %array_bound12, align 4
+  br label %ifcont15
 
-else18:                                           ; preds = %loop.head15
-  br label %ifcont19
+else14:                                           ; preds = %loop.head11
+  br label %ifcont15
 
-ifcont19:                                         ; preds = %else18, %then17
-  %24 = load i32, i32* %array_bound16, align 4
+ifcont15:                                         ; preds = %else14, %then13
+  %24 = load i32, i32* %array_bound12, align 4
   %25 = icmp sle i32 %23, %24
-  br i1 %25, label %loop.body20, label %loop.end23
+  br i1 %25, label %loop.body16, label %loop.end19
 
-loop.body20:                                      ; preds = %ifcont19
-  %26 = load i32, i32* %__libasr_index_0_13, align 4
+loop.body16:                                      ; preds = %ifcont15
+  %26 = load i32, i32* %__libasr_index_0_1, align 4
   %27 = add i32 %26, 1
-  store i32 %27, i32* %__libasr_index_0_13, align 4
-  %28 = load i32, i32* %__libasr_index_0_13, align 4
+  store i32 %27, i32* %__libasr_index_0_1, align 4
+  %28 = load i32, i32* %__libasr_index_0_1, align 4
   %29 = sub i32 %28, 1
   %30 = mul i32 1, %29
   %31 = add i32 0, %30
   %32 = icmp slt i32 %28, 1
   %33 = icmp sgt i32 %28, 2000
   %34 = or i1 %32, %33
-  br i1 %34, label %then21, label %ifcont22
+  br i1 %34, label %then17, label %ifcont18
 
-then21:                                           ; preds = %loop.body20
+then17:                                           ; preds = %loop.body16
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @2, i32 0, i32 0), i32 %28, i32 1, i32 1, i32 2000)
   call void @exit(i32 1)
   unreachable
 
-ifcont22:                                         ; preds = %loop.body20
+ifcont18:                                         ; preds = %loop.body16
   %35 = getelementptr [2000 x float], [2000 x float]* %3, i32 0, i32 %31
   store float 2.000000e+00, float* %35, align 4
-  br label %loop.head15
+  br label %loop.head11
 
-loop.end23:                                       ; preds = %ifcont19
-  br i1 false, label %then24, label %ifcont25
+loop.end19:                                       ; preds = %ifcont15
+  br i1 false, label %then20, label %ifcont21
 
-then24:                                           ; preds = %loop.end23
+then20:                                           ; preds = %loop.end19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @4, i32 0, i32 0), i32 1, i32 1, i32 1, i32 100)
   call void @exit(i32 1)
   unreachable
 
-ifcont25:                                         ; preds = %loop.end23
+ifcont21:                                         ; preds = %loop.end19
   %36 = getelementptr [100 x float], [100 x float]* %small_arr, i32 0, i32 0
   %37 = load float, float* %36, align 4
   %38 = fcmp une float %37, 1.000000e+00
-  br i1 %38, label %then26, label %else27
+  br i1 %38, label %then22, label %else23
 
-then26:                                           ; preds = %ifcont25
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont28
+  br label %ifcont24
 
-else27:                                           ; preds = %ifcont25
-  br label %ifcont28
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont28:                                         ; preds = %else27, %then26
-  br i1 false, label %then29, label %ifcont30
+ifcont24:                                         ; preds = %else23, %then22
+  br i1 false, label %then25, label %ifcont26
 
-then29:                                           ; preds = %ifcont28
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([178 x i8], [178 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), i32 1, i32 1, i32 1, i32 2000)
   call void @exit(i32 1)
   unreachable
 
-ifcont30:                                         ; preds = %ifcont28
+ifcont26:                                         ; preds = %ifcont24
   %39 = getelementptr [2000 x float], [2000 x float]* %3, i32 0, i32 0
   %40 = load float, float* %39, align 4
   %41 = fcmp une float %40, 2.000000e+00
-  br i1 %41, label %then31, label %else32
+  br i1 %41, label %then27, label %else28
 
-then31:                                           ; preds = %ifcont30
+then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont29
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else28:                                           ; preds = %ifcont26
+  br label %ifcont29
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont29:                                         ; preds = %else28, %then27
   store float 0.000000e+00, float* %sum, align 4
-  store i32 0, i32* %i4, align 4
-  br label %loop.head34
+  store i32 0, i32* %i, align 4
+  br label %loop.head30
 
-loop.head34:                                      ; preds = %FINALIZE_SYMTABLE_block, %ifcont33
-  %42 = load i32, i32* %i4, align 4
+loop.head30:                                      ; preds = %FINALIZE_SYMTABLE_block, %ifcont29
+  %42 = load i32, i32* %i, align 4
   %43 = add i32 %42, 1
   %44 = icmp sle i32 %43, 1000
-  br i1 %44, label %loop.body35, label %loop.end52
+  br i1 %44, label %loop.body31, label %loop.end48
 
-loop.body35:                                      ; preds = %loop.head34
-  %45 = load i32, i32* %i4, align 4
+loop.body31:                                      ; preds = %loop.head30
+  %45 = load i32, i32* %i, align 4
   %46 = add i32 %45, 1
-  store i32 %46, i32* %i4, align 4
+  store i32 %46, i32* %i, align 4
   br label %block.start
 
-block.start:                                      ; preds = %loop.body35
-  %__libasr_index_0_36 = alloca i32, align 4
+block.start:                                      ; preds = %loop.body31
+  %__libasr_index_0_32 = alloca i32, align 4
   %47 = call i8* @_lfortran_malloc(i64 2000)
   %48 = bitcast i8* %47 to [500 x float]*
-  br i1 true, label %then38, label %else39
+  br i1 true, label %then34, label %else35
 
-then38:                                           ; preds = %block.start
-  store i32 1, i32* %array_bound37, align 4
-  br label %ifcont40
+then34:                                           ; preds = %block.start
+  store i32 1, i32* %array_bound33, align 4
+  br label %ifcont36
 
-else39:                                           ; preds = %block.start
-  br label %ifcont40
+else35:                                           ; preds = %block.start
+  br label %ifcont36
 
-ifcont40:                                         ; preds = %else39, %then38
-  %49 = load i32, i32* %array_bound37, align 4
+ifcont36:                                         ; preds = %else35, %then34
+  %49 = load i32, i32* %array_bound33, align 4
   %50 = sub i32 %49, 1
-  store i32 %50, i32* %__libasr_index_0_36, align 4
-  br label %loop.head41
+  store i32 %50, i32* %__libasr_index_0_32, align 4
+  br label %loop.head37
 
-loop.head41:                                      ; preds = %ifcont48, %ifcont40
-  %51 = load i32, i32* %__libasr_index_0_36, align 4
+loop.head37:                                      ; preds = %ifcont44, %ifcont36
+  %51 = load i32, i32* %__libasr_index_0_32, align 4
   %52 = add i32 %51, 1
-  br i1 true, label %then43, label %else44
+  br i1 true, label %then39, label %else40
 
-then43:                                           ; preds = %loop.head41
-  store i32 500, i32* %array_bound42, align 4
-  br label %ifcont45
+then39:                                           ; preds = %loop.head37
+  store i32 500, i32* %array_bound38, align 4
+  br label %ifcont41
 
-else44:                                           ; preds = %loop.head41
-  br label %ifcont45
+else40:                                           ; preds = %loop.head37
+  br label %ifcont41
 
-ifcont45:                                         ; preds = %else44, %then43
-  %53 = load i32, i32* %array_bound42, align 4
+ifcont41:                                         ; preds = %else40, %then39
+  %53 = load i32, i32* %array_bound38, align 4
   %54 = icmp sle i32 %52, %53
-  br i1 %54, label %loop.body46, label %loop.end49
+  br i1 %54, label %loop.body42, label %loop.end45
 
-loop.body46:                                      ; preds = %ifcont45
-  %55 = load i32, i32* %__libasr_index_0_36, align 4
+loop.body42:                                      ; preds = %ifcont41
+  %55 = load i32, i32* %__libasr_index_0_32, align 4
   %56 = add i32 %55, 1
-  store i32 %56, i32* %__libasr_index_0_36, align 4
-  %57 = load i32, i32* %__libasr_index_0_36, align 4
+  store i32 %56, i32* %__libasr_index_0_32, align 4
+  %57 = load i32, i32* %__libasr_index_0_32, align 4
   %58 = sub i32 %57, 1
   %59 = mul i32 1, %58
   %60 = add i32 0, %59
   %61 = icmp slt i32 %57, 1
   %62 = icmp sgt i32 %57, 500
   %63 = or i1 %61, %62
-  br i1 %63, label %then47, label %ifcont48
+  br i1 %63, label %then43, label %ifcont44
 
-then47:                                           ; preds = %loop.body46
+then43:                                           ; preds = %loop.body42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @12, i32 0, i32 0), i32 %57, i32 1, i32 1, i32 500)
   call void @exit(i32 1)
   unreachable
 
-ifcont48:                                         ; preds = %loop.body46
+ifcont44:                                         ; preds = %loop.body42
   %64 = getelementptr [500 x float], [500 x float]* %48, i32 0, i32 %60
-  %65 = call float @_lcompilers_real_i32(i32* %i4)
+  %65 = call float @_lcompilers_real_i32(i32* %i)
   store float %65, float* %64, align 4
-  br label %loop.head41
+  br label %loop.head37
 
-loop.end49:                                       ; preds = %ifcont45
+loop.end45:                                       ; preds = %ifcont41
   %66 = load float, float* %sum, align 4
-  br i1 false, label %then50, label %ifcont51
+  br i1 false, label %then46, label %ifcont47
 
-then50:                                           ; preds = %loop.end49
+then46:                                           ; preds = %loop.end45
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([179 x i8], [179 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @14, i32 0, i32 0), i32 1, i32 1, i32 1, i32 500)
   call void @exit(i32 1)
   unreachable
 
-ifcont51:                                         ; preds = %loop.end49
+ifcont47:                                         ; preds = %loop.end45
   %67 = getelementptr [500 x float], [500 x float]* %48, i32 0, i32 0
   %68 = load float, float* %67, align 4
   %69 = fadd float %66, %68
@@ -311,52 +308,52 @@ ifcont51:                                         ; preds = %loop.end49
   %70 = icmp eq i8* %47, null
   br i1 %70, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont51
+free_nonnull:                                     ; preds = %ifcont47
   call void @_lfortran_free(i8* %47)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont51
+free_done:                                        ; preds = %free_nonnull, %ifcont47
   br label %block.end
 
 block.end:                                        ; preds = %free_done
   br label %FINALIZE_SYMTABLE_block
 
 FINALIZE_SYMTABLE_block:                          ; preds = %block.end
-  br label %loop.head34
+  br label %loop.head30
 
-loop.end52:                                       ; preds = %loop.head34
+loop.end48:                                       ; preds = %loop.head30
   %71 = load float, float* %sum, align 4
   %72 = fsub float %71, 5.005000e+05
   %73 = call float @llvm.fabs.f32(float %72)
   %74 = fcmp ogt float %73, 0x3FB99999A0000000
-  br i1 %74, label %then53, label %else54
+  br i1 %74, label %then49, label %else50
 
-then53:                                           ; preds = %loop.end52
+then49:                                           ; preds = %loop.end48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont55
+  br label %ifcont51
 
-else54:                                           ; preds = %loop.end52
-  br label %ifcont55
+else50:                                           ; preds = %loop.end48
+  br label %ifcont51
 
-ifcont55:                                         ; preds = %else54, %then53
+ifcont51:                                         ; preds = %else50, %then49
   %75 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %75, i32 2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont55
+return:                                           ; preds = %ifcont51
   br label %FINALIZE_SYMTABLE_static_large_array
 
 FINALIZE_SYMTABLE_static_large_array:             ; preds = %return
   %76 = icmp eq i8* %2, null
-  br i1 %76, label %free_done57, label %free_nonnull56
+  br i1 %76, label %free_done53, label %free_nonnull52
 
-free_nonnull56:                                   ; preds = %FINALIZE_SYMTABLE_static_large_array
+free_nonnull52:                                   ; preds = %FINALIZE_SYMTABLE_static_large_array
   call void @_lfortran_free(i8* %2)
-  br label %free_done57
+  br label %free_done53
 
-free_done57:                                      ; preds = %free_nonnull56, %FINALIZE_SYMTABLE_static_large_array
+free_done53:                                      ; preds = %free_nonnull52, %FINALIZE_SYMTABLE_static_large_array
   ret i32 0
 }
 

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "6a0ff7192ae7d60f609f840caba7a0170f3cd9b7603be03ae9e2ab38",
+    "stdout_hash": "b22bf40c55ff78f93b966668201bf8ee24c3a0d3d50b0590634ec369",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -17,9 +17,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
   %2 = alloca i64, align 8
@@ -62,46 +61,46 @@ ifcont:                                           ; preds = %else, %then
   %17 = load i32*, i32** %p1, align 8
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %17)
   %19 = load i64, i64* %16, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %25 = load i64, i64* %24, align 4
   %26 = trunc i64 %25 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done4, label %free_nonnull3
+  br i1 %27, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %ifcont
+free_nonnull2:                                    ; preds = %ifcont
   call void @_lfortran_free(i8* %18)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %ifcont
+free_done3:                                       ; preds = %free_nonnull2, %ifcont
   %28 = load i32*, i32** %p1, align 8
   %29 = load i32, i32* %28, align 4
-  store i32 %29, i32* %i1, align 4
-  %30 = load i32, i32* %i1, align 4
+  store i32 %29, i32* %i, align 4
+  %30 = load i32, i32* %i, align 4
   %31 = load i32, i32* @associate_03.t2, align 4
   %32 = icmp eq i32 %30, %31
-  br i1 %32, label %then5, label %else6
+  br i1 %32, label %then4, label %else5
 
-then5:                                            ; preds = %free_done4
+then4:                                            ; preds = %free_done3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont7
+  br label %ifcont6
 
-else6:                                            ; preds = %free_done4
-  br label %ifcont7
+else5:                                            ; preds = %free_done3
+  br label %ifcont6
 
-ifcont7:                                          ; preds = %else6, %then5
+ifcont6:                                          ; preds = %else5, %then4
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont7
+return:                                           ; preds = %ifcont6
   br label %FINALIZE_SYMTABLE_associate_03
 
 FINALIZE_SYMTABLE_associate_03:                   ; preds = %return

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "3b27d9d7c4abaf79835515eab56143f111a43bb1a2348b627b8606ad",
+    "stdout_hash": "ee5b6635fe1154321948856ef813f50a15cbb16946d55ceb1799a47d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -13,12 +13,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %y = alloca i16, align 2
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
   store i16* null, i16** %x, align 8
-  %y1 = alloca i16, align 2
+  %y = alloca i16, align 2
   %2 = load void*, void** %queries, align 8
   %3 = bitcast void* %2 to i16*
   store i16* %3, i16** %x, align 8
@@ -48,40 +47,40 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i16* %y1, i16** %x, align 8
+  store i16* %y, i16** %x, align 8
   %18 = alloca i64, align 8
   %19 = load i16*, i16** %x, align 8
   %20 = bitcast i16* %19 to void*
   %21 = alloca void*, align 8
   store void* %20, void** %21, align 8
-  %22 = bitcast i16* %y1 to void*
+  %22 = bitcast i16* %y to void*
   %23 = alloca void*, align 8
   store void* %22, void** %23, align 8
   %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, void** %21, void** %23)
   %25 = load i64, i64* %18, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %24, i8** %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %25, i64* %27, align 4
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %29 = load i8*, i8** %28, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %31 = load i64, i64* %30, align 4
   %32 = trunc i64 %31 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %33 = icmp eq i8* %24, null
-  br i1 %33, label %free_done4, label %free_nonnull3
+  br i1 %33, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %24)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done4
+return:                                           ; preds = %free_done3
   br label %FINALIZE_SYMTABLE_bindc3
 
 FINALIZE_SYMTABLE_bindc3:                         ; preds = %return

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "90d31b860c296fa6eb2ac52c3508f69c06a24c56d7dc7ac82d27a654",
+    "stdout_hash": "fa00b91dde1dd3753ca446d0ba04d06ddae6b2020796161b9f9450b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -17,16 +17,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %x1 = alloca i64, align 8
+  %x = alloca i64, align 8
   %y = alloca double, align 8
-  store i64 665663010, i64* %x1, align 4
-  %2 = load i64, i64* %x1, align 4
+  store i64 665663010, i64* %x, align 4
+  %2 = load i64, i64* %x, align 4
   %simplified_pow_operation = mul i64 %2, %2
-  store i64 %simplified_pow_operation, i64* %x1, align 4
+  store i64 %simplified_pow_operation, i64* %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %x1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %x)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -47,7 +46,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load i64, i64* %x1, align 4
+  %14 = load i64, i64* %x, align 4
   %15 = icmp ne i64 %14, 443107242882260100
   br i1 %15, label %then, label %else
 
@@ -62,49 +61,49 @@ else:                                             ; preds = %free_done
 ifcont:                                           ; preds = %else, %then
   store double 0x41C3D69B11000000, double* %y, align 8
   %16 = load double, double* %y, align 8
-  %simplified_pow_operation2 = fmul double %16, %16
-  store double %simplified_pow_operation2, double* %y, align 8
+  %simplified_pow_operation1 = fmul double %16, %16
+  store double %simplified_pow_operation1, double* %y, align 8
   %17 = alloca i64, align 8
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, double* %y)
   %19 = load i64, i64* %17, align 4
-  %stringFormat_desc3 = alloca %string_descriptor, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc3, i32 0, i32 0
+  %stringFormat_desc2 = alloca %string_descriptor, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc3, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
   store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc3, i32 0, i32 0
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc3, i32 0, i32 1
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
   %25 = load i64, i64* %24, align 4
   %26 = trunc i64 %25 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done5, label %free_nonnull4
+  br i1 %27, label %free_done4, label %free_nonnull3
 
-free_nonnull4:                                    ; preds = %ifcont
+free_nonnull3:                                    ; preds = %ifcont
   call void @_lfortran_free(i8* %18)
-  br label %free_done5
+  br label %free_done4
 
-free_done5:                                       ; preds = %free_nonnull4, %ifcont
+free_done4:                                       ; preds = %free_nonnull3, %ifcont
   %28 = load double, double* %y, align 8
   %29 = fsub double %28, 0x439898EEC2459972
   %30 = call double @llvm.fabs.f64(double %29)
   %31 = fcmp ogt double %30, 0x3BFD83C940000000
-  br i1 %31, label %then6, label %else7
+  br i1 %31, label %then5, label %else6
 
-then6:                                            ; preds = %free_done5
+then5:                                            ; preds = %free_done4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont7
 
-else7:                                            ; preds = %free_done5
-  br label %ifcont8
+else6:                                            ; preds = %free_done4
+  br label %ifcont7
 
-ifcont8:                                          ; preds = %else7, %then6
+ifcont7:                                          ; preds = %else6, %then5
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont8
+return:                                           ; preds = %ifcont7
   br label %FINALIZE_SYMTABLE_binop_03
 
 FINALIZE_SYMTABLE_binop_03:                       ; preds = %return

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "94c808e9c6fab5f92e6b6aa2182f503bb7a82d8262d85ee29e7c3f2f",
+    "stdout_hash": "ccfe828bc9c2df79e3981bcb27a3b9a41de171fd42710231fa6d1194",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -15,19 +15,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %all_ones = alloca i64, align 8
   store i64 -1, i64* %all_ones, align 4
   %all_zeros = alloca i64, align 8
   store i64 0, i64* %all_zeros, align 4
   %block_size = alloca i32, align 4
   store i32 64, i32* %block_size, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %all_ones1 = alloca i64, align 8
-  store i64 -1, i64* %all_ones1, align 4
-  %all_zeros2 = alloca i64, align 8
-  store i64 0, i64* %all_zeros2, align 4
-  %block_size3 = alloca i32, align 4
-  store i32 64, i32* %block_size3, align 4
   %2 = alloca i64, align 8
   %3 = alloca i32, align 4
   store i32 64, i32* %3, align 4
@@ -57,53 +51,53 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i64 0, i64* %15, align 4
   %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i64* %15)
   %17 = load i64, i64* %14, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %17, i64* %19, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %23 = load i64, i64* %22, align 4
   %24 = trunc i64 %23 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %25 = icmp eq i8* %16, null
-  br i1 %25, label %free_done6, label %free_nonnull5
+  br i1 %25, label %free_done3, label %free_nonnull2
 
-free_nonnull5:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %16)
-  br label %free_done6
+  br label %free_done3
 
-free_done6:                                       ; preds = %free_nonnull5, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   %26 = alloca i64, align 8
   %27 = alloca i64, align 8
   store i64 -1, i64* %27, align 4
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %26, i32 0, i32 0, i64* %27)
   %29 = load i64, i64* %26, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   store i64 %29, i64* %31, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %35 = load i64, i64* %34, align 4
   %36 = trunc i64 %35 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %37 = icmp eq i8* %28, null
-  br i1 %37, label %free_done9, label %free_nonnull8
+  br i1 %37, label %free_done6, label %free_nonnull5
 
-free_nonnull8:                                    ; preds = %free_done6
+free_nonnull5:                                    ; preds = %free_done3
   call void @_lfortran_free(i8* %28)
-  br label %free_done9
+  br label %free_done6
 
-free_done9:                                       ; preds = %free_nonnull8, %free_done6
+free_done6:                                       ; preds = %free_nonnull5, %free_done3
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done9
+return:                                           ; preds = %free_done6
   br label %FINALIZE_SYMTABLE_bits_02
 
 FINALIZE_SYMTABLE_bits_02:                        ; preds = %return

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "fffc41d5ab511d7fbe8336440d4d46d2ae9072be63549ddf495736c5",
+    "stdout_hash": "5dbead19c1bddb0b733081ee0242f87fd1bc39bbc289dd780ea33471",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -22,26 +22,21 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
   %boz_3 = alloca i32, align 4
   %boz_4 = alloca i32, align 4
   %boz_5 = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %boz_11 = alloca i32, align 4
-  %boz_22 = alloca i32, align 4
-  %boz_33 = alloca i32, align 4
-  %boz_44 = alloca i32, align 4
-  %boz_55 = alloca i32, align 4
   %boz_6 = alloca float, align 4
-  store i32 93, i32* %boz_11, align 4
-  store i32 1255, i32* %boz_22, align 4
-  store i32 2748, i32* %boz_33, align 4
-  store i32 180150001, i32* %boz_44, align 4
-  store i32 180150001, i32* %boz_55, align 4
+  store i32 93, i32* %boz_1, align 4
+  store i32 1255, i32* %boz_2, align 4
+  store i32 2748, i32* %boz_3, align 4
+  store i32 180150001, i32* %boz_4, align 4
+  store i32 180150001, i32* %boz_5, align 4
   store float 0x36DA000000000000, float* %boz_6, align 4
-  %2 = load i32, i32* %boz_44, align 4
-  %3 = load i32, i32* %boz_55, align 4
+  %2 = load i32, i32* %boz_4, align 4
+  %3 = load i32, i32* %boz_5, align 4
   %4 = icmp ne i32 %2, %3
   br i1 %4, label %then, label %else
 
@@ -54,73 +49,73 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load i32, i32* %boz_11, align 4
+  %5 = load i32, i32* %boz_1, align 4
   %6 = icmp ne i32 %5, 93
-  br i1 %6, label %then6, label %else7
+  br i1 %6, label %then1, label %else2
 
-then6:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont3
 
-else7:                                            ; preds = %ifcont
-  br label %ifcont8
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont8:                                          ; preds = %else7, %then6
-  %7 = load i32, i32* %boz_22, align 4
+ifcont3:                                          ; preds = %else2, %then1
+  %7 = load i32, i32* %boz_2, align 4
   %8 = icmp ne i32 %7, 1255
-  br i1 %8, label %then9, label %else10
+  br i1 %8, label %then4, label %else5
 
-then9:                                            ; preds = %ifcont8
+then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont6
 
-else10:                                           ; preds = %ifcont8
-  br label %ifcont11
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
 
-ifcont11:                                         ; preds = %else10, %then9
-  %9 = load i32, i32* %boz_33, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  %9 = load i32, i32* %boz_3, align 4
   %10 = icmp ne i32 %9, 2748
-  br i1 %10, label %then12, label %else13
+  br i1 %10, label %then7, label %else8
 
-then12:                                           ; preds = %ifcont11
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont9
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont14:                                         ; preds = %else13, %then12
-  %11 = load i32, i32* %boz_44, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %11 = load i32, i32* %boz_4, align 4
   %12 = icmp ne i32 %11, 180150001
-  br i1 %12, label %then15, label %else16
+  br i1 %12, label %then10, label %else11
 
-then15:                                           ; preds = %ifcont14
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont17
+  br label %ifcont12
 
-else16:                                           ; preds = %ifcont14
-  br label %ifcont17
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont17:                                         ; preds = %else16, %then15
-  %13 = load i32, i32* %boz_55, align 4
+ifcont12:                                         ; preds = %else11, %then10
+  %13 = load i32, i32* %boz_5, align 4
   %14 = icmp ne i32 %13, 180150001
-  br i1 %14, label %then18, label %else19
+  br i1 %14, label %then13, label %else14
 
-then18:                                           ; preds = %ifcont17
+then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont15
 
-else19:                                           ; preds = %ifcont17
-  br label %ifcont20
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
 
-ifcont20:                                         ; preds = %else19, %then18
+ifcont15:                                         ; preds = %else14, %then13
   %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %boz_11, i32* %boz_22, i32* %boz_33, i32* %boz_44, i32* %boz_55, float* %boz_6)
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %boz_1, i32* %boz_2, i32* %boz_3, i32* %boz_4, i32* %boz_5, float* %boz_6)
   %17 = load i64, i64* %15, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -136,11 +131,11 @@ ifcont20:                                         ; preds = %else19, %then18
   %25 = icmp eq i8* %16, null
   br i1 %25, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont20
+free_nonnull:                                     ; preds = %ifcont15
   call void @_lfortran_free(i8* %16)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont20
+free_done:                                        ; preds = %free_nonnull, %ifcont15
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "40af1ac66b27893eda071bc84c4e1d3af307602881f3b1c5f70006c6",
+    "stdout_hash": "0a95b21ef2014f0dfd2dcb5f90b0cf3560074ee97352227eb12c9ef0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -35,134 +35,132 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i64, align 8
   %out = alloca i64, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i64, align 8
-  %out2 = alloca i64, align 8
-  store i64 4, i64* %i1, align 4
-  %2 = load i64, i64* %i1, align 4
+  store i64 4, i64* %i, align 4
+  %2 = load i64, i64* %i, align 4
   %3 = icmp eq i64 %2, 1
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i64 10, i64* %out2, align 4
+  store i64 10, i64* %out, align 4
   %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  br label %ifcont11
-
-else:                                             ; preds = %.entry
-  %5 = load i64, i64* %i1, align 4
-  %6 = icmp eq i64 %5, 2
-  br i1 %6, label %then3, label %else4
-
-then3:                                            ; preds = %else
-  store i64 20, i64* %out2, align 4
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  br label %ifcont10
-
-else4:                                            ; preds = %else
-  %8 = load i64, i64* %i1, align 4
-  %9 = icmp eq i64 %8, 3
-  br i1 %9, label %then5, label %else6
-
-then5:                                            ; preds = %else4
-  store i64 30, i64* %out2, align 4
-  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont9
 
-else6:                                            ; preds = %else4
-  %11 = load i64, i64* %i1, align 4
-  %12 = icmp eq i64 %11, 4
-  br i1 %12, label %then7, label %else8
+else:                                             ; preds = %.entry
+  %5 = load i64, i64* %i, align 4
+  %6 = icmp eq i64 %5, 2
+  br i1 %6, label %then1, label %else2
 
-then7:                                            ; preds = %else6
-  store i64 40, i64* %out2, align 4
+then1:                                            ; preds = %else
+  store i64 20, i64* %out, align 4
+  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  br label %ifcont8
+
+else2:                                            ; preds = %else
+  %8 = load i64, i64* %i, align 4
+  %9 = icmp eq i64 %8, 3
+  br i1 %9, label %then3, label %else4
+
+then3:                                            ; preds = %else2
+  store i64 30, i64* %out, align 4
+  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  br label %ifcont7
+
+else4:                                            ; preds = %else2
+  %11 = load i64, i64* %i, align 4
+  %12 = icmp eq i64 %11, 4
+  br i1 %12, label %then5, label %else6
+
+then5:                                            ; preds = %else4
+  store i64 40, i64* %out, align 4
   %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont
 
-else8:                                            ; preds = %else6
+else6:                                            ; preds = %else4
   br label %ifcont
 
-ifcont:                                           ; preds = %else8, %then7
+ifcont:                                           ; preds = %else6, %then5
+  br label %ifcont7
+
+ifcont7:                                          ; preds = %ifcont, %then3
+  br label %ifcont8
+
+ifcont8:                                          ; preds = %ifcont7, %then1
   br label %ifcont9
 
-ifcont9:                                          ; preds = %ifcont, %then5
-  br label %ifcont10
-
-ifcont10:                                         ; preds = %ifcont9, %then3
-  br label %ifcont11
-
-ifcont11:                                         ; preds = %ifcont10, %then
-  %14 = load i64, i64* %out2, align 4
+ifcont9:                                          ; preds = %ifcont8, %then
+  %14 = load i64, i64* %out, align 4
   %15 = icmp ne i64 %14, 40
-  br i1 %15, label %then12, label %else13
+  br i1 %15, label %then10, label %else11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %then12
-  %16 = load i64, i64* %i1, align 4
+ifcont12:                                         ; preds = %else11, %then10
+  %16 = load i64, i64* %i, align 4
   %17 = icmp eq i64 %16, 1
-  br i1 %17, label %then15, label %else16
+  br i1 %17, label %then13, label %else14
 
-then15:                                           ; preds = %ifcont14
-  store i64 11, i64* %out2, align 4
+then13:                                           ; preds = %ifcont12
+  store i64 11, i64* %out, align 4
   %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %18, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else16:                                           ; preds = %ifcont14
-  %19 = load i64, i64* %i1, align 4
+else14:                                           ; preds = %ifcont12
+  %19 = load i64, i64* %i, align 4
   %20 = icmp eq i64 %19, 2
-  %21 = load i64, i64* %i1, align 4
+  %21 = load i64, i64* %i, align 4
   %22 = icmp eq i64 %21, 3
   %23 = icmp eq i1 %20, false
   %24 = select i1 %23, i1 %22, i1 %20
-  %25 = load i64, i64* %i1, align 4
+  %25 = load i64, i64* %i, align 4
   %26 = icmp eq i64 %25, 4
   %27 = icmp eq i1 %24, false
   %28 = select i1 %27, i1 %26, i1 %24
-  br i1 %28, label %then17, label %else18
+  br i1 %28, label %then15, label %else16
 
-then17:                                           ; preds = %else16
-  store i64 22, i64* %out2, align 4
+then15:                                           ; preds = %else14
+  store i64 22, i64* %out, align 4
   %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %29, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  br label %ifcont19
+  br label %ifcont17
 
-else18:                                           ; preds = %else16
-  br label %ifcont19
+else16:                                           ; preds = %else14
+  br label %ifcont17
 
-ifcont19:                                         ; preds = %else18, %then17
-  br label %ifcont20
+ifcont17:                                         ; preds = %else16, %then15
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %ifcont19, %then15
-  %30 = load i64, i64* %out2, align 4
+ifcont18:                                         ; preds = %ifcont17, %then13
+  %30 = load i64, i64* %out, align 4
   %31 = icmp ne i64 %30, 22
-  br i1 %31, label %then21, label %else22
+  br i1 %31, label %then19, label %else20
 
-then21:                                           ; preds = %ifcont20
+then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont23
+  br label %ifcont21
 
-else22:                                           ; preds = %ifcont20
-  br label %ifcont23
+else20:                                           ; preds = %ifcont18
+  br label %ifcont21
 
-ifcont23:                                         ; preds = %else22, %then21
+ifcont21:                                         ; preds = %else20, %then19
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont23
+return:                                           ; preds = %ifcont21
   br label %FINALIZE_SYMTABLE_case_01
 
 FINALIZE_SYMTABLE_case_01:                        ; preds = %return

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "0ab10debec41ba2cac3bd1b0e4d59b6bf59c6f030313d41bae906686",
+    "stdout_hash": "5c2d625b697a6c95c237bb7e1ce15f0917bba1460db2f832e38967a5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -108,121 +108,119 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %marks = alloca i32, align 4
   %out = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %marks1 = alloca i32, align 4
-  %out2 = alloca i32, align 4
-  store i32 81, i32* %marks1, align 4
-  %2 = load i32, i32* %marks1, align 4
+  store i32 81, i32* %marks, align 4
+  %2 = load i32, i32* %marks, align 4
   %3 = icmp sle i32 91, %2
-  %4 = load i32, i32* %marks1, align 4
+  %4 = load i32, i32* %marks, align 4
   %5 = icmp sle i32 %4, 100
   %6 = icmp eq i1 %3, false
   %7 = select i1 %6, i1 %3, i1 %5
   br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 0, i32* %out2, align 4
+  store i32 0, i32* %out, align 4
   %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  br label %ifcont17
+  br label %ifcont15
 
 else:                                             ; preds = %.entry
-  %9 = load i32, i32* %marks1, align 4
+  %9 = load i32, i32* %marks, align 4
   %10 = icmp sle i32 81, %9
-  %11 = load i32, i32* %marks1, align 4
+  %11 = load i32, i32* %marks, align 4
   %12 = icmp sle i32 %11, 90
   %13 = icmp eq i1 %10, false
   %14 = select i1 %13, i1 %10, i1 %12
-  br i1 %14, label %then3, label %else4
+  br i1 %14, label %then1, label %else2
 
-then3:                                            ; preds = %else
-  store i32 1, i32* %out2, align 4
+then1:                                            ; preds = %else
+  store i32 1, i32* %out, align 4
   %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  br label %ifcont16
+  br label %ifcont14
 
-else4:                                            ; preds = %else
-  %16 = load i32, i32* %marks1, align 4
+else2:                                            ; preds = %else
+  %16 = load i32, i32* %marks, align 4
   %17 = icmp sle i32 71, %16
-  %18 = load i32, i32* %marks1, align 4
+  %18 = load i32, i32* %marks, align 4
   %19 = icmp sle i32 %18, 80
   %20 = icmp eq i1 %17, false
   %21 = select i1 %20, i1 %17, i1 %19
-  br i1 %21, label %then5, label %else6
+  br i1 %21, label %then3, label %else4
 
-then5:                                            ; preds = %else4
-  store i32 2, i32* %out2, align 4
+then3:                                            ; preds = %else2
+  store i32 2, i32* %out, align 4
   %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %22, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  br label %ifcont15
+  br label %ifcont13
 
-else6:                                            ; preds = %else4
-  %23 = load i32, i32* %marks1, align 4
+else4:                                            ; preds = %else2
+  %23 = load i32, i32* %marks, align 4
   %24 = icmp sle i32 61, %23
-  %25 = load i32, i32* %marks1, align 4
+  %25 = load i32, i32* %marks, align 4
   %26 = icmp sle i32 %25, 70
   %27 = icmp eq i1 %24, false
   %28 = select i1 %27, i1 %24, i1 %26
-  br i1 %28, label %then7, label %else8
+  br i1 %28, label %then5, label %else6
 
-then7:                                            ; preds = %else6
-  store i32 3, i32* %out2, align 4
+then5:                                            ; preds = %else4
+  store i32 3, i32* %out, align 4
   %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %29, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else8:                                            ; preds = %else6
-  %30 = load i32, i32* %marks1, align 4
+else6:                                            ; preds = %else4
+  %30 = load i32, i32* %marks, align 4
   %31 = icmp sle i32 41, %30
-  %32 = load i32, i32* %marks1, align 4
+  %32 = load i32, i32* %marks, align 4
   %33 = icmp sle i32 %32, 60
   %34 = icmp eq i1 %31, false
   %35 = select i1 %34, i1 %31, i1 %33
-  br i1 %35, label %then9, label %else10
+  br i1 %35, label %then7, label %else8
 
-then9:                                            ; preds = %else8
-  store i32 4, i32* %out2, align 4
+then7:                                            ; preds = %else6
+  store i32 4, i32* %out, align 4
   %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %36, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  br label %ifcont13
+  br label %ifcont11
 
-else10:                                           ; preds = %else8
-  %37 = load i32, i32* %marks1, align 4
+else8:                                            ; preds = %else6
+  %37 = load i32, i32* %marks, align 4
   %38 = icmp sle i32 %37, 40
-  br i1 %38, label %then11, label %else12
+  br i1 %38, label %then9, label %else10
 
-then11:                                           ; preds = %else10
-  store i32 5, i32* %out2, align 4
+then9:                                            ; preds = %else8
+  store i32 5, i32* %out, align 4
   %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %39, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont
 
-else12:                                           ; preds = %else10
-  store i32 6, i32* %out2, align 4
+else10:                                           ; preds = %else8
+  store i32 6, i32* %out, align 4
   %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %40, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont
 
-ifcont:                                           ; preds = %else12, %then11
+ifcont:                                           ; preds = %else10, %then9
+  br label %ifcont11
+
+ifcont11:                                         ; preds = %ifcont, %then7
+  br label %ifcont12
+
+ifcont12:                                         ; preds = %ifcont11, %then5
   br label %ifcont13
 
-ifcont13:                                         ; preds = %ifcont, %then9
+ifcont13:                                         ; preds = %ifcont12, %then3
   br label %ifcont14
 
-ifcont14:                                         ; preds = %ifcont13, %then7
+ifcont14:                                         ; preds = %ifcont13, %then1
   br label %ifcont15
 
-ifcont15:                                         ; preds = %ifcont14, %then5
-  br label %ifcont16
-
-ifcont16:                                         ; preds = %ifcont15, %then3
-  br label %ifcont17
-
-ifcont17:                                         ; preds = %ifcont16, %then
+ifcont15:                                         ; preds = %ifcont14, %then
   %41 = alloca i64, align 8
-  %42 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks1)
+  %42 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
   %43 = load i64, i64* %41, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -238,272 +236,272 @@ ifcont17:                                         ; preds = %ifcont16, %then
   %51 = icmp eq i8* %42, null
   br i1 %51, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont17
+free_nonnull:                                     ; preds = %ifcont15
   call void @_lfortran_free(i8* %42)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont17
-  %52 = load i32, i32* %out2, align 4
+free_done:                                        ; preds = %free_nonnull, %ifcont15
+  %52 = load i32, i32* %out, align 4
   %53 = icmp ne i32 %52, 1
-  br i1 %53, label %then18, label %else19
+  br i1 %53, label %then16, label %else17
 
-then18:                                           ; preds = %free_done
+then16:                                           ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else19:                                           ; preds = %free_done
-  br label %ifcont20
+else17:                                           ; preds = %free_done
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %else19, %then18
-  %54 = load i32, i32* %marks1, align 4
+ifcont18:                                         ; preds = %else17, %then16
+  %54 = load i32, i32* %marks, align 4
   %55 = icmp sle i32 91, %54
-  %56 = load i32, i32* %marks1, align 4
+  %56 = load i32, i32* %marks, align 4
   %57 = icmp sle i32 %56, 100
   %58 = icmp eq i1 %55, false
   %59 = select i1 %58, i1 %55, i1 %57
-  br i1 %59, label %then21, label %else22
+  br i1 %59, label %then19, label %else20
 
-then21:                                           ; preds = %ifcont20
+then19:                                           ; preds = %ifcont18
   %60 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %60, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
-  br label %ifcont38
+  br label %ifcont36
 
-else22:                                           ; preds = %ifcont20
-  %61 = load i32, i32* %marks1, align 4
+else20:                                           ; preds = %ifcont18
+  %61 = load i32, i32* %marks, align 4
   %62 = icmp sle i32 81, %61
-  %63 = load i32, i32* %marks1, align 4
+  %63 = load i32, i32* %marks, align 4
   %64 = icmp sle i32 %63, 90
   %65 = icmp eq i1 %62, false
   %66 = select i1 %65, i1 %62, i1 %64
-  br i1 %66, label %then23, label %else24
+  br i1 %66, label %then21, label %else22
 
-then23:                                           ; preds = %else22
+then21:                                           ; preds = %else20
   %67 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %67, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
-  br label %ifcont37
+  br label %ifcont35
 
-else24:                                           ; preds = %else22
-  %68 = load i32, i32* %marks1, align 4
+else22:                                           ; preds = %else20
+  %68 = load i32, i32* %marks, align 4
   %69 = icmp sle i32 71, %68
-  %70 = load i32, i32* %marks1, align 4
+  %70 = load i32, i32* %marks, align 4
   %71 = icmp sle i32 %70, 80
   %72 = icmp eq i1 %69, false
   %73 = select i1 %72, i1 %69, i1 %71
-  br i1 %73, label %then25, label %else26
+  br i1 %73, label %then23, label %else24
 
-then25:                                           ; preds = %else24
+then23:                                           ; preds = %else22
   %74 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %74, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
-  br label %ifcont36
+  br label %ifcont34
 
-else26:                                           ; preds = %else24
-  %75 = load i32, i32* %marks1, align 4
+else24:                                           ; preds = %else22
+  %75 = load i32, i32* %marks, align 4
   %76 = icmp sle i32 61, %75
-  %77 = load i32, i32* %marks1, align 4
+  %77 = load i32, i32* %marks, align 4
   %78 = icmp sle i32 %77, 70
   %79 = icmp eq i1 %76, false
   %80 = select i1 %79, i1 %76, i1 %78
-  br i1 %80, label %then27, label %else28
+  br i1 %80, label %then25, label %else26
 
-then27:                                           ; preds = %else26
+then25:                                           ; preds = %else24
   %81 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %81, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
-  br label %ifcont35
+  br label %ifcont33
 
-else28:                                           ; preds = %else26
-  %82 = load i32, i32* %marks1, align 4
+else26:                                           ; preds = %else24
+  %82 = load i32, i32* %marks, align 4
   %83 = icmp sle i32 41, %82
-  %84 = load i32, i32* %marks1, align 4
+  %84 = load i32, i32* %marks, align 4
   %85 = icmp sle i32 %84, 60
   %86 = icmp eq i1 %83, false
   %87 = select i1 %86, i1 %83, i1 %85
-  br i1 %87, label %then29, label %else30
+  br i1 %87, label %then27, label %else28
 
-then29:                                           ; preds = %else28
+then27:                                           ; preds = %else26
   %88 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %88, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
-  br label %ifcont34
+  br label %ifcont32
 
-else30:                                           ; preds = %else28
-  %89 = load i32, i32* %marks1, align 4
+else28:                                           ; preds = %else26
+  %89 = load i32, i32* %marks, align 4
   %90 = icmp sle i32 %89, 40
-  br i1 %90, label %then31, label %else32
+  br i1 %90, label %then29, label %else30
 
-then31:                                           ; preds = %else30
+then29:                                           ; preds = %else28
   %91 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %91, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
-  br label %ifcont33
+  br label %ifcont31
 
-else32:                                           ; preds = %else30
+else30:                                           ; preds = %else28
   %92 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %92, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  br label %ifcont31
+
+ifcont31:                                         ; preds = %else30, %then29
+  br label %ifcont32
+
+ifcont32:                                         ; preds = %ifcont31, %then27
   br label %ifcont33
 
-ifcont33:                                         ; preds = %else32, %then31
+ifcont33:                                         ; preds = %ifcont32, %then25
   br label %ifcont34
 
-ifcont34:                                         ; preds = %ifcont33, %then29
+ifcont34:                                         ; preds = %ifcont33, %then23
   br label %ifcont35
 
-ifcont35:                                         ; preds = %ifcont34, %then27
+ifcont35:                                         ; preds = %ifcont34, %then21
   br label %ifcont36
 
-ifcont36:                                         ; preds = %ifcont35, %then25
-  br label %ifcont37
-
-ifcont37:                                         ; preds = %ifcont36, %then23
-  br label %ifcont38
-
-ifcont38:                                         ; preds = %ifcont37, %then21
+ifcont36:                                         ; preds = %ifcont35, %then19
   %93 = alloca i64, align 8
-  %94 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks1)
+  %94 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
   %95 = load i64, i64* %93, align 4
-  %stringFormat_desc39 = alloca %string_descriptor, align 8
-  %96 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc39, i32 0, i32 0
+  %stringFormat_desc37 = alloca %string_descriptor, align 8
+  %96 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
   store i8* %94, i8** %96, align 8
-  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc39, i32 0, i32 1
+  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
   store i64 %95, i64* %97, align 4
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc39, i32 0, i32 0
+  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
   %99 = load i8*, i8** %98, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc39, i32 0, i32 1
+  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
   %101 = load i64, i64* %100, align 4
   %102 = trunc i64 %101 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %99, i32 %102, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
   %103 = icmp eq i8* %94, null
-  br i1 %103, label %free_done41, label %free_nonnull40
+  br i1 %103, label %free_done39, label %free_nonnull38
 
-free_nonnull40:                                   ; preds = %ifcont38
+free_nonnull38:                                   ; preds = %ifcont36
   call void @_lfortran_free(i8* %94)
-  br label %free_done41
+  br label %free_done39
 
-free_done41:                                      ; preds = %free_nonnull40, %ifcont38
-  %104 = load i32, i32* %marks1, align 4
+free_done39:                                      ; preds = %free_nonnull38, %ifcont36
+  %104 = load i32, i32* %marks, align 4
   %105 = icmp sle i32 91, %104
-  %106 = load i32, i32* %marks1, align 4
+  %106 = load i32, i32* %marks, align 4
   %107 = icmp sle i32 %106, 100
   %108 = icmp eq i1 %105, false
   %109 = select i1 %108, i1 %105, i1 %107
-  br i1 %109, label %then42, label %else43
+  br i1 %109, label %then40, label %else41
 
-then42:                                           ; preds = %free_done41
+then40:                                           ; preds = %free_done39
   %110 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.33, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %110, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
-  br label %ifcont59
+  br label %ifcont57
 
-else43:                                           ; preds = %free_done41
-  %111 = load i32, i32* %marks1, align 4
+else41:                                           ; preds = %free_done39
+  %111 = load i32, i32* %marks, align 4
   %112 = icmp sle i32 81, %111
-  %113 = load i32, i32* %marks1, align 4
+  %113 = load i32, i32* %marks, align 4
   %114 = icmp sle i32 %113, 90
   %115 = icmp eq i1 %112, false
   %116 = select i1 %115, i1 %112, i1 %114
-  br i1 %116, label %then44, label %else45
+  br i1 %116, label %then42, label %else43
 
-then44:                                           ; preds = %else43
+then42:                                           ; preds = %else41
   %117 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.35, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %117, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
-  br label %ifcont58
+  br label %ifcont56
 
-else45:                                           ; preds = %else43
-  %118 = load i32, i32* %marks1, align 4
+else43:                                           ; preds = %else41
+  %118 = load i32, i32* %marks, align 4
   %119 = icmp sle i32 71, %118
-  %120 = load i32, i32* %marks1, align 4
+  %120 = load i32, i32* %marks, align 4
   %121 = icmp sle i32 %120, 80
   %122 = icmp eq i1 %119, false
   %123 = select i1 %122, i1 %119, i1 %121
-  br i1 %123, label %then46, label %else47
+  br i1 %123, label %then44, label %else45
 
-then46:                                           ; preds = %else45
+then44:                                           ; preds = %else43
   %124 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.37, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %124, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
-  br label %ifcont57
+  br label %ifcont55
 
-else47:                                           ; preds = %else45
-  %125 = load i32, i32* %marks1, align 4
+else45:                                           ; preds = %else43
+  %125 = load i32, i32* %marks, align 4
   %126 = icmp sle i32 61, %125
-  %127 = load i32, i32* %marks1, align 4
+  %127 = load i32, i32* %marks, align 4
   %128 = icmp sle i32 %127, 70
   %129 = icmp eq i1 %126, false
   %130 = select i1 %129, i1 %126, i1 %128
-  br i1 %130, label %then48, label %else49
+  br i1 %130, label %then46, label %else47
 
-then48:                                           ; preds = %else47
+then46:                                           ; preds = %else45
   %131 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.39, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %131, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
-  br label %ifcont56
+  br label %ifcont54
 
-else49:                                           ; preds = %else47
-  %132 = load i32, i32* %marks1, align 4
+else47:                                           ; preds = %else45
+  %132 = load i32, i32* %marks, align 4
   %133 = icmp sle i32 41, %132
-  %134 = load i32, i32* %marks1, align 4
+  %134 = load i32, i32* %marks, align 4
   %135 = icmp sle i32 %134, 60
   %136 = icmp eq i1 %133, false
   %137 = select i1 %136, i1 %133, i1 %135
-  br i1 %137, label %then50, label %else51
+  br i1 %137, label %then48, label %else49
 
-then50:                                           ; preds = %else49
+then48:                                           ; preds = %else47
   %138 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.41, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %138, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
-  br label %ifcont55
+  br label %ifcont53
 
-else51:                                           ; preds = %else49
-  %139 = load i32, i32* %marks1, align 4
+else49:                                           ; preds = %else47
+  %139 = load i32, i32* %marks, align 4
   %140 = icmp sle i32 %139, 40
-  br i1 %140, label %then52, label %else53
+  br i1 %140, label %then50, label %else51
 
-then52:                                           ; preds = %else51
+then50:                                           ; preds = %else49
   %141 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.43, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %141, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
-  br label %ifcont54
+  br label %ifcont52
 
-else53:                                           ; preds = %else51
+else51:                                           ; preds = %else49
   %142 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.45, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %142, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
+  br label %ifcont52
+
+ifcont52:                                         ; preds = %else51, %then50
+  br label %ifcont53
+
+ifcont53:                                         ; preds = %ifcont52, %then48
   br label %ifcont54
 
-ifcont54:                                         ; preds = %else53, %then52
+ifcont54:                                         ; preds = %ifcont53, %then46
   br label %ifcont55
 
-ifcont55:                                         ; preds = %ifcont54, %then50
+ifcont55:                                         ; preds = %ifcont54, %then44
   br label %ifcont56
 
-ifcont56:                                         ; preds = %ifcont55, %then48
+ifcont56:                                         ; preds = %ifcont55, %then42
   br label %ifcont57
 
-ifcont57:                                         ; preds = %ifcont56, %then46
-  br label %ifcont58
-
-ifcont58:                                         ; preds = %ifcont57, %then44
-  br label %ifcont59
-
-ifcont59:                                         ; preds = %ifcont58, %then42
+ifcont57:                                         ; preds = %ifcont56, %then40
   %143 = alloca i64, align 8
-  %144 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %143, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks1)
+  %144 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %143, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
   %145 = load i64, i64* %143, align 4
-  %stringFormat_desc60 = alloca %string_descriptor, align 8
-  %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc60, i32 0, i32 0
+  %stringFormat_desc58 = alloca %string_descriptor, align 8
+  %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
   store i8* %144, i8** %146, align 8
-  %147 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc60, i32 0, i32 1
+  %147 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1
   store i64 %145, i64* %147, align 4
-  %148 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc60, i32 0, i32 0
+  %148 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
   %149 = load i8*, i8** %148, align 8
-  %150 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc60, i32 0, i32 1
+  %150 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1
   %151 = load i64, i64* %150, align 4
   %152 = trunc i64 %151 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %149, i32 %152, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
   %153 = icmp eq i8* %144, null
-  br i1 %153, label %free_done62, label %free_nonnull61
+  br i1 %153, label %free_done60, label %free_nonnull59
 
-free_nonnull61:                                   ; preds = %ifcont59
+free_nonnull59:                                   ; preds = %ifcont57
   call void @_lfortran_free(i8* %144)
-  br label %free_done62
+  br label %free_done60
 
-free_done62:                                      ; preds = %free_nonnull61, %ifcont59
+free_done60:                                      ; preds = %free_nonnull59, %ifcont57
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done62
+return:                                           ; preds = %free_done60
   br label %FINALIZE_SYMTABLE_case_02
 
 FINALIZE_SYMTABLE_case_02:                        ; preds = %return

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "2d1d880d1e13dd652ce82ae286a2a10f48737ef2bbb6608d8f0f777b",
+    "stdout_hash": "433cb208c3bc226f1385b9b8fae2e1d9dbe9b5ba2bbabc66c2de965a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -40,48 +40,43 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   store i32 1, i32* %a, align 4
   %b = alloca i32, align 4
   store i32 2, i32* %b, align 4
   %marks = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a1 = alloca i32, align 4
-  store i32 1, i32* %a1, align 4
-  %b2 = alloca i32, align 4
-  store i32 2, i32* %b2, align 4
-  %marks3 = alloca i32, align 4
-  store i32 94, i32* %marks3, align 4
-  %2 = load i32, i32* %marks3, align 4
+  store i32 94, i32* %marks, align 4
+  %2 = load i32, i32* %marks, align 4
   %3 = icmp sle i32 42, %2
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
   %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  br label %ifcont6
+  br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %5 = load i32, i32* %marks3, align 4
+  %5 = load i32, i32* %marks, align 4
   %6 = icmp sle i32 %5, 38
-  br i1 %6, label %then4, label %else5
+  br i1 %6, label %then1, label %else2
 
-then4:                                            ; preds = %else
+then1:                                            ; preds = %else
   %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont
 
-else5:                                            ; preds = %else
+else2:                                            ; preds = %else
   %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %8, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont
 
-ifcont:                                           ; preds = %else5, %then4
-  br label %ifcont6
+ifcont:                                           ; preds = %else2, %then1
+  br label %ifcont3
 
-ifcont6:                                          ; preds = %ifcont, %then
+ifcont3:                                          ; preds = %ifcont, %then
   %9 = alloca i64, align 8
-  %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks3)
+  %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
   %11 = load i64, i64* %9, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -97,70 +92,70 @@ ifcont6:                                          ; preds = %ifcont, %then
   %19 = icmp eq i8* %10, null
   br i1 %19, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont6
+free_nonnull:                                     ; preds = %ifcont3
   call void @_lfortran_free(i8* %10)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont6
-  store i32 -1, i32* %marks3, align 4
-  %20 = load i32, i32* %marks3, align 4
+free_done:                                        ; preds = %free_nonnull, %ifcont3
+  store i32 -1, i32* %marks, align 4
+  %20 = load i32, i32* %marks, align 4
   %21 = icmp sle i32 42, %20
-  br i1 %21, label %then7, label %else8
+  br i1 %21, label %then4, label %else5
 
-then7:                                            ; preds = %free_done
+then4:                                            ; preds = %free_done
   %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %22, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  br label %ifcont12
+  br label %ifcont9
 
-else8:                                            ; preds = %free_done
-  %23 = load i32, i32* %marks3, align 4
+else5:                                            ; preds = %free_done
+  %23 = load i32, i32* %marks, align 4
   %24 = icmp sle i32 0, %23
-  %25 = load i32, i32* %marks3, align 4
+  %25 = load i32, i32* %marks, align 4
   %26 = icmp sle i32 %25, 38
   %27 = icmp eq i1 %24, false
   %28 = select i1 %27, i1 %24, i1 %26
-  br i1 %28, label %then9, label %else10
+  br i1 %28, label %then6, label %else7
 
-then9:                                            ; preds = %else8
+then6:                                            ; preds = %else5
   %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  br label %ifcont11
+  br label %ifcont8
 
-else10:                                           ; preds = %else8
+else7:                                            ; preds = %else5
   %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %30, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  br label %ifcont11
+  br label %ifcont8
 
-ifcont11:                                         ; preds = %else10, %then9
-  br label %ifcont12
+ifcont8:                                          ; preds = %else7, %then6
+  br label %ifcont9
 
-ifcont12:                                         ; preds = %ifcont11, %then7
+ifcont9:                                          ; preds = %ifcont8, %then4
   %31 = alloca i64, align 8
-  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks3)
+  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
   %33 = load i64, i64* %31, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   store i64 %33, i64* %35, align 4
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %39 = load i64, i64* %38, align 4
   %40 = trunc i64 %39 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %41 = icmp eq i8* %32, null
-  br i1 %41, label %free_done15, label %free_nonnull14
+  br i1 %41, label %free_done12, label %free_nonnull11
 
-free_nonnull14:                                   ; preds = %ifcont12
+free_nonnull11:                                   ; preds = %ifcont9
   call void @_lfortran_free(i8* %32)
-  br label %free_done15
+  br label %free_done12
 
-free_done15:                                      ; preds = %free_nonnull14, %ifcont12
+free_done12:                                      ; preds = %free_nonnull11, %ifcont9
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done15
+return:                                           ; preds = %free_done12
   br label %FINALIZE_SYMTABLE_case03
 
 FINALIZE_SYMTABLE_case03:                         ; preds = %return

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "742289fce89e8ee644d28a3482e8067f5b07139648c6820a9660e2a2",
+    "stdout_hash": "208f0903740833f342c5dc73f3b67ecca19de2469f8f4e8298e874f7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -14,15 +14,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %prec11 = alloca i32, align 4
-  store i32 4, i32* %prec11, align 4
-  %prec22 = alloca i32, align 4
-  store i32 8, i32* %prec22, align 4
   store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, %complex_4* @complex_dp_param.u, align 1
   store %complex_8 <{ double 0x3FF0CCCCC0000000, double 1.050000e+00 }>, %complex_8* @complex_dp_param.v, align 1
   store %complex_8 zeroinitializer, %complex_8* @complex_dp_param.zero, align 1

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "9b40c4a68647046e1d970f566fe6627efc039a2148410ffe3cf7bc89",
+    "stdout_hash": "6ffd524566b9138ae5e2052579cfdfb88ee3b6fe9082e5dd8c4b8b5a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -4,27 +4,25 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   %i = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a1 = alloca i32, align 4
-  %i2 = alloca i32, align 4
-  store i32 0, i32* %i2, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i2, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i2, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i2, align 4
+  store i32 %6, i32* %i, align 4
   store i32 5, i32* %call_arg_value, align 4
   %7 = call i32 @f(i32* %call_arg_value)
-  store i32 %7, i32* %a1, align 4
+  store i32 %7, i32* %a, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "8d4a49f7a46fbcaf10aecc62b0543b0185212839ff4a5c74ca351c83",
+    "stdout_hash": "87118ca8bea5d05ddb350263fae058a09814e478137d31580b67d1a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -62,33 +62,31 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i1, align 4
-  %7 = load i32, i32* %j2, align 4
-  %8 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %i, align 4
+  %7 = load i32, i32* %j, align 4
+  %8 = load i32, i32* %i, align 4
   %9 = add i32 %7, %8
-  store i32 %9, i32* %j2, align 4
+  store i32 %9, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %10 = load i32, i32* %j2, align 4
+  %10 = load i32, i32* %j, align 4
   %11 = icmp ne i32 %10, 55
   br i1 %11, label %then, label %else
 
@@ -102,7 +100,7 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32* %j2)
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32* %j)
   %14 = load i64, i64* %12, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -123,570 +121,570 @@ free_nonnull:                                     ; preds = %ifcont
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %j2, align 4
-  store i32 11, i32* %i1, align 4
-  br label %loop.head3
+  store i32 0, i32* %j, align 4
+  store i32 11, i32* %i, align 4
+  br label %loop.head1
 
-loop.head3:                                       ; preds = %loop.body4, %free_done
-  %23 = load i32, i32* %i1, align 4
+loop.head1:                                       ; preds = %loop.body2, %free_done
+  %23 = load i32, i32* %i, align 4
   %24 = add i32 %23, -1
   %25 = icmp sge i32 %24, 1
-  br i1 %25, label %loop.body4, label %loop.end5
+  br i1 %25, label %loop.body2, label %loop.end3
 
-loop.body4:                                       ; preds = %loop.head3
-  %26 = load i32, i32* %i1, align 4
+loop.body2:                                       ; preds = %loop.head1
+  %26 = load i32, i32* %i, align 4
   %27 = add i32 %26, -1
-  store i32 %27, i32* %i1, align 4
-  %28 = load i32, i32* %j2, align 4
-  %29 = load i32, i32* %i1, align 4
+  store i32 %27, i32* %i, align 4
+  %28 = load i32, i32* %j, align 4
+  %29 = load i32, i32* %i, align 4
   %30 = add i32 %28, %29
-  store i32 %30, i32* %j2, align 4
-  br label %loop.head3
+  store i32 %30, i32* %j, align 4
+  br label %loop.head1
 
-loop.end5:                                        ; preds = %loop.head3
-  %31 = load i32, i32* %j2, align 4
+loop.end3:                                        ; preds = %loop.head1
+  %31 = load i32, i32* %j, align 4
   %32 = icmp ne i32 %31, 55
-  br i1 %32, label %then6, label %else7
+  br i1 %32, label %then4, label %else5
 
-then6:                                            ; preds = %loop.end5
+then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont6
 
-else7:                                            ; preds = %loop.end5
-  br label %ifcont8
+else5:                                            ; preds = %loop.end3
+  br label %ifcont6
 
-ifcont8:                                          ; preds = %else7, %then6
+ifcont6:                                          ; preds = %else5, %then4
   %33 = alloca i64, align 8
-  %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %33, i32 0, i32 0, i32* %j2)
+  %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %33, i32 0, i32 0, i32* %j)
   %35 = load i64, i64* %33, align 4
-  %stringFormat_desc9 = alloca %string_descriptor, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc9, i32 0, i32 0
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %34, i8** %36, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc9, i32 0, i32 1
+  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   store i64 %35, i64* %37, align 4
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc9, i32 0, i32 0
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   %39 = load i8*, i8** %38, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc9, i32 0, i32 1
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %41 = load i64, i64* %40, align 4
   %42 = trunc i64 %41 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %39, i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %43 = icmp eq i8* %34, null
-  br i1 %43, label %free_done11, label %free_nonnull10
+  br i1 %43, label %free_done9, label %free_nonnull8
 
-free_nonnull10:                                   ; preds = %ifcont8
+free_nonnull8:                                    ; preds = %ifcont6
   call void @_lfortran_free(i8* %34)
-  br label %free_done11
+  br label %free_done9
 
-free_done11:                                      ; preds = %free_nonnull10, %ifcont8
-  store i32 0, i32* %j2, align 4
-  store i32 -1, i32* %i1, align 4
-  br label %loop.head12
+free_done9:                                       ; preds = %free_nonnull8, %ifcont6
+  store i32 0, i32* %j, align 4
+  store i32 -1, i32* %i, align 4
+  br label %loop.head10
 
-loop.head12:                                      ; preds = %loop.body13, %free_done11
-  %44 = load i32, i32* %i1, align 4
+loop.head10:                                      ; preds = %loop.body11, %free_done9
+  %44 = load i32, i32* %i, align 4
   %45 = add i32 %44, 2
   %46 = icmp sle i32 %45, 9
-  br i1 %46, label %loop.body13, label %loop.end14
+  br i1 %46, label %loop.body11, label %loop.end12
 
-loop.body13:                                      ; preds = %loop.head12
-  %47 = load i32, i32* %i1, align 4
+loop.body11:                                      ; preds = %loop.head10
+  %47 = load i32, i32* %i, align 4
   %48 = add i32 %47, 2
-  store i32 %48, i32* %i1, align 4
-  %49 = load i32, i32* %j2, align 4
-  %50 = load i32, i32* %i1, align 4
+  store i32 %48, i32* %i, align 4
+  %49 = load i32, i32* %j, align 4
+  %50 = load i32, i32* %i, align 4
   %51 = add i32 %49, %50
-  store i32 %51, i32* %j2, align 4
-  br label %loop.head12
+  store i32 %51, i32* %j, align 4
+  br label %loop.head10
 
-loop.end14:                                       ; preds = %loop.head12
-  %52 = load i32, i32* %j2, align 4
+loop.end12:                                       ; preds = %loop.head10
+  %52 = load i32, i32* %j, align 4
   %53 = icmp ne i32 %52, 25
-  br i1 %53, label %then15, label %else16
+  br i1 %53, label %then13, label %else14
 
-then15:                                           ; preds = %loop.end14
+then13:                                           ; preds = %loop.end12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont17
+  br label %ifcont15
 
-else16:                                           ; preds = %loop.end14
-  br label %ifcont17
+else14:                                           ; preds = %loop.end12
+  br label %ifcont15
 
-ifcont17:                                         ; preds = %else16, %then15
+ifcont15:                                         ; preds = %else14, %then13
   %54 = alloca i64, align 8
-  %55 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %54, i32 0, i32 0, i32* %j2)
+  %55 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %54, i32 0, i32 0, i32* %j)
   %56 = load i64, i64* %54, align 4
-  %stringFormat_desc18 = alloca %string_descriptor, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc18, i32 0, i32 0
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %55, i8** %57, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc18, i32 0, i32 1
+  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   store i64 %56, i64* %58, align 4
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc18, i32 0, i32 0
+  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   %60 = load i8*, i8** %59, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc18, i32 0, i32 1
+  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %62 = load i64, i64* %61, align 4
   %63 = trunc i64 %62 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %60, i32 %63, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %64 = icmp eq i8* %55, null
-  br i1 %64, label %free_done20, label %free_nonnull19
+  br i1 %64, label %free_done18, label %free_nonnull17
 
-free_nonnull19:                                   ; preds = %ifcont17
+free_nonnull17:                                   ; preds = %ifcont15
   call void @_lfortran_free(i8* %55)
-  br label %free_done20
+  br label %free_done18
 
-free_done20:                                      ; preds = %free_nonnull19, %ifcont17
-  store i32 0, i32* %j2, align 4
-  store i32 11, i32* %i1, align 4
-  br label %loop.head21
+free_done18:                                      ; preds = %free_nonnull17, %ifcont15
+  store i32 0, i32* %j, align 4
+  store i32 11, i32* %i, align 4
+  br label %loop.head19
 
-loop.head21:                                      ; preds = %loop.body22, %free_done20
-  %65 = load i32, i32* %i1, align 4
+loop.head19:                                      ; preds = %loop.body20, %free_done18
+  %65 = load i32, i32* %i, align 4
   %66 = add i32 %65, -2
   %67 = icmp sge i32 %66, 1
-  br i1 %67, label %loop.body22, label %loop.end23
+  br i1 %67, label %loop.body20, label %loop.end21
 
-loop.body22:                                      ; preds = %loop.head21
-  %68 = load i32, i32* %i1, align 4
+loop.body20:                                      ; preds = %loop.head19
+  %68 = load i32, i32* %i, align 4
   %69 = add i32 %68, -2
-  store i32 %69, i32* %i1, align 4
-  %70 = load i32, i32* %j2, align 4
-  %71 = load i32, i32* %i1, align 4
+  store i32 %69, i32* %i, align 4
+  %70 = load i32, i32* %j, align 4
+  %71 = load i32, i32* %i, align 4
   %72 = add i32 %70, %71
-  store i32 %72, i32* %j2, align 4
-  br label %loop.head21
+  store i32 %72, i32* %j, align 4
+  br label %loop.head19
 
-loop.end23:                                       ; preds = %loop.head21
-  %73 = load i32, i32* %j2, align 4
+loop.end21:                                       ; preds = %loop.head19
+  %73 = load i32, i32* %j, align 4
   %74 = icmp ne i32 %73, 25
-  br i1 %74, label %then24, label %else25
+  br i1 %74, label %then22, label %else23
 
-then24:                                           ; preds = %loop.end23
+then22:                                           ; preds = %loop.end21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %loop.end23
-  br label %ifcont26
+else23:                                           ; preds = %loop.end21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %then24
+ifcont24:                                         ; preds = %else23, %then22
   %75 = alloca i64, align 8
-  %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %75, i32 0, i32 0, i32* %j2)
+  %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %75, i32 0, i32 0, i32* %j)
   %77 = load i64, i64* %75, align 4
-  %stringFormat_desc27 = alloca %string_descriptor, align 8
-  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc27, i32 0, i32 0
+  %stringFormat_desc25 = alloca %string_descriptor, align 8
+  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
   store i8* %76, i8** %78, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc27, i32 0, i32 1
+  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
   store i64 %77, i64* %79, align 4
-  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc27, i32 0, i32 0
+  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
   %81 = load i8*, i8** %80, align 8
-  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc27, i32 0, i32 1
+  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
   %83 = load i64, i64* %82, align 4
   %84 = trunc i64 %83 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %81, i32 %84, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %85 = icmp eq i8* %76, null
-  br i1 %85, label %free_done29, label %free_nonnull28
+  br i1 %85, label %free_done27, label %free_nonnull26
 
-free_nonnull28:                                   ; preds = %ifcont26
+free_nonnull26:                                   ; preds = %ifcont24
   call void @_lfortran_free(i8* %76)
-  br label %free_done29
+  br label %free_done27
 
-free_done29:                                      ; preds = %free_nonnull28, %ifcont26
-  store i32 0, i32* %j2, align 4
-  store i32 -1, i32* %i1, align 4
-  br label %loop.head30
+free_done27:                                      ; preds = %free_nonnull26, %ifcont24
+  store i32 0, i32* %j, align 4
+  store i32 -1, i32* %i, align 4
+  br label %loop.head28
 
-loop.head30:                                      ; preds = %loop.body31, %free_done29
-  %86 = load i32, i32* %i1, align 4
+loop.head28:                                      ; preds = %loop.body29, %free_done27
+  %86 = load i32, i32* %i, align 4
   %87 = add i32 %86, 2
   %88 = icmp sle i32 %87, 10
-  br i1 %88, label %loop.body31, label %loop.end32
+  br i1 %88, label %loop.body29, label %loop.end30
 
-loop.body31:                                      ; preds = %loop.head30
-  %89 = load i32, i32* %i1, align 4
+loop.body29:                                      ; preds = %loop.head28
+  %89 = load i32, i32* %i, align 4
   %90 = add i32 %89, 2
-  store i32 %90, i32* %i1, align 4
-  %91 = load i32, i32* %j2, align 4
-  %92 = load i32, i32* %i1, align 4
+  store i32 %90, i32* %i, align 4
+  %91 = load i32, i32* %j, align 4
+  %92 = load i32, i32* %i, align 4
   %93 = add i32 %91, %92
-  store i32 %93, i32* %j2, align 4
-  br label %loop.head30
+  store i32 %93, i32* %j, align 4
+  br label %loop.head28
 
-loop.end32:                                       ; preds = %loop.head30
-  %94 = load i32, i32* %j2, align 4
+loop.end30:                                       ; preds = %loop.head28
+  %94 = load i32, i32* %j, align 4
   %95 = icmp ne i32 %94, 25
-  br i1 %95, label %then33, label %else34
+  br i1 %95, label %then31, label %else32
 
-then33:                                           ; preds = %loop.end32
+then31:                                           ; preds = %loop.end30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont35
+  br label %ifcont33
 
-else34:                                           ; preds = %loop.end32
-  br label %ifcont35
+else32:                                           ; preds = %loop.end30
+  br label %ifcont33
 
-ifcont35:                                         ; preds = %else34, %then33
+ifcont33:                                         ; preds = %else32, %then31
   %96 = alloca i64, align 8
-  %97 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %96, i32 0, i32 0, i32* %j2)
+  %97 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %96, i32 0, i32 0, i32* %j)
   %98 = load i64, i64* %96, align 4
-  %stringFormat_desc36 = alloca %string_descriptor, align 8
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc36, i32 0, i32 0
+  %stringFormat_desc34 = alloca %string_descriptor, align 8
+  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
   store i8* %97, i8** %99, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc36, i32 0, i32 1
+  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
   store i64 %98, i64* %100, align 4
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc36, i32 0, i32 0
+  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
   %102 = load i8*, i8** %101, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc36, i32 0, i32 1
+  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
   %104 = load i64, i64* %103, align 4
   %105 = trunc i64 %104 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   %106 = icmp eq i8* %97, null
-  br i1 %106, label %free_done38, label %free_nonnull37
+  br i1 %106, label %free_done36, label %free_nonnull35
 
-free_nonnull37:                                   ; preds = %ifcont35
+free_nonnull35:                                   ; preds = %ifcont33
   call void @_lfortran_free(i8* %97)
-  br label %free_done38
+  br label %free_done36
 
-free_done38:                                      ; preds = %free_nonnull37, %ifcont35
-  store i32 0, i32* %j2, align 4
-  store i32 -2, i32* %i1, align 4
-  br label %loop.head39
+free_done36:                                      ; preds = %free_nonnull35, %ifcont33
+  store i32 0, i32* %j, align 4
+  store i32 -2, i32* %i, align 4
+  br label %loop.head37
 
-loop.head39:                                      ; preds = %loop.body40, %free_done38
-  %107 = load i32, i32* %i1, align 4
+loop.head37:                                      ; preds = %loop.body38, %free_done36
+  %107 = load i32, i32* %i, align 4
   %108 = add i32 %107, 3
   %109 = icmp sle i32 %108, 10
-  br i1 %109, label %loop.body40, label %loop.end41
+  br i1 %109, label %loop.body38, label %loop.end39
 
-loop.body40:                                      ; preds = %loop.head39
-  %110 = load i32, i32* %i1, align 4
+loop.body38:                                      ; preds = %loop.head37
+  %110 = load i32, i32* %i, align 4
   %111 = add i32 %110, 3
-  store i32 %111, i32* %i1, align 4
-  %112 = load i32, i32* %j2, align 4
-  %113 = load i32, i32* %i1, align 4
+  store i32 %111, i32* %i, align 4
+  %112 = load i32, i32* %j, align 4
+  %113 = load i32, i32* %i, align 4
   %114 = add i32 %112, %113
-  store i32 %114, i32* %j2, align 4
-  br label %loop.head39
+  store i32 %114, i32* %j, align 4
+  br label %loop.head37
 
-loop.end41:                                       ; preds = %loop.head39
-  %115 = load i32, i32* %j2, align 4
+loop.end39:                                       ; preds = %loop.head37
+  %115 = load i32, i32* %j, align 4
   %116 = icmp ne i32 %115, 22
-  br i1 %116, label %then42, label %else43
+  br i1 %116, label %then40, label %else41
 
-then42:                                           ; preds = %loop.end41
+then40:                                           ; preds = %loop.end39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont44
+  br label %ifcont42
 
-else43:                                           ; preds = %loop.end41
-  br label %ifcont44
+else41:                                           ; preds = %loop.end39
+  br label %ifcont42
 
-ifcont44:                                         ; preds = %else43, %then42
+ifcont42:                                         ; preds = %else41, %then40
   %117 = alloca i64, align 8
-  %118 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %117, i32 0, i32 0, i32* %j2)
+  %118 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %117, i32 0, i32 0, i32* %j)
   %119 = load i64, i64* %117, align 4
-  %stringFormat_desc45 = alloca %string_descriptor, align 8
-  %120 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc45, i32 0, i32 0
+  %stringFormat_desc43 = alloca %string_descriptor, align 8
+  %120 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
   store i8* %118, i8** %120, align 8
-  %121 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc45, i32 0, i32 1
+  %121 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
   store i64 %119, i64* %121, align 4
-  %122 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc45, i32 0, i32 0
+  %122 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
   %123 = load i8*, i8** %122, align 8
-  %124 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc45, i32 0, i32 1
+  %124 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
   %125 = load i64, i64* %124, align 4
   %126 = trunc i64 %125 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %123, i32 %126, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   %127 = icmp eq i8* %118, null
-  br i1 %127, label %free_done47, label %free_nonnull46
+  br i1 %127, label %free_done45, label %free_nonnull44
 
-free_nonnull46:                                   ; preds = %ifcont44
+free_nonnull44:                                   ; preds = %ifcont42
   call void @_lfortran_free(i8* %118)
-  br label %free_done47
+  br label %free_done45
 
-free_done47:                                      ; preds = %free_nonnull46, %ifcont44
-  store i32 0, i32* %j2, align 4
-  store i32 13, i32* %i1, align 4
-  br label %loop.head48
+free_done45:                                      ; preds = %free_nonnull44, %ifcont42
+  store i32 0, i32* %j, align 4
+  store i32 13, i32* %i, align 4
+  br label %loop.head46
 
-loop.head48:                                      ; preds = %loop.body49, %free_done47
-  %128 = load i32, i32* %i1, align 4
+loop.head46:                                      ; preds = %loop.body47, %free_done45
+  %128 = load i32, i32* %i, align 4
   %129 = add i32 %128, -3
   %130 = icmp sge i32 %129, 1
-  br i1 %130, label %loop.body49, label %loop.end50
+  br i1 %130, label %loop.body47, label %loop.end48
 
-loop.body49:                                      ; preds = %loop.head48
-  %131 = load i32, i32* %i1, align 4
+loop.body47:                                      ; preds = %loop.head46
+  %131 = load i32, i32* %i, align 4
   %132 = add i32 %131, -3
-  store i32 %132, i32* %i1, align 4
-  %133 = load i32, i32* %j2, align 4
-  %134 = load i32, i32* %i1, align 4
+  store i32 %132, i32* %i, align 4
+  %133 = load i32, i32* %j, align 4
+  %134 = load i32, i32* %i, align 4
   %135 = add i32 %133, %134
-  store i32 %135, i32* %j2, align 4
-  br label %loop.head48
+  store i32 %135, i32* %j, align 4
+  br label %loop.head46
 
-loop.end50:                                       ; preds = %loop.head48
-  %136 = load i32, i32* %j2, align 4
+loop.end48:                                       ; preds = %loop.head46
+  %136 = load i32, i32* %j, align 4
   %137 = icmp ne i32 %136, 22
-  br i1 %137, label %then51, label %else52
+  br i1 %137, label %then49, label %else50
 
-then51:                                           ; preds = %loop.end50
+then49:                                           ; preds = %loop.end48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont53
+  br label %ifcont51
 
-else52:                                           ; preds = %loop.end50
-  br label %ifcont53
+else50:                                           ; preds = %loop.end48
+  br label %ifcont51
 
-ifcont53:                                         ; preds = %else52, %then51
+ifcont51:                                         ; preds = %else50, %then49
   %138 = alloca i64, align 8
-  %139 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %138, i32 0, i32 0, i32* %j2)
+  %139 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %138, i32 0, i32 0, i32* %j)
   %140 = load i64, i64* %138, align 4
-  %stringFormat_desc54 = alloca %string_descriptor, align 8
-  %141 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc54, i32 0, i32 0
+  %stringFormat_desc52 = alloca %string_descriptor, align 8
+  %141 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
   store i8* %139, i8** %141, align 8
-  %142 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc54, i32 0, i32 1
+  %142 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
   store i64 %140, i64* %142, align 4
-  %143 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc54, i32 0, i32 0
+  %143 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
   %144 = load i8*, i8** %143, align 8
-  %145 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc54, i32 0, i32 1
+  %145 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
   %146 = load i64, i64* %145, align 4
   %147 = trunc i64 %146 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %144, i32 %147, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   %148 = icmp eq i8* %139, null
-  br i1 %148, label %free_done56, label %free_nonnull55
+  br i1 %148, label %free_done54, label %free_nonnull53
 
-free_nonnull55:                                   ; preds = %ifcont53
+free_nonnull53:                                   ; preds = %ifcont51
   call void @_lfortran_free(i8* %139)
-  br label %free_done56
+  br label %free_done54
 
-free_done56:                                      ; preds = %free_nonnull55, %ifcont53
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
-  br label %loop.head57
+free_done54:                                      ; preds = %free_nonnull53, %ifcont51
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head55
 
-loop.head57:                                      ; preds = %loop.body58, %free_done56
-  %149 = load i32, i32* %i1, align 4
+loop.head55:                                      ; preds = %loop.body56, %free_done54
+  %149 = load i32, i32* %i, align 4
   %150 = add i32 %149, 1
   %151 = icmp sle i32 %150, 1
-  br i1 %151, label %loop.body58, label %loop.end59
+  br i1 %151, label %loop.body56, label %loop.end57
 
-loop.body58:                                      ; preds = %loop.head57
-  %152 = load i32, i32* %i1, align 4
+loop.body56:                                      ; preds = %loop.head55
+  %152 = load i32, i32* %i, align 4
   %153 = add i32 %152, 1
-  store i32 %153, i32* %i1, align 4
-  %154 = load i32, i32* %j2, align 4
-  %155 = load i32, i32* %i1, align 4
+  store i32 %153, i32* %i, align 4
+  %154 = load i32, i32* %j, align 4
+  %155 = load i32, i32* %i, align 4
   %156 = add i32 %154, %155
-  store i32 %156, i32* %j2, align 4
-  br label %loop.head57
+  store i32 %156, i32* %j, align 4
+  br label %loop.head55
 
-loop.end59:                                       ; preds = %loop.head57
-  %157 = load i32, i32* %j2, align 4
+loop.end57:                                       ; preds = %loop.head55
+  %157 = load i32, i32* %j, align 4
   %158 = icmp ne i32 %157, 1
-  br i1 %158, label %then60, label %else61
+  br i1 %158, label %then58, label %else59
 
-then60:                                           ; preds = %loop.end59
+then58:                                           ; preds = %loop.end57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont62
+  br label %ifcont60
 
-else61:                                           ; preds = %loop.end59
-  br label %ifcont62
+else59:                                           ; preds = %loop.end57
+  br label %ifcont60
 
-ifcont62:                                         ; preds = %else61, %then60
+ifcont60:                                         ; preds = %else59, %then58
   %159 = alloca i64, align 8
-  %160 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %159, i32 0, i32 0, i32* %j2)
+  %160 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %159, i32 0, i32 0, i32* %j)
   %161 = load i64, i64* %159, align 4
-  %stringFormat_desc63 = alloca %string_descriptor, align 8
-  %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc63, i32 0, i32 0
+  %stringFormat_desc61 = alloca %string_descriptor, align 8
+  %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
   store i8* %160, i8** %162, align 8
-  %163 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc63, i32 0, i32 1
+  %163 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
   store i64 %161, i64* %163, align 4
-  %164 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc63, i32 0, i32 0
+  %164 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
   %165 = load i8*, i8** %164, align 8
-  %166 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc63, i32 0, i32 1
+  %166 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
   %167 = load i64, i64* %166, align 4
   %168 = trunc i64 %167 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %165, i32 %168, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   %169 = icmp eq i8* %160, null
-  br i1 %169, label %free_done65, label %free_nonnull64
+  br i1 %169, label %free_done63, label %free_nonnull62
 
-free_nonnull64:                                   ; preds = %ifcont62
+free_nonnull62:                                   ; preds = %ifcont60
   call void @_lfortran_free(i8* %160)
-  br label %free_done65
+  br label %free_done63
 
-free_done65:                                      ; preds = %free_nonnull64, %ifcont62
-  store i32 0, i32* %j2, align 4
-  store i32 2, i32* %i1, align 4
-  br label %loop.head66
+free_done63:                                      ; preds = %free_nonnull62, %ifcont60
+  store i32 0, i32* %j, align 4
+  store i32 2, i32* %i, align 4
+  br label %loop.head64
 
-loop.head66:                                      ; preds = %loop.body67, %free_done65
-  %170 = load i32, i32* %i1, align 4
+loop.head64:                                      ; preds = %loop.body65, %free_done63
+  %170 = load i32, i32* %i, align 4
   %171 = add i32 %170, -1
   %172 = icmp sge i32 %171, 1
-  br i1 %172, label %loop.body67, label %loop.end68
+  br i1 %172, label %loop.body65, label %loop.end66
 
-loop.body67:                                      ; preds = %loop.head66
-  %173 = load i32, i32* %i1, align 4
+loop.body65:                                      ; preds = %loop.head64
+  %173 = load i32, i32* %i, align 4
   %174 = add i32 %173, -1
-  store i32 %174, i32* %i1, align 4
-  %175 = load i32, i32* %j2, align 4
-  %176 = load i32, i32* %i1, align 4
+  store i32 %174, i32* %i, align 4
+  %175 = load i32, i32* %j, align 4
+  %176 = load i32, i32* %i, align 4
   %177 = add i32 %175, %176
-  store i32 %177, i32* %j2, align 4
-  br label %loop.head66
+  store i32 %177, i32* %j, align 4
+  br label %loop.head64
 
-loop.end68:                                       ; preds = %loop.head66
-  %178 = load i32, i32* %j2, align 4
+loop.end66:                                       ; preds = %loop.head64
+  %178 = load i32, i32* %j, align 4
   %179 = icmp ne i32 %178, 1
-  br i1 %179, label %then69, label %else70
+  br i1 %179, label %then67, label %else68
 
-then69:                                           ; preds = %loop.end68
+then67:                                           ; preds = %loop.end66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont71
+  br label %ifcont69
 
-else70:                                           ; preds = %loop.end68
-  br label %ifcont71
+else68:                                           ; preds = %loop.end66
+  br label %ifcont69
 
-ifcont71:                                         ; preds = %else70, %then69
+ifcont69:                                         ; preds = %else68, %then67
   %180 = alloca i64, align 8
-  %181 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %180, i32 0, i32 0, i32* %j2)
+  %181 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %180, i32 0, i32 0, i32* %j)
   %182 = load i64, i64* %180, align 4
-  %stringFormat_desc72 = alloca %string_descriptor, align 8
-  %183 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc72, i32 0, i32 0
+  %stringFormat_desc70 = alloca %string_descriptor, align 8
+  %183 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
   store i8* %181, i8** %183, align 8
-  %184 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc72, i32 0, i32 1
+  %184 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
   store i64 %182, i64* %184, align 4
-  %185 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc72, i32 0, i32 0
+  %185 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
   %186 = load i8*, i8** %185, align 8
-  %187 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc72, i32 0, i32 1
+  %187 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
   %188 = load i64, i64* %187, align 4
   %189 = trunc i64 %188 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %186, i32 %189, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   %190 = icmp eq i8* %181, null
-  br i1 %190, label %free_done74, label %free_nonnull73
+  br i1 %190, label %free_done72, label %free_nonnull71
 
-free_nonnull73:                                   ; preds = %ifcont71
+free_nonnull71:                                   ; preds = %ifcont69
   call void @_lfortran_free(i8* %181)
-  br label %free_done74
+  br label %free_done72
 
-free_done74:                                      ; preds = %free_nonnull73, %ifcont71
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
-  br label %loop.head75
+free_done72:                                      ; preds = %free_nonnull71, %ifcont69
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head73
 
-loop.head75:                                      ; preds = %loop.body76, %free_done74
-  %191 = load i32, i32* %i1, align 4
+loop.head73:                                      ; preds = %loop.body74, %free_done72
+  %191 = load i32, i32* %i, align 4
   %192 = add i32 %191, 1
   %193 = icmp sle i32 %192, 0
-  br i1 %193, label %loop.body76, label %loop.end77
+  br i1 %193, label %loop.body74, label %loop.end75
 
-loop.body76:                                      ; preds = %loop.head75
-  %194 = load i32, i32* %i1, align 4
+loop.body74:                                      ; preds = %loop.head73
+  %194 = load i32, i32* %i, align 4
   %195 = add i32 %194, 1
-  store i32 %195, i32* %i1, align 4
-  %196 = load i32, i32* %j2, align 4
-  %197 = load i32, i32* %i1, align 4
+  store i32 %195, i32* %i, align 4
+  %196 = load i32, i32* %j, align 4
+  %197 = load i32, i32* %i, align 4
   %198 = add i32 %196, %197
-  store i32 %198, i32* %j2, align 4
-  br label %loop.head75
+  store i32 %198, i32* %j, align 4
+  br label %loop.head73
 
-loop.end77:                                       ; preds = %loop.head75
-  %199 = load i32, i32* %j2, align 4
+loop.end75:                                       ; preds = %loop.head73
+  %199 = load i32, i32* %j, align 4
   %200 = icmp ne i32 %199, 0
-  br i1 %200, label %then78, label %else79
+  br i1 %200, label %then76, label %else77
 
-then78:                                           ; preds = %loop.end77
+then76:                                           ; preds = %loop.end75
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont80
+  br label %ifcont78
 
-else79:                                           ; preds = %loop.end77
-  br label %ifcont80
+else77:                                           ; preds = %loop.end75
+  br label %ifcont78
 
-ifcont80:                                         ; preds = %else79, %then78
+ifcont78:                                         ; preds = %else77, %then76
   %201 = alloca i64, align 8
-  %202 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %201, i32 0, i32 0, i32* %j2)
+  %202 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %201, i32 0, i32 0, i32* %j)
   %203 = load i64, i64* %201, align 4
-  %stringFormat_desc81 = alloca %string_descriptor, align 8
-  %204 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc81, i32 0, i32 0
+  %stringFormat_desc79 = alloca %string_descriptor, align 8
+  %204 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
   store i8* %202, i8** %204, align 8
-  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc81, i32 0, i32 1
+  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
   store i64 %203, i64* %205, align 4
-  %206 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc81, i32 0, i32 0
+  %206 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
   %207 = load i8*, i8** %206, align 8
-  %208 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc81, i32 0, i32 1
+  %208 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
   %209 = load i64, i64* %208, align 4
   %210 = trunc i64 %209 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %207, i32 %210, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   %211 = icmp eq i8* %202, null
-  br i1 %211, label %free_done83, label %free_nonnull82
+  br i1 %211, label %free_done81, label %free_nonnull80
 
-free_nonnull82:                                   ; preds = %ifcont80
+free_nonnull80:                                   ; preds = %ifcont78
   call void @_lfortran_free(i8* %202)
-  br label %free_done83
+  br label %free_done81
 
-free_done83:                                      ; preds = %free_nonnull82, %ifcont80
-  store i32 0, i32* %j2, align 4
-  store i32 1, i32* %i1, align 4
-  br label %loop.head84
+free_done81:                                      ; preds = %free_nonnull80, %ifcont78
+  store i32 0, i32* %j, align 4
+  store i32 1, i32* %i, align 4
+  br label %loop.head82
 
-loop.head84:                                      ; preds = %loop.body85, %free_done83
-  %212 = load i32, i32* %i1, align 4
+loop.head82:                                      ; preds = %loop.body83, %free_done81
+  %212 = load i32, i32* %i, align 4
   %213 = add i32 %212, -1
   %214 = icmp sge i32 %213, 1
-  br i1 %214, label %loop.body85, label %loop.end86
+  br i1 %214, label %loop.body83, label %loop.end84
 
-loop.body85:                                      ; preds = %loop.head84
-  %215 = load i32, i32* %i1, align 4
+loop.body83:                                      ; preds = %loop.head82
+  %215 = load i32, i32* %i, align 4
   %216 = add i32 %215, -1
-  store i32 %216, i32* %i1, align 4
-  %217 = load i32, i32* %j2, align 4
-  %218 = load i32, i32* %i1, align 4
+  store i32 %216, i32* %i, align 4
+  %217 = load i32, i32* %j, align 4
+  %218 = load i32, i32* %i, align 4
   %219 = add i32 %217, %218
-  store i32 %219, i32* %j2, align 4
-  br label %loop.head84
+  store i32 %219, i32* %j, align 4
+  br label %loop.head82
 
-loop.end86:                                       ; preds = %loop.head84
-  %220 = load i32, i32* %j2, align 4
+loop.end84:                                       ; preds = %loop.head82
+  %220 = load i32, i32* %j, align 4
   %221 = icmp ne i32 %220, 0
-  br i1 %221, label %then87, label %else88
+  br i1 %221, label %then85, label %else86
 
-then87:                                           ; preds = %loop.end86
+then85:                                           ; preds = %loop.end84
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont89
+  br label %ifcont87
 
-else88:                                           ; preds = %loop.end86
-  br label %ifcont89
+else86:                                           ; preds = %loop.end84
+  br label %ifcont87
 
-ifcont89:                                         ; preds = %else88, %then87
+ifcont87:                                         ; preds = %else86, %then85
   %222 = alloca i64, align 8
-  %223 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %222, i32 0, i32 0, i32* %j2)
+  %223 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %222, i32 0, i32 0, i32* %j)
   %224 = load i64, i64* %222, align 4
-  %stringFormat_desc90 = alloca %string_descriptor, align 8
-  %225 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc90, i32 0, i32 0
+  %stringFormat_desc88 = alloca %string_descriptor, align 8
+  %225 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
   store i8* %223, i8** %225, align 8
-  %226 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc90, i32 0, i32 1
+  %226 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1
   store i64 %224, i64* %226, align 4
-  %227 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc90, i32 0, i32 0
+  %227 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
   %228 = load i8*, i8** %227, align 8
-  %229 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc90, i32 0, i32 1
+  %229 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1
   %230 = load i64, i64* %229, align 4
   %231 = trunc i64 %230 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %228, i32 %231, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
   %232 = icmp eq i8* %223, null
-  br i1 %232, label %free_done92, label %free_nonnull91
+  br i1 %232, label %free_done90, label %free_nonnull89
 
-free_nonnull91:                                   ; preds = %ifcont89
+free_nonnull89:                                   ; preds = %ifcont87
   call void @_lfortran_free(i8* %223)
-  br label %free_done92
+  br label %free_done90
 
-free_done92:                                      ; preds = %free_nonnull91, %ifcont89
+free_done90:                                      ; preds = %free_nonnull89, %ifcont87
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done92
+return:                                           ; preds = %free_done90
   br label %FINALIZE_SYMTABLE_doloop_01
 
 FINALIZE_SYMTABLE_doloop_01:                      ; preds = %return

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "4d2ec2500fd0fa313fcec73cc0906b0c5335efb9221eae4d2da1068c",
+    "stdout_hash": "0f0cd6d7e799cea658271f9d22d69951d12ffa61a7f31634256275c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -22,42 +22,38 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a1 = alloca i32, align 4
-  %b2 = alloca i32, align 4
-  %i3 = alloca i32, align 4
-  %j4 = alloca i32, align 4
-  store i32 0, i32* %j4, align 4
-  store i32 1, i32* %a1, align 4
-  store i32 10, i32* %b2, align 4
-  %2 = load i32, i32* %a1, align 4
+  store i32 0, i32* %j, align 4
+  store i32 1, i32* %a, align 4
+  store i32 10, i32* %b, align 4
+  %2 = load i32, i32* %a, align 4
   %3 = sub i32 %2, 1
-  store i32 %3, i32* %i3, align 4
+  store i32 %3, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %4 = load i32, i32* %i3, align 4
+  %4 = load i32, i32* %i, align 4
   %5 = add i32 %4, 1
-  %6 = load i32, i32* %b2, align 4
+  %6 = load i32, i32* %b, align 4
   %7 = icmp sle i32 %5, %6
   br i1 %7, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %8 = load i32, i32* %i3, align 4
+  %8 = load i32, i32* %i, align 4
   %9 = add i32 %8, 1
-  store i32 %9, i32* %i3, align 4
-  %10 = load i32, i32* %j4, align 4
-  %11 = load i32, i32* %i3, align 4
+  store i32 %9, i32* %i, align 4
+  %10 = load i32, i32* %j, align 4
+  %11 = load i32, i32* %i, align 4
   %12 = add i32 %10, %11
-  store i32 %12, i32* %j4, align 4
+  store i32 %12, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %13 = load i32, i32* %j4, align 4
+  %13 = load i32, i32* %j, align 4
   %14 = icmp ne i32 %13, 55
   br i1 %14, label %then, label %else
 
@@ -71,7 +67,7 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %j4)
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %j)
   %17 = load i64, i64* %15, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -92,159 +88,159 @@ free_nonnull:                                     ; preds = %ifcont
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %a1, align 4
-  store i32 0, i32* %i3, align 4
-  br label %loop.head5
+  store i32 0, i32* %a, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head1
 
-loop.head5:                                       ; preds = %loop.end9, %free_done
-  %26 = load i32, i32* %i3, align 4
+loop.head1:                                       ; preds = %loop.end5, %free_done
+  %26 = load i32, i32* %i, align 4
   %27 = add i32 %26, 1
   %28 = icmp sle i32 %27, 10
-  br i1 %28, label %loop.body6, label %loop.end10
+  br i1 %28, label %loop.body2, label %loop.end6
 
-loop.body6:                                       ; preds = %loop.head5
-  %29 = load i32, i32* %i3, align 4
+loop.body2:                                       ; preds = %loop.head1
+  %29 = load i32, i32* %i, align 4
   %30 = add i32 %29, 1
-  store i32 %30, i32* %i3, align 4
-  store i32 0, i32* %j4, align 4
-  br label %loop.head7
+  store i32 %30, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head3
 
-loop.head7:                                       ; preds = %loop.body8, %loop.body6
-  %31 = load i32, i32* %j4, align 4
+loop.head3:                                       ; preds = %loop.body4, %loop.body2
+  %31 = load i32, i32* %j, align 4
   %32 = add i32 %31, 1
   %33 = icmp sle i32 %32, 10
-  br i1 %33, label %loop.body8, label %loop.end9
+  br i1 %33, label %loop.body4, label %loop.end5
 
-loop.body8:                                       ; preds = %loop.head7
-  %34 = load i32, i32* %j4, align 4
+loop.body4:                                       ; preds = %loop.head3
+  %34 = load i32, i32* %j, align 4
   %35 = add i32 %34, 1
-  store i32 %35, i32* %j4, align 4
-  %36 = load i32, i32* %a1, align 4
-  %37 = load i32, i32* %i3, align 4
+  store i32 %35, i32* %j, align 4
+  %36 = load i32, i32* %a, align 4
+  %37 = load i32, i32* %i, align 4
   %38 = sub i32 %37, 1
   %39 = mul i32 %38, 10
   %40 = add i32 %36, %39
-  %41 = load i32, i32* %j4, align 4
+  %41 = load i32, i32* %j, align 4
   %42 = add i32 %40, %41
-  store i32 %42, i32* %a1, align 4
-  br label %loop.head7
+  store i32 %42, i32* %a, align 4
+  br label %loop.head3
 
-loop.end9:                                        ; preds = %loop.head7
-  br label %loop.head5
+loop.end5:                                        ; preds = %loop.head3
+  br label %loop.head1
 
-loop.end10:                                       ; preds = %loop.head5
-  %43 = load i32, i32* %a1, align 4
+loop.end6:                                        ; preds = %loop.head1
+  %43 = load i32, i32* %a, align 4
   %44 = icmp ne i32 %43, 5050
-  br i1 %44, label %then11, label %else12
+  br i1 %44, label %then7, label %else8
 
-then11:                                           ; preds = %loop.end10
+then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont13
+  br label %ifcont9
 
-else12:                                           ; preds = %loop.end10
-  br label %ifcont13
+else8:                                            ; preds = %loop.end6
+  br label %ifcont9
 
-ifcont13:                                         ; preds = %else12, %then11
+ifcont9:                                          ; preds = %else8, %then7
   %45 = alloca i64, align 8
-  %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %45, i32 0, i32 0, i32* %a1)
+  %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %45, i32 0, i32 0, i32* %a)
   %47 = load i64, i64* %45, align 4
-  %stringFormat_desc14 = alloca %string_descriptor, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 0
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %46, i8** %48, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 1
+  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   store i64 %47, i64* %49, align 4
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 0
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   %51 = load i8*, i8** %50, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 1
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %53 = load i64, i64* %52, align 4
   %54 = trunc i64 %53 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %51, i32 %54, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %55 = icmp eq i8* %46, null
-  br i1 %55, label %free_done16, label %free_nonnull15
+  br i1 %55, label %free_done12, label %free_nonnull11
 
-free_nonnull15:                                   ; preds = %ifcont13
+free_nonnull11:                                   ; preds = %ifcont9
   call void @_lfortran_free(i8* %46)
-  br label %free_done16
+  br label %free_done12
 
-free_done16:                                      ; preds = %free_nonnull15, %ifcont13
-  store i32 0, i32* %a1, align 4
-  store i32 0, i32* %i3, align 4
-  br label %loop.head17
+free_done12:                                      ; preds = %free_nonnull11, %ifcont9
+  store i32 0, i32* %a, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head13
 
-loop.head17:                                      ; preds = %loop.end21, %free_done16
-  %56 = load i32, i32* %i3, align 4
+loop.head13:                                      ; preds = %loop.end17, %free_done12
+  %56 = load i32, i32* %i, align 4
   %57 = add i32 %56, 1
   %58 = icmp sle i32 %57, 10
-  br i1 %58, label %loop.body18, label %loop.end22
+  br i1 %58, label %loop.body14, label %loop.end18
 
-loop.body18:                                      ; preds = %loop.head17
-  %59 = load i32, i32* %i3, align 4
+loop.body14:                                      ; preds = %loop.head13
+  %59 = load i32, i32* %i, align 4
   %60 = add i32 %59, 1
-  store i32 %60, i32* %i3, align 4
-  store i32 0, i32* %j4, align 4
-  br label %loop.head19
+  store i32 %60, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head15
 
-loop.head19:                                      ; preds = %loop.body20, %loop.body18
-  %61 = load i32, i32* %j4, align 4
+loop.head15:                                      ; preds = %loop.body16, %loop.body14
+  %61 = load i32, i32* %j, align 4
   %62 = add i32 %61, 1
-  %63 = load i32, i32* %i3, align 4
+  %63 = load i32, i32* %i, align 4
   %64 = icmp sle i32 %62, %63
-  br i1 %64, label %loop.body20, label %loop.end21
+  br i1 %64, label %loop.body16, label %loop.end17
 
-loop.body20:                                      ; preds = %loop.head19
-  %65 = load i32, i32* %j4, align 4
+loop.body16:                                      ; preds = %loop.head15
+  %65 = load i32, i32* %j, align 4
   %66 = add i32 %65, 1
-  store i32 %66, i32* %j4, align 4
-  %67 = load i32, i32* %a1, align 4
-  %68 = load i32, i32* %j4, align 4
+  store i32 %66, i32* %j, align 4
+  %67 = load i32, i32* %a, align 4
+  %68 = load i32, i32* %j, align 4
   %69 = add i32 %67, %68
-  store i32 %69, i32* %a1, align 4
-  br label %loop.head19
+  store i32 %69, i32* %a, align 4
+  br label %loop.head15
 
-loop.end21:                                       ; preds = %loop.head19
-  br label %loop.head17
+loop.end17:                                       ; preds = %loop.head15
+  br label %loop.head13
 
-loop.end22:                                       ; preds = %loop.head17
-  %70 = load i32, i32* %a1, align 4
+loop.end18:                                       ; preds = %loop.head13
+  %70 = load i32, i32* %a, align 4
   %71 = icmp ne i32 %70, 220
-  br i1 %71, label %then23, label %else24
+  br i1 %71, label %then19, label %else20
 
-then23:                                           ; preds = %loop.end22
+then19:                                           ; preds = %loop.end18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont25
+  br label %ifcont21
 
-else24:                                           ; preds = %loop.end22
-  br label %ifcont25
+else20:                                           ; preds = %loop.end18
+  br label %ifcont21
 
-ifcont25:                                         ; preds = %else24, %then23
+ifcont21:                                         ; preds = %else20, %then19
   %72 = alloca i64, align 8
-  %73 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %72, i32 0, i32 0, i32* %a1)
+  %73 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %72, i32 0, i32 0, i32* %a)
   %74 = load i64, i64* %72, align 4
-  %stringFormat_desc26 = alloca %string_descriptor, align 8
-  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc26, i32 0, i32 0
+  %stringFormat_desc22 = alloca %string_descriptor, align 8
+  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
   store i8* %73, i8** %75, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc26, i32 0, i32 1
+  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1
   store i64 %74, i64* %76, align 4
-  %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc26, i32 0, i32 0
+  %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
   %78 = load i8*, i8** %77, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc26, i32 0, i32 1
+  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1
   %80 = load i64, i64* %79, align 4
   %81 = trunc i64 %80 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %78, i32 %81, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %82 = icmp eq i8* %73, null
-  br i1 %82, label %free_done28, label %free_nonnull27
+  br i1 %82, label %free_done24, label %free_nonnull23
 
-free_nonnull27:                                   ; preds = %ifcont25
+free_nonnull23:                                   ; preds = %ifcont21
   call void @_lfortran_free(i8* %73)
-  br label %free_done28
+  br label %free_done24
 
-free_done28:                                      ; preds = %free_nonnull27, %ifcont25
+free_done24:                                      ; preds = %free_nonnull23, %ifcont21
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done28
+return:                                           ; preds = %free_done24
   br label %FINALIZE_SYMTABLE_doloop_02
 
 FINALIZE_SYMTABLE_doloop_02:                      ; preds = %return

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "1141d34c07edacb5205137b21986e9f6118a0410dbae6e84951efeb4",
+    "stdout_hash": "226ee91892f31198923a7df99c5607752507c7c564025ed596e8bbe1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -22,30 +22,28 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont5, %.entry
-  %2 = load i32, i32* %i1, align 4
+loop.head:                                        ; preds = %ifcont3, %.entry
+  %2 = load i32, i32* %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i1, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i1, align 4
-  %7 = load i32, i32* %j2, align 4
-  %8 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %i, align 4
+  %7 = load i32, i32* %j, align 4
+  %8 = load i32, i32* %i, align 4
   %9 = add i32 %7, %8
-  store i32 %9, i32* %j2, align 4
-  %10 = load i32, i32* %i1, align 4
+  store i32 %9, i32* %j, align 4
+  %10 = load i32, i32* %i, align 4
   %11 = icmp eq i32 %10, 3
   br i1 %11, label %then, label %else
 
@@ -56,38 +54,38 @@ else:                                             ; preds = %loop.body
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load i32, i32* %i1, align 4
+  %12 = load i32, i32* %i, align 4
   %13 = icmp eq i32 %12, 2
-  br i1 %13, label %then3, label %else4
+  br i1 %13, label %then1, label %else2
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   br label %loop.end
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %unreachable_after_exit
+ifcont3:                                          ; preds = %else2, %unreachable_after_exit
   br label %loop.head
 
-loop.end:                                         ; preds = %then3, %loop.head
-  %14 = load i32, i32* %j2, align 4
+loop.end:                                         ; preds = %then1, %loop.head
+  %14 = load i32, i32* %j, align 4
   %15 = icmp ne i32 %14, 3
-  br i1 %15, label %then6, label %else7
+  br i1 %15, label %then4, label %else5
 
-then6:                                            ; preds = %loop.end
+then4:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont6
 
-else7:                                            ; preds = %loop.end
-  br label %ifcont8
+else5:                                            ; preds = %loop.end
+  br label %ifcont6
 
-ifcont8:                                          ; preds = %else7, %then6
+ifcont6:                                          ; preds = %else5, %then4
   %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j2)
+  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j)
   %18 = load i64, i64* %16, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -103,155 +101,155 @@ ifcont8:                                          ; preds = %else7, %then6
   %26 = icmp eq i8* %17, null
   br i1 %26, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont8
+free_nonnull:                                     ; preds = %ifcont6
   call void @_lfortran_free(i8* %17)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont8
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
-  br label %loop.head9
+free_done:                                        ; preds = %free_nonnull, %ifcont6
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head7
 
-loop.head9:                                       ; preds = %ifcont14, %free_done
-  %27 = load i32, i32* %i1, align 4
+loop.head7:                                       ; preds = %ifcont12, %free_done
+  %27 = load i32, i32* %i, align 4
   %28 = add i32 %27, 1
   %29 = icmp sle i32 %28, 10
-  br i1 %29, label %loop.body10, label %loop.end15
+  br i1 %29, label %loop.body8, label %loop.end13
 
-loop.body10:                                      ; preds = %loop.head9
-  %30 = load i32, i32* %i1, align 4
+loop.body8:                                       ; preds = %loop.head7
+  %30 = load i32, i32* %i, align 4
   %31 = add i32 %30, 1
-  store i32 %31, i32* %i1, align 4
-  %32 = load i32, i32* %i1, align 4
+  store i32 %31, i32* %i, align 4
+  %32 = load i32, i32* %i, align 4
   %33 = icmp eq i32 %32, 2
-  br i1 %33, label %then11, label %else13
+  br i1 %33, label %then9, label %else11
 
-then11:                                           ; preds = %loop.body10
-  br label %loop.end15
+then9:                                            ; preds = %loop.body8
+  br label %loop.end13
 
-unreachable_after_exit12:                         ; No predecessors!
-  br label %ifcont14
+unreachable_after_exit10:                         ; No predecessors!
+  br label %ifcont12
 
-else13:                                           ; preds = %loop.body10
-  br label %ifcont14
+else11:                                           ; preds = %loop.body8
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %unreachable_after_exit12
-  %34 = load i32, i32* %j2, align 4
-  %35 = load i32, i32* %i1, align 4
+ifcont12:                                         ; preds = %else11, %unreachable_after_exit10
+  %34 = load i32, i32* %j, align 4
+  %35 = load i32, i32* %i, align 4
   %36 = add i32 %34, %35
-  store i32 %36, i32* %j2, align 4
-  br label %loop.head9
+  store i32 %36, i32* %j, align 4
+  br label %loop.head7
 
-loop.end15:                                       ; preds = %then11, %loop.head9
-  %37 = load i32, i32* %j2, align 4
+loop.end13:                                       ; preds = %then9, %loop.head7
+  %37 = load i32, i32* %j, align 4
   %38 = icmp ne i32 %37, 1
-  br i1 %38, label %then16, label %else17
+  br i1 %38, label %then14, label %else15
 
-then16:                                           ; preds = %loop.end15
+then14:                                           ; preds = %loop.end13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont16
 
-else17:                                           ; preds = %loop.end15
-  br label %ifcont18
+else15:                                           ; preds = %loop.end13
+  br label %ifcont16
 
-ifcont18:                                         ; preds = %else17, %then16
+ifcont16:                                         ; preds = %else15, %then14
   %39 = alloca i64, align 8
-  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %j2)
+  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %j)
   %41 = load i64, i64* %39, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
+  %stringFormat_desc17 = alloca %string_descriptor, align 8
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
   store i8* %40, i8** %42, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
   store i64 %41, i64* %43, align 4
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
   %45 = load i8*, i8** %44, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
+  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
   %47 = load i64, i64* %46, align 4
   %48 = trunc i64 %47 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %45, i32 %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %49 = icmp eq i8* %40, null
-  br i1 %49, label %free_done21, label %free_nonnull20
+  br i1 %49, label %free_done19, label %free_nonnull18
 
-free_nonnull20:                                   ; preds = %ifcont18
+free_nonnull18:                                   ; preds = %ifcont16
   call void @_lfortran_free(i8* %40)
-  br label %free_done21
+  br label %free_done19
 
-free_done21:                                      ; preds = %free_nonnull20, %ifcont18
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
-  br label %loop.head22
+free_done19:                                      ; preds = %free_nonnull18, %ifcont16
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
+  br label %loop.head20
 
-loop.head22:                                      ; preds = %ifcont26, %then24, %free_done21
-  %50 = load i32, i32* %i1, align 4
+loop.head20:                                      ; preds = %ifcont24, %then22, %free_done19
+  %50 = load i32, i32* %i, align 4
   %51 = add i32 %50, 1
   %52 = icmp sle i32 %51, 10
-  br i1 %52, label %loop.body23, label %loop.end27
+  br i1 %52, label %loop.body21, label %loop.end25
 
-loop.body23:                                      ; preds = %loop.head22
-  %53 = load i32, i32* %i1, align 4
+loop.body21:                                      ; preds = %loop.head20
+  %53 = load i32, i32* %i, align 4
   %54 = add i32 %53, 1
-  store i32 %54, i32* %i1, align 4
-  %55 = load i32, i32* %i1, align 4
+  store i32 %54, i32* %i, align 4
+  %55 = load i32, i32* %i, align 4
   %56 = icmp eq i32 %55, 2
-  br i1 %56, label %then24, label %else25
+  br i1 %56, label %then22, label %else23
 
-then24:                                           ; preds = %loop.body23
-  br label %loop.head22
+then22:                                           ; preds = %loop.body21
+  br label %loop.head20
 
 unreachable_after_cycle:                          ; No predecessors!
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %loop.body23
-  br label %ifcont26
+else23:                                           ; preds = %loop.body21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %unreachable_after_cycle
-  %57 = load i32, i32* %j2, align 4
-  %58 = load i32, i32* %i1, align 4
+ifcont24:                                         ; preds = %else23, %unreachable_after_cycle
+  %57 = load i32, i32* %j, align 4
+  %58 = load i32, i32* %i, align 4
   %59 = add i32 %57, %58
-  store i32 %59, i32* %j2, align 4
-  br label %loop.head22
+  store i32 %59, i32* %j, align 4
+  br label %loop.head20
 
-loop.end27:                                       ; preds = %loop.head22
-  %60 = load i32, i32* %j2, align 4
+loop.end25:                                       ; preds = %loop.head20
+  %60 = load i32, i32* %j, align 4
   %61 = icmp ne i32 %60, 53
-  br i1 %61, label %then28, label %else29
+  br i1 %61, label %then26, label %else27
 
-then28:                                           ; preds = %loop.end27
+then26:                                           ; preds = %loop.end25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont30
+  br label %ifcont28
 
-else29:                                           ; preds = %loop.end27
-  br label %ifcont30
+else27:                                           ; preds = %loop.end25
+  br label %ifcont28
 
-ifcont30:                                         ; preds = %else29, %then28
+ifcont28:                                         ; preds = %else27, %then26
   %62 = alloca i64, align 8
-  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %62, i32 0, i32 0, i32* %j2)
+  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %62, i32 0, i32 0, i32* %j)
   %64 = load i64, i64* %62, align 4
-  %stringFormat_desc31 = alloca %string_descriptor, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
+  %stringFormat_desc29 = alloca %string_descriptor, align 8
+  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
   store i8* %63, i8** %65, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1
   store i64 %64, i64* %66, align 4
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
+  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
   %68 = load i8*, i8** %67, align 8
-  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
+  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1
   %70 = load i64, i64* %69, align 4
   %71 = trunc i64 %70 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %68, i32 %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %72 = icmp eq i8* %63, null
-  br i1 %72, label %free_done33, label %free_nonnull32
+  br i1 %72, label %free_done31, label %free_nonnull30
 
-free_nonnull32:                                   ; preds = %ifcont30
+free_nonnull30:                                   ; preds = %ifcont28
   call void @_lfortran_free(i8* %63)
-  br label %free_done33
+  br label %free_done31
 
-free_done33:                                      ; preds = %free_nonnull32, %ifcont30
+free_done31:                                      ; preds = %free_nonnull30, %ifcont28
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done33
+return:                                           ; preds = %free_done31
   br label %FINALIZE_SYMTABLE_doloop_03
 
 FINALIZE_SYMTABLE_doloop_03:                      ; preds = %return

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "8daf7c1f447a7698d63ce6e1139810b92439b4d2367bed9e66e983d0",
+    "stdout_hash": "5e5baf1d0a606f74493997c21341161742e8dd99844ac4ebbc195fd4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -23,33 +23,30 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  %k3 = alloca i32, align 4
-  store i32 0, i32* %j2, align 4
-  store i32 2, i32* %k3, align 4
-  %2 = load i32, i32* %k3, align 4
+  store i32 0, i32* %j, align 4
+  store i32 2, i32* %k, align 4
+  %2 = load i32, i32* %k, align 4
   %3 = sub i32 1, %2
-  store i32 %3, i32* %i1, align 4
+  store i32 %3, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %4 = load i32, i32* %k3, align 4
+  %4 = load i32, i32* %k, align 4
   %5 = icmp sgt i32 %4, 0
-  %6 = load i32, i32* %i1, align 4
-  %7 = load i32, i32* %k3, align 4
+  %6 = load i32, i32* %i, align 4
+  %7 = load i32, i32* %k, align 4
   %8 = add i32 %6, %7
   %9 = icmp sle i32 %8, 10
   %10 = icmp eq i1 %5, false
   %11 = select i1 %10, i1 %5, i1 %9
-  %12 = load i32, i32* %k3, align 4
+  %12 = load i32, i32* %k, align 4
   %13 = icmp sle i32 %12, 0
-  %14 = load i32, i32* %i1, align 4
-  %15 = load i32, i32* %k3, align 4
+  %14 = load i32, i32* %i, align 4
+  %15 = load i32, i32* %k, align 4
   %16 = add i32 %14, %15
   %17 = icmp sge i32 %16, 10
   %18 = icmp eq i1 %13, false
@@ -59,18 +56,18 @@ loop.head:                                        ; preds = %loop.body, %.entry
   br i1 %21, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %22 = load i32, i32* %i1, align 4
-  %23 = load i32, i32* %k3, align 4
+  %22 = load i32, i32* %i, align 4
+  %23 = load i32, i32* %k, align 4
   %24 = add i32 %22, %23
-  store i32 %24, i32* %i1, align 4
-  %25 = load i32, i32* %j2, align 4
-  %26 = load i32, i32* %i1, align 4
+  store i32 %24, i32* %i, align 4
+  %25 = load i32, i32* %j, align 4
+  %26 = load i32, i32* %i, align 4
   %27 = add i32 %25, %26
-  store i32 %27, i32* %j2, align 4
+  store i32 %27, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %28 = load i32, i32* %j2, align 4
+  %28 = load i32, i32* %j, align 4
   %29 = icmp ne i32 %28, 25
   br i1 %29, label %then, label %else
 
@@ -84,7 +81,7 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %30 = alloca i64, align 8
-  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %30, i32 0, i32 0, i32* %j2)
+  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %30, i32 0, i32 0, i32* %j)
   %32 = load i64, i64* %30, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -105,264 +102,264 @@ free_nonnull:                                     ; preds = %ifcont
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %j2, align 4
-  store i32 -2, i32* %k3, align 4
-  %41 = load i32, i32* %k3, align 4
+  store i32 0, i32* %j, align 4
+  store i32 -2, i32* %k, align 4
+  %41 = load i32, i32* %k, align 4
   %42 = sub i32 10, %41
-  store i32 %42, i32* %i1, align 4
-  br label %loop.head4
+  store i32 %42, i32* %i, align 4
+  br label %loop.head1
 
-loop.head4:                                       ; preds = %loop.body5, %free_done
-  %43 = load i32, i32* %k3, align 4
+loop.head1:                                       ; preds = %loop.body2, %free_done
+  %43 = load i32, i32* %k, align 4
   %44 = icmp sgt i32 %43, 0
-  %45 = load i32, i32* %i1, align 4
-  %46 = load i32, i32* %k3, align 4
+  %45 = load i32, i32* %i, align 4
+  %46 = load i32, i32* %k, align 4
   %47 = add i32 %45, %46
   %48 = icmp sle i32 %47, 1
   %49 = icmp eq i1 %44, false
   %50 = select i1 %49, i1 %44, i1 %48
-  %51 = load i32, i32* %k3, align 4
+  %51 = load i32, i32* %k, align 4
   %52 = icmp sle i32 %51, 0
-  %53 = load i32, i32* %i1, align 4
-  %54 = load i32, i32* %k3, align 4
+  %53 = load i32, i32* %i, align 4
+  %54 = load i32, i32* %k, align 4
   %55 = add i32 %53, %54
   %56 = icmp sge i32 %55, 1
   %57 = icmp eq i1 %52, false
   %58 = select i1 %57, i1 %52, i1 %56
   %59 = icmp eq i1 %50, false
   %60 = select i1 %59, i1 %58, i1 %50
-  br i1 %60, label %loop.body5, label %loop.end6
+  br i1 %60, label %loop.body2, label %loop.end3
 
-loop.body5:                                       ; preds = %loop.head4
-  %61 = load i32, i32* %i1, align 4
-  %62 = load i32, i32* %k3, align 4
+loop.body2:                                       ; preds = %loop.head1
+  %61 = load i32, i32* %i, align 4
+  %62 = load i32, i32* %k, align 4
   %63 = add i32 %61, %62
-  store i32 %63, i32* %i1, align 4
-  %64 = load i32, i32* %j2, align 4
-  %65 = load i32, i32* %i1, align 4
+  store i32 %63, i32* %i, align 4
+  %64 = load i32, i32* %j, align 4
+  %65 = load i32, i32* %i, align 4
   %66 = add i32 %64, %65
-  store i32 %66, i32* %j2, align 4
-  br label %loop.head4
+  store i32 %66, i32* %j, align 4
+  br label %loop.head1
 
-loop.end6:                                        ; preds = %loop.head4
-  %67 = load i32, i32* %j2, align 4
+loop.end3:                                        ; preds = %loop.head1
+  %67 = load i32, i32* %j, align 4
   %68 = icmp ne i32 %67, 30
-  br i1 %68, label %then7, label %else8
+  br i1 %68, label %then4, label %else5
 
-then7:                                            ; preds = %loop.end6
+then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont9
+  br label %ifcont6
 
-else8:                                            ; preds = %loop.end6
-  br label %ifcont9
+else5:                                            ; preds = %loop.end3
+  br label %ifcont6
 
-ifcont9:                                          ; preds = %else8, %then7
+ifcont6:                                          ; preds = %else5, %then4
   %69 = alloca i64, align 8
-  %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %69, i32 0, i32 0, i32* %j2)
+  %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %69, i32 0, i32 0, i32* %j)
   %71 = load i64, i64* %69, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %70, i8** %72, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   store i64 %71, i64* %73, align 4
-  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   %75 = load i8*, i8** %74, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %77 = load i64, i64* %76, align 4
   %78 = trunc i64 %77 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %79 = icmp eq i8* %70, null
-  br i1 %79, label %free_done12, label %free_nonnull11
+  br i1 %79, label %free_done9, label %free_nonnull8
 
-free_nonnull11:                                   ; preds = %ifcont9
+free_nonnull8:                                    ; preds = %ifcont6
   call void @_lfortran_free(i8* %70)
-  br label %free_done12
+  br label %free_done9
 
-free_done12:                                      ; preds = %free_nonnull11, %ifcont9
-  store i32 0, i32* %j2, align 4
-  store i32 0, i32* %i1, align 4
+free_done9:                                       ; preds = %free_nonnull8, %ifcont6
+  store i32 0, i32* %j, align 4
+  store i32 0, i32* %i, align 4
   br label %a.head
 
-a.head:                                           ; preds = %ifcont15, %free_done12
-  %80 = load i32, i32* %i1, align 4
+a.head:                                           ; preds = %ifcont12, %free_done9
+  %80 = load i32, i32* %i, align 4
   %81 = add i32 %80, 1
   %82 = icmp sle i32 %81, 10
   br i1 %82, label %a.body, label %a.end
 
 a.body:                                           ; preds = %a.head
-  %83 = load i32, i32* %i1, align 4
+  %83 = load i32, i32* %i, align 4
   %84 = add i32 %83, 1
-  store i32 %84, i32* %i1, align 4
-  %85 = load i32, i32* %j2, align 4
-  %86 = load i32, i32* %i1, align 4
+  store i32 %84, i32* %i, align 4
+  %85 = load i32, i32* %j, align 4
+  %86 = load i32, i32* %i, align 4
   %87 = add i32 %85, %86
-  store i32 %87, i32* %j2, align 4
-  %88 = load i32, i32* %i1, align 4
+  store i32 %87, i32* %j, align 4
+  %88 = load i32, i32* %i, align 4
   %89 = icmp eq i32 %88, 2
-  br i1 %89, label %then13, label %else14
+  br i1 %89, label %then10, label %else11
 
-then13:                                           ; preds = %a.body
+then10:                                           ; preds = %a.body
   br label %a.end
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont15
+  br label %ifcont12
 
-else14:                                           ; preds = %a.body
-  br label %ifcont15
+else11:                                           ; preds = %a.body
+  br label %ifcont12
 
-ifcont15:                                         ; preds = %else14, %unreachable_after_exit
+ifcont12:                                         ; preds = %else11, %unreachable_after_exit
   br label %a.head
 
-a.end:                                            ; preds = %then13, %a.head
-  %90 = load i32, i32* %j2, align 4
+a.end:                                            ; preds = %then10, %a.head
+  %90 = load i32, i32* %j, align 4
   %91 = icmp ne i32 %90, 3
-  br i1 %91, label %then16, label %else17
+  br i1 %91, label %then13, label %else14
 
-then16:                                           ; preds = %a.end
+then13:                                           ; preds = %a.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont18
+  br label %ifcont15
 
-else17:                                           ; preds = %a.end
-  br label %ifcont18
+else14:                                           ; preds = %a.end
+  br label %ifcont15
 
-ifcont18:                                         ; preds = %else17, %then16
-  store i32 0, i32* %j2, align 4
-  store i32 -1, i32* %i1, align 4
+ifcont15:                                         ; preds = %else14, %then13
+  store i32 0, i32* %j, align 4
+  store i32 -1, i32* %i, align 4
   br label %b.head
 
-b.head:                                           ; preds = %ifcont22, %ifcont18
-  %92 = load i32, i32* %i1, align 4
+b.head:                                           ; preds = %ifcont19, %ifcont15
+  %92 = load i32, i32* %i, align 4
   %93 = add i32 %92, 2
   %94 = icmp sle i32 %93, 10
   br i1 %94, label %b.body, label %b.end
 
 b.body:                                           ; preds = %b.head
-  %95 = load i32, i32* %i1, align 4
+  %95 = load i32, i32* %i, align 4
   %96 = add i32 %95, 2
-  store i32 %96, i32* %i1, align 4
-  %97 = load i32, i32* %j2, align 4
-  %98 = load i32, i32* %i1, align 4
+  store i32 %96, i32* %i, align 4
+  %97 = load i32, i32* %j, align 4
+  %98 = load i32, i32* %i, align 4
   %99 = add i32 %97, %98
-  store i32 %99, i32* %j2, align 4
-  %100 = load i32, i32* %i1, align 4
+  store i32 %99, i32* %j, align 4
+  %100 = load i32, i32* %i, align 4
   %101 = icmp eq i32 %100, 3
-  br i1 %101, label %then19, label %else21
+  br i1 %101, label %then16, label %else18
 
-then19:                                           ; preds = %b.body
+then16:                                           ; preds = %b.body
   br label %b.end
 
-unreachable_after_exit20:                         ; No predecessors!
-  br label %ifcont22
+unreachable_after_exit17:                         ; No predecessors!
+  br label %ifcont19
 
-else21:                                           ; preds = %b.body
-  br label %ifcont22
+else18:                                           ; preds = %b.body
+  br label %ifcont19
 
-ifcont22:                                         ; preds = %else21, %unreachable_after_exit20
+ifcont19:                                         ; preds = %else18, %unreachable_after_exit17
   br label %b.head
 
-b.end:                                            ; preds = %then19, %b.head
-  %102 = load i32, i32* %j2, align 4
+b.end:                                            ; preds = %then16, %b.head
+  %102 = load i32, i32* %j, align 4
   %103 = icmp ne i32 %102, 4
-  br i1 %103, label %then23, label %else24
+  br i1 %103, label %then20, label %else21
 
-then23:                                           ; preds = %b.end
+then20:                                           ; preds = %b.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont25
+  br label %ifcont22
 
-else24:                                           ; preds = %b.end
-  br label %ifcont25
+else21:                                           ; preds = %b.end
+  br label %ifcont22
 
-ifcont25:                                         ; preds = %else24, %then23
-  store i32 0, i32* %j2, align 4
-  store i32 1, i32* %i1, align 4
+ifcont22:                                         ; preds = %else21, %then20
+  store i32 0, i32* %j, align 4
+  store i32 1, i32* %i, align 4
   br label %c.head
 
-c.head:                                           ; preds = %ifcont29, %ifcont25
+c.head:                                           ; preds = %ifcont26, %ifcont22
   br i1 true, label %c.body, label %c.end
 
 c.body:                                           ; preds = %c.head
-  %104 = load i32, i32* %j2, align 4
-  %105 = load i32, i32* %i1, align 4
+  %104 = load i32, i32* %j, align 4
+  %105 = load i32, i32* %i, align 4
   %106 = add i32 %104, %105
-  store i32 %106, i32* %j2, align 4
-  %107 = load i32, i32* %i1, align 4
+  store i32 %106, i32* %j, align 4
+  %107 = load i32, i32* %i, align 4
   %108 = icmp eq i32 %107, 2
-  br i1 %108, label %then26, label %else28
+  br i1 %108, label %then23, label %else25
 
-then26:                                           ; preds = %c.body
+then23:                                           ; preds = %c.body
   br label %c.end
 
-unreachable_after_exit27:                         ; No predecessors!
-  br label %ifcont29
+unreachable_after_exit24:                         ; No predecessors!
+  br label %ifcont26
 
-else28:                                           ; preds = %c.body
-  br label %ifcont29
+else25:                                           ; preds = %c.body
+  br label %ifcont26
 
-ifcont29:                                         ; preds = %else28, %unreachable_after_exit27
-  %109 = load i32, i32* %i1, align 4
+ifcont26:                                         ; preds = %else25, %unreachable_after_exit24
+  %109 = load i32, i32* %i, align 4
   %110 = add i32 %109, 1
-  store i32 %110, i32* %i1, align 4
+  store i32 %110, i32* %i, align 4
   br label %c.head
 
-c.end:                                            ; preds = %then26, %c.head
-  %111 = load i32, i32* %j2, align 4
+c.end:                                            ; preds = %then23, %c.head
+  %111 = load i32, i32* %j, align 4
   %112 = icmp ne i32 %111, 3
-  br i1 %112, label %then30, label %else31
+  br i1 %112, label %then27, label %else28
 
-then30:                                           ; preds = %c.end
+then27:                                           ; preds = %c.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont32
+  br label %ifcont29
 
-else31:                                           ; preds = %c.end
-  br label %ifcont32
+else28:                                           ; preds = %c.end
+  br label %ifcont29
 
-ifcont32:                                         ; preds = %else31, %then30
-  store i32 2, i32* %k3, align 4
-  %113 = load i32, i32* %k3, align 4
+ifcont29:                                         ; preds = %else28, %then27
+  store i32 2, i32* %k, align 4
+  %113 = load i32, i32* %k, align 4
   %114 = sub i32 1, %113
-  store i32 %114, i32* %i1, align 4
-  br label %loop.head33
+  store i32 %114, i32* %i, align 4
+  br label %loop.head30
 
-loop.head33:                                      ; preds = %goto_target, %ifcont32
-  %115 = load i32, i32* %k3, align 4
+loop.head30:                                      ; preds = %goto_target, %ifcont29
+  %115 = load i32, i32* %k, align 4
   %116 = icmp sgt i32 %115, 0
-  %117 = load i32, i32* %i1, align 4
-  %118 = load i32, i32* %k3, align 4
+  %117 = load i32, i32* %i, align 4
+  %118 = load i32, i32* %k, align 4
   %119 = add i32 %117, %118
   %120 = icmp sle i32 %119, 10
   %121 = icmp eq i1 %116, false
   %122 = select i1 %121, i1 %116, i1 %120
-  %123 = load i32, i32* %k3, align 4
+  %123 = load i32, i32* %k, align 4
   %124 = icmp sle i32 %123, 0
-  %125 = load i32, i32* %i1, align 4
-  %126 = load i32, i32* %k3, align 4
+  %125 = load i32, i32* %i, align 4
+  %126 = load i32, i32* %k, align 4
   %127 = add i32 %125, %126
   %128 = icmp sge i32 %127, 10
   %129 = icmp eq i1 %124, false
   %130 = select i1 %129, i1 %124, i1 %128
   %131 = icmp eq i1 %122, false
   %132 = select i1 %131, i1 %130, i1 %122
-  br i1 %132, label %loop.body34, label %loop.end35
+  br i1 %132, label %loop.body31, label %loop.end32
 
-loop.body34:                                      ; preds = %loop.head33
-  %133 = load i32, i32* %i1, align 4
-  %134 = load i32, i32* %k3, align 4
+loop.body31:                                      ; preds = %loop.head30
+  %133 = load i32, i32* %i, align 4
+  %134 = load i32, i32* %k, align 4
   %135 = add i32 %133, %134
-  store i32 %135, i32* %i1, align 4
+  store i32 %135, i32* %i, align 4
   br label %goto_target
 
-goto_target:                                      ; preds = %loop.body34
-  br label %loop.head33
+goto_target:                                      ; preds = %loop.body31
+  br label %loop.head30
 
-loop.end35:                                       ; preds = %loop.head33
+loop.end32:                                       ; preds = %loop.head30
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %loop.end35
+return:                                           ; preds = %loop.end32
   br label %FINALIZE_SYMTABLE_doloop_04
 
 FINALIZE_SYMTABLE_doloop_04:                      ; preds = %return

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "7b6c319f2d127b1ab8ec02465a45e5672d5ae57df587d77633463f55",
+    "stdout_hash": "a02c5355af3fdc41f830b45e6a19a2e8bf264d1e1af15482a590a20d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -7,11 +7,10 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %x1 = alloca i32, align 4
-  store i32 25, i32* %x1, align 4
-  %2 = load i32, i32* %x1, align 4
+  %x = alloca i32, align 4
+  store i32 25, i32* %x, align 4
+  %2 = load i32, i32* %x, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "62710c8c0ed9ac708e73f92f22b7f23c9d98cc0c643832b231bd6c8a",
+    "stdout_hash": "67e59d971a52727c0ba2818127d87ab749d468081df2389afcd8d723",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -11,12 +11,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %a = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a1 = alloca i32, align 4
+  %a = alloca i32, align 4
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %a1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %a)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "304895a1eaa6e9ba4e6c30d0e5ce045edff9fe02d6e0f323faebe526",
+    "stdout_hash": "4dd475279eb77e60c06728a9b6a20419100a3d5d9ca99b1b43d510d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -100,8 +100,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %ione = alloca i32, align 4
-  %izero = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca %complextype, align 8
   %2 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
@@ -112,14 +110,14 @@ define i32 @main(i32 %0, i8** %1) {
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
-  %ione1 = alloca i32, align 4
-  %izero2 = alloca i32, align 4
+  %ione = alloca i32, align 4
+  %izero = alloca i32, align 4
   %negfpone = alloca float, align 4
   store float 1.000000e+00, float* %fpone, align 4
   store float 2.000000e+00, float* %fptwo, align 4
   store float 0.000000e+00, float* %fpzero, align 4
-  store i32 1, i32* %ione1, align 4
-  store i32 0, i32* %izero2, align 4
+  store i32 1, i32* %ione, align 4
+  store i32 0, i32* %izero, align 4
   store float -1.000000e+00, float* %negfpone, align 4
   %6 = getelementptr %complextype, %complextype* %c, i32 0, i32 0
   %7 = load float, float* %fpone, align 4
@@ -132,7 +130,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %11, align 8
   %12 = getelementptr %complextype_class, %complextype_class* %10, i32 0, i32 1
   store %complextype* %c, %complextype** %12, align 8
-  call void @__module_complex_module_integer_add_subrout(%complextype_class* %10, i32* %ione1, i32* %izero2, %complextype* %a)
+  call void @__module_complex_module_integer_add_subrout(%complextype_class* %10, i32* %ione, i32* %izero, %complextype* %a)
   %13 = alloca i64, align 8
   %14 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %15 = load float, float* %14, align 4
@@ -180,17 +178,17 @@ ifcont:                                           ; preds = %else, %then
   %33 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
   %34 = load float, float* %33, align 4
   %35 = fcmp une float %34, 2.000000e+00
-  br i1 %35, label %then3, label %else4
+  br i1 %35, label %then1, label %else2
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %then3
+ifcont3:                                          ; preds = %else2, %then1
   %36 = alloca %complextype_class, align 8
   %37 = getelementptr %complextype_class, %complextype_class* %36, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %37, align 8
@@ -208,57 +206,57 @@ ifcont5:                                          ; preds = %else4, %then3
   store float %44, float* %45, align 4
   %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, float* %42, float* %45)
   %47 = load i64, i64* %39, align 4
-  %stringFormat_desc6 = alloca %string_descriptor, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 0
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %46, i8** %48, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 1
+  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   store i64 %47, i64* %49, align 4
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 0
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   %51 = load i8*, i8** %50, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 1
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %53 = load i64, i64* %52, align 4
   %54 = trunc i64 %53 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %51, i32 %54, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %55 = icmp eq i8* %46, null
-  br i1 %55, label %free_done8, label %free_nonnull7
+  br i1 %55, label %free_done6, label %free_nonnull5
 
-free_nonnull7:                                    ; preds = %ifcont5
+free_nonnull5:                                    ; preds = %ifcont3
   call void @_lfortran_free(i8* %46)
-  br label %free_done8
+  br label %free_done6
 
-free_done8:                                       ; preds = %free_nonnull7, %ifcont5
+free_done6:                                       ; preds = %free_nonnull5, %ifcont3
   %56 = getelementptr %complextype, %complextype* %a, i32 0, i32 0
   %57 = load float, float* %56, align 4
   %58 = fcmp une float %57, 1.000000e+00
-  br i1 %58, label %then9, label %else10
+  br i1 %58, label %then7, label %else8
 
-then9:                                            ; preds = %free_done8
+then7:                                            ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %free_done8
-  br label %ifcont11
+else8:                                            ; preds = %free_done6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
+ifcont9:                                          ; preds = %else8, %then7
   %59 = getelementptr %complextype, %complextype* %a, i32 0, i32 1
   %60 = load float, float* %59, align 4
   %61 = fcmp une float %60, 1.000000e+00
-  br i1 %61, label %then12, label %else13
+  br i1 %61, label %then10, label %else11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %then12
+ifcont12:                                         ; preds = %else11, %then10
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont14
+return:                                           ; preds = %ifcont12
   br label %FINALIZE_SYMTABLE_generic_name_01
 
 FINALIZE_SYMTABLE_generic_name_01:                ; preds = %return

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "c00640c8650e1faff43a20288fbdbab80b614f8fca8b21e9982e296f",
+    "stdout_hash": "fbd4fc084bd167933102601bd7109fe4c1892ede41301f1805189d60",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -3,7 +3,6 @@ source_filename = "LFortran"
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@main.n = internal global i32 3
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -27,6 +26,7 @@ source_filename = "LFortran"
 @18 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @19 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @main.b = internal global [3 x i32] zeroinitializer
+@main.n = internal global i32 3
 @20 = private unnamed_addr constant [2 x i8] c"b\00", align 1
 @21 = private unnamed_addr constant [189 x i8] c"At 3:12 of file tests/../integration_tests/implicit_interface_04.f90\0ARuntime error: Array '%s' index out of bounds.\0A\0ATried to access index %d of dimension %d, but valid range is %d to %d.\0A\00", align 1
 @22 = private unnamed_addr constant [2 x i8] c"b\00", align 1
@@ -38,11 +38,10 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %__1_k = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__1_k1 = alloca i32, align 4
-  store i32 1, i32* %__1_k1, align 4
-  %2 = load i32, i32* %__1_k1, align 4
+  %__1_k = alloca i32, align 4
+  store i32 1, i32* %__1_k, align 4
+  %2 = load i32, i32* %__1_k, align 4
   %3 = sub i32 %2, 1
   %4 = mul i32 1, %3
   %5 = add i32 0, %4
@@ -59,57 +58,57 @@ then:                                             ; preds = %.entry
 ifcont:                                           ; preds = %.entry
   %9 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %5
   store i32 10, i32* %9, align 4
-  store i32 2, i32* %__1_k1, align 4
-  %10 = load i32, i32* %__1_k1, align 4
+  store i32 2, i32* %__1_k, align 4
+  %10 = load i32, i32* %__1_k, align 4
   %11 = sub i32 %10, 1
   %12 = mul i32 1, %11
   %13 = add i32 0, %12
   %14 = icmp slt i32 %10, 1
   %15 = icmp sgt i32 %10, 3
   %16 = or i1 %14, %15
-  br i1 %16, label %then2, label %ifcont3
+  br i1 %16, label %then1, label %ifcont2
 
-then2:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([189 x i8], [189 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 %10, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont3:                                          ; preds = %ifcont
+ifcont2:                                          ; preds = %ifcont
   %17 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %13
   store i32 20, i32* %17, align 4
-  store i32 3, i32* %__1_k1, align 4
-  %18 = load i32, i32* %__1_k1, align 4
+  store i32 3, i32* %__1_k, align 4
+  %18 = load i32, i32* %__1_k, align 4
   %19 = sub i32 %18, 1
   %20 = mul i32 1, %19
   %21 = add i32 0, %20
   %22 = icmp slt i32 %18, 1
   %23 = icmp sgt i32 %18, 3
   %24 = or i1 %22, %23
-  br i1 %24, label %then4, label %ifcont5
+  br i1 %24, label %then3, label %ifcont4
 
-then4:                                            ; preds = %ifcont3
+then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([189 x i8], [189 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 %18, i32 1, i32 1, i32 3)
   call void @exit(i32 1)
   unreachable
 
-ifcont5:                                          ; preds = %ifcont3
+ifcont4:                                          ; preds = %ifcont2
   %25 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i32 %21
   store i32 30, i32* %25, align 4
   %26 = load i32, i32* @main.n, align 4
   %27 = icmp slt i32 3, %26
-  br i1 %27, label %then6, label %ifcont7
+  br i1 %27, label %then5, label %ifcont6
 
-then6:                                            ; preds = %ifcont5
+then5:                                            ; preds = %ifcont4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([212 x i8], [212 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([7 x i8], [7 x i8]* @26, i32 0, i32 0), i32 3, i32 1, i32 2, i32 %26)
   call void @exit(i32 1)
   unreachable
 
-ifcont7:                                          ; preds = %ifcont5
+ifcont6:                                          ; preds = %ifcont4
   call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont7
+return:                                           ; preds = %ifcont6
   br label %FINALIZE_SYMTABLE_main
 
 FINALIZE_SYMTABLE_main:                           ; preds = %return

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "037b9eddf79dfec43677e9d99f782599c1c213f8a5525b110b05e858",
+    "stdout_hash": "086315ed1dc32c8439263915c3fc2cc19dd7ea6fe75c2cb615c8b10e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -18,19 +18,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %a = alloca i32, align 4
-  store i32 3, i32* %a, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   store i32 1, i32* %i, align 4
   %j = alloca i32, align 4
   store i32 2, i32* %j, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  store i32 1, i32* %i1, align 4
-  %j2 = alloca i32, align 4
-  store i32 2, i32* %j2, align 4
-  %a3 = alloca i32, align 4
-  store i32 3, i32* %a3, align 4
+  %a = alloca i32, align 4
+  store i32 3, i32* %a, align 4
   %l = alloca i1, align 1
   store i1 true, i1* %l, align 1
   %b = alloca i1, align 1

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "a81823eb870fa6592d598a95f2c2d17a260efbe5562593354d0aaf1c",
+    "stdout_hash": "7b7c8cb0b3b16c319223db99f45dda496187f348484b0eb57b4266bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -11,15 +11,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %prec11 = alloca i32, align 4
-  store i32 4, i32* %prec11, align 4
-  %prec22 = alloca i32, align 4
-  store i32 8, i32* %prec22, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @int_dp_param.u, i64* @int_dp_param.v)
   %4 = load i64, i64* %2, align 4

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "d33e34016f291617cef59acb44f7a3b6b6825416eeee4e01ae2fd408",
+    "stdout_hash": "b4b93905f6ee4168c20c7db3cab0e054539eb9cfee7d21f78347f796",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -27,11 +27,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %dp = alloca i32, align 4
   store i32 8, i32* %dp, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %dp1 = alloca i32, align 4
-  store i32 8, i32* %dp1, align 4
   %x = alloca float, align 4
   store float 0x3FEFFFFFE0000000, float* %x, align 4
   %2 = alloca i64, align 8
@@ -60,144 +58,144 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %13 = alloca i64, align 8
   %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, float* %x)
   %15 = load i64, i64* %13, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %15, i64* %17, align 4
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %21 = load i64, i64* %20, align 4
   %22 = trunc i64 %21 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %23 = icmp eq i8* %14, null
-  br i1 %23, label %free_done4, label %free_nonnull3
+  br i1 %23, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %14)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   store float 1.000000e+00, float* %x, align 4
   %24 = alloca i64, align 8
   %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %24, i32 0, i32 0, float* %x)
   %26 = load i64, i64* %24, align 4
-  %stringFormat_desc5 = alloca %string_descriptor, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 0
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %25, i8** %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 1
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   store i64 %26, i64* %28, align 4
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 0
+  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   %30 = load i8*, i8** %29, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 1
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %32 = load i64, i64* %31, align 4
   %33 = trunc i64 %32 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %30, i32 %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %34 = icmp eq i8* %25, null
-  br i1 %34, label %free_done7, label %free_nonnull6
+  br i1 %34, label %free_done6, label %free_nonnull5
 
-free_nonnull6:                                    ; preds = %free_done4
+free_nonnull5:                                    ; preds = %free_done3
   call void @_lfortran_free(i8* %25)
-  br label %free_done7
+  br label %free_done6
 
-free_done7:                                       ; preds = %free_nonnull6, %free_done4
+free_done6:                                       ; preds = %free_nonnull5, %free_done3
   store float 1.000000e+00, float* %x, align 4
   %35 = alloca i64, align 8
   %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %35, i32 0, i32 0, float* %x)
   %37 = load i64, i64* %35, align 4
-  %stringFormat_desc8 = alloca %string_descriptor, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 0
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 1
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   store i64 %37, i64* %39, align 4
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 0
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   %41 = load i8*, i8** %40, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 1
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %43 = load i64, i64* %42, align 4
   %44 = trunc i64 %43 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %45 = icmp eq i8* %36, null
-  br i1 %45, label %free_done10, label %free_nonnull9
+  br i1 %45, label %free_done9, label %free_nonnull8
 
-free_nonnull9:                                    ; preds = %free_done7
+free_nonnull8:                                    ; preds = %free_done6
   call void @_lfortran_free(i8* %36)
-  br label %free_done10
+  br label %free_done9
 
-free_done10:                                      ; preds = %free_nonnull9, %free_done7
+free_done9:                                       ; preds = %free_nonnull8, %free_done6
   store float 1.000000e+00, float* %x, align 4
   %46 = alloca i64, align 8
   %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %46, i32 0, i32 0, float* %x)
   %48 = load i64, i64* %46, align 4
-  %stringFormat_desc11 = alloca %string_descriptor, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc11, i32 0, i32 0
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %47, i8** %49, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc11, i32 0, i32 1
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   store i64 %48, i64* %50, align 4
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc11, i32 0, i32 0
+  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   %52 = load i8*, i8** %51, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc11, i32 0, i32 1
+  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %54 = load i64, i64* %53, align 4
   %55 = trunc i64 %54 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %56 = icmp eq i8* %47, null
-  br i1 %56, label %free_done13, label %free_nonnull12
+  br i1 %56, label %free_done12, label %free_nonnull11
 
-free_nonnull12:                                   ; preds = %free_done10
+free_nonnull11:                                   ; preds = %free_done9
   call void @_lfortran_free(i8* %47)
-  br label %free_done13
+  br label %free_done12
 
-free_done13:                                      ; preds = %free_nonnull12, %free_done10
+free_done12:                                      ; preds = %free_nonnull11, %free_done9
   store float 0x3FEFFFFFE0000000, float* %x, align 4
   %57 = alloca i64, align 8
   %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %57, i32 0, i32 0, float* %x)
   %59 = load i64, i64* %57, align 4
-  %stringFormat_desc14 = alloca %string_descriptor, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 0
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %58, i8** %60, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 1
+  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   store i64 %59, i64* %61, align 4
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 0
+  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   %63 = load i8*, i8** %62, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc14, i32 0, i32 1
+  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %65 = load i64, i64* %64, align 4
   %66 = trunc i64 %65 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %67 = icmp eq i8* %58, null
-  br i1 %67, label %free_done16, label %free_nonnull15
+  br i1 %67, label %free_done15, label %free_nonnull14
 
-free_nonnull15:                                   ; preds = %free_done13
+free_nonnull14:                                   ; preds = %free_done12
   call void @_lfortran_free(i8* %58)
-  br label %free_done16
+  br label %free_done15
 
-free_done16:                                      ; preds = %free_nonnull15, %free_done13
+free_done15:                                      ; preds = %free_nonnull14, %free_done12
   store float 1.000000e+00, float* %x, align 4
   %68 = alloca i64, align 8
   %69 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %68, i32 0, i32 0, float* %x)
   %70 = load i64, i64* %68, align 4
-  %stringFormat_desc17 = alloca %string_descriptor, align 8
-  %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %69, i8** %71, align 8
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
+  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   store i64 %70, i64* %72, align 4
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
+  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   %74 = load i8*, i8** %73, align 8
-  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
+  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %76 = load i64, i64* %75, align 4
   %77 = trunc i64 %76 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %74, i32 %77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %78 = icmp eq i8* %69, null
-  br i1 %78, label %free_done19, label %free_nonnull18
+  br i1 %78, label %free_done18, label %free_nonnull17
 
-free_nonnull18:                                   ; preds = %free_done16
+free_nonnull17:                                   ; preds = %free_done15
   call void @_lfortran_free(i8* %69)
-  br label %free_done19
+  br label %free_done18
 
-free_done19:                                      ; preds = %free_nonnull18, %free_done16
+free_done18:                                      ; preds = %free_nonnull17, %free_done15
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done19
+return:                                           ; preds = %free_done18
   br label %FINALIZE_SYMTABLE_intrinsics_06
 
 FINALIZE_SYMTABLE_intrinsics_06:                  ; preds = %return

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "c4999a5eeb268abab7e299ffabd31daba452aabeb9353160d6584f28",
+    "stdout_hash": "f7a801cca450fa6f6628b190d20475170692255f5a4bb9848c214d3d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -79,11 +79,10 @@ declare void @exit(i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %array_bound2 = alloca i32, align 4
+  %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  %__libasr_index_0_ = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %__libasr_index_0_1 = alloca i32, align 4
+  %__libasr_index_0_ = alloca i32, align 4
   %w = alloca [5 x double], align 8
   br i1 true, label %then, label %else
 
@@ -97,58 +96,58 @@ else:                                             ; preds = %.entry
 ifcont:                                           ; preds = %else, %then
   %2 = load i32, i32* %array_bound, align 4
   %3 = sub i32 %2, 1
-  store i32 %3, i32* %__libasr_index_0_1, align 4
+  store i32 %3, i32* %__libasr_index_0_, align 4
   br label %loop.head
 
-loop.head:                                        ; preds = %ifcont7, %ifcont
-  %4 = load i32, i32* %__libasr_index_0_1, align 4
+loop.head:                                        ; preds = %ifcont6, %ifcont
+  %4 = load i32, i32* %__libasr_index_0_, align 4
   %5 = add i32 %4, 1
-  br i1 true, label %then3, label %else4
+  br i1 true, label %then2, label %else3
 
-then3:                                            ; preds = %loop.head
-  store i32 5, i32* %array_bound2, align 4
-  br label %ifcont5
+then2:                                            ; preds = %loop.head
+  store i32 5, i32* %array_bound1, align 4
+  br label %ifcont4
 
-else4:                                            ; preds = %loop.head
-  br label %ifcont5
+else3:                                            ; preds = %loop.head
+  br label %ifcont4
 
-ifcont5:                                          ; preds = %else4, %then3
-  %6 = load i32, i32* %array_bound2, align 4
+ifcont4:                                          ; preds = %else3, %then2
+  %6 = load i32, i32* %array_bound1, align 4
   %7 = icmp sle i32 %5, %6
   br i1 %7, label %loop.body, label %loop.end
 
-loop.body:                                        ; preds = %ifcont5
-  %8 = load i32, i32* %__libasr_index_0_1, align 4
+loop.body:                                        ; preds = %ifcont4
+  %8 = load i32, i32* %__libasr_index_0_, align 4
   %9 = add i32 %8, 1
-  store i32 %9, i32* %__libasr_index_0_1, align 4
-  %10 = load i32, i32* %__libasr_index_0_1, align 4
+  store i32 %9, i32* %__libasr_index_0_, align 4
+  %10 = load i32, i32* %__libasr_index_0_, align 4
   %11 = sub i32 %10, 1
   %12 = mul i32 1, %11
   %13 = add i32 0, %12
   %14 = icmp slt i32 %10, 1
   %15 = icmp sgt i32 %10, 5
   %16 = or i1 %14, %15
-  br i1 %16, label %then6, label %ifcont7
+  br i1 %16, label %then5, label %ifcont6
 
-then6:                                            ; preds = %loop.body
+then5:                                            ; preds = %loop.body
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([192 x i8], [192 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 %10, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
-ifcont7:                                          ; preds = %loop.body
+ifcont6:                                          ; preds = %loop.body
   %17 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 %13
   store double 1.390000e+00, double* %17, align 8
   br label %loop.head
 
-loop.end:                                         ; preds = %ifcont5
-  br i1 false, label %then8, label %ifcont9
+loop.end:                                         ; preds = %ifcont4
+  br i1 false, label %then7, label %ifcont8
 
-then8:                                            ; preds = %loop.end
+then7:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([215 x i8], [215 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 5, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
-ifcont9:                                          ; preds = %loop.end
+ifcont8:                                          ; preds = %loop.end
   %18 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
   call void @a(double* %18)
   %19 = alloca i64, align 8
@@ -169,63 +168,63 @@ ifcont9:                                          ; preds = %loop.end
   %30 = icmp eq i8* %21, null
   br i1 %30, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont9
+free_nonnull:                                     ; preds = %ifcont8
   call void @_lfortran_free(i8* %21)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont9
-  br i1 false, label %then10, label %ifcont11
+free_done:                                        ; preds = %free_nonnull, %ifcont8
+  br i1 false, label %then9, label %ifcont10
 
-then10:                                           ; preds = %free_done
+then9:                                            ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([192 x i8], [192 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 5, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
-ifcont11:                                         ; preds = %free_done
+ifcont10:                                         ; preds = %free_done
   %31 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 4
   %32 = load double, double* %31, align 8
   %33 = fsub double %32, -4.830000e+00
   %34 = call double @llvm.fabs.f64(double %33)
   %35 = fcmp ogt double %34, 1.000000e-08
-  br i1 %35, label %then12, label %else13
+  br i1 %35, label %then11, label %else12
 
-then12:                                           ; preds = %ifcont11
+then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont13
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else12:                                           ; preds = %ifcont10
+  br label %ifcont13
 
-ifcont14:                                         ; preds = %else13, %then12
-  br i1 false, label %then15, label %ifcont16
+ifcont13:                                         ; preds = %else12, %then11
+  br i1 false, label %then14, label %ifcont15
 
-then15:                                           ; preds = %ifcont14
+then14:                                           ; preds = %ifcont13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([192 x i8], [192 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 4, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
-ifcont16:                                         ; preds = %ifcont14
+ifcont15:                                         ; preds = %ifcont13
   %36 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 3
   %37 = load double, double* %36, align 8
   %38 = fsub double %37, 3.140000e+00
   %39 = call double @llvm.fabs.f64(double %38)
   %40 = fcmp ogt double %39, 1.000000e-10
-  br i1 %40, label %then17, label %else18
+  br i1 %40, label %then16, label %else17
 
-then17:                                           ; preds = %ifcont16
+then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont19
+  br label %ifcont18
 
-else18:                                           ; preds = %ifcont16
-  br label %ifcont19
+else17:                                           ; preds = %ifcont15
+  br label %ifcont18
 
-ifcont19:                                         ; preds = %else18, %then17
+ifcont18:                                         ; preds = %else17, %then16
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont19
+return:                                           ; preds = %ifcont18
   br label %FINALIZE_SYMTABLE_legacy_array_sections_01
 
 FINALIZE_SYMTABLE_legacy_array_sections_01:       ; preds = %return

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "99cd9643d54767f1a939fa5ee05d8e6316934cf9547c41fce3a6c40f",
+    "stdout_hash": "592c097b2c9ec68d4e2d1a6d70fa8dcd5f93e5b4a6a68d14d92272df",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -31,13 +31,12 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %2 = call i32 @__module_modules_06_a_b()
-  store i32 %2, i32* %i1, align 4
+  store i32 %2, i32* %i, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "36732ec8096355e2d25c71aacb5b472c043a9c1ce19243005ff01c19",
+    "stdout_hash": "2927f300656c5b072e23db5b9bc74ae40e5618573c28e1ad1ef9880d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -38,13 +38,12 @@ FINALIZE_SYMTABLE_f2:                             ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %f = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %f1 = alloca i32, align 4
+  %f = alloca i32, align 4
   %2 = call i32 @__module_module_13_f1()
-  store i32 %2, i32* %f1, align 4
+  store i32 %2, i32* %f, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %f1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %f)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "75eb64e3e72a1de4fa61e94a71c97de976bee8db9faa7cdfe5758a8b",
+    "stdout_hash": "dc47da351835522557a74d92dfcc4e7618ac7b233989ca6e3003b550",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -51,11 +51,10 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %c = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c1 = alloca i32, align 4
+  %c = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
-  store i32 %2, i32* %c1, align 4
+  store i32 %2, i32* %c, align 4
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "a71f987d38e864e23fc1d59b24b2398a4104bd3987332388fa931466",
+    "stdout_hash": "486d5525e5607fecc859b3bdbc0ff152311e628d778fd7c74e27b23c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -141,12 +141,11 @@ declare void @_lfortran_free(i8*)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  %test = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %test1 = alloca i32, align 4
+  %test = alloca i32, align 4
   store i32 5, i32* %call_arg_value, align 4
   %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
-  store i32 %2, i32* %test1, align 4
+  store i32 %2, i32* %test, align 4
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "50425c52ad20231d33de6a3d6a80878ea88800d708b1cad4e27297b4",
+    "stdout_hash": "d4ff6673331076c761c4df711bc43cb7f4445b65159db40423596b1c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -3,15 +3,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %t1 = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
   %p2 = alloca i32*, align 8
   store i32* null, i32** %p2, align 8
-  %t11 = alloca i32, align 4
-  store i32* %t11, i32** %p1, align 8
-  store i32* %t11, i32** %p2, align 8
+  %t1 = alloca i32, align 4
+  store i32* %t1, i32** %p1, align 8
+  store i32* %t1, i32** %p2, align 8
   %2 = load i32*, i32** %p1, align 8
   store i32 1, i32* %2, align 4
   store i32* null, i32** %p1, align 8

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "798602b19d1f001adca9a0b1005d539249feffce4b8c0eced16e00e0",
+    "stdout_hash": "e1bcff622339eede432b224c15da72e7825baad29abdd6915dc5f6a7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -3,18 +3,17 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %t2 = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca float*, align 8
   store float* null, float** %p1, align 8
   %p2 = alloca i32*, align 8
   store i32* null, i32** %p2, align 8
   %t1 = alloca float, align 4
-  %t21 = alloca i32, align 4
+  %t2 = alloca i32, align 4
   store float* %t1, float** %p1, align 8
   %2 = load float*, float** %p1, align 8
   store float 1.000000e+00, float* %2, align 4
-  store i32* %t21, i32** %p2, align 8
+  store i32* %t2, i32** %p2, align 8
   %3 = load i32*, i32** %p2, align 8
   store i32 2, i32* %3, align 4
   store float* null, float** %p1, align 8

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "c23b3146fefe89441d66137df904db8fa51fbc78ca31e29808d20378",
+    "stdout_hash": "1d191ddacdb053bb995535adad4aa958d873d884cb4b8adfa4196dad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -12,20 +12,19 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %x1 = alloca i32, align 4
-  store i32 25, i32* %x1, align 4
+  %x = alloca i32, align 4
+  store i32 25, i32* %x, align 4
   %2 = alloca i64, align 8
   %3 = alloca i32, align 4
   store i32 1, i32* %3, align 4
   %4 = alloca i32, align 4
   store i32 3, i32* %4, align 4
-  %5 = load i32, i32* %x1, align 4
+  %5 = load i32, i32* %x, align 4
   %6 = add i32 25, %5
   %7 = alloca i32, align 4
   store i32 %6, i32* %7, align 4
-  %8 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %x1, i32* %3, i32* %4, i32* %x1, i32* %7)
+  %8 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %x, i32* %3, i32* %4, i32* %x, i32* %7)
   %9 = load i64, i64* %2, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -51,35 +50,35 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 1, i32* %19, align 4
   %20 = alloca i32, align 4
   store i32 3, i32* %20, align 4
-  %21 = load i32, i32* %x1, align 4
+  %21 = load i32, i32* %x, align 4
   %22 = add i32 25, %21
   %23 = alloca i32, align 4
   store i32 %22, i32* %23, align 4
-  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, i32* %x1, i32* %19, i32* %20, i32* %x1, i32* %23)
+  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, i32* %x, i32* %19, i32* %20, i32* %x, i32* %23)
   %25 = load i64, i64* %18, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %24, i8** %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %25, i64* %27, align 4
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %29 = load i8*, i8** %28, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %31 = load i64, i64* %30, align 4
   %32 = trunc i64 %31 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %33 = icmp eq i8* %24, null
-  br i1 %33, label %free_done4, label %free_nonnull3
+  br i1 %33, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %24)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done4
+return:                                           ; preds = %free_done3
   br label %FINALIZE_SYMTABLE_print_01
 
 FINALIZE_SYMTABLE_print_01:                       ; preds = %return

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "18a6d7961b7260fcb6d6b53f7294ffa9a31f23fd383ee4d7591919fb",
+    "stdout_hash": "d2ba4a52b0d0e2a8951914a1e28e0b9f2d699c0389bbe58a1067aee3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -12,12 +12,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  store i32 5, i32* %i1, align 4
+  %i = alloca i32, align 4
+  store i32 5, i32* %i, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i1)
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i)
   %4 = load i64, i64* %2, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -39,35 +38,35 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = alloca i64, align 8
-  %14 = load i32, i32* %i1, align 4
+  %14 = load i32, i32* %i, align 4
   %15 = add i32 %14, 1
   %16 = alloca i32, align 4
   store i32 %15, i32* %16, align 4
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32* %16)
   %18 = load i64, i64* %13, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %18, i64* %20, align 4
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %24 = load i64, i64* %23, align 4
   %25 = trunc i64 %24 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %26 = icmp eq i8* %17, null
-  br i1 %26, label %free_done4, label %free_nonnull3
+  br i1 %26, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %17)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done4
+return:                                           ; preds = %free_done3
   br label %FINALIZE_SYMTABLE_program1
 
 FINALIZE_SYMTABLE_program1:                       ; preds = %return

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "e3fdaa08ced27d2ca1666796196105bb3373d33eb9df204d9e16a01f",
+    "stdout_hash": "5560475e6c9d14282bc9d5be1fcc964b58811ec8306ff4638831ad51",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -11,23 +11,22 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  %z = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %z1 = alloca i32, align 4
-  store i32 0, i32* %z1, align 4
+  %z = alloca i32, align 4
+  store i32 0, i32* %z, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %free_done, %.entry
-  %2 = load i32, i32* %z1, align 4
+  %2 = load i32, i32* %z, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %z1, align 4
+  %5 = load i32, i32* %z, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %z1, align 4
-  %7 = load i32, i32* %z1, align 4
+  store i32 %6, i32* %z, align 4
+  %7 = load i32, i32* %z, align 4
   store i32 %7, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
   %8 = alloca i64, align 8
   store i32 1, i32* %call_arg_value, align 4
@@ -56,7 +55,7 @@ free_nonnull:                                     ; preds = %loop.body
 
 free_done:                                        ; preds = %free_nonnull, %loop.body
   %21 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
-  store i32 %21, i32* %z1, align 4
+  store i32 %21, i32* %z, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "9d9dbe7d918ad16a5a4c124e2e6fa35f7e311c3299b27941b0807d24",
+    "stdout_hash": "07870ff682c0bdfcd68cbd14b29770e728ff8ccbe2acfd275adb8471",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -12,15 +12,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %prec11 = alloca i32, align 4
-  store i32 4, i32* %prec11, align 4
-  %prec22 = alloca i32, align 4
-  store i32 8, i32* %prec22, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @real_dp_param.u, double* @real_dp_param.v, double* @real_dp_param.zero)
   %4 = load i64, i64* %2, align 4

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "f323e8bd72db0515dfaddf57ef4c1cff32712bb90fdaf59b4673c4bc",
+    "stdout_hash": "510b963b4339df0ebeb5622d9de2da743245184d3b9682f530e52c81",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -192,17 +192,16 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value2 = alloca i32, align 4
+  %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  %r = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %r1 = alloca i32, align 4
+  %r = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value2, align 4
-  %2 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value2)
-  store i32 %2, i32* %r1, align 4
+  store i32 3, i32* %call_arg_value1, align 4
+  %2 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %2, i32* %r, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "2098717da2189ebdb64dc1a4f1343dd33c9fb6a951f6dc2119466d16",
+    "stdout_hash": "e8b5bf5efcecf3c1fde126fef0a8449c3f5eca8dfeeca5317b21f5d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -209,17 +209,16 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %call_arg_value2 = alloca i32, align 4
+  %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  %r = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %r1 = alloca i32, align 4
+  %r = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value2, align 4
-  %2 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value2)
-  store i32 %2, i32* %r1, align 4
+  store i32 3, i32* %call_arg_value1, align 4
+  %2 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %2, i32* %r, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "9922cec3e8093849a379ebd220f7ccddc660da990b124370a295f9b6",
+    "stdout_hash": "0fc27de719ced6ae5187dae7f9d7ffada1c20165f210ebbee6c5f953",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -18,11 +18,10 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %main_out = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %main_out1 = alloca i32, align 4
+  %main_out = alloca i32, align 4
   %2 = call i32 @main1()
-  store i32 %2, i32* %main_out1, align 4
+  store i32 %2, i32* %main_out, align 4
   %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   call void @_lpython_free_argv()

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "ea57bdcf5555cea4e3e10e0f8e6cb6d9c1e878e3ef90d601df3f93e5",
+    "stdout_hash": "e62c5b6f9e2520c4f4c671648cf86f4500fab7e2ea307f3ae0182002",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -102,14 +102,13 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  %c = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c1 = alloca i32, align 4
+  %c = alloca i32, align 4
   store i32 1, i32* %call_arg_value, align 4
   %2 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %2, i32* %c1, align 4
+  store i32 %2, i32* %c, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %c1)
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %c)
   %5 = load i64, i64* %3, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -132,83 +131,83 @@ free_nonnull:                                     ; preds = %.entry
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i32 2, i32* %call_arg_value, align 4
   %14 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %14, i32* %c1, align 4
+  store i32 %14, i32* %c, align 4
   %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %c1)
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %c)
   %17 = load i64, i64* %15, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %17, i64* %19, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %23 = load i64, i64* %22, align 4
   %24 = trunc i64 %23 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %25 = icmp eq i8* %16, null
-  br i1 %25, label %free_done4, label %free_nonnull3
+  br i1 %25, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %16)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   store i32 3, i32* %call_arg_value, align 4
   %26 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %26, i32* %c1, align 4
+  store i32 %26, i32* %c, align 4
   %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %c1)
+  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %c)
   %29 = load i64, i64* %27, align 4
-  %stringFormat_desc5 = alloca %string_descriptor, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 0
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 1
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   store i64 %29, i64* %31, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 0
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc5, i32 0, i32 1
+  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %35 = load i64, i64* %34, align 4
   %36 = trunc i64 %35 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %37 = icmp eq i8* %28, null
-  br i1 %37, label %free_done7, label %free_nonnull6
+  br i1 %37, label %free_done6, label %free_nonnull5
 
-free_nonnull6:                                    ; preds = %free_done4
+free_nonnull5:                                    ; preds = %free_done3
   call void @_lfortran_free(i8* %28)
-  br label %free_done7
+  br label %free_done6
 
-free_done7:                                       ; preds = %free_nonnull6, %free_done4
+free_done6:                                       ; preds = %free_nonnull5, %free_done3
   store i32 4, i32* %call_arg_value, align 4
   %38 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %38, i32* %c1, align 4
+  store i32 %38, i32* %c, align 4
   %39 = alloca i64, align 8
-  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %c1)
+  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %c)
   %41 = load i64, i64* %39, align 4
-  %stringFormat_desc8 = alloca %string_descriptor, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 0
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %40, i8** %42, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 1
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   store i64 %41, i64* %43, align 4
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 0
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   %45 = load i8*, i8** %44, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc8, i32 0, i32 1
+  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %47 = load i64, i64* %46, align 4
   %48 = trunc i64 %47 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %45, i32 %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %49 = icmp eq i8* %40, null
-  br i1 %49, label %free_done10, label %free_nonnull9
+  br i1 %49, label %free_done9, label %free_nonnull8
 
-free_nonnull9:                                    ; preds = %free_done7
+free_nonnull8:                                    ; preds = %free_done6
   call void @_lfortran_free(i8* %40)
-  br label %free_done10
+  br label %free_done9
 
-free_done10:                                      ; preds = %free_nonnull9, %free_done7
+free_done9:                                       ; preds = %free_nonnull8, %free_done6
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done10
+return:                                           ; preds = %free_done9
   br label %FINALIZE_SYMTABLE_returns
 
 FINALIZE_SYMTABLE_returns:                        ; preds = %return

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "df2ef9629c65f923dec0a17a2b52fca4f44b8ac9ce2da7a21373efc0",
+    "stdout_hash": "159bc30ed3640f946464d289bea06c8d53773af24072c29aff219022",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -3,7 +3,6 @@ source_filename = "LFortran"
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@main.main_out = internal global i32 999
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [12 x i8] c"early return"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
@@ -12,6 +11,7 @@ source_filename = "LFortran"
 @string_const_data.1 = private constant [13 x i8] c"normal return"
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.1, i32 0, i32 0), i64 13 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@main.main_out = internal global i32 999
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [12 x i8] c"main1 called"
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data.3, i32 0, i32 0), i64 12 }>

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "4e1385c56a6bd5eb333f0daa83ef733b9add880f75adfc328939674d",
+    "stdout_hash": "25664f5a74ead27cac1c65e20ee42d0ca11bd41a29e8e860f0ec60aa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -7,11 +7,10 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %x1 = alloca i32, align 4
-  store i32 25, i32* %x1, align 4
-  %2 = load i32, i32* %x1, align 4
+  %x = alloca i32, align 4
+  store i32 25, i32* %x, align 4
+  %2 = load i32, i32* %x, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "0b069a51299b30bd98d55c3bf32bca64e362b7ddc39e53908d0a15c4",
+    "stdout_hash": "8f68f39ce484339bdc0e5ab52ca53d113d3d49f43c80ff3307a8fed3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -16,19 +16,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %ia0 = alloca i32, align 4
   store i32 48, i32* %ia0, align 4
   %ia5 = alloca i32, align 4
   store i32 53, i32* %ia5, align 4
   %ia9 = alloca i32, align 4
   store i32 57, i32* %ia9, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %ia01 = alloca i32, align 4
-  store i32 48, i32* %ia01, align 4
-  %ia52 = alloca i32, align 4
-  store i32 53, i32* %ia52, align 4
-  %ia93 = alloca i32, align 4
-  store i32 57, i32* %ia93, align 4
   br i1 false, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -40,28 +34,28 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
+  br i1 false, label %then1, label %else2
+
+then1:                                            ; preds = %ifcont
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont3
+
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %then1
   br i1 false, label %then4, label %else5
 
-then4:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+then4:                                            ; preds = %ifcont3
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   br label %ifcont6
 
-else5:                                            ; preds = %ifcont
+else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  br i1 false, label %then7, label %else8
-
-then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont9
-
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
-
-ifcont9:                                          ; preds = %else8, %then7
   %2 = alloca i64, align 8
   %3 = alloca i32, align 4
   store i32 48, i32* %3, align 4
@@ -85,11 +79,11 @@ ifcont9:                                          ; preds = %else8, %then7
   %15 = icmp eq i8* %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont9
+free_nonnull:                                     ; preds = %ifcont6
   call void @_lfortran_free(i8* %6)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont9
+free_done:                                        ; preds = %free_nonnull, %ifcont6
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-string_54-06ad64c.json
+++ b/tests/reference/llvm-string_54-06ad64c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_54-06ad64c.stdout",
-    "stdout_hash": "1157f067279f47dca775bf16e1e32665f9fca32ed043f449de12aaf0",
+    "stdout_hash": "d00c88ca36a87d39c38ce7ce9b4f0864ee20b150fff5c904dc0d2f32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_54-06ad64c.stdout
+++ b/tests/reference/llvm-string_54-06ad64c.stdout
@@ -32,7 +32,6 @@ FINALIZE_SYMTABLE_foo_sub:                        ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %char = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %char, align 1
@@ -41,9 +40,9 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = getelementptr %string_descriptor, %string_descriptor* %char, i32 0, i32 0
   %4 = call i8* @_lfortran_malloc(i64 10)
   store i8* %4, i8** %3, align 8
-  %x1 = alloca i32, align 4
-  store i32 10, i32* %x1, align 4
-  call void @__module_string_54_mod_foo_sub(i32* %x1, %string_descriptor* %char)
+  %x = alloca i32, align 4
+  store i32 10, i32* %x, align 4
+  call void @__module_string_54_mod_foo_sub(i32* %x, %string_descriptor* %char)
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "ef32b81de9cb9767818bbbfdf498922f9e62cd51d3a19f502c285143",
+    "stdout_hash": "2af3c886f18d2a108de5b6e22ff43685f69b3e1eab9992088c344abf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -38,14 +38,12 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 1, i32* %i1, align 4
-  store i32 1, i32* %j2, align 4
-  %2 = load i32, i32* %j2, align 4
+  store i32 1, i32* %i, align 4
+  store i32 1, i32* %j, align 4
+  %2 = load i32, i32* %j, align 4
   %3 = icmp ne i32 %2, 1
   br i1 %3, label %then, label %else
 
@@ -58,9 +56,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @f(i32* %i1, i32* %j2)
+  call void @f(i32* %i, i32* %j)
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %i1, i32* %j2)
+  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %i, i32* %j)
   %6 = load i64, i64* %4, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -81,191 +79,191 @@ free_nonnull:                                     ; preds = %ifcont
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  %15 = load i32, i32* %i1, align 4
+  %15 = load i32, i32* %i, align 4
   %16 = icmp ne i32 %15, 1
-  br i1 %16, label %then3, label %else4
+  br i1 %16, label %then1, label %else2
 
-then3:                                            ; preds = %free_done
+then1:                                            ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %free_done
-  br label %ifcont5
+else2:                                            ; preds = %free_done
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %then3
-  %17 = load i32, i32* %j2, align 4
+ifcont3:                                          ; preds = %else2, %then1
+  %17 = load i32, i32* %j, align 4
   %18 = icmp ne i32 %17, 2
-  br i1 %18, label %then6, label %else7
+  br i1 %18, label %then4, label %else5
 
-then6:                                            ; preds = %ifcont5
+then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont8
+  br label %ifcont6
 
-else7:                                            ; preds = %ifcont5
-  br label %ifcont8
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
 
-ifcont8:                                          ; preds = %else7, %then6
-  store i32 1, i32* %j2, align 4
-  %19 = load i32, i32* %j2, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  store i32 1, i32* %j, align 4
+  %19 = load i32, i32* %j, align 4
   %20 = icmp ne i32 %19, 1
-  br i1 %20, label %then9, label %else10
+  br i1 %20, label %then7, label %else8
 
-then9:                                            ; preds = %ifcont8
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %ifcont8
-  br label %ifcont11
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
+ifcont9:                                          ; preds = %else8, %then7
   store i32 3, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j2)
+  call void @f(i32* %call_arg_value, i32* %j)
   %21 = alloca i64, align 8
-  %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %21, i32 0, i32 0, i32* %j2)
+  %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %21, i32 0, i32 0, i32* %j)
   %23 = load i64, i64* %21, align 4
-  %stringFormat_desc12 = alloca %string_descriptor, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc12, i32 0, i32 0
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %22, i8** %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc12, i32 0, i32 1
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   store i64 %23, i64* %25, align 4
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc12, i32 0, i32 0
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   %27 = load i8*, i8** %26, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc12, i32 0, i32 1
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %29 = load i64, i64* %28, align 4
   %30 = trunc i64 %29 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %31 = icmp eq i8* %22, null
-  br i1 %31, label %free_done14, label %free_nonnull13
+  br i1 %31, label %free_done12, label %free_nonnull11
 
-free_nonnull13:                                   ; preds = %ifcont11
+free_nonnull11:                                   ; preds = %ifcont9
   call void @_lfortran_free(i8* %22)
-  br label %free_done14
+  br label %free_done12
 
-free_done14:                                      ; preds = %free_nonnull13, %ifcont11
-  %32 = load i32, i32* %j2, align 4
+free_done12:                                      ; preds = %free_nonnull11, %ifcont9
+  %32 = load i32, i32* %j, align 4
   %33 = icmp ne i32 %32, 4
-  br i1 %33, label %then15, label %else16
+  br i1 %33, label %then13, label %else14
 
-then15:                                           ; preds = %free_done14
+then13:                                           ; preds = %free_done12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont17
+  br label %ifcont15
 
-else16:                                           ; preds = %free_done14
-  br label %ifcont17
+else14:                                           ; preds = %free_done12
+  br label %ifcont15
 
-ifcont17:                                         ; preds = %else16, %then15
-  store i32 1, i32* %j2, align 4
-  %34 = load i32, i32* %j2, align 4
+ifcont15:                                         ; preds = %else14, %then13
+  store i32 1, i32* %j, align 4
+  %34 = load i32, i32* %j, align 4
   %35 = icmp ne i32 %34, 1
-  br i1 %35, label %then18, label %else19
+  br i1 %35, label %then16, label %else17
 
-then18:                                           ; preds = %ifcont17
+then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else19:                                           ; preds = %ifcont17
-  br label %ifcont20
+else17:                                           ; preds = %ifcont15
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %else19, %then18
+ifcont18:                                         ; preds = %else17, %then16
   store i32 3, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j2)
+  call void @f(i32* %call_arg_value, i32* %j)
   %36 = alloca i64, align 8
-  %37 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %36, i32 0, i32 0, i32* %j2)
+  %37 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %36, i32 0, i32 0, i32* %j)
   %38 = load i64, i64* %36, align 4
-  %stringFormat_desc21 = alloca %string_descriptor, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc21, i32 0, i32 0
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc21, i32 0, i32 1
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   store i64 %38, i64* %40, align 4
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc21, i32 0, i32 0
+  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc21, i32 0, i32 1
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %44 = load i64, i64* %43, align 4
   %45 = trunc i64 %44 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
   %46 = icmp eq i8* %37, null
-  br i1 %46, label %free_done23, label %free_nonnull22
+  br i1 %46, label %free_done21, label %free_nonnull20
 
-free_nonnull22:                                   ; preds = %ifcont20
+free_nonnull20:                                   ; preds = %ifcont18
   call void @_lfortran_free(i8* %37)
-  br label %free_done23
+  br label %free_done21
 
-free_done23:                                      ; preds = %free_nonnull22, %ifcont20
-  %47 = load i32, i32* %j2, align 4
+free_done21:                                      ; preds = %free_nonnull20, %ifcont18
+  %47 = load i32, i32* %j, align 4
   %48 = icmp ne i32 %47, 4
-  br i1 %48, label %then24, label %else25
+  br i1 %48, label %then22, label %else23
 
-then24:                                           ; preds = %free_done23
+then22:                                           ; preds = %free_done21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %free_done23
-  br label %ifcont26
+else23:                                           ; preds = %free_done21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %then24
-  store i32 1, i32* %j2, align 4
-  %49 = load i32, i32* %j2, align 4
+ifcont24:                                         ; preds = %else23, %then22
+  store i32 1, i32* %j, align 4
+  %49 = load i32, i32* %j, align 4
   %50 = icmp ne i32 %49, 1
-  br i1 %50, label %then27, label %else28
+  br i1 %50, label %then25, label %else26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont29
+  br label %ifcont27
 
-else28:                                           ; preds = %ifcont26
-  br label %ifcont29
+else26:                                           ; preds = %ifcont24
+  br label %ifcont27
 
-ifcont29:                                         ; preds = %else28, %then27
-  %51 = load i32, i32* %i1, align 4
+ifcont27:                                         ; preds = %else26, %then25
+  %51 = load i32, i32* %i, align 4
   %52 = add i32 %51, 2
   store i32 %52, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j2)
+  call void @f(i32* %call_arg_value, i32* %j)
   %53 = alloca i64, align 8
-  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %53, i32 0, i32 0, i32* %j2)
+  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %53, i32 0, i32 0, i32* %j)
   %55 = load i64, i64* %53, align 4
-  %stringFormat_desc30 = alloca %string_descriptor, align 8
-  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc30, i32 0, i32 0
+  %stringFormat_desc28 = alloca %string_descriptor, align 8
+  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
   store i8* %54, i8** %56, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc30, i32 0, i32 1
+  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1
   store i64 %55, i64* %57, align 4
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc30, i32 0, i32 0
+  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
   %59 = load i8*, i8** %58, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc30, i32 0, i32 1
+  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1
   %61 = load i64, i64* %60, align 4
   %62 = trunc i64 %61 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %59, i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   %63 = icmp eq i8* %54, null
-  br i1 %63, label %free_done32, label %free_nonnull31
+  br i1 %63, label %free_done30, label %free_nonnull29
 
-free_nonnull31:                                   ; preds = %ifcont29
+free_nonnull29:                                   ; preds = %ifcont27
   call void @_lfortran_free(i8* %54)
-  br label %free_done32
+  br label %free_done30
 
-free_done32:                                      ; preds = %free_nonnull31, %ifcont29
-  %64 = load i32, i32* %j2, align 4
+free_done30:                                      ; preds = %free_nonnull29, %ifcont27
+  %64 = load i32, i32* %j, align 4
   %65 = icmp ne i32 %64, 4
-  br i1 %65, label %then33, label %else34
+  br i1 %65, label %then31, label %else32
 
-then33:                                           ; preds = %free_done32
+then31:                                           ; preds = %free_done30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont35
+  br label %ifcont33
 
-else34:                                           ; preds = %free_done32
-  br label %ifcont35
+else32:                                           ; preds = %free_done30
+  br label %ifcont33
 
-ifcont35:                                         ; preds = %else34, %then33
+ifcont33:                                         ; preds = %else32, %then31
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont35
+return:                                           ; preds = %ifcont33
   br label %FINALIZE_SYMTABLE_subroutines_01
 
 FINALIZE_SYMTABLE_subroutines_01:                 ; preds = %return

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "18c06d09e359792fc7fba498afc9bae0ad87b13a0b1dbb99672baed8",
+    "stdout_hash": "75688d1068b991b52465d0338841d9b5037353e7bb2f2e767330595b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -28,16 +28,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 1, i32* %i1, align 4
-  store i32 1, i32* %j2, align 4
-  call void @f(i32* %i1, i32* %j2)
+  store i32 1, i32* %i, align 4
+  store i32 1, i32* %j, align 4
+  call void @f(i32* %i, i32* %j)
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i1, i32* %j2)
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i, i32* %j)
   %4 = load i64, i64* %2, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -58,7 +56,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = load i32, i32* %i1, align 4
+  %13 = load i32, i32* %i, align 4
   %14 = icmp ne i32 %13, 1
   br i1 %14, label %then, label %else
 
@@ -71,121 +69,121 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %15 = load i32, i32* %j2, align 4
+  %15 = load i32, i32* %j, align 4
   %16 = icmp ne i32 %15, 2
-  br i1 %16, label %then3, label %else4
+  br i1 %16, label %then1, label %else2
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %then3
-  call void @g(i32* %i1, i32* %j2)
+ifcont3:                                          ; preds = %else2, %then1
+  call void @g(i32* %i, i32* %j)
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32* %i1, i32* %j2)
+  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32* %i, i32* %j)
   %19 = load i64, i64* %17, align 4
-  %stringFormat_desc6 = alloca %string_descriptor, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 0
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 0
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc6, i32 0, i32 1
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %25 = load i64, i64* %24, align 4
   %26 = trunc i64 %25 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done8, label %free_nonnull7
+  br i1 %27, label %free_done6, label %free_nonnull5
 
-free_nonnull7:                                    ; preds = %ifcont5
+free_nonnull5:                                    ; preds = %ifcont3
   call void @_lfortran_free(i8* %18)
-  br label %free_done8
+  br label %free_done6
 
-free_done8:                                       ; preds = %free_nonnull7, %ifcont5
-  %28 = load i32, i32* %i1, align 4
+free_done6:                                       ; preds = %free_nonnull5, %ifcont3
+  %28 = load i32, i32* %i, align 4
   %29 = icmp ne i32 %28, 1
-  br i1 %29, label %then9, label %else10
+  br i1 %29, label %then7, label %else8
 
-then9:                                            ; preds = %free_done8
+then7:                                            ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %free_done8
-  br label %ifcont11
+else8:                                            ; preds = %free_done6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
-  %30 = load i32, i32* %j2, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %30 = load i32, i32* %j, align 4
   %31 = icmp ne i32 %30, 0
-  br i1 %31, label %then12, label %else13
+  br i1 %31, label %then10, label %else11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %then12
-  call void @h(i32* %i1, i32* %j2)
+ifcont12:                                         ; preds = %else11, %then10
+  call void @h(i32* %i, i32* %j)
   %32 = alloca i64, align 8
-  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %32, i32 0, i32 0, i32* %i1, i32* %j2)
+  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %32, i32 0, i32 0, i32* %i, i32* %j)
   %34 = load i64, i64* %32, align 4
-  %stringFormat_desc15 = alloca %string_descriptor, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc15, i32 0, i32 0
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %33, i8** %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc15, i32 0, i32 1
+  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   store i64 %34, i64* %36, align 4
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc15, i32 0, i32 0
+  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   %38 = load i8*, i8** %37, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc15, i32 0, i32 1
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %40 = load i64, i64* %39, align 4
   %41 = trunc i64 %40 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %38, i32 %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %42 = icmp eq i8* %33, null
-  br i1 %42, label %free_done17, label %free_nonnull16
+  br i1 %42, label %free_done15, label %free_nonnull14
 
-free_nonnull16:                                   ; preds = %ifcont14
+free_nonnull14:                                   ; preds = %ifcont12
   call void @_lfortran_free(i8* %33)
-  br label %free_done17
+  br label %free_done15
 
-free_done17:                                      ; preds = %free_nonnull16, %ifcont14
-  %43 = load i32, i32* %i1, align 4
+free_done15:                                      ; preds = %free_nonnull14, %ifcont12
+  %43 = load i32, i32* %i, align 4
   %44 = icmp ne i32 %43, 1
-  br i1 %44, label %then18, label %else19
+  br i1 %44, label %then16, label %else17
 
-then18:                                           ; preds = %free_done17
+then16:                                           ; preds = %free_done15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else19:                                           ; preds = %free_done17
-  br label %ifcont20
+else17:                                           ; preds = %free_done15
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %else19, %then18
-  %45 = load i32, i32* %j2, align 4
+ifcont18:                                         ; preds = %else17, %then16
+  %45 = load i32, i32* %j, align 4
   %46 = icmp ne i32 %45, 0
-  br i1 %46, label %then21, label %else22
+  br i1 %46, label %then19, label %else20
 
-then21:                                           ; preds = %ifcont20
+then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont23
+  br label %ifcont21
 
-else22:                                           ; preds = %ifcont20
-  br label %ifcont23
+else20:                                           ; preds = %ifcont18
+  br label %ifcont21
 
-ifcont23:                                         ; preds = %else22, %then21
+ifcont21:                                         ; preds = %else20, %then19
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont23
+return:                                           ; preds = %ifcont21
   br label %FINALIZE_SYMTABLE_subroutines_02
 
 FINALIZE_SYMTABLE_subroutines_02:                 ; preds = %return

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "9c0191f01325df7f2f91ddc54efafe22a8078ef090c9dc33b5c42bc2",
+    "stdout_hash": "3e6b692e0d6c6dffe538915c059875468d7aa95ef19ec91d56dfb953",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -3,13 +3,12 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %r = alloca float, align 4
-  store i32 1, i32* %i1, align 4
+  store i32 1, i32* %i, align 4
   store float 1.000000e+00, float* %r, align 4
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = sitofp i32 %2 to float
   store float %3, float* %r, align 4
   call void @_lpython_free_argv()

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "a37c6928ed5098e18069c434b871e27826335567fe70e7f60fe5101c",
+    "stdout_hash": "e2f0d503e2431267a6732a2da406ab9e00fbcf8ac4933b98d4cf69e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -12,9 +12,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %r = alloca float, align 4
   store float 1.500000e+00, float* %r, align 4
   %2 = alloca i64, align 8
@@ -41,33 +40,33 @@ free_nonnull:                                     ; preds = %.entry
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = load float, float* %r, align 4
   %14 = fptosi float %13 to i32
-  store i32 %14, i32* %i1, align 4
+  store i32 %14, i32* %i, align 4
   %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %i1)
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %i)
   %17 = load i64, i64* %15, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   store i64 %17, i64* %19, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %23 = load i64, i64* %22, align 4
   %24 = trunc i64 %23 to i32
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %25 = icmp eq i8* %16, null
-  br i1 %25, label %free_done4, label %free_nonnull3
+  br i1 %25, label %free_done3, label %free_nonnull2
 
-free_nonnull3:                                    ; preds = %free_done
+free_nonnull2:                                    ; preds = %free_done
   call void @_lfortran_free(i8* %16)
-  br label %free_done4
+  br label %free_done3
 
-free_done4:                                       ; preds = %free_nonnull3, %free_done
+free_done3:                                       ; preds = %free_nonnull2, %free_done
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %free_done4
+return:                                           ; preds = %free_done3
   br label %FINALIZE_SYMTABLE_types_03
 
 FINALIZE_SYMTABLE_types_03:                       ; preds = %return

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "f860d4a81e41460cbd4fce57a115b4bf5301488a672193540d64011b",
+    "stdout_hash": "cf26fda90ffb2dd5aedf88cf74d289d9a97d66da369f0c7e480f6af9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -3,15 +3,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %r = alloca float, align 4
   %x = alloca float, align 4
   store float 1.500000e+00, float* %r, align 4
-  store i32 2, i32* %i1, align 4
-  %2 = load i32, i32* %i1, align 4
-  %3 = load i32, i32* %i1, align 4
+  store i32 2, i32* %i, align 4
+  %2 = load i32, i32* %i, align 4
+  %3 = load i32, i32* %i, align 4
   %4 = mul i32 %2, %3
   %5 = sitofp i32 %4 to float
   store float %5, float* %x, align 4
@@ -19,18 +18,18 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = load float, float* %r, align 4
   %8 = fmul float %6, %7
   store float %8, float* %x, align 4
-  %9 = load i32, i32* %i1, align 4
+  %9 = load i32, i32* %i, align 4
   %10 = sitofp i32 %9 to float
   %11 = load float, float* %r, align 4
   %12 = fmul float %10, %11
   store float %12, float* %x, align 4
   %13 = load float, float* %r, align 4
-  %14 = load i32, i32* %i1, align 4
+  %14 = load i32, i32* %i, align 4
   %15 = sitofp i32 %14 to float
   %16 = fmul float %13, %15
   store float %16, float* %x, align 4
-  %17 = load i32, i32* %i1, align 4
-  %18 = load i32, i32* %i1, align 4
+  %17 = load i32, i32* %i, align 4
+  %18 = load i32, i32* %i, align 4
   %19 = add i32 %17, %18
   %20 = sitofp i32 %19 to float
   store float %20, float* %x, align 4
@@ -39,17 +38,17 @@ define i32 @main(i32 %0, i8** %1) {
   %23 = fadd float %21, %22
   store float %23, float* %x, align 4
   %24 = load float, float* %r, align 4
-  %25 = load i32, i32* %i1, align 4
+  %25 = load i32, i32* %i, align 4
   %26 = sitofp i32 %25 to float
   %27 = fadd float %24, %26
   store float %27, float* %x, align 4
-  %28 = load i32, i32* %i1, align 4
+  %28 = load i32, i32* %i, align 4
   %29 = sitofp i32 %28 to float
   %30 = load float, float* %r, align 4
   %31 = fadd float %29, %30
   store float %31, float* %x, align 4
-  %32 = load i32, i32* %i1, align 4
-  %33 = load i32, i32* %i1, align 4
+  %32 = load i32, i32* %i, align 4
+  %33 = load i32, i32* %i, align 4
   %34 = sub i32 %32, %33
   %35 = sitofp i32 %34 to float
   store float %35, float* %x, align 4
@@ -58,17 +57,17 @@ define i32 @main(i32 %0, i8** %1) {
   %38 = fsub float %36, %37
   store float %38, float* %x, align 4
   %39 = load float, float* %r, align 4
-  %40 = load i32, i32* %i1, align 4
+  %40 = load i32, i32* %i, align 4
   %41 = sitofp i32 %40 to float
   %42 = fsub float %39, %41
   store float %42, float* %x, align 4
-  %43 = load i32, i32* %i1, align 4
+  %43 = load i32, i32* %i, align 4
   %44 = sitofp i32 %43 to float
   %45 = load float, float* %r, align 4
   %46 = fsub float %44, %45
   store float %46, float* %x, align 4
-  %47 = load i32, i32* %i1, align 4
-  %48 = load i32, i32* %i1, align 4
+  %47 = load i32, i32* %i, align 4
+  %48 = load i32, i32* %i, align 4
   %49 = sdiv i32 %47, %48
   %50 = sitofp i32 %49 to float
   store float %50, float* %x, align 4
@@ -76,13 +75,13 @@ define i32 @main(i32 %0, i8** %1) {
   %52 = load float, float* %r, align 4
   %53 = fdiv float %51, %52
   store float %53, float* %x, align 4
-  %54 = load i32, i32* %i1, align 4
+  %54 = load i32, i32* %i, align 4
   %55 = sitofp i32 %54 to float
   %56 = load float, float* %r, align 4
   %57 = fdiv float %55, %56
   store float %57, float* %x, align 4
   %58 = load float, float* %r, align 4
-  %59 = load i32, i32* %i1, align 4
+  %59 = load i32, i32* %i, align 4
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
   store float %61, float* %x, align 4

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "34d1f5d1356c0e0d771f70bcd06beba345675d1dd95e7feecd7fc377",
+    "stdout_hash": "4f54beeb28d9295aa2783e992b04ceefa824ba29c3cc673228322833",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -3,9 +3,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %r, align 4
   store float 2.000000e+00, float* %r, align 4
@@ -14,13 +13,13 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %r, align 4
   store float 5.000000e-01, float* %r, align 4
   store float 5.000000e-01, float* %r, align 4
-  store i32 2, i32* %i1, align 4
-  store i32 2, i32* %i1, align 4
-  store i32 8, i32* %i1, align 4
-  store i32 4, i32* %i1, align 4
-  store i32 0, i32* %i1, align 4
-  store i32 0, i32* %i1, align 4
-  store i32 0, i32* %i1, align 4
+  store i32 2, i32* %i, align 4
+  store i32 2, i32* %i, align 4
+  store i32 8, i32* %i, align 4
+  store i32 4, i32* %i, align 4
+  store i32 0, i32* %i, align 4
+  store i32 0, i32* %i, align 4
+  store i32 0, i32* %i, align 4
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "16f6a2590a57292349710a1c7ae0f3aa00d26e0d0e994423269aaee0",
+    "stdout_hash": "addfeef86620c798c4fd3c914febc22a1688116bb9c6ae55158c3575",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -53,14 +53,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %i = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
+  %i = alloca i32, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %r, align 4
-  store i32 2, i32* %i1, align 4
-  %2 = load i32, i32* %i1, align 4
-  %3 = load i32, i32* %i1, align 4
+  store i32 2, i32* %i, align 4
+  %2 = load i32, i32* %i, align 4
+  %3 = load i32, i32* %i, align 4
   %4 = icmp slt i32 %2, %3
   br i1 %4, label %then, label %else
 
@@ -76,353 +75,353 @@ ifcont:                                           ; preds = %else, %then
   %5 = load float, float* %r, align 4
   %6 = load float, float* %r, align 4
   %7 = fcmp olt float %5, %6
-  br i1 %7, label %then2, label %else3
+  br i1 %7, label %then1, label %else2
 
-then2:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont4
+  br label %ifcont3
 
-else3:                                            ; preds = %ifcont
-  br label %ifcont4
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont4:                                          ; preds = %else3, %then2
+ifcont3:                                          ; preds = %else2, %then1
   %8 = load float, float* %r, align 4
-  %9 = load i32, i32* %i1, align 4
+  %9 = load i32, i32* %i, align 4
   %10 = sitofp i32 %9 to float
   %11 = fcmp olt float %8, %10
-  br i1 %11, label %then5, label %else6
+  br i1 %11, label %then4, label %else5
 
-then5:                                            ; preds = %ifcont4
+then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont7
+  br label %ifcont6
 
-else6:                                            ; preds = %ifcont4
-  br label %ifcont7
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
 
-ifcont7:                                          ; preds = %else6, %then5
-  %12 = load i32, i32* %i1, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  %12 = load i32, i32* %i, align 4
   %13 = sitofp i32 %12 to float
   %14 = load float, float* %r, align 4
   %15 = fcmp olt float %13, %14
-  br i1 %15, label %then8, label %else9
+  br i1 %15, label %then7, label %else8
 
-then8:                                            ; preds = %ifcont7
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont10
+  br label %ifcont9
 
-else9:                                            ; preds = %ifcont7
-  br label %ifcont10
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont10:                                         ; preds = %else9, %then8
-  %16 = load i32, i32* %i1, align 4
-  %17 = load i32, i32* %i1, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %16 = load i32, i32* %i, align 4
+  %17 = load i32, i32* %i, align 4
   %18 = icmp sgt i32 %16, %17
-  br i1 %18, label %then11, label %else12
+  br i1 %18, label %then10, label %else11
 
-then11:                                           ; preds = %ifcont10
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont13
+  br label %ifcont12
 
-else12:                                           ; preds = %ifcont10
-  br label %ifcont13
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont13:                                         ; preds = %else12, %then11
+ifcont12:                                         ; preds = %else11, %then10
   %19 = load float, float* %r, align 4
   %20 = load float, float* %r, align 4
   %21 = fcmp ogt float %19, %20
-  br i1 %21, label %then14, label %else15
+  br i1 %21, label %then13, label %else14
 
-then14:                                           ; preds = %ifcont13
+then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont16
+  br label %ifcont15
 
-else15:                                           ; preds = %ifcont13
-  br label %ifcont16
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
 
-ifcont16:                                         ; preds = %else15, %then14
+ifcont15:                                         ; preds = %else14, %then13
   %22 = load float, float* %r, align 4
-  %23 = load i32, i32* %i1, align 4
+  %23 = load i32, i32* %i, align 4
   %24 = sitofp i32 %23 to float
   %25 = fcmp ogt float %22, %24
-  br i1 %25, label %then17, label %else18
+  br i1 %25, label %then16, label %else17
 
-then17:                                           ; preds = %ifcont16
+then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont19
+  br label %ifcont18
 
-else18:                                           ; preds = %ifcont16
-  br label %ifcont19
+else17:                                           ; preds = %ifcont15
+  br label %ifcont18
 
-ifcont19:                                         ; preds = %else18, %then17
-  %26 = load i32, i32* %i1, align 4
+ifcont18:                                         ; preds = %else17, %then16
+  %26 = load i32, i32* %i, align 4
   %27 = sitofp i32 %26 to float
   %28 = load float, float* %r, align 4
   %29 = fcmp ogt float %27, %28
-  br i1 %29, label %then20, label %else21
+  br i1 %29, label %then19, label %else20
 
-then20:                                           ; preds = %ifcont19
+then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont22
+  br label %ifcont21
 
-else21:                                           ; preds = %ifcont19
-  br label %ifcont22
+else20:                                           ; preds = %ifcont18
+  br label %ifcont21
 
-ifcont22:                                         ; preds = %else21, %then20
-  %30 = load i32, i32* %i1, align 4
-  %31 = load i32, i32* %i1, align 4
+ifcont21:                                         ; preds = %else20, %then19
+  %30 = load i32, i32* %i, align 4
+  %31 = load i32, i32* %i, align 4
   %32 = icmp ne i32 %30, %31
-  br i1 %32, label %then23, label %else24
+  br i1 %32, label %then22, label %else23
 
-then23:                                           ; preds = %ifcont22
+then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont25
+  br label %ifcont24
 
-else24:                                           ; preds = %ifcont22
-  br label %ifcont25
+else23:                                           ; preds = %ifcont21
+  br label %ifcont24
 
-ifcont25:                                         ; preds = %else24, %then23
+ifcont24:                                         ; preds = %else23, %then22
   %33 = load float, float* %r, align 4
   %34 = load float, float* %r, align 4
   %35 = fcmp une float %33, %34
-  br i1 %35, label %then26, label %else27
+  br i1 %35, label %then25, label %else26
 
-then26:                                           ; preds = %ifcont25
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont28
+  br label %ifcont27
 
-else27:                                           ; preds = %ifcont25
-  br label %ifcont28
+else26:                                           ; preds = %ifcont24
+  br label %ifcont27
 
-ifcont28:                                         ; preds = %else27, %then26
+ifcont27:                                         ; preds = %else26, %then25
   %36 = load float, float* %r, align 4
-  %37 = load i32, i32* %i1, align 4
+  %37 = load i32, i32* %i, align 4
   %38 = sitofp i32 %37 to float
   %39 = fcmp une float %36, %38
-  br i1 %39, label %then29, label %else30
+  br i1 %39, label %then28, label %else29
 
-then29:                                           ; preds = %ifcont28
+then28:                                           ; preds = %ifcont27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont31
+  br label %ifcont30
 
-else30:                                           ; preds = %ifcont28
-  br label %ifcont31
+else29:                                           ; preds = %ifcont27
+  br label %ifcont30
 
-ifcont31:                                         ; preds = %else30, %then29
-  %40 = load i32, i32* %i1, align 4
+ifcont30:                                         ; preds = %else29, %then28
+  %40 = load i32, i32* %i, align 4
   %41 = sitofp i32 %40 to float
   %42 = load float, float* %r, align 4
   %43 = fcmp une float %41, %42
-  br i1 %43, label %then32, label %else33
+  br i1 %43, label %then31, label %else32
 
-then32:                                           ; preds = %ifcont31
+then31:                                           ; preds = %ifcont30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont34
+  br label %ifcont33
 
-else33:                                           ; preds = %ifcont31
-  br label %ifcont34
+else32:                                           ; preds = %ifcont30
+  br label %ifcont33
 
-ifcont34:                                         ; preds = %else33, %then32
-  %44 = load i32, i32* %i1, align 4
+ifcont33:                                         ; preds = %else32, %then31
+  %44 = load i32, i32* %i, align 4
   %45 = add i32 %44, 1
-  %46 = load i32, i32* %i1, align 4
+  %46 = load i32, i32* %i, align 4
   %47 = icmp sle i32 %45, %46
-  br i1 %47, label %then35, label %else36
+  br i1 %47, label %then34, label %else35
 
-then35:                                           ; preds = %ifcont34
+then34:                                           ; preds = %ifcont33
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont37
+  br label %ifcont36
 
-else36:                                           ; preds = %ifcont34
-  br label %ifcont37
+else35:                                           ; preds = %ifcont33
+  br label %ifcont36
 
-ifcont37:                                         ; preds = %else36, %then35
+ifcont36:                                         ; preds = %else35, %then34
   %48 = load float, float* %r, align 4
   %49 = fadd float %48, 1.000000e+00
   %50 = load float, float* %r, align 4
   %51 = fcmp ole float %49, %50
-  br i1 %51, label %then38, label %else39
+  br i1 %51, label %then37, label %else38
 
-then38:                                           ; preds = %ifcont37
+then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont40
+  br label %ifcont39
 
-else39:                                           ; preds = %ifcont37
-  br label %ifcont40
+else38:                                           ; preds = %ifcont36
+  br label %ifcont39
 
-ifcont40:                                         ; preds = %else39, %then38
+ifcont39:                                         ; preds = %else38, %then37
   %52 = load float, float* %r, align 4
   %53 = fadd float %52, 1.000000e+00
-  %54 = load i32, i32* %i1, align 4
+  %54 = load i32, i32* %i, align 4
   %55 = sitofp i32 %54 to float
   %56 = fcmp ole float %53, %55
-  br i1 %56, label %then41, label %else42
+  br i1 %56, label %then40, label %else41
 
-then41:                                           ; preds = %ifcont40
+then40:                                           ; preds = %ifcont39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont43
+  br label %ifcont42
 
-else42:                                           ; preds = %ifcont40
-  br label %ifcont43
+else41:                                           ; preds = %ifcont39
+  br label %ifcont42
 
-ifcont43:                                         ; preds = %else42, %then41
-  %57 = load i32, i32* %i1, align 4
+ifcont42:                                         ; preds = %else41, %then40
+  %57 = load i32, i32* %i, align 4
   %58 = add i32 %57, 1
   %59 = sitofp i32 %58 to float
   %60 = load float, float* %r, align 4
   %61 = fcmp ole float %59, %60
-  br i1 %61, label %then44, label %else45
+  br i1 %61, label %then43, label %else44
 
-then44:                                           ; preds = %ifcont43
+then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont46
+  br label %ifcont45
 
-else45:                                           ; preds = %ifcont43
-  br label %ifcont46
+else44:                                           ; preds = %ifcont42
+  br label %ifcont45
 
-ifcont46:                                         ; preds = %else45, %then44
-  %62 = load i32, i32* %i1, align 4
-  %63 = load i32, i32* %i1, align 4
+ifcont45:                                         ; preds = %else44, %then43
+  %62 = load i32, i32* %i, align 4
+  %63 = load i32, i32* %i, align 4
   %64 = add i32 %63, 1
   %65 = icmp sge i32 %62, %64
-  br i1 %65, label %then47, label %else48
+  br i1 %65, label %then46, label %else47
 
-then47:                                           ; preds = %ifcont46
+then46:                                           ; preds = %ifcont45
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont49
+  br label %ifcont48
 
-else48:                                           ; preds = %ifcont46
-  br label %ifcont49
+else47:                                           ; preds = %ifcont45
+  br label %ifcont48
 
-ifcont49:                                         ; preds = %else48, %then47
+ifcont48:                                         ; preds = %else47, %then46
   %66 = load float, float* %r, align 4
   %67 = load float, float* %r, align 4
   %68 = fadd float %67, 1.000000e+00
   %69 = fcmp oge float %66, %68
-  br i1 %69, label %then50, label %else51
+  br i1 %69, label %then49, label %else50
 
-then50:                                           ; preds = %ifcont49
+then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont52
+  br label %ifcont51
 
-else51:                                           ; preds = %ifcont49
-  br label %ifcont52
+else50:                                           ; preds = %ifcont48
+  br label %ifcont51
 
-ifcont52:                                         ; preds = %else51, %then50
+ifcont51:                                         ; preds = %else50, %then49
   %70 = load float, float* %r, align 4
-  %71 = load i32, i32* %i1, align 4
+  %71 = load i32, i32* %i, align 4
   %72 = add i32 %71, 1
   %73 = sitofp i32 %72 to float
   %74 = fcmp oge float %70, %73
-  br i1 %74, label %then53, label %else54
+  br i1 %74, label %then52, label %else53
 
-then53:                                           ; preds = %ifcont52
+then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont55
+  br label %ifcont54
 
-else54:                                           ; preds = %ifcont52
-  br label %ifcont55
+else53:                                           ; preds = %ifcont51
+  br label %ifcont54
 
-ifcont55:                                         ; preds = %else54, %then53
-  %75 = load i32, i32* %i1, align 4
+ifcont54:                                         ; preds = %else53, %then52
+  %75 = load i32, i32* %i, align 4
   %76 = sitofp i32 %75 to float
   %77 = load float, float* %r, align 4
   %78 = fadd float %77, 1.000000e+00
   %79 = fcmp oge float %76, %78
-  br i1 %79, label %then56, label %else57
+  br i1 %79, label %then55, label %else56
 
-then56:                                           ; preds = %ifcont55
+then55:                                           ; preds = %ifcont54
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont58
+  br label %ifcont57
 
-else57:                                           ; preds = %ifcont55
-  br label %ifcont58
+else56:                                           ; preds = %ifcont54
+  br label %ifcont57
 
-ifcont58:                                         ; preds = %else57, %then56
-  %80 = load i32, i32* %i1, align 4
-  %81 = load i32, i32* %i1, align 4
+ifcont57:                                         ; preds = %else56, %then55
+  %80 = load i32, i32* %i, align 4
+  %81 = load i32, i32* %i, align 4
   %82 = add i32 %81, 1
   %83 = icmp eq i32 %80, %82
-  br i1 %83, label %then59, label %else60
+  br i1 %83, label %then58, label %else59
 
-then59:                                           ; preds = %ifcont58
+then58:                                           ; preds = %ifcont57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont61
+  br label %ifcont60
 
-else60:                                           ; preds = %ifcont58
-  br label %ifcont61
+else59:                                           ; preds = %ifcont57
+  br label %ifcont60
 
-ifcont61:                                         ; preds = %else60, %then59
+ifcont60:                                         ; preds = %else59, %then58
   %84 = load float, float* %r, align 4
   %85 = load float, float* %r, align 4
   %86 = fadd float %85, 1.000000e+00
   %87 = fcmp oeq float %84, %86
-  br i1 %87, label %then62, label %else63
+  br i1 %87, label %then61, label %else62
 
-then62:                                           ; preds = %ifcont61
+then61:                                           ; preds = %ifcont60
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont64
+  br label %ifcont63
 
-else63:                                           ; preds = %ifcont61
-  br label %ifcont64
+else62:                                           ; preds = %ifcont60
+  br label %ifcont63
 
-ifcont64:                                         ; preds = %else63, %then62
+ifcont63:                                         ; preds = %else62, %then61
   %88 = load float, float* %r, align 4
-  %89 = load i32, i32* %i1, align 4
+  %89 = load i32, i32* %i, align 4
   %90 = add i32 %89, 1
   %91 = sitofp i32 %90 to float
   %92 = fcmp oeq float %88, %91
-  br i1 %92, label %then65, label %else66
+  br i1 %92, label %then64, label %else65
 
-then65:                                           ; preds = %ifcont64
+then64:                                           ; preds = %ifcont63
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont67
+  br label %ifcont66
 
-else66:                                           ; preds = %ifcont64
-  br label %ifcont67
+else65:                                           ; preds = %ifcont63
+  br label %ifcont66
 
-ifcont67:                                         ; preds = %else66, %then65
-  %93 = load i32, i32* %i1, align 4
+ifcont66:                                         ; preds = %else65, %then64
+  %93 = load i32, i32* %i, align 4
   %94 = sitofp i32 %93 to float
   %95 = load float, float* %r, align 4
   %96 = fadd float %95, 1.000000e+00
   %97 = fcmp oeq float %94, %96
-  br i1 %97, label %then68, label %else69
+  br i1 %97, label %then67, label %else68
 
-then68:                                           ; preds = %ifcont67
+then67:                                           ; preds = %ifcont66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont70
+  br label %ifcont69
 
-else69:                                           ; preds = %ifcont67
-  br label %ifcont70
+else68:                                           ; preds = %ifcont66
+  br label %ifcont69
 
-ifcont70:                                         ; preds = %else69, %then68
+ifcont69:                                         ; preds = %else68, %then67
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont70
+return:                                           ; preds = %ifcont69
   br label %FINALIZE_SYMTABLE_types_06
 
 FINALIZE_SYMTABLE_types_06:                       ; preds = %return

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "50e74a9e5f778ba87cb17447b1324a92ad308d60e67c53b7fac7ddaf",
+    "stdout_hash": "3c54164bf4fca9d31b6b4b47871a2df9bfc164cbceeb4a6dcc2c3424",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -27,12 +27,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %var = alloca %"~unlimited_polymorphic_type"*, align 8
   store %"~unlimited_polymorphic_type"* null, %"~unlimited_polymorphic_type"** %var, align 8
-  %x1 = alloca i64, align 8
-  store i64 10, i64* %x1, align 4
+  %x = alloca i64, align 8
+  store i64 10, i64* %x, align 4
   %2 = call i8* @_lfortran_malloc(i64 8)
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 8, i1 false)
   %3 = call i8* @_lfortran_malloc(i64 16)
@@ -46,7 +45,7 @@ define i32 @main(i32 %0, i8** %1) {
   %8 = bitcast i8* %7 to i64*
   %9 = bitcast %"~unlimited_polymorphic_type"* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [3 x i8*] }, { [3 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %9, align 8
-  %10 = load i64, i64* %x1, align 4
+  %10 = load i64, i64* %x, align 4
   store i64 %10, i64* %8, align 4
   %11 = alloca i1, align 1
   %12 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
@@ -79,12 +78,12 @@ else:                                             ; preds = %.entry
   %22 = icmp ne i8* %21, null
   store i1 %22, i1* %18, align 1
   %23 = load i1, i1* %18, align 1
-  br i1 %23, label %then2, label %else3
+  br i1 %23, label %then1, label %else2
 
-then2:                                            ; preds = %else
+then1:                                            ; preds = %else
   br label %"~select_type_block_1.start"
 
-"~select_type_block_1.start":                     ; preds = %then2
+"~select_type_block_1.start":                     ; preds = %then1
   %24 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %"~select_type_block_1.end"
@@ -95,7 +94,7 @@ then2:                                            ; preds = %else
 "FINALIZE_SYMTABLE_~select_type_block_1":         ; preds = %"~select_type_block_1.end"
   br label %ifcont
 
-else3:                                            ; preds = %else
+else2:                                            ; preds = %else
   %25 = alloca i1, align 1
   %26 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
   %27 = bitcast %"~unlimited_polymorphic_type"* %26 to i8*
@@ -103,12 +102,12 @@ else3:                                            ; preds = %else
   %29 = icmp ne i8* %28, null
   store i1 %29, i1* %25, align 1
   %30 = load i1, i1* %25, align 1
-  br i1 %30, label %then4, label %else5
+  br i1 %30, label %then3, label %else4
 
-then4:                                            ; preds = %else3
+then3:                                            ; preds = %else2
   br label %"~select_type_block_2.start"
 
-"~select_type_block_2.start":                     ; preds = %then4
+"~select_type_block_2.start":                     ; preds = %then3
   %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %"~select_type_block_2.end"
@@ -119,12 +118,12 @@ then4:                                            ; preds = %else3
 "FINALIZE_SYMTABLE_~select_type_block_2":         ; preds = %"~select_type_block_2.end"
   br label %ifcont
 
-else5:                                            ; preds = %else3
+else4:                                            ; preds = %else2
   %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %32, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont
 
-ifcont:                                           ; preds = %else5, %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
+ifcont:                                           ; preds = %else4, %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
   call void @_lpython_free_argv()
   br label %return
 

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "48a7bd43dd7bec57dfaa90acd00c36b391d1087b844f6b1202662c23",
+    "stdout_hash": "b3af5c0ecb13f72d3d00da87445b49c27b9022823190729d82cb09d2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -13,12 +13,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %x = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %b = alloca i1, align 1
-  %x1 = alloca i32, align 4
-  store i32 2, i32* %x1, align 4
-  %2 = load i32, i32* %x1, align 4
+  %x = alloca i32, align 4
+  store i32 2, i32* %x, align 4
+  %2 = load i32, i32* %x, align 4
   %3 = icmp ne i32 %2, 2
   store i1 %3, i1* %b, align 1
   %4 = load i1, i1* %b, align 1
@@ -33,60 +32,60 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load i32, i32* %x1, align 4
+  %5 = load i32, i32* %x, align 4
   %6 = icmp eq i32 %5, 2
   store i1 %6, i1* %b, align 1
   %7 = load i1, i1* %b, align 1
   %8 = xor i1 %7, true
-  br i1 %8, label %then2, label %else3
+  br i1 %8, label %then1, label %else2
 
-then2:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont4
+  br label %ifcont3
 
-else3:                                            ; preds = %ifcont
-  br label %ifcont4
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont4:                                          ; preds = %else3, %then2
-  %9 = load i32, i32* %x1, align 4
+ifcont3:                                          ; preds = %else2, %then1
+  %9 = load i32, i32* %x, align 4
   %10 = icmp eq i32 %9, 2
   %11 = xor i1 %10, true
   store i1 %11, i1* %b, align 1
   %12 = load i1, i1* %b, align 1
-  br i1 %12, label %then5, label %else6
+  br i1 %12, label %then4, label %else5
 
-then5:                                            ; preds = %ifcont4
+then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont7
+  br label %ifcont6
 
-else6:                                            ; preds = %ifcont4
-  br label %ifcont7
+else5:                                            ; preds = %ifcont3
+  br label %ifcont6
 
-ifcont7:                                          ; preds = %else6, %then5
-  %13 = load i32, i32* %x1, align 4
+ifcont6:                                          ; preds = %else5, %then4
+  %13 = load i32, i32* %x, align 4
   %14 = icmp eq i32 %13, 2
   store i1 %14, i1* %b, align 1
   %15 = load i1, i1* %b, align 1
   %16 = xor i1 %15, true
   store i1 %16, i1* %b, align 1
   %17 = load i1, i1* %b, align 1
-  br i1 %17, label %then8, label %else9
+  br i1 %17, label %then7, label %else8
 
-then8:                                            ; preds = %ifcont7
+then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont10
+  br label %ifcont9
 
-else9:                                            ; preds = %ifcont7
-  br label %ifcont10
+else8:                                            ; preds = %ifcont6
+  br label %ifcont9
 
-ifcont10:                                         ; preds = %else9, %then8
+ifcont9:                                          ; preds = %else8, %then7
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont10
+return:                                           ; preds = %ifcont9
   br label %FINALIZE_SYMTABLE_variables_03
 
 FINALIZE_SYMTABLE_variables_03:                   ; preds = %return

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "33db24ff4708bb60d04b4548eca91a440f7d4227a47c232d4abc8a46",
+    "stdout_hash": "78a37b2597d9198521a328ad0b27d6aeb5098fe2181ecce5ea95ce8f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -17,32 +17,30 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 1, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
+  store i32 1, i32* %i, align 4
+  store i32 0, i32* %j, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = icmp slt i32 %2, 11
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %j2, align 4
-  %5 = load i32, i32* %i1, align 4
+  %4 = load i32, i32* %j, align 4
+  %5 = load i32, i32* %i, align 4
   %6 = add i32 %4, %5
-  store i32 %6, i32* %j2, align 4
-  %7 = load i32, i32* %i1, align 4
+  store i32 %6, i32* %j, align 4
+  %7 = load i32, i32* %i, align 4
   %8 = add i32 %7, 1
-  store i32 %8, i32* %i1, align 4
+  store i32 %8, i32* %i, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j2, align 4
+  %9 = load i32, i32* %j, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
@@ -55,115 +53,115 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i1, align 4
+  %11 = load i32, i32* %i, align 4
   %12 = icmp ne i32 %11, 11
-  br i1 %12, label %then3, label %else4
+  br i1 %12, label %then1, label %else2
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %then3
-  store i32 1, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head6
+ifcont3:                                          ; preds = %else2, %then1
+  store i32 1, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head4
 
-loop.head6:                                       ; preds = %loop.body7, %ifcont5
-  %13 = load i32, i32* %i1, align 4
+loop.head4:                                       ; preds = %loop.body5, %ifcont3
+  %13 = load i32, i32* %i, align 4
   %14 = icmp sle i32 %13, 10
-  br i1 %14, label %loop.body7, label %loop.end8
+  br i1 %14, label %loop.body5, label %loop.end6
 
-loop.body7:                                       ; preds = %loop.head6
-  %15 = load i32, i32* %j2, align 4
-  %16 = load i32, i32* %i1, align 4
+loop.body5:                                       ; preds = %loop.head4
+  %15 = load i32, i32* %j, align 4
+  %16 = load i32, i32* %i, align 4
   %17 = add i32 %15, %16
-  store i32 %17, i32* %j2, align 4
-  %18 = load i32, i32* %i1, align 4
+  store i32 %17, i32* %j, align 4
+  %18 = load i32, i32* %i, align 4
   %19 = add i32 %18, 1
-  store i32 %19, i32* %i1, align 4
-  br label %loop.head6
+  store i32 %19, i32* %i, align 4
+  br label %loop.head4
 
-loop.end8:                                        ; preds = %loop.head6
-  %20 = load i32, i32* %j2, align 4
+loop.end6:                                        ; preds = %loop.head4
+  %20 = load i32, i32* %j, align 4
   %21 = icmp ne i32 %20, 55
-  br i1 %21, label %then9, label %else10
+  br i1 %21, label %then7, label %else8
 
-then9:                                            ; preds = %loop.end8
+then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont11
+  br label %ifcont9
 
-else10:                                           ; preds = %loop.end8
-  br label %ifcont11
+else8:                                            ; preds = %loop.end6
+  br label %ifcont9
 
-ifcont11:                                         ; preds = %else10, %then9
-  %22 = load i32, i32* %i1, align 4
+ifcont9:                                          ; preds = %else8, %then7
+  %22 = load i32, i32* %i, align 4
   %23 = icmp ne i32 %22, 11
-  br i1 %23, label %then12, label %else13
+  br i1 %23, label %then10, label %else11
 
-then12:                                           ; preds = %ifcont11
+then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
+else11:                                           ; preds = %ifcont9
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %then12
-  store i32 1, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head15
+ifcont12:                                         ; preds = %else11, %then10
+  store i32 1, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head13
 
-loop.head15:                                      ; preds = %loop.body16, %ifcont14
-  %24 = load i32, i32* %i1, align 4
+loop.head13:                                      ; preds = %loop.body14, %ifcont12
+  %24 = load i32, i32* %i, align 4
   %25 = icmp slt i32 %24, 1
-  br i1 %25, label %loop.body16, label %loop.end17
+  br i1 %25, label %loop.body14, label %loop.end15
 
-loop.body16:                                      ; preds = %loop.head15
-  %26 = load i32, i32* %j2, align 4
-  %27 = load i32, i32* %i1, align 4
+loop.body14:                                      ; preds = %loop.head13
+  %26 = load i32, i32* %j, align 4
+  %27 = load i32, i32* %i, align 4
   %28 = add i32 %26, %27
-  store i32 %28, i32* %j2, align 4
-  %29 = load i32, i32* %i1, align 4
+  store i32 %28, i32* %j, align 4
+  %29 = load i32, i32* %i, align 4
   %30 = add i32 %29, 1
-  store i32 %30, i32* %i1, align 4
-  br label %loop.head15
+  store i32 %30, i32* %i, align 4
+  br label %loop.head13
 
-loop.end17:                                       ; preds = %loop.head15
-  %31 = load i32, i32* %j2, align 4
+loop.end15:                                       ; preds = %loop.head13
+  %31 = load i32, i32* %j, align 4
   %32 = icmp ne i32 %31, 0
-  br i1 %32, label %then18, label %else19
+  br i1 %32, label %then16, label %else17
 
-then18:                                           ; preds = %loop.end17
+then16:                                           ; preds = %loop.end15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont20
+  br label %ifcont18
 
-else19:                                           ; preds = %loop.end17
-  br label %ifcont20
+else17:                                           ; preds = %loop.end15
+  br label %ifcont18
 
-ifcont20:                                         ; preds = %else19, %then18
-  %33 = load i32, i32* %i1, align 4
+ifcont18:                                         ; preds = %else17, %then16
+  %33 = load i32, i32* %i, align 4
   %34 = icmp ne i32 %33, 1
-  br i1 %34, label %then21, label %else22
+  br i1 %34, label %then19, label %else20
 
-then21:                                           ; preds = %ifcont20
+then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont23
+  br label %ifcont21
 
-else22:                                           ; preds = %ifcont20
-  br label %ifcont23
+else20:                                           ; preds = %ifcont18
+  br label %ifcont21
 
-ifcont23:                                         ; preds = %else22, %then21
+ifcont21:                                         ; preds = %else20, %then19
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont23
+return:                                           ; preds = %ifcont21
   br label %FINALIZE_SYMTABLE_while_01
 
 FINALIZE_SYMTABLE_while_01:                       ; preds = %return

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "b870bee406a59d72dbd248c0e247d03e1643b0dd1ea69bca0cf57797",
+    "stdout_hash": "fc7cdda19a4d6f778ecdf5287e42efebb9632b11898066abbc1fe3a0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -17,32 +17,30 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %i1 = alloca i32, align 4
-  %j2 = alloca i32, align 4
-  store i32 0, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
+  store i32 0, i32* %i, align 4
+  store i32 0, i32* %j, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i1, align 4
+  %2 = load i32, i32* %i, align 4
   %3 = icmp slt i32 %2, 10
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %i1, align 4
+  %4 = load i32, i32* %i, align 4
   %5 = add i32 %4, 1
-  store i32 %5, i32* %i1, align 4
-  %6 = load i32, i32* %j2, align 4
-  %7 = load i32, i32* %i1, align 4
+  store i32 %5, i32* %i, align 4
+  %6 = load i32, i32* %j, align 4
+  %7 = load i32, i32* %i, align 4
   %8 = add i32 %6, %7
-  store i32 %8, i32* %j2, align 4
+  store i32 %8, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j2, align 4
+  %9 = load i32, i32* %j, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
@@ -55,143 +53,143 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i1, align 4
+  %11 = load i32, i32* %i, align 4
   %12 = icmp ne i32 %11, 10
-  br i1 %12, label %then3, label %else4
+  br i1 %12, label %then1, label %else2
 
-then3:                                            ; preds = %ifcont
+then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont5
+  br label %ifcont3
 
-else4:                                            ; preds = %ifcont
-  br label %ifcont5
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
 
-ifcont5:                                          ; preds = %else4, %then3
-  store i32 0, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head6
+ifcont3:                                          ; preds = %else2, %then1
+  store i32 0, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head4
 
-loop.head6:                                       ; preds = %ifcont10, %ifcont5
-  %13 = load i32, i32* %i1, align 4
+loop.head4:                                       ; preds = %ifcont8, %ifcont3
+  %13 = load i32, i32* %i, align 4
   %14 = icmp slt i32 %13, 10
-  br i1 %14, label %loop.body7, label %loop.end11
+  br i1 %14, label %loop.body5, label %loop.end9
 
-loop.body7:                                       ; preds = %loop.head6
-  %15 = load i32, i32* %i1, align 4
+loop.body5:                                       ; preds = %loop.head4
+  %15 = load i32, i32* %i, align 4
   %16 = add i32 %15, 1
-  store i32 %16, i32* %i1, align 4
-  %17 = load i32, i32* %i1, align 4
+  store i32 %16, i32* %i, align 4
+  %17 = load i32, i32* %i, align 4
   %18 = icmp eq i32 %17, 2
-  br i1 %18, label %then8, label %else9
+  br i1 %18, label %then6, label %else7
 
-then8:                                            ; preds = %loop.body7
-  br label %loop.end11
+then6:                                            ; preds = %loop.body5
+  br label %loop.end9
 
 unreachable_after_exit:                           ; No predecessors!
-  br label %ifcont10
+  br label %ifcont8
 
-else9:                                            ; preds = %loop.body7
-  br label %ifcont10
+else7:                                            ; preds = %loop.body5
+  br label %ifcont8
 
-ifcont10:                                         ; preds = %else9, %unreachable_after_exit
-  %19 = load i32, i32* %j2, align 4
-  %20 = load i32, i32* %i1, align 4
+ifcont8:                                          ; preds = %else7, %unreachable_after_exit
+  %19 = load i32, i32* %j, align 4
+  %20 = load i32, i32* %i, align 4
   %21 = add i32 %19, %20
-  store i32 %21, i32* %j2, align 4
-  br label %loop.head6
+  store i32 %21, i32* %j, align 4
+  br label %loop.head4
 
-loop.end11:                                       ; preds = %then8, %loop.head6
-  %22 = load i32, i32* %j2, align 4
+loop.end9:                                        ; preds = %then6, %loop.head4
+  %22 = load i32, i32* %j, align 4
   %23 = icmp ne i32 %22, 1
-  br i1 %23, label %then12, label %else13
+  br i1 %23, label %then10, label %else11
 
-then12:                                           ; preds = %loop.end11
+then10:                                           ; preds = %loop.end9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont14
+  br label %ifcont12
 
-else13:                                           ; preds = %loop.end11
-  br label %ifcont14
+else11:                                           ; preds = %loop.end9
+  br label %ifcont12
 
-ifcont14:                                         ; preds = %else13, %then12
-  %24 = load i32, i32* %i1, align 4
+ifcont12:                                         ; preds = %else11, %then10
+  %24 = load i32, i32* %i, align 4
   %25 = icmp ne i32 %24, 2
-  br i1 %25, label %then15, label %else16
+  br i1 %25, label %then13, label %else14
 
-then15:                                           ; preds = %ifcont14
+then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont17
+  br label %ifcont15
 
-else16:                                           ; preds = %ifcont14
-  br label %ifcont17
+else14:                                           ; preds = %ifcont12
+  br label %ifcont15
 
-ifcont17:                                         ; preds = %else16, %then15
-  store i32 0, i32* %i1, align 4
-  store i32 0, i32* %j2, align 4
-  br label %loop.head18
+ifcont15:                                         ; preds = %else14, %then13
+  store i32 0, i32* %i, align 4
+  store i32 0, i32* %j, align 4
+  br label %loop.head16
 
-loop.head18:                                      ; preds = %ifcont22, %then20, %ifcont17
-  %26 = load i32, i32* %i1, align 4
+loop.head16:                                      ; preds = %ifcont20, %then18, %ifcont15
+  %26 = load i32, i32* %i, align 4
   %27 = icmp slt i32 %26, 10
-  br i1 %27, label %loop.body19, label %loop.end23
+  br i1 %27, label %loop.body17, label %loop.end21
 
-loop.body19:                                      ; preds = %loop.head18
-  %28 = load i32, i32* %i1, align 4
+loop.body17:                                      ; preds = %loop.head16
+  %28 = load i32, i32* %i, align 4
   %29 = add i32 %28, 1
-  store i32 %29, i32* %i1, align 4
-  %30 = load i32, i32* %i1, align 4
+  store i32 %29, i32* %i, align 4
+  %30 = load i32, i32* %i, align 4
   %31 = icmp eq i32 %30, 2
-  br i1 %31, label %then20, label %else21
+  br i1 %31, label %then18, label %else19
 
-then20:                                           ; preds = %loop.body19
-  br label %loop.head18
+then18:                                           ; preds = %loop.body17
+  br label %loop.head16
 
 unreachable_after_cycle:                          ; No predecessors!
-  br label %ifcont22
+  br label %ifcont20
 
-else21:                                           ; preds = %loop.body19
-  br label %ifcont22
+else19:                                           ; preds = %loop.body17
+  br label %ifcont20
 
-ifcont22:                                         ; preds = %else21, %unreachable_after_cycle
-  %32 = load i32, i32* %j2, align 4
-  %33 = load i32, i32* %i1, align 4
+ifcont20:                                         ; preds = %else19, %unreachable_after_cycle
+  %32 = load i32, i32* %j, align 4
+  %33 = load i32, i32* %i, align 4
   %34 = add i32 %32, %33
-  store i32 %34, i32* %j2, align 4
-  br label %loop.head18
+  store i32 %34, i32* %j, align 4
+  br label %loop.head16
 
-loop.end23:                                       ; preds = %loop.head18
-  %35 = load i32, i32* %j2, align 4
+loop.end21:                                       ; preds = %loop.head16
+  %35 = load i32, i32* %j, align 4
   %36 = icmp ne i32 %35, 53
-  br i1 %36, label %then24, label %else25
+  br i1 %36, label %then22, label %else23
 
-then24:                                           ; preds = %loop.end23
+then22:                                           ; preds = %loop.end21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont26
+  br label %ifcont24
 
-else25:                                           ; preds = %loop.end23
-  br label %ifcont26
+else23:                                           ; preds = %loop.end21
+  br label %ifcont24
 
-ifcont26:                                         ; preds = %else25, %then24
-  %37 = load i32, i32* %i1, align 4
+ifcont24:                                         ; preds = %else23, %then22
+  %37 = load i32, i32* %i, align 4
   %38 = icmp ne i32 %37, 10
-  br i1 %38, label %then27, label %else28
+  br i1 %38, label %then25, label %else26
 
-then27:                                           ; preds = %ifcont26
+then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont29
+  br label %ifcont27
 
-else28:                                           ; preds = %ifcont26
-  br label %ifcont29
+else26:                                           ; preds = %ifcont24
+  br label %ifcont27
 
-ifcont29:                                         ; preds = %else28, %then27
+ifcont27:                                         ; preds = %else26, %then25
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont29
+return:                                           ; preds = %ifcont27
   br label %FINALIZE_SYMTABLE_while_02
 
 FINALIZE_SYMTABLE_while_02:                       ; preds = %return

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "c98c555def251f79bb01630c7b297ddbfc519713e1a899360c42480a",
+    "stdout_hash": "4865d773e2191ecaaa6f5aafec5a158cd20bbbab56aaeeafaec489d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -11,12 +11,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %nwrite = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %nwrite1 = alloca i32, align 4
-  store i32 6, i32* %nwrite1, align 4
-  store i32 6, i32* %nwrite1, align 4
-  %2 = load i32, i32* %nwrite1, align 4
+  %nwrite = alloca i32, align 4
+  store i32 6, i32* %nwrite, align 4
+  store i32 6, i32* %nwrite, align 4
+  %2 = load i32, i32* %nwrite, align 4
   %3 = alloca i32*, align 8
   store i32* null, i32** %3, align 8
   %4 = load i32*, i32** %3, align 8


### PR DESCRIPTION
In the past this was needed to make some nested functions work, but this is not needed anymore, the pre-declared variables are not used in LLVM. This removes the pre-declaration and updates reference tests.