### PR TITLE
Fixed move_alloc for allocatable descriptor arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1320,6 +1320,7 @@ RUN(NAME intrinsics_331 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_332 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME intrinsics_333 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME intrinsics_334 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # move_alloc
+RUN(NAME move_alloc_pointer_alias LABELS gfortran llvm)
 RUN(NAME intrinsics_335 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #kind, real
 RUN(NAME intrinsics_336 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #any
 RUN(NAME intrinsics_337 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # dble, dfloat, float, shifta

--- a/integration_tests/move_alloc_pointer_alias.f90
+++ b/integration_tests/move_alloc_pointer_alias.f90
@@ -1,0 +1,17 @@
+program move_alloc_pointer_alias
+    implicit none
+    real, allocatable, target :: a(:), b(:)
+    real, pointer :: c(:)
+
+    allocate(a(10), source=10.0)
+    c => a
+
+    call move_alloc(a, b)
+
+    if (.not. associated(c)) error stop
+    if (size(b) /= 10) error stop
+    if (any(b /= 10.0)) error stop
+
+    c(2) = 2.0
+    if (b(2) /= 2.0) error stop
+end program


### PR DESCRIPTION
Use move-assignment instead of allocate+copy+deallocate, preventing pointer alias invalidation and heap corruption.

Fixes #9855.