### PR TITLE
ci: add LAPACK ILP64 testing to third party codes

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -877,9 +877,9 @@ time_section "🧪 Testing LAPACK" '
 
 
 ##########################
-# Section 14: Reference-LAPACK with BUILD_TESTING (Full Suite)
+# Section 14: Reference-LAPACK Full Test Suite (32-bit and 64-bit integers)
 ##########################
-time_section "🧪 Testing Reference-LAPACK v3.12.1 with BUILD_TESTING (Full Suite)" '
+time_section "🧪 Testing Reference-LAPACK v3.12.1 Full Test Suite" '
     export PATH="$(pwd)/../src/bin:$PATH"
     git clone --depth 1 --branch v3.12.1 https://github.com/Reference-LAPACK/lapack.git lapack-testing
     cd lapack-testing
@@ -899,7 +899,95 @@ time_section "🧪 Testing Reference-LAPACK v3.12.1 with BUILD_TESTING (Full Sui
         TOOLCHAIN_OPT="-DCMAKE_TOOLCHAIN_FILE=lfortran.cmake"
     fi
 
-    # Configure with LFortran and BUILD_TESTING=ON (full suite including complex)
+    # Helper function to run a single LAPACK test and check results
+    run_lapack_test() {
+        local TEST_EXE="$1"
+        local INPUT_FILE="$2"
+        local TEST_NAME="$3"
+
+        print_subsection "Running $TEST_NAME"
+        set +e
+        timeout 300 ./bin/$TEST_EXE < ../TESTING/$INPUT_FILE 2>&1 | tee ${TEST_EXE}_${INPUT_FILE%.in}.out
+        exit_code=$?
+        set -e
+
+        if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 124 ]; then
+            echo "ERROR: $TEST_NAME exited with code $exit_code"
+            exit 1
+        fi
+
+        if grep -qE "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
+            echo "ERROR: threshold failures in $TEST_NAME"
+            grep "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out | head -20
+            exit 1
+        fi
+
+        if grep -E "[1-9][0-9]* error messages recorded" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
+            echo "ERROR: error messages recorded in $TEST_NAME"
+            exit 1
+        fi
+
+        print_success "$TEST_NAME passed"
+    }
+
+    # Function to run the full LAPACK test suite
+    run_lapack_test_suite() {
+        local MODE="$1"  # empty or "(ILP64)"
+
+        # === LINEAR EQUATION TESTS ===
+        print_section "Linear Equation Tests ${MODE}"
+        run_lapack_test xlintsts stest.in "Single Real Linear Equations ${MODE}"
+        run_lapack_test xlintstd dtest.in "Double Real Linear Equations ${MODE}"
+        run_lapack_test xlintstc ctest.in "Single Complex Linear Equations ${MODE}"
+        run_lapack_test xlintstz ztest.in "Double Complex Linear Equations ${MODE}"
+        run_lapack_test xlintstrfs stest_rfp.in "Single Real RFP Linear Equations ${MODE}"
+        run_lapack_test xlintstrfd dtest_rfp.in "Double Real RFP Linear Equations ${MODE}"
+        run_lapack_test xlintstrfc ctest_rfp.in "Single Complex RFP Linear Equations ${MODE}"
+        run_lapack_test xlintstrfz ztest_rfp.in "Double Complex RFP Linear Equations ${MODE}"
+
+        # === MIXED PRECISION LINEAR EQUATION TESTS ===
+        print_section "Mixed Precision Linear Equation Tests ${MODE}"
+        run_lapack_test xlintstds dstest.in "Double-Single Mixed Precision ${MODE}"
+        run_lapack_test xlintstzc zctest.in "Double-Single Complex Mixed Precision ${MODE}"
+
+        # === EIGENVALUE TESTS ===
+        print_section "Eigenvalue Tests ${MODE}"
+
+        # Single Real Eigenvalue Tests
+        for input in nep sep se2 svd sec sed sgg sgd ssb ssg sbal sbak sgbal sgbak sbb glm gqr gsv csd lse sdmd; do
+            if [ -f "../TESTING/${input}.in" ]; then
+                run_lapack_test xeigtsts ${input}.in "Single Real Eigenvalue: ${input} ${MODE}"
+            fi
+        done
+
+        # Double Real Eigenvalue Tests
+        for input in nep sep se2 svd dec ded dgg dgd dsb dsg dbal dbak dgbal dgbak dbb glm gqr gsv csd lse ddmd; do
+            if [ -f "../TESTING/${input}.in" ]; then
+                run_lapack_test xeigtstd ${input}.in "Double Real Eigenvalue: ${input} ${MODE}"
+            fi
+        done
+
+        # Single Complex Eigenvalue Tests
+        for input in nep sep se2 svd cec ced cgg cgd csb csg cbal cbak cgbal cgbak cbb glm gqr gsv csd lse cdmd; do
+            if [ -f "../TESTING/${input}.in" ]; then
+                run_lapack_test xeigtstc ${input}.in "Single Complex Eigenvalue: ${input} ${MODE}"
+            fi
+        done
+
+        # Double Complex Eigenvalue Tests
+        for input in nep sep se2 svd zec zed zgg zgd zsb zsg zbal zbak zgbal zgbak zbb glm gqr gsv csd lse zdmd; do
+            if [ -f "../TESTING/${input}.in" ]; then
+                run_lapack_test xeigtstz ${input}.in "Double Complex Eigenvalue: ${input} ${MODE}"
+            fi
+        done
+
+        print_success "All LAPACK tests passed ${MODE}"
+    }
+
+    # =======================================================================
+    # Build and test with 32-bit integers (standard mode)
+    # =======================================================================
+    print_section "Building LAPACK with 32-bit integers"
     cmake -S . -B build -G Ninja \
       $TOOLCHAIN_OPT \
       -DCMAKE_Fortran_COMPILER=lfortran \
