### PR TITLE
test: add integration tests for 2 fixed issues (#8407, #7952)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1551,6 +1551,7 @@ RUN(NAME case_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME case_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME case_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -2321,6 +2322,7 @@ RUN(NAME class_94 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_95 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_96 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_97 LABELS gfortran llvm)
+RUN(NAME class_98 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/case_09.f90
+++ b/integration_tests/case_09.f90
@@ -1,0 +1,29 @@
+! Test for https://github.com/lfortran/lfortran/issues/8407
+! Select case with multiple range conditions in a single case
+! Exact MRE from issue body
+program casetest
+  implicit none
+  integer :: i
+  do i = 1,5
+     select case (i)
+     case (2:3,5)
+        print "(A,I0)",'case (2:3,5) i=',i
+     case default
+        print "(A,I0)",'case default i=',i
+     end select
+  end do
+  if (.not. check()) error stop
+contains
+  logical function check()
+    integer :: j
+    check = .true.
+    do j = 1,5
+       select case (j)
+       case (2:3,5)
+          if (j /= 2 .and. j /= 3 .and. j /= 5) check = .false.
+       case default
+          if (j /= 1 .and. j /= 4) check = .false.
+       end select
+    end do
+  end function check
+end program casetest

--- a/integration_tests/class_98.f90
+++ b/integration_tests/class_98.f90
@@ -1,0 +1,15 @@
+! Test for https://github.com/lfortran/lfortran/issues/7952
+! move_alloc with unallocated source must deallocate destination
+! Exact MRE from issue body
+program badalloc
+  implicit none
+  type,abstract :: foo
+  end type foo
+  type, extends(foo) :: bar
+  end type bar
+  type(bar), allocatable :: x
+  class(foo), allocatable :: y
+  call move_alloc(x, y)
+  if(allocated(y)) error stop 'Y SHOULD BE UNALLOCATED!'
+  print "(A)", 'Y IS UNALLOCATED.'
+end program badalloc


### PR DESCRIPTION
## Summary
- Add integration tests for 2 issues with clearly traced fixes on main
- Tests use exact MREs from the issue reports

Closes #8407
Closes #7952

## Why
These issues are fixed on main but lack integration tests to prevent regressions. Each fix is traced to specific PRs. This is a focused subset of #9813.

## Changes
- [`integration_tests/case_09.f90`](https://github.com/lfortran/lfortran/blob/ba73bc46f692376f9e8ac6901881d34a0c8025c1/integration_tests/case_09.f90): #8407 - `select case` with multiple range conditions (`case (2:3,5)`). Exact MRE from issue body, with assertions added. Note: existing `case_04.f90` has a similar case but is gfortran-only with no assertions.
- [`integration_tests/class_98.f90`](https://github.com/lfortran/lfortran/blob/ba73bc46f692376f9e8ac6901881d34a0c8025c1/integration_tests/class_98.f90): #7952 - `move_alloc` with unallocated `type(bar)` source to `class(foo)` destination must deallocate destination. Exact MRE from issue body. Note: existing `class_73.f90` tests `move_alloc` with an allocated source, but not the unallocated-source code path.
- [`integration_tests/CMakeLists.txt`](https://github.com/lfortran/lfortran/blob/ba73bc46f692376f9e8ac6901881d34a0c8025c1/integration_tests/CMakeLists.txt): register both tests with labels `gfortran llvm llvm_wasm llvm_wasm_emcc`

## Fix attribution
| Issue | Fixed by | Merged | Description |
|-------|----------|--------|-------------|
| #8407 | #8835 | 2025-11-12 | `enh: support multiple arguments in case stmt` |
| #7952 | #8221, #8157 | 2025-08-03, 2025-07-28 | `fix: check class type assignment in intrinsics` + `enh: add type_declaration for struct type args in move_alloc` |

## Tests

Both tests pass with LLVM and gfortran backends.

## Verification

### Before fixes
- #8407: `semantic error: Not implemented: more than one range condition` for `case (2:3,5)`
- #7952: `ERROR STOP Y SHOULD BE UNALLOCATED!` -- `move_alloc` with unallocated source did not deallocate destination

### Tests pass on current main (this branch = upstream/main + test files only)
```
$ scripts/lf.sh itest -b llvm -t case_09
1/1 Test #1064: case_09 ..........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t class_98
1/1 Test #1727: class_98 .........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b gfortran -t case_09
1/1 Test #1082: case_09 ..........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t class_98
1/1 Test #1782: class_98 .........................   Passed    0.00 sec
```