### PR TITLE
fix: make optional class type dummy allocatable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2783,6 +2783,7 @@ RUN(NAME optional_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     GFORTRAN_ARGS -cpp)
 RUN(NAME optional_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME optional_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME optional_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME end_name_match LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/optional_08.f90
+++ b/integration_tests/optional_08.f90
@@ -1,0 +1,78 @@
+program optional_08
+    implicit none
+
+    type :: base
+        character(len=:), allocatable :: working_dir
+    end type base
+
+    class(base), allocatable :: obj
+    character(len=:), allocatable :: working_dir
+
+    ! ---------------------------
+    ! Initial setup
+    ! ---------------------------
+    working_dir = "Hello"
+
+    if (.not. allocated(working_dir)) then
+        error stop "ERROR: working_dir not allocated after assignment"
+    end if
+
+    ! ---------------------------
+    ! Get command-line settings
+    ! ---------------------------
+    call get_command_line_settings(obj)
+
+    if (.not. allocated(obj)) then
+        error stop "ERROR: obj not allocated by get_command_line_settings"
+    end if
+
+    ! ---------------------------
+    ! Extract working directory
+    ! ---------------------------
+    call get_working_dir(obj, working_dir)
+
+    if (.not. allocated(working_dir)) then
+        error stop "ERROR: working_dir not allocated after get_working_dir"
+    end if
+
+    print *, "SUCCESS"
+    print *, "working_dir =", trim(working_dir)
+
+contains
+
+    subroutine get_working_dir(settings, working_dir_)
+        class(base), optional, intent(in) :: settings
+        character(len=:), allocatable, intent(out) :: working_dir_
+
+        ! Validate presence
+        if (.not. present(settings)) then
+            error stop "ERROR: settings not present in get_working_dir"
+        end if
+
+        ! Validate allocation of component
+        if (.not. allocated(settings%working_dir)) then
+            error stop "ERROR: settings%working_dir not allocated"
+        end if
+
+        ! Safe assignment (auto-allocates working_dir_)
+        working_dir_ = settings%working_dir
+    end subroutine get_working_dir
+
+    subroutine get_command_line_settings(cmd_settings)
+        class(base), allocatable, intent(out) :: cmd_settings
+
+        allocate(cmd_settings)
+
+        if (.not. allocated(cmd_settings)) then
+            error stop "ERROR: failed to allocate cmd_settings"
+        end if
+
+        ! Initialize component explicitly
+        cmd_settings%working_dir = "Hello"
+
+        if (.not. allocated(cmd_settings%working_dir)) then
+            error stop "ERROR: cmd_settings%working_dir not allocated"
+        end if
+    end subroutine get_command_line_settings
+
+end program

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -526,6 +526,13 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
                 // This is to prevent passing in unallocated arguments when non-allocatable arguments are expected by the procedure
                 ASR::symbol_t* arg_decl = func_arg_j->m_type_declaration;
                 ASR::ttype_t* dummy_variable_type = ASRUtils::duplicate_type(al, func_arg_j->m_type);
+
+                // We make dummy variable allocatable if class type because 
+                // local class variable should be llvm pointer
+                if (ASRUtils::is_class_type(dummy_variable_type)) {
+                    dummy_variable_type = ASRUtils::TYPE(ASRUtils::make_Allocatable_t_util(
+                        al, dummy_variable_type->base.loc, dummy_variable_type));
+                }
                 if (arg_decl && ASRUtils::is_unlimited_polymorphic_type(arg_decl)) {
                     dummy_variable_type = ASRUtils::duplicate_type(al, ASRUtils::type_get_past_allocatable_pointer(arg_expr_type));
                 }


### PR DESCRIPTION
Towards #6840
Fixes #9683 
This fixes silent segfault in `new_test` of FPM