### PR TITLE
test: add integration tests for 4 fixed I/O issues

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -957,6 +957,7 @@ RUN(NAME format_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_57 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME format_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME format_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)
@@ -2201,6 +2202,7 @@ RUN(NAME file_45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_47 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_48 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME file_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
@@ -2221,6 +2223,7 @@ RUN(NAME inquire_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME inquire_08 LABELS gfortran llvm)
+RUN(NAME inquire_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_inquire_size LABELS gfortran llvm )
 RUN(NAME test_backspace_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN file_01_data.txt)
 
@@ -2574,6 +2577,7 @@ RUN(NAME read_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc COPY_TO_BIN read_
 RUN(NAME read_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_33 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME read_35 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/file_49.f90
+++ b/integration_tests/file_49.f90
@@ -1,0 +1,14 @@
+! Test for https://github.com/lfortran/lfortran/issues/4647
+! Scratch file with form='unformatted'
+! Exact MRE from issue body
+program file_49
+    implicit none
+    character :: q*12
+    open(42, status='scratch', form='unformatted')
+    write(42) 'Hello world!'
+    rewind 42
+    read(42) q
+    close(42)
+    print *, q
+    if (q /= 'Hello world!') error stop
+end program file_49

--- a/integration_tests/format_59.f90
+++ b/integration_tests/format_59.f90
@@ -1,0 +1,12 @@
+! Test for https://github.com/lfortran/lfortran/issues/4056
+! Format string variable with trailing spaces (character(12))
+! Exact MRE from issue comment (corrected version with character(12))
+program format_59
+    implicit none
+    character(12) :: fmt = "(2(1X,A))"
+    character(80) :: output
+    print "(A)", 'fmt = "' // fmt // '"'
+    print fmt, 'Hello', 'world!'
+    write(output, fmt) 'Hello', 'world!'
+    if (trim(adjustl(output)) /= 'Hello world!') error stop
+end program format_59

--- a/integration_tests/inquire_09.f90
+++ b/integration_tests/inquire_09.f90
@@ -1,0 +1,21 @@
+! Test for https://github.com/lfortran/lfortran/issues/4640
+! Inquire iolength with different type kinds
+! Exact MRE from issue body
+program inquire_09
+    use iso_fortran_env, only: int8, int16, int32, int64, real32, real64
+    implicit none
+    integer :: i, len(6) = -huge(1)
+    inquire(iolength=len(1)) 42_int8
+    inquire(iolength=len(2)) 42_int16
+    inquire(iolength=len(3)) 42_int32
+    inquire(iolength=len(4)) 42_int64
+    inquire(iolength=len(5)) 4.2_real32
+    inquire(iolength=len(6)) 4.2_real64
+    print "(6(I0,1X))", len
+    if (len(1) /= 1) error stop
+    if (len(2) /= 2) error stop
+    if (len(3) /= 4) error stop
+    if (len(4) /= 8) error stop
+    if (len(5) /= 4) error stop
+    if (len(6) /= 8) error stop
+end program inquire_09

--- a/integration_tests/read_35.f90
+++ b/integration_tests/read_35.f90
@@ -1,0 +1,17 @@
+! Test for https://github.com/lfortran/lfortran/issues/6811
+! Reading from character variable into integer array
+! Exact MRE from issue body
+program read_35
+    implicit none
+    character(23) :: cinput = '42 666 -42 -666 10 9 0 '
+    integer :: input(7)
+    read(cinput, *) input
+    print "(A,7(1X,I0))", 'input was ', input
+    if (input(1) /= 42) error stop
+    if (input(2) /= 666) error stop
+    if (input(3) /= -42) error stop
+    if (input(4) /= -666) error stop
+    if (input(5) /= 10) error stop
+    if (input(6) /= 9) error stop
+    if (input(7) /= 0) error stop
+end program read_35


### PR DESCRIPTION
## Summary
- Add integration tests for 4 I/O-related issues that are already fixed on main but lack test coverage
- Tests use exact MREs from the issue reports (bodies/comments)

Closes #6811
Closes #4056
Closes #4647
Closes #4640

## Why
These 4 issues were identified as fixed on main (verified by running exact MREs) but have no integration tests to prevent regressions. This is a focused subset of #9813 covering only I/O-related bugs.

## Changes
- [`integration_tests/read_35.f90`](https://github.com/lfortran/lfortran/blob/54616911cb476761b8902b779931ecc2c77a8aa3/integration_tests/read_35.f90): #6811 - read from character variable into integer array (exact MRE from issue body)
- [`integration_tests/format_59.f90`](https://github.com/lfortran/lfortran/blob/54616911cb476761b8902b779931ecc2c77a8aa3/integration_tests/format_59.f90): #4056 - format string variable with trailing spaces, uses `character(12)` per issue comment correction
- [`integration_tests/file_49.f90`](https://github.com/lfortran/lfortran/blob/54616911cb476761b8902b779931ecc2c77a8aa3/integration_tests/file_49.f90): #4647 - scratch file with `form='unformatted'` (exact MRE from issue body)
- [`integration_tests/inquire_09.f90`](https://github.com/lfortran/lfortran/blob/54616911cb476761b8902b779931ecc2c77a8aa3/integration_tests/inquire_09.f90): #4640 - inquire iolength with different type kinds (exact MRE from issue body)
- [`integration_tests/CMakeLists.txt`](https://github.com/lfortran/lfortran/blob/54616911cb476761b8902b779931ecc2c77a8aa3/integration_tests/CMakeLists.txt): register all 4 tests with labels `gfortran llvm llvm_wasm llvm_wasm_emcc`

## Tests

All 4 tests pass with both LLVM and gfortran backends.

## Verification

### MREs fail on old main (before fixes were merged)
These issues were originally reported as compiler errors (semantic errors, ICEs, wrong results). The fixes have already been merged to main over time. The MREs now compile and run correctly.

### Tests pass on current main (this branch = upstream/main + test files only)
```
$ scripts/lf.sh itest -b llvm -t read_35
1/1 Test #1922: read_35 ..........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t format_59
1/1 Test #536: format_59 ........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t file_49
1/1 Test #1614: file_49 ..........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t inquire_09
1/1 Test #1631: inquire_09 .......................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b gfortran -t read_35
1/1 Test #1953: read_35 ..........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t format_59
1/1 Test #536: format_59 ........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t file_49
1/1 Test #1669: file_49 ..........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t inquire_09
1/1 Test #1685: inquire_09 .......................   Passed    0.00 sec
```

### MRE source verification
| Issue | MRE source | Key detail |
|-------|-----------|------------|
| #6811 | Issue body | `read(cinput, *) input` with integer array |
| #4056 | Issue comment (corrected) | `character(12)` triggers trailing-space bug path |
| #4647 | Issue body | `status='scratch', form='unformatted'` |
| #4640 | Issue body | Array-based `len(6)` with all int/real kinds |