### PR TITLE
fix: cast stop/error stop code to kind=4 in ILP64 mode

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -364,6 +364,7 @@ RUN(NAME error_stop_04 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME stop_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm2 c fortran)
 RUN(NAME stop_02 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME stop_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME ilp64_stop_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME print_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm2 wasm fortran mlir)
 RUN(NAME print_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm fortran)

--- a/integration_tests/ilp64_stop_01.f90
+++ b/integration_tests/ilp64_stop_01.f90
@@ -1,0 +1,10 @@
+program ilp64_stop_01
+    implicit none
+    integer :: x
+    x = 1
+    ! Test error stop with literal
+    if (x /= 1) error stop 1
+    ! Test stop with literal
+    ! (only test success path - we just need the compilation to succeed)
+    print *, "PASS"
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -22,6 +22,26 @@ namespace LCompilers::LFortran {
 class BodyVisitor : public CommonVisitor<BodyVisitor> {
 private:
 
+    // The Fortran standard allows the stop code to be a default integer,
+    // but the runtime ABI expects a 32-bit (kind=4) integer. When
+    // -fdefault-integer-8 is active, integer literals become kind=8.
+    // This helper inserts an explicit Cast to kind=4 when needed.
+    ASR::expr_t* cast_stop_code_to_int32(ASR::expr_t* code,
+                                         const Location& loc) {
+        if (code && ASR::is_a<ASR::Integer_t>(
+                *ASRUtils::expr_type(code))) {
+            int kind = ASRUtils::extract_kind_from_ttype_t(
+                ASRUtils::expr_type(code));
+            if (kind != 4) {
+                ASR::ttype_t* int32_type = ASRUtils::TYPE(
+                    ASR::make_Integer_t(al, loc, 4));
+                code = CastingUtil::perform_casting(
+                    code, int32_type, al, loc);
+            }
+        }
+        return code;
+    }
+
 public:
     ASR::asr_t *asr;
     bool from_block;
@@ -6760,6 +6780,7 @@ public:
         if (x.m_code) {
             visit_expr(*x.m_code);
             code = ASRUtils::EXPR(tmp);
+            code = cast_stop_code_to_int32(code, x.base.base.loc);
         } else {
             code = nullptr;
         }
@@ -6771,6 +6792,7 @@ public:
         if (x.m_code) {
             visit_expr(*x.m_code);
             code = ASRUtils::EXPR(tmp);
+            code = cast_stop_code_to_int32(code, x.base.base.loc);
         } else {
             code = nullptr;
         }


### PR DESCRIPTION
## Summary
- Cast integer stop/error stop codes to kind=4 in semantics when `-fdefault-integer-8` makes literals kind=8

Refs: #9640

## Why
The runtime ABI expects a 32-bit integer for stop codes, but `-fdefault-integer-8` promotes all integer literals to kind=8, causing ICE: "Kind in Stop code should be = 4".

**Stage:** Semantics

## Changes
- [`ast_body_visitor.cpp`]: Add `cast_stop_code_to_int32()` helper, call from `visit_Stop` and `visit_ErrorStop`

## Tests
- `integration_tests/ilp64_stop_01.f90`: error stop with literal under `-fdefault-integer-8`