### PR TITLE
fix: implement INQUIRE iostat= and nextrec= parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2204,6 +2204,7 @@ RUN(NAME inquire_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME inquire_08 LABELS gfortran llvm)
 RUN(NAME test_inquire_size LABELS gfortran llvm )
 RUN(NAME test_backspace_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt)
 

--- a/integration_tests/inquire_08.f90
+++ b/integration_tests/inquire_08.f90
@@ -1,0 +1,21 @@
+program inquire_08
+    implicit none
+    integer :: ioerr, nxtrec, recl, unit_no
+
+    inquire (iolength=recl) 42, 42.0, 'xyzzy'
+    if (recl /= 13) error stop "iolength wrong"
+
+    ioerr = -42
+    open (newunit=unit_no, file='test_inquire.dat', status='replace', &
+          access='direct', recl=recl, form='unformatted', iostat=ioerr)
+    if (ioerr /= 0) error stop "open failed"
+
+    ioerr = -42
+    nxtrec = -43
+    inquire (unit_no, iostat=ioerr, nextrec=nxtrec)
+    if (ioerr /= 0) error stop "iostat should be 0"
+    if (nxtrec /= 1) error stop "nextrec should be 1"
+
+    close (unit_no, status='delete')
+    print *, "All tests passed"
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -4647,8 +4647,8 @@ _lfortran_open(int32_t unit_num,
 
     _lfortran_inquire(
         (const fchar*)f_name, f_name_len, file_exists, -1, NULL, NULL, NULL,
-        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 
-        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
+        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL,
+        NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, 0, NULL, NULL);
     char* access_mode = NULL;
     /*
      STATUS=`specifier` in the OPEN statement
@@ -4902,7 +4902,8 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
                                     char* direct, int64_t direct_len,
                                     char* form, int64_t form_len,
                                     char* formatted, int64_t formatted_len,
-                                    char* unformatted, int64_t unformatted_len) {
+                                    char* unformatted, int64_t unformatted_len,
+                                    int32_t *iostat, int32_t *nextrec) {
     if (f_name_data && unit_num != -1) {
         printf("File name and file unit number cannot be specified together.\n");
         exit(1);
@@ -5042,6 +5043,13 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
                 _lfortran_copy_str_and_pad(unformatted, unformatted_len, "NO", 2);
             }
         }
+        if (nextrec != NULL && access_id == 2 && fp != NULL) {
+            long current_pos = ftell(fp);
+            *nextrec = (int32_t)(current_pos / unit_recl) + 1;
+        }
+        if (iostat != NULL) {
+            *iostat = 0;
+        }
     }
     if (unit_num != -1) {
         bool unit_file_bin;
@@ -5164,6 +5172,13 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
             } else {
                 _lfortran_copy_str_and_pad(unformatted, unformatted_len, "NO", 2);
             }
+        }
+        if (nextrec != NULL && access_id == 2 && fp != NULL) {
+            long current_pos = ftell(fp);
+            *nextrec = (int32_t)(current_pos / unit_recl) + 1;
+        }
+        if (iostat != NULL) {
+            *iostat = 0;
         }
     }
 }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -256,13 +256,14 @@ LFORTRAN_API void _lfortran_inquire(
     char *access, int64_t access_len,
     char *name, int64_t name_len,
     char *blank, int64_t blank_len,
-    int32_t *recl,    
+    int32_t *recl,
     int32_t *number, bool *named,
     char *sequential, int64_t sequential_len,
     char *direct, int64_t direct_len,
     char *form, int64_t form_len,
     char *formatted, int64_t formatted_len,
-    char *unformatted, int64_t unformatted_len
+    char *unformatted, int64_t unformatted_len,
+    int32_t *iostat, int32_t *nextrec
 );
 LFORTRAN_API void _lfortran_seek_record(int32_t unit_num, int32_t rec, int32_t *iostat);
 LFORTRAN_API void _lfortran_formatted_read(int32_t unit_num, int32_t* iostat, int32_t* chunk, fchar* advance, int64_t advance_length, fchar* fmt, int64_t fmt_len, int32_t no_of_args, ...);


### PR DESCRIPTION
## Summary
- Add `iostat` output parameter to INQUIRE statement (set to 0 on success)
- Add `nextrec` output parameter to INQUIRE statement for direct access files (returns next record number)

Fixes #9662

## Why
The INQUIRE statement was missing support for `iostat=` and `nextrec=` specifiers, preventing programs that rely on error checking and direct access file positioning from compiling.

**Stage:** Codegen (runtime library extension)

## Changes
- [`src/libasr/runtime/lfortran_intrinsics.h`](https://github.com/lfortran/lfortran/blob/3bf3e256d50e25ae652538c589d056eeb3d5a701/src/libasr/runtime/lfortran_intrinsics.h#L249-L268): Add iostat and nextrec parameters to _lfortran_inquire declaration
- [`src/libasr/runtime/lfortran_intrinsics.c`](https://github.com/lfortran/lfortran/blob/3bf3e256d50e25ae652538c589d056eeb3d5a701/src/libasr/runtime/lfortran_intrinsics.c#L4892-L5183): Implement iostat and nextrec in _lfortran_inquire function
- [`src/libasr/codegen/asr_to_llvm.cpp`](https://github.com/lfortran/lfortran/blob/3bf3e256d50e25ae652538c589d056eeb3d5a701/src/libasr/codegen/asr_to_llvm.cpp#L14234-L14595): Update visit_FileInquire to pass iostat and nextrec to runtime

## Tests
- [`integration_tests/inquire_08.f90`](https://github.com/lfortran/lfortran/blob/3bf3e256d50e25ae652538c589d056eeb3d5a701/integration_tests/inquire_08.f90): Test iostat and nextrec for direct access files

## Verification

### Test fails on main
```
$ git checkout upstream/main
HEAD is now at bdda5f74b cmake: add FILE parameter to RUN macro for test reuse (#9791)
$ lfortran /tmp/inquire_08.f90
ERROR STOP iostat should be 0
```

### Test passes after fix
```
$ git checkout fix/inquire-iostat-nextrec
Switched to branch 'fix/inquire-iostat-nextrec'
$ lfortran /tmp/inquire_08.f90
 All tests passed
```