### PR TITLE
fix: cast KIND argument to int32 in CMPLX for ILP64 mode

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3169,3 +3169,6 @@ RUN(NAME intent_out_allocatable_component_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_struct_member_no_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
+# ILP64 KIND argument bug - intrinsics with KIND parameters that are INTEGER PARAMETER
+RUN(NAME ilp64_kind_arg_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)

--- a/integration_tests/ilp64_kind_arg_01.f90
+++ b/integration_tests/ilp64_kind_arg_01.f90
@@ -1,0 +1,15 @@
+program ilp64_kind_arg_01
+    use, intrinsic :: iso_fortran_env, only: real32
+    implicit none
+    integer, parameter :: WP = real32
+    complex(kind=WP) :: c
+    real(kind=WP) :: r
+    integer(4) :: exit_code
+    r = 1.0_WP
+    c = cmplx(r, 0.0_WP, kind=WP)
+    exit_code = 0
+    if (abs(real(c) - 1.0_WP) > 0.001_WP) exit_code = 1
+    if (abs(aimag(c)) > 0.001_WP) exit_code = 2
+    if (exit_code /= 0) stop exit_code
+    print *, "PASS"
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -4318,7 +4318,6 @@ namespace Cmplx {
         m_args.push_back(al, args[0]);
         if (args[1])  m_args.push_back(al, args[1]);
         else m_args.push_back(al, b.f32(0.0));
-        m_args.push_back(al, args[2]);
         if ( args[2] != nullptr ) {
             int kind = -1;
             if (!ASR::is_a<ASR::Integer_t>(*expr_type(args[2])) || !extract_value(ASRUtils::expr_value(args[2]), kind)) {
@@ -4326,6 +4325,14 @@ namespace Cmplx {
                 return nullptr;
             }
             set_kind_to_ttype_t(return_type, kind);
+            // Cast KIND argument to int32 if it has a larger integer kind (e.g., from ILP64)
+            ASR::expr_t* kind_arg = args[2];
+            if (extract_kind_from_ttype_t(expr_type(args[2])) != 4) {
+                kind_arg = b.i2i_t(args[2], int32);
+            }
+            m_args.push_back(al, kind_arg);
+        } else {
+            m_args.push_back(al, args[2]);
         }
         for( size_t i = 0; i < 1; i++ ) {
             ASR::ttype_t* type = ASRUtils::expr_type(args[i]);


### PR DESCRIPTION
## Summary
- Cast KIND argument to int32 in CMPLX intrinsic for ILP64 compatibility

## Why
In ILP64 mode (`-fdefault-integer-8`), `INTEGER, PARAMETER :: WP = real32` becomes `INTEGER(8), PARAMETER :: WP = 4`. When `KIND=WP` is passed to intrinsics like `CMPLX(r, z, KIND=WP)`, the argument is `i64` but the intrinsic expects `i32`, causing a type mismatch assertion.

**Stage:** Intrinsic function registry (semantic analysis)

## Changes
- [`src/libasr/pass/intrinsic_functions.h`](https://github.com/lfortran/lfortran/blob/fix/ilp64-kind-arg/src/libasr/pass/intrinsic_functions.h#L4328-L4334): Cast KIND argument to int32 if its integer kind is larger than 4

## Tests
- [`integration_tests/ilp64_kind_arg_01.f90`](https://github.com/lfortran/lfortran/blob/fix/ilp64-kind-arg/integration_tests/ilp64_kind_arg_01.f90): Tests CMPLX with KIND parameter from INTEGER PARAMETER under ILP64 mode
