### PR TITLE
fix: get i8* for character arrays in bind(c) context

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1543,6 +1543,7 @@ RUN(NAME bindc_08 LABELS gfortran llvm EXTRAFILES bindc_08.c EXTRA_ARGS --reallo
 RUN(NAME bindc_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME bindc_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc_11 LABELS gfortran llvm)
+RUN(NAME bindc_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/bindc_12.f90
+++ b/integration_tests/bindc_12.f90
@@ -1,0 +1,28 @@
+program bindc_12
+    use, intrinsic :: iso_c_binding, only : c_char, c_int, c_null_char
+    implicit none
+
+    interface
+        function c_chdir(path) bind(C, name="chdir") result(stat)
+            import :: c_char, c_int
+            character(kind=c_char, len=1), intent(in) :: path(*)
+            integer(c_int) :: stat
+        end function c_chdir
+    end interface
+
+    character(kind=c_char, len=1), allocatable :: cpath(:)
+    integer(c_int) :: stat
+
+    allocate(cpath(5))
+    cpath = [ '/', 't', 'm', 'p', c_null_char ]
+
+    if (cpath(5) /= c_null_char) then
+        error stop "C string not NUL terminated"
+    end if
+    stat = c_chdir(cpath)
+    if (stat /= 0) then
+        error stop "chdir failed"
+    end if
+
+    print *, "OK: chdir(/tmp) succeeded"
+end program bindc_12

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9610,13 +9610,10 @@ public:
             m_old == ASR::array_physical_typeType::PointerArray) {
             if (ASRUtils::is_character(*ASRUtils::extract_type(ASRUtils::expr_type(m_arg)))) {
                 // For character arrays in bind(c) context
-                if (ASRUtils::is_fixed_size_array(m_type)) {
-                    // Fixed size character array - ensure correct type
-                    ASR::ttype_t* old_ttype = ASRUtils::extract_type(ASRUtils::expr_type(m_arg));
-                    llvm::Type* str_desc = llvm_utils->get_type_from_ttype_t_util(m_arg, old_ttype, module.get());
-                    tmp = llvm_utils->create_gep2(str_desc, tmp, 0);
-                    tmp = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(),tmp);
-                }
+                ASR::ttype_t* old_ttype = ASRUtils::extract_type(ASRUtils::expr_type(m_arg));
+                llvm::Type* str_desc = llvm_utils->get_type_from_ttype_t_util(m_arg, old_ttype, module.get());
+                tmp = llvm_utils->create_gep2(str_desc, tmp, 0);
+                tmp = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(),tmp);
             }
         } else if (
             m_new == ASR::array_physical_typeType::DescriptorArray &&


### PR DESCRIPTION
Towards #9860
