### PR TITLE
Fix string concatenation bug

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -434,6 +434,7 @@ RUN(NAME expr_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran) # it u
 RUN(NAME expr_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME expr_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME expr_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
+RUN(NAME string_concat_deferred_len LABELS gfortran llvm)
 RUN(NAME expr_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME expr_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME expr_18 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)

--- a/integration_tests/string_concat_deferred_len.f90
+++ b/integration_tests/string_concat_deferred_len.f90
@@ -1,0 +1,14 @@
+program string_concat_deferred_len
+implicit none
+character(len=:), allocatable :: p, c
+
+p = '././src/fpm_meta.f90'
+c = ''
+
+if (p(1:1) /= '.') c = c // p(1:1) // '/'
+c = c // p(5:len(p)) // '/'
+
+if (len(c) > 1 .and. c(len(c):) == '/') c = c(:len(c)-1)
+
+if (trim(c) /= 'src/fpm_meta.f90') error stop 1
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5287,7 +5287,7 @@ namespace StringConcat {
                 extract_value(s2->m_len, s2_len);
                 return_type = b.String(b.i64(s1_len + s2_len), ASR::ExpressionLength);
             } else {
-                return_type = b.String(nullptr, ASR::DeferredLength);
+                return_type = b.allocatable(b.String(nullptr, ASR::DeferredLength));
             }
         }
 
@@ -5309,7 +5309,6 @@ namespace StringConcat {
                                                         0, return_type, value);
     }
 
-    
     // Compute string length expression without embedding nested StringConcats.
     // For StringConcat expressions, recursively compute len(arg1) + len(arg2).
     // For other expressions, use StringLen directly.
@@ -5369,8 +5368,10 @@ namespace StringConcat {
 
         ASR::expr_t* ret_var = declare(
             "concat_result",
-            b.String(b.Add(args[2], args[3]), ASR::ExpressionLength),
+            b.allocatable(b.String(nullptr, ASR::DeferredLength)),
             ReturnVar);
+
+        body.push_back(al, b.Allocate(ret_var, nullptr, 0, b.Add(args[2], args[3])));
 
         /* Body: copy s1 then s2 into result using explicit lengths */
         body.push_back(al, b.Assignment(

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3596,6 +3596,25 @@ LFORTRAN_API void _lfortran_strcpy(
         if (*lhs == NULL) *lhs = (char*)malloc(MAX((*lhs_len), 1) * sizeof(char));
         _lfortran_copy_str_and_pad(*lhs, *lhs_len, rhs, rhs_len);
     } else if (is_lhs_deferred && is_lhs_allocatable) { // Automatic Reallocation
+        if (*lhs != NULL && rhs != NULL) {
+            char* lhs_start = *lhs;
+            char* lhs_end = lhs_start + (*lhs_len);
+            if (rhs >= lhs_start && rhs < lhs_end) {
+                if (rhs_len <= *lhs_len) {
+                    memmove(*lhs, rhs, rhs_len * sizeof(char));
+                    *lhs_len = rhs_len;
+                    return;
+                } else {
+                    char* tmp = (char*)malloc(MAX(rhs_len, 1) * sizeof(char));
+                    memcpy(tmp, rhs, rhs_len * sizeof(char));
+                    *lhs = (char*)realloc(*lhs, MAX(rhs_len, 1) * sizeof(char));
+                    *lhs_len = rhs_len;
+                    memcpy(*lhs, tmp, rhs_len * sizeof(char));
+                    free(tmp);
+                    return;
+                }
+            }
+        }
         *lhs = (char*)realloc(*lhs, MAX(rhs_len, 1) * sizeof(char));
         *lhs_len = rhs_len;
         for(int64_t i = 0; i < rhs_len; i++) {(*lhs)[i] = rhs[i];}

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "a209ec2088f8bf700f999ee28bd3cce5b7e0550678ecee6937d9dfad",
+    "stdout_hash": "d68d0ddb307fbda19866861e5f100e89902f134e4afe622d4ba9d511",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -3,6 +3,7 @@ source_filename = "LFortran"
 
 %string_descriptor = type <{ i8*, i64 }>
 
+@__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
 @string_const_data = private constant [8 x i8] c"learned "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data, i32 0, i32 0), i64 8 }>
 @string_const_data.1 = private constant [5 x i8] c"from "
@@ -11,7 +12,6 @@ source_filename = "LFortran"
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.3, i32 0, i32 0), i64 4 }>
 @string_const_data.5 = private constant [4 x i8] c"best"
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
-@__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
 @string_const_data.7 = private constant [5 x i8] c"I've "
 @string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.7, i32 0, i32 0), i64 5 }>
 @0 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
