### PR TITLE
chore: remove noise comment from test registration

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3197,5 +3197,4 @@ RUN(NAME intent_out_struct_member_no_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
-# ILP64 KIND argument bug - intrinsics with KIND parameters that are INTEGER PARAMETER
 RUN(NAME ilp64_kind_arg_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)


### PR DESCRIPTION
## Summary
Remove unnecessary comment from test registration in CMakeLists.txt.

ref: https://github.com/lfortran/lfortran/pull/9733#discussion_r2729568481

## Changes
- Remove `# ILP64 KIND argument bug - intrinsics with KIND parameters that are INTEGER PARAMETER` comment

The test name `ilp64_kind_arg_01` is self-documenting; the comment adds no value.