@@ -911,113 +999,16 @@ time_section "🧪 Testing Reference-LAPACK v3.12.1 with BUILD_TESTING (Full Sui
       -DBUILD_COMPLEX16=ON \
       -DBUILD_TESTING=ON
 
-    # Build BLAS, LAPACK, and test executables
     cmake --build build -j8
-
     cd build
+    run_lapack_test_suite ""
+    cd ..
 
-    # Helper function to run LAPACK test and check results
-    run_lapack_test() {
-        local TEST_EXE="$1"
-        local INPUT_FILE="$2"
-        local TEST_NAME="$3"
-
-        print_subsection "Running $TEST_NAME"
-        set +e
-        timeout 300 ./bin/$TEST_EXE < ../TESTING/$INPUT_FILE 2>&1 | tee ${TEST_EXE}_${INPUT_FILE%.in}.out
-        exit_code=$?
-        set -e
-
-        if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 124 ]; then
-            echo "ERROR: $TEST_NAME exited with code $exit_code"
-            exit 1
-        fi
-
-        if grep -qE "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
-            echo "ERROR: threshold failures in $TEST_NAME"
-            grep "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out | head -20
-            exit 1
-        fi
-
-        if grep -E "[1-9][0-9]* error messages recorded" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
-            echo "ERROR: error messages recorded in $TEST_NAME"
-            exit 1
-        fi
-
-        print_success "$TEST_NAME passed"
-    }
-
-    # === LINEAR EQUATION TESTS ===
-    print_section "Linear Equation Tests"
-    run_lapack_test xlintsts stest.in "Single Real Linear Equations"
-    run_lapack_test xlintstd dtest.in "Double Real Linear Equations"
-    run_lapack_test xlintstc ctest.in "Single Complex Linear Equations"
-    run_lapack_test xlintstz ztest.in "Double Complex Linear Equations"
-    run_lapack_test xlintstrfs stest_rfp.in "Single Real RFP Linear Equations"
-    run_lapack_test xlintstrfd dtest_rfp.in "Double Real RFP Linear Equations"
-    run_lapack_test xlintstrfc ctest_rfp.in "Single Complex RFP Linear Equations"
-    run_lapack_test xlintstrfz ztest_rfp.in "Double Complex RFP Linear Equations"
-
-    # === EIGENVALUE TESTS ===
-    print_section "Eigenvalue Tests"
-
-    # Single Real Eigenvalue Tests
-    for input in nep sep se2 svd sec sed sgg sgd ssb ssg sbal sbak sgbal sgbak sbb glm gqr gsv csd lse sdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtsts ${input}.in "Single Real Eigenvalue: ${input}"
-        fi
-    done
-
-    # Double Real Eigenvalue Tests
-    for input in nep sep se2 svd sec ded dgg dgd dsb dsg dbal dbak dgbal dgbak dbb glm gqr gsv csd lse ddmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstd ${input}.in "Double Real Eigenvalue: ${input}"
-        fi
-    done
-
-    # Single Complex Eigenvalue Tests
-    for input in nep sep se2 svd ced cgg cgd csb csg cbal cbak cgbal cgbak cbb glm gqr gsv csd lse cdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstc ${input}.in "Single Complex Eigenvalue: ${input}"
-        fi
-    done
-
-    # Double Complex Eigenvalue Tests
-    for input in nep sep se2 svd zed zgg zgd zsb zsg zbal zbak zgbal zgbak zbb glm gqr gsv csd lse zdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstz ${input}.in "Double Complex Eigenvalue: ${input}"
-        fi
-    done
-
-    print_success "All LAPACK tests passed"
-    cd ../..
-'
-
-##########################
-# Section 15: Reference-LAPACK ILP64 (64-bit integers)
-##########################
-time_section "🧪 Testing Reference-LAPACK v3.12.1 ILP64 (64-bit integers)" '
-    export PATH="$(pwd)/../src/bin:$PATH"
-    git clone --depth 1 --branch v3.12.1 https://github.com/Reference-LAPACK/lapack.git lapack-testing-ilp64
-    cd lapack-testing-ilp64
-
-    # Patch to skip FortranCInterface_VERIFY (requires mixed Fortran/C linking)
-    sed -i "/FortranCInterface_VERIFY/d" LAPACKE/include/CMakeLists.txt
-
-    # Patch dgd.in to use custom seed that avoids FMA-sensitive ill-conditioned matrix
-    # See: https://github.com/Reference-LAPACK/lapack/issues/1186
-    sed -i "s/^0                 Code to interpret the seed$/2                 Code to interpret the seed\n1234 5678 9012 3456/" TESTING/dgd.in
-
-    # CMake < 3.31 needs CMAKE_Fortran_PREPROCESS_SOURCE for LFortran
-    CMAKE_VERSION=$(cmake --version | head -1 | grep -oE "[0-9]+\.[0-9]+")
-    TOOLCHAIN_OPT=""
-    if [ "$(printf "%s\n3.31" "$CMAKE_VERSION" | sort -V | head -1)" != "3.31" ]; then
-        echo "set(CMAKE_Fortran_PREPROCESS_SOURCE \"<CMAKE_Fortran_COMPILER> -E <SOURCE> > <PREPROCESSED_SOURCE>\")" > lfortran.cmake
-        TOOLCHAIN_OPT="-DCMAKE_TOOLCHAIN_FILE=lfortran.cmake"
-    fi
-
-    # Configure with LFortran and BUILD_TESTING=ON (full suite including complex)
-    # ILP64 mode: -fdefault-integer-8 and BUILD_INDEX64=ON
+    # =======================================================================
+    # Build and test with 64-bit integers (ILP64 mode)
+    # =======================================================================
+    print_section "Building LAPACK with 64-bit integers (ILP64)"
+    rm -rf build
     cmake -S . -B build -G Ninja \
       $TOOLCHAIN_OPT \
       -DCMAKE_Fortran_COMPILER=lfortran \
