### PR TITLE
fix: skip UTF-8 BOM at start of source files

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3222,3 +3222,6 @@ RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME ilp64_kind_arg_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
+
+# UTF-8 BOM handling
+RUN(NAME utf8_bom_01 LABELS gfortran llvm)

--- a/integration_tests/utf8_bom_01.f90
+++ b/integration_tests/utf8_bom_01.f90
@@ -1,0 +1,6 @@
+﻿program utf8_bom_01
+integer :: x
+x = 42
+if (x /= 42) error stop
+print *, "UTF-8 BOM test passed"
+end program

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -302,6 +302,10 @@ void FixedFormTokenizer::set_string(const std::string &str)
     // to end with \0, but we check this here just in case.
     LCOMPILERS_ASSERT(str[str.size()] == '\0');
     cur = (unsigned char *)(&str[0]);
+    // Skip UTF-8 BOM (EF BB BF) if present at start of file
+    if (str.size() >= 3 && cur[0] == 0xEF && cur[1] == 0xBB && cur[2] == 0xBF) {
+        cur += 3;
+    }
     string_start = cur;
     cur_line = cur;
     line_num = 1;

--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -19,6 +19,10 @@ void Tokenizer::set_string(const std::string &str)
     // to end with \0, but we check this here just in case.
     LCOMPILERS_ASSERT(str[str.size()] == '\0');
     cur = (unsigned char *)(&str[0]);
+    // Skip UTF-8 BOM (EF BB BF) if present at start of file
+    if (str.size() >= 3 && cur[0] == 0xEF && cur[1] == 0xBB && cur[2] == 0xBF) {
+        cur += 3;
+    }
     string_start = cur;
     cur_line = cur;
     line_num = 1;


### PR DESCRIPTION
## Summary

- Skip UTF-8 BOM (EF BB BF) at the start of source files in both free-form and fixed-form tokenizers
- Matches behavior of gfortran and ifort which silently ignore BOM

Fixes #8756

## Why

Files saved with UTF-8 BOM encoding (common on Windows with some editors) fail with a cryptic tokenizer error. Other Fortran compilers handle this silently.

**Stage:** Parser (tokenizer)

## Changes

- [`src/lfortran/parser/tokenizer.re#L22-L25`](https://github.com/lfortran/lfortran/blob/c7febaac3221a50df056ac0522ec4cfb68b55672/src/lfortran/parser/tokenizer.re#L22-L25): Skip BOM in free-form tokenizer
- [`src/lfortran/parser/fixedform_tokenizer.cpp#L305-L308`](https://github.com/lfortran/lfortran/blob/c7febaac3221a50df056ac0522ec4cfb68b55672/src/lfortran/parser/fixedform_tokenizer.cpp#L305-L308): Skip BOM in fixed-form tokenizer

## Tests

- [`integration_tests/utf8_bom_01.f90`](https://github.com/lfortran/lfortran/blob/c7febaac3221a50df056ac0522ec4cfb68b55672/integration_tests/utf8_bom_01.f90): Integration test with UTF-8 BOM at file start

## Verification

### Test fails on main
```
$ git checkout upstream/main
$ printf '\xEF\xBB\xBFprogram main\n  print *, "hello"\nend program\n' > /tmp/bom.f90
$ ./lfortran/build/src/bin/lfortran /tmp/bom.f90
tokenizer error: Token '?' is not recognized
 --> /tmp/bom.f90:1:1
  |
1 | ?program main
  | ^ token not recognized


Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
Exit code: 1
```

### Test passes after fix
```
$ git checkout fix/utf8-bom-skip
$ ./lfortran/build/src/bin/lfortran /tmp/bom.f90 -o /tmp/bom_test && /tmp/bom_test
hello
Exit code: 0
```

### Integration test
```
$ scripts/lf.sh test -t utf8_bom_01 -s
TESTS PASSED
```