### PR TITLE
test: remove wasm test for `intrinsics_409.f90` test

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1368,7 +1368,7 @@ RUN(NAME intrinsics_405 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME intrinsics_406 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # iachar with array arguments
 RUN(NAME intrinsics_407 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # complex abs() overflow
 RUN(NAME intrinsics_408 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # complex abs() underflow
-RUN(NAME intrinsics_409 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # execute_command_line with file flush 
+RUN(NAME intrinsics_409 LABELS gfortran llvm) # execute_command_line with file flush 
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 


### PR DESCRIPTION
This disables wasm tests which fails on main: https://github.com/lfortran/lfortran/actions/runs/21362058272/job/61483694876