### PR TITLE
fix: use dynamic index type for EQUIVALENCE descriptor setup

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2845,6 +2845,9 @@ RUN(NAME equivalence_12 LABELS gfortran)
 RUN(NAME equivalence_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME equivalence_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_FAST)
+RUN(NAME equivalence_16 LABELS gfortran llvm
+    EXTRA_ARGS -fdefault-integer-8
+    GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME fortran_primes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/equivalence_16.f90
+++ b/integration_tests/equivalence_16.f90
@@ -1,0 +1,19 @@
+program equivalence_16
+    ! Test EQUIVALENCE with -fdefault-integer-8 (ILP64 mode)
+    ! Verifies descriptor fields use correct index type width
+    implicit none
+    integer :: iwork(10)
+    double precision :: rwork(5)
+    equivalence (iwork(1), rwork(1))
+
+    rwork(1) = 42.0d0
+
+    ! With ILP64, integer is 8 bytes, same as double precision.
+    ! iwork(1) overlaps rwork(1) exactly, so reinterpreting the
+    ! bit pattern of 42.0d0 as integer(8) must give 4631107791820423168.
+    if (iwork(1) /= transfer(42.0d0, iwork(1))) error stop
+
+    ! Write through integer view and verify via real view
+    iwork(1) = transfer(99.0d0, iwork(1))
+    if (rwork(1) /= 99.0d0) error stop
+end program


### PR DESCRIPTION
## Summary
- Fix LLVM verification failure when using EQUIVALENCE with `-fdefault-integer-8`
- Array descriptor fields (offset, stride, lower_bound, extent) were stored as i32 but are i64 with ILP64 mode

## Why
EQUIVALENCE arrays use CPtrToPointer to set up their descriptors. The descriptor field stores
used hardcoded `APInt(32, ...)` which caused type mismatch errors when the descriptor uses
64-bit indices (`-fdefault-integer-8`).

**Stage:** Codegen (lowering issue - descriptor layout)

## Changes
- [`asr_to_llvm.cpp#L6707-L6775`](https://github.com/lfortran/lfortran/blob/${SHA}/src/libasr/codegen/asr_to_llvm.cpp#L6707-L6775): Use `arr_descr->get_index_type()` for descriptor field stores

## Tests
- [`integration_tests/equivalence_16.f90`](https://github.com/lfortran/lfortran/blob/${SHA}/integration_tests/equivalence_16.f90): EQUIVALENCE test with `-fdefault-integer-8`
- All equivalence tests pass (15 tests)
- All c_f_pointer tests pass
- Reference tests pass