### PR TITLE
Remove last fpm workaround

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -263,9 +263,9 @@ time_section "🧪 Testing FPM" '
   git clone https://github.com/certik/fpm.git
   cd fpm
   export PATH="$(pwd)/../src/bin:$PATH"
-  git checkout lf-24
+  git checkout lf-27
   micromamba install -c conda-forge fpm
-  git checkout 527888fdc3b3a6289eb455f7f32c424e9898f9a6
+  git checkout 5a88c62d161eaca1d746891b09a5f8d97e977edd
   fpm --compiler=$FC build --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   fpm --compiler=$FC test --flag "--cpp --realloc-lhs-arrays --use-loop-variable-after-loop"
   print_success "Done with FPM"


### PR DESCRIPTION
Now the only commit is:

	* 5a88c62d1  XX: unallocated struct member in string concat

Which is an upstream bug fix that has since been merged.