@@ -30,58 +30,88 @@ source_filename = "LFortran"
 define void @_lcompilers_stringconcat(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
 .entry:
   %0 = load i32, i32* %s1_len, align 4
-  %1 = sext i32 %0 to i64
-  %2 = sub i64 %1, 1
-  %3 = add i64 %2, 1
-  %4 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %5 = load i8*, i8** %4, align 8
-  %StrSliceGEP = getelementptr i8, i8* %5, i64 0
+  %1 = load i32, i32* %s2_len, align 4
+  %2 = add i32 %0, %1
+  %3 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %4 = load i8*, i8** %3, align 8
+  %5 = icmp ne i8* %4, null
+  br i1 %5, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %6 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %7 = sext i32 %2 to i64
+  %8 = call i8* @_lfortran_string_malloc(i64 %7)
+  store i8* %8, i8** %6, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %10 = sext i32 %2 to i64
+  store i64 %10, i64* %9, align 4
+  %11 = load i32, i32* %s1_len, align 4
+  %12 = sext i32 %11 to i64
+  %13 = sub i64 %12, 1
+  %14 = add i64 %13, 1
+  %15 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %16 = load i8*, i8** %15, align 8
+  %StrSliceGEP = getelementptr i8, i8* %16, i64 0
   %StrSlice_StrView = alloca %string_descriptor, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %3, i64* %7, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %9 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %10 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 1
-  %13 = load i64, i64* %12, align 4
-  call void @_lfortran_strcpy(i8** %8, i64* %9, i8 0, i8 0, i8* %11, i64 %13)
-  %14 = load i32, i32* %s1_len, align 4
-  %15 = add i32 %14, 1
-  %16 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
-  %17 = load i64, i64* %16, align 4
-  %18 = trunc i64 %17 to i32
-  %19 = sext i32 %15 to i64
-  %20 = sext i32 %18 to i64
-  %21 = sub i64 %20, %19
-  %22 = add i64 %21, 1
-  %23 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = sext i32 %15 to i64
-  %26 = sub i64 %25, 1
-  %StrSliceGEP1 = getelementptr i8, i8* %24, i64 %26
+  %17 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  store i8* %StrSliceGEP, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %14, i64* %18, align 4
+  %19 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 0
+  %22 = load i8*, i8** %21, align 8
+  %23 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 1
+  %24 = load i64, i64* %23, align 4
+  call void @_lfortran_strcpy(i8** %19, i64* %20, i8 0, i8 0, i8* %22, i64 %24)
+  %25 = load i32, i32* %s1_len, align 4
+  %26 = add i32 %25, 1
+  %27 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %28 = load i64, i64* %27, align 4
+  %29 = trunc i64 %28 to i32
+  %30 = sext i32 %26 to i64
+  %31 = sext i32 %29 to i64
+  %32 = sub i64 %31, %30
+  %33 = add i64 %32, 1
+  %34 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %35 = load i8*, i8** %34, align 8
+  %36 = sext i32 %26 to i64
+  %37 = sub i64 %36, 1
+  %StrSliceGEP1 = getelementptr i8, i8* %35, i64 %37
   %StrSlice_StrView2 = alloca %string_descriptor, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  store i8* %StrSliceGEP1, i8** %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  store i64 %22, i64* %28, align 4
-  %29 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  %30 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  %31 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 0
-  %32 = load i8*, i8** %31, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 1
-  %34 = load i64, i64* %33, align 4
-  call void @_lfortran_strcpy(i8** %29, i64* %30, i8 0, i8 0, i8* %32, i64 %34)
+  %38 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
+  store i8* %StrSliceGEP1, i8** %38, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
+  store i64 %33, i64* %39, align 4
+  %40 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
+  %41 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
+  %42 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 0
+  %43 = load i8*, i8** %42, align 8
+  %44 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 1
+  %45 = load i64, i64* %44, align 4
+  call void @_lfortran_strcpy(i8** %40, i64* %41, i8 0, i8 0, i8* %43, i64 %45)
   br label %return
 
-return:                                           ; preds = %.entry
+return:                                           ; preds = %ifcont
   br label %FINALIZE_SYMTABLE__lcompilers_stringconcat
 
 FINALIZE_SYMTABLE__lcompilers_stringconcat:       ; preds = %return
   ret void
 }
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
+
+declare i8* @_lfortran_string_malloc(i64)
 
 declare void @_lfortran_strcpy(i8**, i64*, i8, i8, i8*, i64)
 
