### PR TITLE
test: remove unnecessary --fast flag from arrays_intrin_09

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -848,7 +848,7 @@ RUN(NAME arrays_intrin_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStac
 RUN(NAME arrays_intrin_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran) # minval
 RUN(NAME arrays_intrin_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran) # min
 RUN(NAME arrays_intrin_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
-RUN(NAME arrays_intrin_09 LABELS gfortran llvm EXTRA_ARGS --fast) # any/count logical mask
+RUN(NAME arrays_intrin_09 LABELS gfortran llvm) # any/count logical mask
 RUN(NAME any_01 LABELS gfortran)
 RUN(NAME any_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME sum_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)


### PR DESCRIPTION
## Summary
Remove the explicit `--fast` flag from `arrays_intrin_09` test since the logical mask fix now works correctly in both normal and fast modes.

Part of #9626

## Why
The test was originally added with `EXTRA_ARGS --fast` because the logical mask fix (PR #9559) was only verified under `--fast` mode. Now that byte-backed storage for logical arrays is working correctly, the test passes both with and without `--fast`.

This addresses review comment [r2713267256](https://github.com/lfortran/lfortran/pull/9559#discussion_r2713267256) which asked why `--fast` was needed.

**Note:** The larger refactoring item (moving i1↔i8 casts to ASR level) is addressed in #9798.

## Test plan
- [x] `arrays_intrin_09` passes without `--fast`
- [x] `arrays_intrin_09` passes with `--fast` (via normal test runner)
- [x] All existing tests pass