@@ -1029,86 +1020,12 @@ time_section "🧪 Testing Reference-LAPACK v3.12.1 ILP64 (64-bit integers)" '
       -DBUILD_COMPLEX16=ON \
       -DBUILD_TESTING=ON
 
-    # Build BLAS, LAPACK, and test executables
-    cmake --build build -j$(nproc)
-
+    cmake --build build -j8
     cd build
+    run_lapack_test_suite "(ILP64)"
+    cd ..
 
-    # Helper function to run LAPACK test and check results
-    run_lapack_test() {
-        local TEST_EXE="$1"
-        local INPUT_FILE="$2"
-        local TEST_NAME="$3"
-
-        print_subsection "Running $TEST_NAME"
-        set +e
-        timeout 300 ./bin/$TEST_EXE < ../TESTING/$INPUT_FILE 2>&1 | tee ${TEST_EXE}_${INPUT_FILE%.in}.out
-        exit_code=$?
-        set -e
-
-        if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 124 ]; then
-            echo "ERROR: $TEST_NAME exited with code $exit_code"
-            exit 1
-        fi
-
-        if grep -qE "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
-            echo "ERROR: threshold failures in $TEST_NAME"
-            grep "failed to pass the threshold" ${TEST_EXE}_${INPUT_FILE%.in}.out | head -20
-            exit 1
-        fi
-
-        if grep -E "[1-9][0-9]* error messages recorded" ${TEST_EXE}_${INPUT_FILE%.in}.out; then
-            echo "ERROR: error messages recorded in $TEST_NAME"
-            exit 1
-        fi
-
-        print_success "$TEST_NAME passed"
-    }
-
-    # === LINEAR EQUATION TESTS ===
-    print_section "Linear Equation Tests (ILP64)"
-    run_lapack_test xlintsts stest.in "Single Real Linear Equations (ILP64)"
-    run_lapack_test xlintstd dtest.in "Double Real Linear Equations (ILP64)"
-    run_lapack_test xlintstc ctest.in "Single Complex Linear Equations (ILP64)"
-    run_lapack_test xlintstz ztest.in "Double Complex Linear Equations (ILP64)"
-    run_lapack_test xlintstrfs stest_rfp.in "Single Real RFP Linear Equations (ILP64)"
-    run_lapack_test xlintstrfd dtest_rfp.in "Double Real RFP Linear Equations (ILP64)"
-    run_lapack_test xlintstrfc ctest_rfp.in "Single Complex RFP Linear Equations (ILP64)"
-    run_lapack_test xlintstrfz ztest_rfp.in "Double Complex RFP Linear Equations (ILP64)"
-
-    # === EIGENVALUE TESTS ===
-    print_section "Eigenvalue Tests (ILP64)"
-
-    # Single Real Eigenvalue Tests
-    for input in nep sep se2 svd sec sed sgg sgd ssb ssg sbal sbak sgbal sgbak sbb glm gqr gsv csd lse sdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtsts ${input}.in "Single Real Eigenvalue: ${input} (ILP64)"
-        fi
-    done
-
-    # Double Real Eigenvalue Tests
-    for input in nep sep se2 svd sec ded dgg dgd dsb dsg dbal dbak dgbal dgbak dbb glm gqr gsv csd lse ddmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstd ${input}.in "Double Real Eigenvalue: ${input} (ILP64)"
-        fi
-    done
-
-    # Single Complex Eigenvalue Tests
-    for input in nep sep se2 svd ced cgg cgd csb csg cbal cbak cgbal cgbak cbb glm gqr gsv csd lse cdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstc ${input}.in "Single Complex Eigenvalue: ${input} (ILP64)"
-        fi
-    done
-
-    # Double Complex Eigenvalue Tests
-    for input in nep sep se2 svd zed zgg zgd zsb zsg zbal zbak zgbal zgbak zbb glm gqr gsv csd lse zdmd; do
-        if [ -f "../TESTING/${input}.in" ]; then
-            run_lapack_test xeigtstz ${input}.in "Double Complex Eigenvalue: ${input} (ILP64)"
-        fi
-    done
-
-    print_success "All LAPACK ILP64 tests passed"
-    cd ../..
+    cd ..
 '
 
 ##################################


### PR DESCRIPTION
## Summary
Run the complete LAPACK test suite in both 32-bit and 64-bit integer (ILP64) modes.

## Changes
- Refactor Section 14 to run full test suite twice (32-bit and ILP64) without code duplication
- Add missing eigenvalue condition tests: `dec`, `cec`, `zec`
- Add mixed precision linear equation tests: `dstest`, `zctest`
- Fix double real eigenvalue list (was incorrectly using `sec` instead of `dec`)

## Test Coverage
- **Linear equations**: 8 tests (single/double × real/complex × standard/RFP)
- **Mixed precision**: 2 tests (double-single real and complex)
- **Eigenvalue**: ~100 tests across all precisions (nep, sep, svd, ec, ed, gg, gd, sb, sg, bal, bak, gbal, gbak, bb, glm, gqr, gsv, csd, lse, dmd)

All tests run twice: once with 32-bit integers, once with ILP64 (`-fdefault-integer-8` + `BUILD_INDEX64=ON`).

## Verified locally
All tests pass in both modes.