@@ -157,335 +187,240 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lfortran_free(i8* %31)
   store i8* null, i8** %29, align 8
   store i64 0, i64* %30, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = icmp ne i8* %33, null
-  br i1 %34, label %then, label %else
-
-then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %36 = call i8* @_lfortran_malloc(i64 13)
-  store i8* %36, i8** %35, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  store i64 13, i64* %37, align 4
   store i32 5, i32* %call_arg_value, align 4
   store i32 8, i32* %call_arg_value1, align 4
   call void @_lcompilers_stringconcat(%string_descriptor* @string_const.8, %string_descriptor* %verb, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__0_return_slot)
-  %38 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %39 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %40 = load i8*, i8** %38, align 8
-  call void @_lfortran_free(i8* %40)
-  store i8* null, i8** %38, align 8
-  store i64 0, i64* %39, align 4
-  %41 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = icmp ne i8* %42, null
-  br i1 %43, label %then2, label %else3
+  %32 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %34 = load i8*, i8** %32, align 8
+  call void @_lfortran_free(i8* %34)
+  store i8* null, i8** %32, align 8
+  store i64 0, i64* %33, align 4
+  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %36 = load i8*, i8** %35, align 8
+  %37 = ptrtoint i8* %36 to i64
+  %38 = icmp eq i64 %37, 0
+  br i1 %38, label %then, label %ifcont
 
-then2:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont4
-
-else3:                                            ; preds = %ifcont
-  br label %ifcont4
-
-ifcont4:                                          ; preds = %else3, %then2
-  %44 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %45 = call i8* @_lfortran_malloc(i64 18)
-  store i8* %45, i8** %44, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  store i64 18, i64* %46, align 4
-  %47 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %48 = load i8*, i8** %47, align 8
-  %49 = ptrtoint i8* %48 to i64
-  %50 = icmp eq i64 %49, 0
-  br i1 %50, label %then5, label %ifcont6
-
-then5:                                            ; preds = %ifcont4
+then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([103 x i8], [103 x i8]* @1, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @0, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont6:                                          ; preds = %ifcont4
+ifcont:                                           ; preds = %.entry
   store i32 13, i32* %call_arg_value, align 4
   store i32 5, i32* %call_arg_value1, align 4
   call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__0_return_slot, %string_descriptor* %posit, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__1_return_slot)
-  %51 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %52 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %53 = load i8*, i8** %51, align 8
-  call void @_lfortran_free(i8* %53)
-  store i8* null, i8** %51, align 8
-  store i64 0, i64* %52, align 4
-  %54 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %55 = load i8*, i8** %54, align 8
-  %56 = icmp ne i8* %55, null
-  br i1 %56, label %then7, label %else8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %40 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
+  %41 = load i8*, i8** %39, align 8
+  call void @_lfortran_free(i8* %41)
+  store i8* null, i8** %39, align 8
+  store i64 0, i64* %40, align 4
+  %42 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %43 = load i8*, i8** %42, align 8
+  %44 = ptrtoint i8* %43 to i64
+  %45 = icmp eq i64 %44, 0
+  br i1 %45, label %then2, label %ifcont3
 
