### PR TITLE
Do not use common linkage for global variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3173,6 +3173,7 @@ RUN(NAME separate_compilation_25 LABELS gfortran llvm_submodule EXTRAFILES separ
 RUN(NAME separate_compilation_26 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_26a.f90 separate_compilation_26b.f90)
 RUN(NAME separate_compilation_27 LABELS gfortran llvm_submodule EXTRAFILES separate_compilation_27a.f90 separate_compilation_27b.f90)
 RUN(NAME separate_compilation_28 LABELS gfortran llvm EXTRAFILES separate_compilation_28a.f90 separate_compilation_28b.f90 EXTRA_ARGS --implicit-interface)
+RUN(NAME separate_compilation_29 LABELS gfortran llvm EXTRAFILES separate_compilation_29a.f90 separate_compilation_29b.f90 EXTRA_ARGS --separate-compilation)
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_29.f90
+++ b/integration_tests/separate_compilation_29.f90
@@ -1,0 +1,11 @@
+program separate_compilation_29
+    use separate_compilation_29a_module, only: sa, get_a
+    use separate_compilation_29b_module, only: sb, get_b
+    implicit none
+
+    call sa()
+    call sb()
+
+    if (get_a() /= 1) error stop 1
+    if (get_b() /= 2) error stop 2
+end program separate_compilation_29

--- a/integration_tests/separate_compilation_29a.f90
+++ b/integration_tests/separate_compilation_29a.f90
@@ -1,0 +1,20 @@
+module separate_compilation_29a_module
+    implicit none
+
+    type :: t
+        integer :: x
+    end type t
+
+    type(t) :: targets
+
+contains
+
+    subroutine sa()
+        targets%x = 1
+    end subroutine sa
+
+    integer function get_a()
+        get_a = targets%x
+    end function get_a
+
+end module separate_compilation_29a_module

--- a/integration_tests/separate_compilation_29b.f90
+++ b/integration_tests/separate_compilation_29b.f90
@@ -1,0 +1,20 @@
+module separate_compilation_29b_module
+    implicit none
+
+    type :: t
+        integer :: x
+    end type t
+
+    type(t) :: targets
+
+contains
+
+    subroutine sb()
+        targets%x = 2
+    end subroutine sb
+
+    integer function get_b()
+        get_b = targets%x
+    end function get_b
+
+end module separate_compilation_29b_module

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4310,11 +4310,7 @@ public:
             // for external global variable with bindc, use the C name
             llvm_var_name = x.m_bindc_name;
         } else {
-            if ( !( ASRUtils::is_struct(*x.m_type) || ASRUtils::is_class_type(x.m_type) ) ) {
-                llvm_var_name = mangle_prefix + x.m_name;
-            } else {
-                llvm_var_name = x.m_name;
-            }
+            llvm_var_name = mangle_prefix + x.m_name;
         }
         if (x.m_type->type == ASR::ttypeType::Integer
             || x.m_type->type == ASR::ttypeType::UnsignedInteger) {


### PR DESCRIPTION
This is hard to test in our current testing framework, the LLVM looks the same.

Fixes #9891.