### PR TITLE
fix: add len_expr in allocation of char array temporary

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2066,6 +2066,7 @@ RUN(NAME string_92 LABELS gfortran llvm)
 RUN(NAME string_93 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_94 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc  EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME string_95 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_96 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/string_96.f90
+++ b/integration_tests/string_96.f90
@@ -1,0 +1,11 @@
+program string_96
+    character(len=:), allocatable :: long_short(:)
+    integer :: isize
+    isize = 3
+    allocate(character(len=10) :: long_short(3))
+    long_short(1) = "first"
+    long_short(2) = "second"
+    long_short(3) = "third"
+    long_short=long_short(:isize-1)
+    print *, long_short
+end program string_96

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -523,6 +523,11 @@ bool set_allocation_size(
                     allocate_dims.push_back(al, allocate_dim);
                 }
             }
+            // Set len_allocte_expr for deferred-length character arrays
+            if( ASRUtils::is_character(*ASRUtils::expr_type(value)) ) {
+                ASRUtils::ASRBuilder b(al, loc);
+                len_allocte_expr = b.StringLen(array_section_t->m_v);
+            }
             break;
         }
         case ASR::exprType::ArrayItem: {
@@ -560,6 +565,11 @@ bool set_allocation_size(
                         al, loc, value, nullptr, ASRUtils::expr_type(int32_one), nullptr, false));
                 }
                 allocate_dims.push_back(al, m_dims[i]);
+            }
+            // Set len_allocte_expr for deferred-length character arrays
+            if( ASRUtils::is_character(*ASRUtils::expr_type(value)) ) {
+                ASRUtils::ASRBuilder b(al, loc);
+                len_allocte_expr = b.StringLen(value);
             }
             break;
         }


### PR DESCRIPTION
Fixes #9725 (MCLI2's Older Version)