### PR TITLE
fix: complex literal kind ignores integer argument kinds

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -369,6 +369,7 @@ RUN(NAME stop_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm llvm2 c fortran)
 RUN(NAME stop_02 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME stop_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME ilp64_stop_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
+RUN(NAME ilp64_complex_literal_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME print_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm2 wasm fortran mlir)
 RUN(NAME print_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm fortran)

--- a/integration_tests/ilp64_complex_literal_01.f90
+++ b/integration_tests/ilp64_complex_literal_01.f90
@@ -1,0 +1,31 @@
+! Test: complex literal kind with -fdefault-integer-8
+! Complex literals with integer components should produce default complex kind (4),
+! not complex(8), even when integers are promoted to 64-bit by -fdefault-integer-8.
+program ilp64_complex_literal_01
+    implicit none
+    complex :: c1, c2
+    complex :: arr(2)
+    complex(8) :: c8
+
+    ! Test 1: Simple complex literal assignment with integers
+    c1 = (-1, 0)
+    if (kind(c1) /= 4) error stop "c1 should have kind 4"
+    if (abs(real(c1) - (-1.0)) > 1e-6) error stop "c1 real part wrong"
+    if (abs(aimag(c1)) > 1e-6) error stop "c1 imag part wrong"
+
+    ! Test 2: Complex literal in DATA statement
+    data arr /(-1,0),(1,0)/
+    if (kind(arr(1)) /= 4) error stop "arr should have kind 4"
+    if (abs(real(arr(1)) - (-1.0)) > 1e-6) error stop "arr(1) real part wrong"
+    if (abs(real(arr(2)) - 1.0) > 1e-6) error stop "arr(2) real part wrong"
+
+    ! Test 3: Mixed integer/real should produce kind from real
+    c2 = (-1, 0.0d0)
+    if (kind((-1, 0.0d0)) /= 8) error stop "mixed int/real(8) should give kind 8"
+
+    ! Test 4: Real(8) components should produce complex(8)
+    c8 = (-1.0d0, 0.0d0)
+    if (kind(c8) /= 8) error stop "c8 should have kind 8"
+
+    print *, "PASS: all complex literal kind tests"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -13771,14 +13771,26 @@ public:
         this->visit_expr(*x.m_re);
         ASR::expr_t *re = ASRUtils::EXPR(tmp);
         ASR::expr_t *re_value = ASRUtils::expr_value(re);
-        int a_kind_r = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(re));
+        ASR::ttype_t *re_type = ASRUtils::expr_type(re);
         this->visit_expr(*x.m_im);
         ASR::expr_t *im = ASRUtils::EXPR(tmp);
         ASR::expr_t *im_value = ASRUtils::expr_value(im);
-        int a_kind_i = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(im));
-        // TODO: Add semantic checks what type are allowed
+        ASR::ttype_t *im_type = ASRUtils::expr_type(im);
+        // Determine complex kind per Fortran standard:
+        // - Complex literal kind is determined by real arguments only
+        // - Integer arguments are converted to the result complex kind
+        // - If both parts are integer: use default complex kind (4)
+        int complex_kind = 4;
+        if (ASRUtils::is_real(*re_type)) {
+            complex_kind = std::max(complex_kind,
+                ASRUtils::extract_kind_from_ttype_t(re_type));
+        }
+        if (ASRUtils::is_real(*im_type)) {
+            complex_kind = std::max(complex_kind,
+                ASRUtils::extract_kind_from_ttype_t(im_type));
+        }
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
-                std::max(a_kind_r, a_kind_i)));
+                complex_kind));
         ASR::expr_t *value = nullptr;
         if (re_value && im_value) {
             double re_double;


### PR DESCRIPTION
## Summary

Fix complex literal kind determination with `-fdefault-integer-8` (ILP64 mode).

Fixes #9768

## Why

Per Fortran standard, complex literal `(a, b)` kind is determined only by real arguments. Integer arguments should be converted to the result kind, not influence it. With `-fdefault-integer-8`, integer literals have kind 8, but `(-1, 0)` should still produce default `complex(4)`.

**Stage:** Semantics

## Changes

- [`ast_common_visitor.h`](https://github.com/lfortran/lfortran/blob/d996996d2/src/lfortran/semantics/ast_common_visitor.h#L13770-L13793): Only consider real argument kinds when determining complex literal kind

## Tests

- [`ilp64_complex_literal_01.f90`](https://github.com/lfortran/lfortran/blob/d996996d2/integration_tests/ilp64_complex_literal_01.f90): Tests complex literals with integer, real, and mixed components
