### PR TITLE
fix: use dynamic index type in realloc-lhs shape calculations

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1893,6 +1893,12 @@ RUN(NAME allocate_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --realloc-lhs-arrays)
 
+RUN(NAME realloc_lhs_16 LABELS gfortran llvm
+    EXTRA_ARGS -fdefault-integer-8 --realloc-lhs-arrays
+    GFORTRAN_ARGS -fdefault-integer-8)
+RUN(NAME realloc_lhs_17 LABELS gfortran llvm
+    EXTRA_ARGS --descriptor-index-64 --realloc-lhs-arrays)
+
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/realloc_lhs_16.f90
+++ b/integration_tests/realloc_lhs_16.f90
@@ -1,0 +1,26 @@
+! Test automatic reallocation with -fdefault-integer-8
+! This triggers the bug where hardcoded i32 constants are multiplied with i64 values
+program realloc_lhs_16
+    implicit none
+    real, allocatable :: a(:), b(:), c(:)
+    integer :: i
+
+    ! Allocate source arrays
+    allocate(a(10), b(10))
+    do i = 1, 10
+        a(i) = real(i)
+        b(i) = real(i * 2)
+    end do
+
+    ! c is NOT allocated - triggers automatic reallocation
+    ! This should compute shape and allocate c to match a + b
+    c = a + b
+
+    ! Verify result
+    if (size(c) /= 10) error stop
+    if (abs(c(1) - 3.0) > 0.001) error stop
+    if (abs(c(5) - 15.0) > 0.001) error stop
+    if (abs(c(10) - 30.0) > 0.001) error stop
+
+    print *, "PASS"
+end program

--- a/integration_tests/realloc_lhs_17.f90
+++ b/integration_tests/realloc_lhs_17.f90
@@ -1,0 +1,38 @@
+! Test automatic reallocation with --descriptor-index-64
+! This triggers the bug where hardcoded i32 constants are multiplied with i64 values
+program realloc_lhs_17
+    implicit none
+    real, allocatable :: a(:), b(:), c(:)
+    integer :: i
+
+    ! Allocate source arrays
+    allocate(a(10), b(10))
+    do i = 1, 10
+        a(i) = real(i)
+        b(i) = real(i * 2)
+    end do
+
+    ! c is NOT allocated - triggers automatic reallocation
+    ! This should compute shape and allocate c to match a + b
+    c = a + b
+
+    ! Verify result - avoid using error stop with literal (ILP64 issue)
+    if (size(c) /= 10) then
+        print *, "FAIL: size(c) =", size(c)
+        error stop
+    end if
+    if (abs(c(1) - 3.0) > 0.001) then
+        print *, "FAIL: c(1) =", c(1)
+        error stop
+    end if
+    if (abs(c(5) - 15.0) > 0.001) then
+        print *, "FAIL: c(5) =", c(5)
+        error stop
+    end if
+    if (abs(c(10) - 30.0) > 0.001) then
+        print *, "FAIL: c(10) =", c(10)
+        error stop
+    end if
+
+    print *, "PASS"
+end program


### PR DESCRIPTION
## Summary
- Fix LLVM verification failure when using `--realloc-lhs-arrays` with `-fdefault-integer-8` or `--descriptor-index-64`
- Replace hardcoded i32 constants with dynamic index type from `arr_descr->get_index_type()` in shape product calculations
- Add integration tests for both flags

Fixes type mismatch: `mul i32 1, i64 %152`

## Why
When descriptor indices are 64-bit (via `-fdefault-integer-8` or `--descriptor-index-64`), dimension sizes stored in the descriptor are i64. The realloc-LHS code path used hardcoded i32 constants for shape product initialization and memory size calculations, causing LLVM binary operator type mismatches.

**Stage:** Codegen

## Changes
- [`src/libasr/codegen/asr_to_llvm.cpp`](https://github.com/lfortran/lfortran/blob/5b83e573055b3844f1ac02eb4e1bfb654c35da35/src/libasr/codegen/asr_to_llvm.cpp): Use `arr_descr->get_index_type()` in `fill_array_details` (data-only branch) and `visit_ReAlloc` for shape product constants
- [`src/libasr/codegen/llvm_utils.cpp`](https://github.com/lfortran/lfortran/blob/5b83e573055b3844f1ac02eb4e1bfb654c35da35/src/libasr/codegen/llvm_utils.cpp): Use `arr_api->get_index_type()` in deep copy realloc path and struct deep copy loop for num_elements, offsets, loop variables, and memcpy sizes

## Tests
- [`integration_tests/realloc_lhs_16.f90`](https://github.com/lfortran/lfortran/blob/5b83e573055b3844f1ac02eb4e1bfb654c35da35/integration_tests/realloc_lhs_16.f90): Tests realloc-lhs with `-fdefault-integer-8` (previously crashed with LLVM verification error)
- [`integration_tests/realloc_lhs_17.f90`](https://github.com/lfortran/lfortran/blob/5b83e573055b3844f1ac02eb4e1bfb654c35da35/integration_tests/realloc_lhs_17.f90): Tests realloc-lhs with `--descriptor-index-64` (previously crashed with LLVM verification error)
- Both tests pass with gfortran and lfortran