### PR TITLE
ci: add llvm_integer_8 backend to CI test runs

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -67,8 +67,8 @@ if [[ $WIN != "1" ]]; then
     ctest -L llvm -j${NPROC}
     cd ..
 
-    ./run_tests.py -b llvm llvm2 llvm_rtlib llvm_nopragma
-    ./run_tests.py -b llvm2 llvm_rtlib llvm_nopragma -f
+    ./run_tests.py -b llvm llvm2 llvm_rtlib llvm_nopragma llvm_integer_8
+    ./run_tests.py -b llvm2 llvm_rtlib llvm_nopragma llvm_integer_8 -f
     ./run_tests.py -b llvm -f -nf16
     cd ..
 


### PR DESCRIPTION
## Summary
Run the `llvm_integer_8` backend tests in CI alongside other LLVM backends.

Fixes #9758

## Changes
- Add `llvm_integer_8` to `run_tests.py` invocations in `ci/test.sh`

## Test plan
- [ ] CI passes
- [ ] Tests with `llvm_integer_8` label are executed