### PR TITLE
fix: Handle non-normal process termination in execute_command_line

### DIFF
--- a/integration_tests/intrinsics_387.f90
+++ b/integration_tests/intrinsics_387.f90
@@ -13,5 +13,9 @@ program intrinsics_387
     print *, "Exit status:", stat
     if ( stat /= 0 ) error stop 
 
+    call execute_command_line("exit 2", exitstat=stat)
+    print *, "exitstat =", stat
+    if (stat /= 2) error stop
+
 end program intrinsics_387
 


### PR DESCRIPTION
Towards #6840 