### PR TITLE
asr: add LogicalByteToLogical and LogicalToLogicalByte cast kinds

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2306,6 +2306,7 @@ public:
                 }
             }
             // Assume that tmp is an `ArraySection` or `ArrayItem`
+            tmp_stmt = ASRUtils::unwrap_logical_byte_cast(tmp_stmt);
             if( ASR::is_a<ASR::ArraySection_t>(*tmp_stmt) ) {
                 ASR::ArraySection_t* array_ref = ASR::down_cast<ASR::ArraySection_t>(tmp_stmt);
                 new_arg.m_a = array_ref->m_v;
@@ -4436,9 +4437,9 @@ public:
                     }
                 }
             }
-            // For assigning Array Variable    
-            else if (ASR::is_a<ASR::ArrayItem_t>(*target)) {
-                ASR::ArrayItem_t *array_item = ASR::down_cast<ASR::ArrayItem_t>(target);
+            // For assigning Array Variable
+            else if (ASR::is_a<ASR::ArrayItem_t>(*ASRUtils::unwrap_logical_byte_cast(target))) {
+                ASR::ArrayItem_t *array_item = ASR::down_cast<ASR::ArrayItem_t>(ASRUtils::unwrap_logical_byte_cast(target));
                 if (ASR::is_a<ASR::Real_t>(*array_item->m_type)){
                     current_variable_type_ = array_item->m_type;
                 }
@@ -4510,7 +4511,9 @@ public:
         }
         if (ASR::is_a<ASR::Cast_t>(*target)) {
             ASR::Cast_t* cast = ASR::down_cast<ASR::Cast_t>(target);
-            if (cast->m_kind == ASR::cast_kindType::ComplexToReal) {
+            if (cast->m_kind == ASR::cast_kindType::LogicalByteToLogical) {
+                target = cast->m_arg;
+            } else if (cast->m_kind == ASR::cast_kindType::ComplexToReal) {
                 /*
                     Case: x%re = y
                     we do: x = cmplx(y, x%im)

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -223,7 +223,7 @@ ttype
     | Array(ttype type, dimension* dims, array_physical_type physical_type)
     | FunctionType(ttype* arg_types, ttype? return_var_type, abi abi, deftype deftype, string? bindc_name, bool elemental, bool pure, bool module, bool inline, bool static, symbol* restrictions, bool is_restriction)
 
-cast_kind = RealToInteger | IntegerToReal | LogicalToReal | RealToReal | IntegerToInteger | RealToComplex | IntegerToComplex | IntegerToLogical | RealToLogical | StringToLogical | StringToInteger | StringToList | ComplexToLogical | ComplexToComplex | ComplexToReal | ComplexToInteger | LogicalToInteger | RealToString | IntegerToString | LogicalToString | UnsignedIntegerToInteger | UnsignedIntegerToUnsignedInteger | UnsignedIntegerToReal | UnsignedIntegerToLogical | IntegerToUnsignedInteger | RealToUnsignedInteger | CPtrToUnsignedInteger | UnsignedIntegerToCPtr | IntegerToSymbolicExpression | ListToArray | StringToArray |PointerToInteger
+cast_kind = RealToInteger | IntegerToReal | LogicalToReal | RealToReal | IntegerToInteger | RealToComplex | IntegerToComplex | IntegerToLogical | RealToLogical | StringToLogical | StringToInteger | StringToList | ComplexToLogical | ComplexToComplex | ComplexToReal | ComplexToInteger | LogicalToInteger | RealToString | IntegerToString | LogicalToString | UnsignedIntegerToInteger | UnsignedIntegerToUnsignedInteger | UnsignedIntegerToReal | UnsignedIntegerToLogical | IntegerToUnsignedInteger | RealToUnsignedInteger | CPtrToUnsignedInteger | UnsignedIntegerToCPtr | IntegerToSymbolicExpression | ListToArray | StringToArray | PointerToInteger | LogicalByteToLogical | LogicalToLogicalByte
 storage_type = Default | Save | Parameter
 access = Public | Private
 intent = Local | In | Out | InOut | ReturnVar | Unspecified

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1233,6 +1233,8 @@ ASR::asr_t* make_Assignment_t_util(Allocator &al, const Location &a_loc,
         is_allocatable |= ASRUtils::is_allocatable(a_target_struct->m_v);
     }
     a_realloc_lhs = a_realloc_lhs && is_allocatable;
+    a_target = ASRUtils::unwrap_logical_byte_cast(a_target);
+    a_value = ASRUtils::wrap_logical_value_for_array_store(al, a_loc, a_value, a_target);
     return ASR::make_Assignment_t(al, a_loc, a_target, a_value,
         a_overloaded, a_realloc_lhs, a_move);
 }

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -2285,6 +2285,12 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                 last_expr_precedence = 2;
                 break;
             }
+            case (ASR::cast_kindType::LogicalByteToLogical) :
+            case (ASR::cast_kindType::LogicalToLogicalByte) : {
+                src = "(bool)(" + src + ")";
+                last_expr_precedence = 2;
+                break;
+            }
             default : throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
                 x.base.base.loc);
         }

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -2367,9 +2367,9 @@ public:
         int dest_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
         std::string type_str;
 
-        // If the cast is from Integer to Logical, do nothing
-        if (x.m_kind == ASR::cast_kindType::IntegerToLogical) {
-            // Implicit conversion between integer -> logical
+        if (x.m_kind == ASR::cast_kindType::IntegerToLogical ||
+            x.m_kind == ASR::cast_kindType::LogicalByteToLogical ||
+            x.m_kind == ASR::cast_kindType::LogicalToLogicalByte) {
             return;
         }
 

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1575,6 +1575,12 @@ public:
                 last_expr_precedence = julia_prec::Base;
                 break;
             }
+            case (ASR::cast_kindType::LogicalByteToLogical):
+            case (ASR::cast_kindType::LogicalToLogicalByte): {
+                src = "Bool" + broadcast + "(" + src + ")";
+                last_expr_precedence = julia_prec::Base;
+                break;
+            }
             default:
                 throw CodeGenError("Cast kind " + std::to_string(x.m_kind) + " not implemented",
                                    x.base.base.loc);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -3266,6 +3266,10 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 }
                 break;
             }
+            case (ASR::cast_kindType::LogicalByteToLogical):
+            case (ASR::cast_kindType::LogicalToLogicalByte): {
+                break;
+            }
             default:
                 throw CodeGenError("Cast kind not implemented");
         }

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -596,6 +596,8 @@ namespace LCompilers {
                 is_allocatable |= ASRUtils::is_allocatable(a_target_struct->m_v);
             }
             a_realloc_lhs = a_realloc_lhs && is_allocatable;
+            a_target = ASRUtils::unwrap_logical_byte_cast(a_target);
+            a_value = ASRUtils::wrap_logical_value_for_array_store(al, a_loc, a_value, a_target);
             return ASR::make_Assignment_t(al, a_loc, a_target, a_value,
                 a_overloaded, a_realloc_lhs, false);
         }

--- a/tests/reference/asr-arrays_01_logical-13e0bd7.json
+++ b/tests/reference/asr-arrays_01_logical-13e0bd7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_01_logical-13e0bd7.stdout",
-    "stdout_hash": "aab443c9498cf21d6641b663677f48e53156206facc8c5607a5b9821",
+    "stdout_hash": "119265262176d3c6f3cbd668c42ceb35805f68f3559d3ed81e9e9460",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_01_logical-13e0bd7.stdout
+++ b/tests/reference/asr-arrays_01_logical-13e0bd7.stdout
@@ -142,9 +142,14 @@
                             ColMajor
                             ()
                         )
-                        (LogicalConstant
-                            .true.
+                        (Cast
+                            (LogicalConstant
+                                .true.
+                                (Logical 4)
+                            )
+                            LogicalToLogicalByte
                             (Logical 4)
+                            ()
                         )
                         ()
                         .false.
@@ -166,41 +171,56 @@
                                 ColMajor
                                 ()
                             )
-                            (LogicalNot
+                            (Cast
+                                (LogicalNot
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 a)
+                                            [(()
+                                            (IntegerBinOp
+                                                (Var 2 i)
+                                                Sub
+                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    (Logical 4)
+                                    ()
+                                )
+                                LogicalToLogicalByte
+                                (Logical 4)
+                                ()
+                            )
+                            ()
+                            .false.
+                            .false.
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (LogicalNot
+                            (Cast
                                 (ArrayItem
                                     (Var 2 a)
                                     [(()
-                                    (IntegerBinOp
-                                        (Var 2 i)
-                                        Sub
-                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                        (Integer 4)
-                                        ()
-                                    )
+                                    (IntegerConstant 1 (Integer 4) Decimal)
                                     ())]
                                     (Logical 4)
                                     ColMajor
                                     ()
                                 )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ()
-                            )
-                            ()
-                            .false.
-                            .false.
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (LogicalNot
-                            (ArrayItem
-                                (Var 2 a)
-                                [(()
-                                (IntegerConstant 1 (Integer 4) Decimal)
-                                ())]
-                                (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -213,13 +233,18 @@
                     )
                     (If
                         ()
-                        (ArrayItem
-                            (Var 2 a)
-                            [(()
-                            (IntegerConstant 2 (Integer 4) Decimal)
-                            ())]
+                        (Cast
+                            (ArrayItem
+                                (Var 2 a)
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
                             (Logical 4)
-                            ColMajor
                             ()
                         )
                         [(ErrorStop
@@ -230,13 +255,18 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 a)
-                                [(()
-                                (IntegerConstant 3 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 a)
+                                    [(()
+                                    (IntegerConstant 3 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -257,9 +287,14 @@
                             ColMajor
                             ()
                         )
-                        (LogicalConstant
-                            .false.
+                        (Cast
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
+                            LogicalToLogicalByte
                             (Logical 4)
+                            ()
                         )
                         ()
                         .false.
@@ -287,46 +322,107 @@
                                 ColMajor
                                 ()
                             )
-                            (LogicalNot
+                            (Cast
+                                (LogicalNot
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 b)
+                                            [(()
+                                            (IntegerBinOp
+                                                (IntegerBinOp
+                                                    (Var 2 i)
+                                                    Sub
+                                                    (IntegerConstant 10 (Integer 4) Decimal)
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                Sub
+                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    (Logical 4)
+                                    ()
+                                )
+                                LogicalToLogicalByte
+                                (Logical 4)
+                                ()
+                            )
+                            ()
+                            .false.
+                            .false.
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (Cast
+                            (ArrayItem
+                                (Var 2 b)
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (LogicalNot
+                            (Cast
                                 (ArrayItem
                                     (Var 2 b)
                                     [(()
-                                    (IntegerBinOp
-                                        (IntegerBinOp
-                                            (Var 2 i)
-                                            Sub
-                                            (IntegerConstant 10 (Integer 4) Decimal)
-                                            (Integer 4)
-                                            ()
-                                        )
-                                        Sub
-                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                        (Integer 4)
-                                        ()
-                                    )
+                                    (IntegerConstant 2 (Integer 4) Decimal)
                                     ())]
                                     (Logical 4)
                                     ColMajor
                                     ()
                                 )
+                                LogicalByteToLogical
                                 (Logical 4)
                                 ()
                             )
+                            (Logical 4)
                             ()
-                            .false.
-                            .false.
+                        )
+                        [(ErrorStop
+                            ()
                         )]
                         []
                     )
                     (If
                         ()
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 1 (Integer 4) Decimal)
-                            ())]
+                        (Cast
+                            (ArrayItem
+                                (Var 2 b)
+                                [(()
+                                (IntegerConstant 3 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
                             (Logical 4)
-                            ColMajor
                             ()
                         )
                         [(ErrorStop
@@ -337,49 +433,18 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 b)
-                                [(()
-                                (IntegerConstant 2 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 b)
+                                    [(()
+                                    (IntegerConstant 4 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
-                                ()
-                            )
-                            (Logical 4)
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 3 (Integer 4) Decimal)
-                            ())]
-                            (Logical 4)
-                            ColMajor
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (LogicalNot
-                            (ArrayItem
-                                (Var 2 b)
-                                [(()
-                                (IntegerConstant 4 (Integer 4) Decimal)
-                                ())]
-                                (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -406,129 +471,45 @@
                                 ColMajor
                                 ()
                             )
-                            (LogicalBinOp
-                                (ArrayItem
-                                    (Var 2 a)
-                                    [(()
-                                    (Var 2 i)
-                                    ())]
-                                    (Logical 4)
-                                    ColMajor
-                                    ()
-                                )
-                                And
-                                (LogicalConstant
-                                    .false.
-                                    (Logical 4)
-                                )
-                                (Logical 4)
-                                ()
-                            )
-                            ()
-                            .false.
-                            .false.
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 1 (Integer 4) Decimal)
-                            ())]
-                            (Logical 4)
-                            ColMajor
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 2 (Integer 4) Decimal)
-                            ())]
-                            (Logical 4)
-                            ColMajor
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (If
-                        ()
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 3 (Integer 4) Decimal)
-                            ())]
-                            (Logical 4)
-                            ColMajor
-                            ()
-                        )
-                        [(ErrorStop
-                            ()
-                        )]
-                        []
-                    )
-                    (Assignment
-                        (ArrayItem
-                            (Var 2 b)
-                            [(()
-                            (IntegerConstant 4 (Integer 4) Decimal)
-                            ())]
-                            (Logical 4)
-                            ColMajor
-                            ()
-                        )
-                        (LogicalBinOp
-                            (LogicalBinOp
+                            (Cast
                                 (LogicalBinOp
-                                    (ArrayItem
-                                        (Var 2 b)
-                                        [(()
-                                        (IntegerConstant 1 (Integer 4) Decimal)
-                                        ())]
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 a)
+                                            [(()
+                                            (Var 2 i)
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
                                         (Logical 4)
-                                        ColMajor
                                         ()
                                     )
-                                    Or
-                                    (ArrayItem
-                                        (Var 2 b)
-                                        [(()
-                                        (IntegerConstant 2 (Integer 4) Decimal)
-                                        ())]
+                                    And
+                                    (LogicalConstant
+                                        .false.
                                         (Logical 4)
-                                        ColMajor
-                                        ()
                                     )
                                     (Logical 4)
                                     ()
                                 )
-                                Or
-                                (ArrayItem
-                                    (Var 2 b)
-                                    [(()
-                                    (IntegerConstant 3 (Integer 4) Decimal)
-                                    ())]
-                                    (Logical 4)
-                                    ColMajor
-                                    ()
-                                )
+                                LogicalToLogicalByte
                                 (Logical 4)
                                 ()
                             )
-                            Or
+                            ()
+                            .false.
+                            .false.
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (Cast
                             (ArrayItem
-                                (Var 2 a)
+                                (Var 2 b)
                                 [(()
                                 (IntegerConstant 1 (Integer 4) Decimal)
                                 ())]
@@ -536,6 +517,140 @@
                                 ColMajor
                                 ()
                             )
+                            LogicalByteToLogical
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (Cast
+                            (ArrayItem
+                                (Var 2 b)
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (If
+                        ()
+                        (Cast
+                            (ArrayItem
+                                (Var 2 b)
+                                [(()
+                                (IntegerConstant 3 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
+                            (Logical 4)
+                            ()
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )
+                    (Assignment
+                        (ArrayItem
+                            (Var 2 b)
+                            [(()
+                            (IntegerConstant 4 (Integer 4) Decimal)
+                            ())]
+                            (Logical 4)
+                            ColMajor
+                            ()
+                        )
+                        (Cast
+                            (LogicalBinOp
+                                (LogicalBinOp
+                                    (LogicalBinOp
+                                        (Cast
+                                            (ArrayItem
+                                                (Var 2 b)
+                                                [(()
+                                                (IntegerConstant 1 (Integer 4) Decimal)
+                                                ())]
+                                                (Logical 4)
+                                                ColMajor
+                                                ()
+                                            )
+                                            LogicalByteToLogical
+                                            (Logical 4)
+                                            ()
+                                        )
+                                        Or
+                                        (Cast
+                                            (ArrayItem
+                                                (Var 2 b)
+                                                [(()
+                                                (IntegerConstant 2 (Integer 4) Decimal)
+                                                ())]
+                                                (Logical 4)
+                                                ColMajor
+                                                ()
+                                            )
+                                            LogicalByteToLogical
+                                            (Logical 4)
+                                            ()
+                                        )
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    Or
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 b)
+                                            [(()
+                                            (IntegerConstant 3 (Integer 4) Decimal)
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
+                                        (Logical 4)
+                                        ()
+                                    )
+                                    (Logical 4)
+                                    ()
+                                )
+                                Or
+                                (Cast
+                                    (ArrayItem
+                                        (Var 2 a)
+                                        [(()
+                                        (IntegerConstant 1 (Integer 4) Decimal)
+                                        ())]
+                                        (Logical 4)
+                                        ColMajor
+                                        ()
+                                    )
+                                    LogicalByteToLogical
+                                    (Logical 4)
+                                    ()
+                                )
+                                (Logical 4)
+                                ()
+                            )
+                            LogicalToLogicalByte
                             (Logical 4)
                             ()
                         )
@@ -546,13 +661,18 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 b)
-                                [(()
-                                (IntegerConstant 4 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 b)
+                                    [(()
+                                    (IntegerConstant 4 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -573,13 +693,23 @@
                             ColMajor
                             ()
                         )
-                        (ArrayItem
-                            (Var 2 a)
-                            [(()
-                            (IntegerConstant 1 (Integer 4) Decimal)
-                            ())]
+                        (Cast
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 a)
+                                    [(()
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
+                                (Logical 4)
+                                ()
+                            )
+                            LogicalToLogicalByte
                             (Logical 4)
-                            ColMajor
                             ()
                         )
                         ()
@@ -589,13 +719,18 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 b)
-                                [(()
-                                (IntegerConstant 4 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 b)
+                                    [(()
+                                    (IntegerConstant 4 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -670,9 +805,14 @@
                                         ColMajor
                                         ()
                                     )
-                                    (LogicalConstant
-                                        .true.
+                                    (Cast
+                                        (LogicalConstant
+                                            .true.
+                                            (Logical 4)
+                                        )
+                                        LogicalToLogicalByte
                                         (Logical 4)
+                                        ()
                                     )
                                     ()
                                     .false.
@@ -691,9 +831,14 @@
                                         ColMajor
                                         ()
                                     )
-                                    (LogicalConstant
-                                        .false.
+                                    (Cast
+                                        (LogicalConstant
+                                            .false.
+                                            (Logical 4)
+                                        )
+                                        LogicalToLogicalByte
                                         (Logical 4)
+                                        ()
                                     )
                                     ()
                                     .false.
@@ -706,16 +851,21 @@
                     )
                     (If
                         ()
-                        (ArrayItem
-                            (Var 2 c)
-                            [(()
-                            (IntegerConstant 1 (Integer 4) Decimal)
-                            ())
-                            (()
-                            (IntegerConstant 1 (Integer 4) Decimal)
-                            ())]
+                        (Cast
+                            (ArrayItem
+                                (Var 2 c)
+                                [(()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())
+                                (()
+                                (IntegerConstant 1 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
                             (Logical 4)
-                            ColMajor
                             ()
                         )
                         [(ErrorStop
@@ -726,16 +876,21 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 c)
-                                [(()
-                                (IntegerConstant 1 (Integer 4) Decimal)
-                                ())
-                                (()
-                                (IntegerConstant 2 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 c)
+                                    [(()
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    ())
+                                    (()
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -749,16 +904,21 @@
                     (If
                         ()
                         (LogicalNot
-                            (ArrayItem
-                                (Var 2 c)
-                                [(()
-                                (IntegerConstant 2 (Integer 4) Decimal)
-                                ())
-                                (()
-                                (IntegerConstant 1 (Integer 4) Decimal)
-                                ())]
+                            (Cast
+                                (ArrayItem
+                                    (Var 2 c)
+                                    [(()
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    ())
+                                    (()
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    ())]
+                                    (Logical 4)
+                                    ColMajor
+                                    ()
+                                )
+                                LogicalByteToLogical
                                 (Logical 4)
-                                ColMajor
                                 ()
                             )
                             (Logical 4)
@@ -771,16 +931,21 @@
                     )
                     (If
                         ()
-                        (ArrayItem
-                            (Var 2 c)
-                            [(()
-                            (IntegerConstant 2 (Integer 4) Decimal)
-                            ())
-                            (()
-                            (IntegerConstant 2 (Integer 4) Decimal)
-                            ())]
+                        (Cast
+                            (ArrayItem
+                                (Var 2 c)
+                                [(()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())
+                                (()
+                                (IntegerConstant 2 (Integer 4) Decimal)
+                                ())]
+                                (Logical 4)
+                                ColMajor
+                                ()
+                            )
+                            LogicalByteToLogical
                             (Logical 4)
-                            ColMajor
                             ()
                         )
                         [(ErrorStop

--- a/tests/reference/asr-fn5-3d75eb7.json
+++ b/tests/reference/asr-fn5-3d75eb7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-fn5-3d75eb7.stdout",
-    "stdout_hash": "7474938d7724b3d73f750673d0a02c774704856a3ea51f2b3bdcb87b",
+    "stdout_hash": "76a9a68381e6e40a190f956c390d32e367d1b601ac29ba4639edf604",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-fn5-3d75eb7.stdout
+++ b/tests/reference/asr-fn5-3d75eb7.stdout
@@ -668,13 +668,18 @@
                                                     ColMajor
                                                     ()
                                                 )
-                                                (ArrayItem
-                                                    (Var 4 present_in)
-                                                    [(()
-                                                    (Var 4 i)
-                                                    ())]
+                                                (Cast
+                                                    (ArrayItem
+                                                        (Var 4 present_in)
+                                                        [(()
+                                                        (Var 4 i)
+                                                        ())]
+                                                        (Logical 4)
+                                                        ColMajor
+                                                        ()
+                                                    )
+                                                    LogicalByteToLogical
                                                     (Logical 4)
-                                                    ColMajor
                                                     ()
                                                 )
                                                 (StringSection

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.json
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matrix_01_transpose-fb3276a.stdout",
-    "stdout_hash": "f06ecbef91d4f82bcec7c6d77955dd80f66b29ee75fdbd5194432c6f",
+    "stdout_hash": "882f9889e9aeac33efd87d0da173c5045bad7412000430778ab9bfd2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
@@ -1334,29 +1334,39 @@
                             [(If
                                 ()
                                 (LogicalBinOp
-                                    (ArrayItem
-                                        (Var 2 l)
-                                        [(()
-                                        (Var 2 i)
-                                        ())
-                                        (()
-                                        (Var 2 j)
-                                        ())]
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 l)
+                                            [(()
+                                            (Var 2 i)
+                                            ())
+                                            (()
+                                            (Var 2 j)
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
                                         (Logical 4)
-                                        ColMajor
                                         ()
                                     )
                                     NEqv
-                                    (ArrayItem
-                                        (Var 2 m)
-                                        [(()
-                                        (Var 2 j)
-                                        ())
-                                        (()
-                                        (Var 2 i)
-                                        ())]
+                                    (Cast
+                                        (ArrayItem
+                                            (Var 2 m)
+                                            [(()
+                                            (Var 2 j)
+                                            ())
+                                            (()
+                                            (Var 2 i)
+                                            ())]
+                                            (Logical 4)
+                                            ColMajor
+                                            ()
+                                        )
+                                        LogicalByteToLogical
                                         (Logical 4)
-                                        ColMajor
                                         ()
                                     )
                                     (Logical 4)


### PR DESCRIPTION
## Summary
- Add new cast_kind values: `LogicalByteToLogical`, `LogicalToLogicalByte`
- Handle these casts in all backends (LLVM, C++, Julia, WASM)
- **Insert `LogicalToLogicalByte` cast during semantics** when storing to logical array elements

Refs #9626

## Why
This implements explicit ASR-level representation of logical array byte storage conversion, as discussed in PR #9559 and issue #9626.

**Key architectural points from the discussion:**
1. certik: "I think ASR cast is better" - prefers ASR-level solution
2. certik: "we should be doing all these casts in ASR itself" 
3. certik (on PR #9798): "this must happen already in AST->ASR" - casts should be in semantics, not an ASR pass
4. certik (on PR #9798): "Why does ArrayItem for a logical have to be an integer? That doesn't seem right?" - ArrayItem must stay Logical type

**This PR:**
- Defines the cast kinds that represent byte↔logical conversion
- **Inserts `LogicalToLogicalByte` casts in `make_Assignment_t_util`** during AST→ASR phase
- Keeps ArrayItem type as Logical (not Integer!)
- Maintains backward compatibility with existing codegen fallback for edge cases

**Stage:** Semantics (AST→ASR)

## What these casts represent
- `LogicalByteToLogical`: Convert byte-backed (i8) logical array element to scalar i1 (for reads) - handler ready, not yet used
- `LogicalToLogicalByte`: Convert scalar i1 logical to byte (i8) for storage (for writes) - actively used

## Changes
- `ASR.asdl`: Add `LogicalByteToLogical`, `LogicalToLogicalByte` cast kinds
- `asr_to_llvm.cpp`: Handle casts + clarified comments on fallback logic
- `asr_to_c_cpp.h`, `asr_to_julia.cpp`, `asr_to_wasm.cpp`: Handle casts (no-ops, bool is byte-sized)
- `asr_utils.h`: Add helper `wrap_logical_value_for_array_store()`
- `asr_utils.cpp`: Insert `LogicalToLogicalByte` cast in `make_Assignment_t_util`
- `pass/pass_utils.cpp`: Same for the local `make_Assignment_t_util`

## Tests
- Updated `tests/reference/asr-arrays_01_logical-*` to reflect new ASR with explicit casts
- All tests pass locally

## Future work
- The `LogicalByteToLogical` cast kind and handler are ready for when logical array reads are moved from codegen to ASR level
- Current read handling via `get_el_type()` works correctly