### PR TITLE
Fix: exclude class(*) arrays from pass_array_by_data

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3218,6 +3218,7 @@ RUN(NAME str_to_char LABELS gfortran llvm)
 
 # test for polymorphic select type
 RUN(NAME polymorphic_select_type_01 LABELS gfortran llvm)
+RUN(NAME polymorphic_select_type_02 LABELS gfortran llvm)
 RUN(NAME defined_op_match_01 LABELS gfortran llvm)
 
 #test for forward declaration of derived type

--- a/integration_tests/polymorphic_select_type_02.f90
+++ b/integration_tests/polymorphic_select_type_02.f90
@@ -1,0 +1,19 @@
+program polymorphic_select_type_02
+    integer :: a(3) = [1, 2, 3]
+    call print_generic(a)
+
+contains
+
+    subroutine print_generic(generic)
+        class(*), intent(in) :: generic(:)
+
+        select type (generic)
+        type is (integer)
+            if (size(generic) /= 3) error stop 1
+            if (any(generic /= [1, 2, 3])) error stop 2
+        class default
+            error stop 3
+        end select
+    end subroutine print_generic
+
+end program polymorphic_select_type_02

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5759,8 +5759,9 @@ static inline bool is_pass_array_by_data_possible(ASR::Function_t* x, std::vecto
         if( !ASR::is_a<ASR::Variable_t>(*arg_Var->m_v) ) {
             continue;
         }
-        if( ASRUtils::is_class_type(typei) ||
-            ASR::is_a<ASR::FunctionType_t>(*typei) ) {
+        ASR::ttype_t* typei_noarray = ASRUtils::type_get_past_array(typei);
+        if( ASRUtils::is_class_type(typei_noarray) ||
+            ASR::is_a<ASR::FunctionType_t>(*typei_noarray) ) {
             continue ;
         }
         int n_dims = ASRUtils::extract_dimensions_from_ttype(typei, dims);
@@ -5786,7 +5787,7 @@ static inline bool is_pass_array_by_data_possible(ASR::Function_t* x, std::vecto
              argi->m_intent == ASRUtils::intent_inout) &&
             !ASR::is_a<ASR::Allocatable_t>(*argi->m_type) &&
             !ASR::is_a<ASR::StructType_t>(*argi->m_type) &&
-            !ASRUtils::is_class_type(argi->m_type) &&
+            !ASRUtils::is_class_type(ASRUtils::type_get_past_array(argi->m_type)) &&
             !ASR::is_a<ASR::String_t>(*argi->m_type) &&
             argi->m_presence != ASR::presenceType::Optional) {
             v.push_back(i);


### PR DESCRIPTION
The `pass_array_by_data` pass was only checking the top-level type, so `class(*)` assumed-shape arrays were treated as plain arrays and rewritten into `(data_ptr, size...)`. That breaks select type codegen, which expects a descriptor and caused a segfault.

The fix is to unwrap array types before the class check so arrays of class types are excluded from the pass. Test added.

Fixes #9863.