-then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont9
-
-else8:                                            ; preds = %ifcont6
-  br label %ifcont9
-
-ifcont9:                                          ; preds = %else8, %then7
-  %57 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %58 = call i8* @_lfortran_malloc(i64 22)
-  store i8* %58, i8** %57, align 8
-  %59 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  store i64 22, i64* %59, align 4
-  %60 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %61 = load i8*, i8** %60, align 8
-  %62 = ptrtoint i8* %61 to i64
-  %63 = icmp eq i64 %62, 0
-  br i1 %63, label %then10, label %ifcont11
-
-then10:                                           ; preds = %ifcont9
+then2:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([103 x i8], [103 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @2, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont11:                                         ; preds = %ifcont9
+ifcont3:                                          ; preds = %ifcont
   store i32 18, i32* %call_arg_value, align 4
   store i32 4, i32* %call_arg_value1, align 4
   call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__1_return_slot, %string_descriptor* %title, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__2_return_slot)
-  %64 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %65 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
-  %66 = load i8*, i8** %64, align 8
-  call void @_lfortran_free(i8* %66)
-  store i8* null, i8** %64, align 8
-  store i64 0, i64* %65, align 4
-  %67 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %68 = load i8*, i8** %67, align 8
-  %69 = icmp ne i8* %68, null
-  br i1 %69, label %then12, label %else13
+  %46 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %47 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
+  %48 = load i8*, i8** %46, align 8
+  call void @_lfortran_free(i8* %48)
+  store i8* null, i8** %46, align 8
+  store i64 0, i64* %47, align 4
+  %49 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %50 = load i8*, i8** %49, align 8
+  %51 = ptrtoint i8* %50 to i64
+  %52 = icmp eq i64 %51, 0
+  br i1 %52, label %then4, label %ifcont5
 
-then12:                                           ; preds = %ifcont11
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont14
-
-else13:                                           ; preds = %ifcont11
-  br label %ifcont14
-
-ifcont14:                                         ; preds = %else13, %then12
-  %70 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %71 = call i8* @_lfortran_malloc(i64 29)
-  store i8* %71, i8** %70, align 8
-  %72 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
-  store i64 29, i64* %72, align 4
-  %73 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %74 = load i8*, i8** %73, align 8
-  %75 = ptrtoint i8* %74 to i64
-  %76 = icmp eq i64 %75, 0
-  br i1 %76, label %then15, label %ifcont16
-
-then15:                                           ; preds = %ifcont14
+then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([103 x i8], [103 x i8]* @5, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont16:                                         ; preds = %ifcont14
+ifcont5:                                          ; preds = %ifcont3
   store i32 22, i32* %call_arg_value, align 4
   store i32 7, i32* %call_arg_value1, align 4
   call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__2_return_slot, %string_descriptor* %last_name, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__3_return_slot)
-  %77 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %78 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  %79 = load i8*, i8** %77, align 8
-  call void @_lfortran_free(i8* %79)
-  store i8* null, i8** %77, align 8
-  store i64 0, i64* %78, align 4
-  %80 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %81 = load i8*, i8** %80, align 8
-  %82 = icmp ne i8* %81, null
-  br i1 %82, label %then17, label %else18
+  %53 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %54 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
+  %55 = load i8*, i8** %53, align 8
+  call void @_lfortran_free(i8* %55)
+  store i8* null, i8** %53, align 8
+  store i64 0, i64* %54, align 4
+  %56 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %57 = load i8*, i8** %56, align 8
+  %58 = ptrtoint i8* %57 to i64
+  %59 = icmp eq i64 %58, 0
+  br i1 %59, label %then6, label %ifcont7
 
-then17:                                           ; preds = %ifcont16
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont19
-
-else18:                                           ; preds = %ifcont16
-  br label %ifcont19
-
-ifcont19:                                         ; preds = %else18, %then17
-  %83 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %84 = call i8* @_lfortran_malloc(i64 30)
-  store i8* %84, i8** %83, align 8
-  %85 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  store i64 30, i64* %85, align 4
-  %86 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %87 = load i8*, i8** %86, align 8
-  %88 = ptrtoint i8* %87 to i64
-  %89 = icmp eq i64 %88, 0
-  br i1 %89, label %then20, label %ifcont21
-
-then20:                                           ; preds = %ifcont19
+then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([103 x i8], [103 x i8]* @7, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @6, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont21:                                         ; preds = %ifcont19
+ifcont7:                                          ; preds = %ifcont5
   store i32 29, i32* %call_arg_value, align 4
   store i32 1, i32* %call_arg_value1, align 4
   call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__3_return_slot, %string_descriptor* @string_const.10, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__4_return_slot)
-  %90 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %91 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 1
-  %92 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %93 = load i8*, i8** %92, align 8
-  %94 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  %95 = load i64, i64* %94, align 4
-  call void @_lfortran_strcpy(i8** %90, i64* %91, i8 0, i8 0, i8* %93, i64 %95)
-  %96 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %97 = load i8*, i8** %96, align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %97, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %60 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
+  %61 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 1
+  %62 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %63 = load i8*, i8** %62, align 8
+  %64 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
+  %65 = load i64, i64* %64, align 4
+  call void @_lfortran_strcpy(i8** %60, i64* %61, i8 0, i8 0, i8* %63, i64 %65)
+  %66 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
+  %67 = load i8*, i8** %66, align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %67, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   call void @_lpython_free_argv()
   br label %return
 
-return:                                           ; preds = %ifcont21
+return:                                           ; preds = %ifcont7
   br label %FINALIZE_SYMTABLE_string_03
 
 FINALIZE_SYMTABLE_string_03:                      ; preds = %return
   br label %Finalize_Variable___libasr__created__var__0_return_slot
 
 Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_string_03
-  %98 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %99 = load i8*, i8** %98, align 8
-  %100 = icmp eq i8* %99, null
-  br i1 %100, label %free_done, label %free_nonnull
+  %68 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %69 = load i8*, i8** %68, align 8
+  %70 = icmp eq i8* %69, null
+  br i1 %70, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
-  call void @_lfortran_free(i8* %99)
+  call void @_lfortran_free(i8* %69)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %Finalize_Variable___libasr__created__var__0_return_slot
   br label %Finalize_Variable___libasr__created__var__1_return_slot
 
 Finalize_Variable___libasr__created__var__1_return_slot: ; preds = %free_done
-  %101 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %102 = load i8*, i8** %101, align 8
-  %103 = icmp eq i8* %102, null
-  br i1 %103, label %free_done23, label %free_nonnull22
+  %71 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %72 = load i8*, i8** %71, align 8
+  %73 = icmp eq i8* %72, null
+  br i1 %73, label %free_done9, label %free_nonnull8
 
-free_nonnull22:                                   ; preds = %Finalize_Variable___libasr__created__var__1_return_slot
-  call void @_lfortran_free(i8* %102)
-  br label %free_done23
+free_nonnull8:                                    ; preds = %Finalize_Variable___libasr__created__var__1_return_slot
+  call void @_lfortran_free(i8* %72)
+  br label %free_done9
 
-free_done23:                                      ; preds = %free_nonnull22, %Finalize_Variable___libasr__created__var__1_return_slot
+free_done9:                                       ; preds = %free_nonnull8, %Finalize_Variable___libasr__created__var__1_return_slot
   br label %Finalize_Variable___libasr__created__var__2_return_slot
 
-Finalize_Variable___libasr__created__var__2_return_slot: ; preds = %free_done23
-  %104 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %105 = load i8*, i8** %104, align 8
-  %106 = icmp eq i8* %105, null
-  br i1 %106, label %free_done25, label %free_nonnull24
+Finalize_Variable___libasr__created__var__2_return_slot: ; preds = %free_done9
+  %74 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %75 = load i8*, i8** %74, align 8
+  %76 = icmp eq i8* %75, null
+  br i1 %76, label %free_done11, label %free_nonnull10
 
-free_nonnull24:                                   ; preds = %Finalize_Variable___libasr__created__var__2_return_slot
-  call void @_lfortran_free(i8* %105)
-  br label %free_done25
+free_nonnull10:                                   ; preds = %Finalize_Variable___libasr__created__var__2_return_slot
+  call void @_lfortran_free(i8* %75)
+  br label %free_done11
 
-free_done25:                                      ; preds = %free_nonnull24, %Finalize_Variable___libasr__created__var__2_return_slot
+free_done11:                                      ; preds = %free_nonnull10, %Finalize_Variable___libasr__created__var__2_return_slot
   br label %Finalize_Variable___libasr__created__var__3_return_slot
 
-Finalize_Variable___libasr__created__var__3_return_slot: ; preds = %free_done25
-  %107 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %108 = load i8*, i8** %107, align 8
-  %109 = icmp eq i8* %108, null
-  br i1 %109, label %free_done27, label %free_nonnull26
+Finalize_Variable___libasr__created__var__3_return_slot: ; preds = %free_done11
+  %77 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %78 = load i8*, i8** %77, align 8
+  %79 = icmp eq i8* %78, null
+  br i1 %79, label %free_done13, label %free_nonnull12
 
-free_nonnull26:                                   ; preds = %Finalize_Variable___libasr__created__var__3_return_slot
-  call void @_lfortran_free(i8* %108)
-  br label %free_done27
+free_nonnull12:                                   ; preds = %Finalize_Variable___libasr__created__var__3_return_slot
+  call void @_lfortran_free(i8* %78)
+  br label %free_done13
 
-free_done27:                                      ; preds = %free_nonnull26, %Finalize_Variable___libasr__created__var__3_return_slot
+free_done13:                                      ; preds = %free_nonnull12, %Finalize_Variable___libasr__created__var__3_return_slot
   br label %Finalize_Variable___libasr__created__var__4_return_slot
 
-Finalize_Variable___libasr__created__var__4_return_slot: ; preds = %free_done27
-  %110 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %111 = load i8*, i8** %110, align 8
-  %112 = icmp eq i8* %111, null
-  br i1 %112, label %free_done29, label %free_nonnull28
+Finalize_Variable___libasr__created__var__4_return_slot: ; preds = %free_done13
+  %80 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %81 = load i8*, i8** %80, align 8
+  %82 = icmp eq i8* %81, null
+  br i1 %82, label %free_done15, label %free_nonnull14
 
-free_nonnull28:                                   ; preds = %Finalize_Variable___libasr__created__var__4_return_slot
-  call void @_lfortran_free(i8* %111)
-  br label %free_done29
+free_nonnull14:                                   ; preds = %Finalize_Variable___libasr__created__var__4_return_slot
+  call void @_lfortran_free(i8* %81)
+  br label %free_done15
 
-free_done29:                                      ; preds = %free_nonnull28, %Finalize_Variable___libasr__created__var__4_return_slot
+free_done15:                                      ; preds = %free_nonnull14, %Finalize_Variable___libasr__created__var__4_return_slot
   br label %Finalize_Variable_combined
 
-Finalize_Variable_combined:                       ; preds = %free_done29
-  %113 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %114 = load i8*, i8** %113, align 8
-  %115 = icmp eq i8* %114, null
-  br i1 %115, label %free_done31, label %free_nonnull30
+Finalize_Variable_combined:                       ; preds = %free_done15
+  %83 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
+  %84 = load i8*, i8** %83, align 8
+  %85 = icmp eq i8* %84, null
+  br i1 %85, label %free_done17, label %free_nonnull16
 
-free_nonnull30:                                   ; preds = %Finalize_Variable_combined
-  call void @_lfortran_free(i8* %114)
-  br label %free_done31
+free_nonnull16:                                   ; preds = %Finalize_Variable_combined
+  call void @_lfortran_free(i8* %84)
+  br label %free_done17
 
-free_done31:                                      ; preds = %free_nonnull30, %Finalize_Variable_combined
+free_done17:                                      ; preds = %free_nonnull16, %Finalize_Variable_combined
   br label %Finalize_Variable_last_name
 
-Finalize_Variable_last_name:                      ; preds = %free_done31
-  %116 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
-  %117 = load i8*, i8** %116, align 8
-  %118 = icmp eq i8* %117, null
-  br i1 %118, label %free_done33, label %free_nonnull32
+Finalize_Variable_last_name:                      ; preds = %free_done17
+  %86 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
+  %87 = load i8*, i8** %86, align 8
+  %88 = icmp eq i8* %87, null
+  br i1 %88, label %free_done19, label %free_nonnull18
 
-free_nonnull32:                                   ; preds = %Finalize_Variable_last_name
-  call void @_lfortran_free(i8* %117)
-  br label %free_done33
+free_nonnull18:                                   ; preds = %Finalize_Variable_last_name
+  call void @_lfortran_free(i8* %87)
+  br label %free_done19
 
-free_done33:                                      ; preds = %free_nonnull32, %Finalize_Variable_last_name
+free_done19:                                      ; preds = %free_nonnull18, %Finalize_Variable_last_name
   br label %Finalize_Variable_posit
 
-Finalize_Variable_posit:                          ; preds = %free_done33
-  %119 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
-  %120 = load i8*, i8** %119, align 8
-  %121 = icmp eq i8* %120, null
-  br i1 %121, label %free_done35, label %free_nonnull34
+Finalize_Variable_posit:                          ; preds = %free_done19
+  %89 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
+  %90 = load i8*, i8** %89, align 8
+  %91 = icmp eq i8* %90, null
+  br i1 %91, label %free_done21, label %free_nonnull20
 
-free_nonnull34:                                   ; preds = %Finalize_Variable_posit
-  call void @_lfortran_free(i8* %120)
-  br label %free_done35
+free_nonnull20:                                   ; preds = %Finalize_Variable_posit
+  call void @_lfortran_free(i8* %90)
+  br label %free_done21
 
-free_done35:                                      ; preds = %free_nonnull34, %Finalize_Variable_posit
+free_done21:                                      ; preds = %free_nonnull20, %Finalize_Variable_posit
   br label %Finalize_Variable_title
 
-Finalize_Variable_title:                          ; preds = %free_done35
-  %122 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %123 = load i8*, i8** %122, align 8
-  %124 = icmp eq i8* %123, null
-  br i1 %124, label %free_done37, label %free_nonnull36
+Finalize_Variable_title:                          ; preds = %free_done21
+  %92 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
+  %93 = load i8*, i8** %92, align 8
+  %94 = icmp eq i8* %93, null
+  br i1 %94, label %free_done23, label %free_nonnull22
 
-free_nonnull36:                                   ; preds = %Finalize_Variable_title
-  call void @_lfortran_free(i8* %123)
-  br label %free_done37
+free_nonnull22:                                   ; preds = %Finalize_Variable_title
+  call void @_lfortran_free(i8* %93)
+  br label %free_done23
 
-free_done37:                                      ; preds = %free_nonnull36, %Finalize_Variable_title
+free_done23:                                      ; preds = %free_nonnull22, %Finalize_Variable_title
   br label %Finalize_Variable_verb
 
-Finalize_Variable_verb:                           ; preds = %free_done37
-  %125 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
-  %126 = load i8*, i8** %125, align 8
-  %127 = icmp eq i8* %126, null
-  br i1 %127, label %free_done39, label %free_nonnull38
+Finalize_Variable_verb:                           ; preds = %free_done23
+  %95 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
+  %96 = load i8*, i8** %95, align 8
+  %97 = icmp eq i8* %96, null
+  br i1 %97, label %free_done25, label %free_nonnull24
 
-free_nonnull38:                                   ; preds = %Finalize_Variable_verb
-  call void @_lfortran_free(i8* %126)
-  br label %free_done39
+free_nonnull24:                                   ; preds = %Finalize_Variable_verb
+  call void @_lfortran_free(i8* %96)
+  br label %free_done25
 
-free_done39:                                      ; preds = %free_nonnull38, %Finalize_Variable_verb
+free_done25:                                      ; preds = %free_nonnull24, %Finalize_Variable_verb
   ret i32 0
 }
 
@@ -494,10 +429,6 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lfortran_malloc(i64)
 
 declare void @_lfortran_free(i8*)
-
-declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @exit(i32)
 
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 


### PR DESCRIPTION
Two changes were made:

* StringConcat returns an allocatable string, which is one way to allow _lcompilers_stringconcat() writing into it --- previously it was writing into uninitialized memory. There might be other ways to fix it, but for now I think this is fine.
* _lfortran_strcpy() was upgraded to handle overlapping slices

Fixes #9852.