### PR TITLE
test: allocate with source= to extract dimensions from source array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1917,6 +1917,7 @@ RUN(NAME allocate_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME allocate_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME allocate_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME realloc_lhs_16 LABELS gfortran llvm
     EXTRA_ARGS -fdefault-integer-8 --realloc-lhs-arrays

--- a/integration_tests/allocate_37.f90
+++ b/integration_tests/allocate_37.f90
@@ -1,0 +1,13 @@
+program alloc_source
+  implicit none
+
+  integer, allocatable :: a(:), b(:)
+
+  allocate(a(4))
+  a = [1, 2, 3, 4]
+
+  allocate(b, source=a)
+  if (any(b /= a)) error stop "wrong output: b contents do not match a"
+  print *, "test passed"
+end program alloc_source
+


### PR DESCRIPTION
fixes #9793 