### PR TITLE
test: add integration tests for 5 fixed class/polymorphism issues

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2332,6 +2332,11 @@ RUN(NAME class_95 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_96 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_97 LABELS gfortran llvm)
 RUN(NAME class_98 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME class_99 LABELS gfortran llvm)
+RUN(NAME class_100 LABELS gfortran llvm)
+RUN(NAME class_101 LABELS gfortran llvm)
+RUN(NAME class_102 LABELS gfortran llvm)
+RUN(NAME class_103 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_100.f90
+++ b/integration_tests/class_100.f90
@@ -1,0 +1,37 @@
+! Test for https://github.com/lfortran/lfortran/issues/6975
+! Segfault upon compilation of select type with deferred function result
+module class_100_module
+
+   type, abstract :: InputType
+   contains
+      procedure(some_method), deferred :: some_method
+   end type InputType
+
+   type, abstract :: OutputType
+   end type OutputType
+
+   abstract interface
+      function some_method(self) result(obj)
+         import
+         class(InputType), intent(in)  :: self
+         class(*),         allocatable :: obj
+      end function some_method
+   end interface
+
+contains
+
+   function some_func(t) result(res)
+      class(InputType), intent(in)  :: t
+      class(*),         allocatable :: res
+      select type( obj => t%some_method() )
+      class is (OutputType)
+         res = obj
+      end select
+   end function some_func
+
+end module class_100_module
+
+program class_100
+   use class_100_module
+   print *, "PASS"
+end program class_100

--- a/integration_tests/class_101.f90
+++ b/integration_tests/class_101.f90
@@ -1,0 +1,68 @@
+! Test for https://github.com/lfortran/lfortran/issues/7640
+! Deferred function on polymorphic member returned wrong results (all zeros)
+! MRE from issue comment by kmr-srbh
+module class_101_mod
+
+   type, abstract :: AbsType
+   contains
+      procedure(method2), deferred :: method2
+   end type AbsType
+
+   abstract interface
+      function method2(self,arr) result(a)
+         import
+         class(AbsType), intent(in) :: self
+         integer,        intent(in) :: arr(:)
+         integer                    :: a(size(arr))
+      end function method2
+   end interface
+
+   type :: SomeType
+      integer,        allocatable :: arr(:)
+      class(AbsType), allocatable :: obj
+   contains
+      procedure :: method1
+   end type SomeType
+
+   type, extends(AbsType) :: MyType
+   contains
+      procedure :: method2 => my_method2
+   end type MyType
+
+contains
+
+   subroutine method1(self)
+      class(SomeType), intent(inout) :: self
+      self%arr = self%obj%method2(self%arr)
+   end subroutine method1
+
+   function my_method2(self, arr) result(a)
+      class(MyType), intent(in) :: self
+      integer, intent(in) :: arr(:)
+      integer :: a(size(arr))
+      integer :: i
+      do i = 1, size(arr)
+         a(i) = arr(i) * 2
+      end do
+   end function my_method2
+
+end module class_101_mod
+
+program class_101
+   use class_101_mod
+   implicit none
+
+   class(SomeType), allocatable :: s
+
+   allocate(s)
+   allocate(s%arr(3))
+   allocate(MyType :: s%obj)
+   s%arr = [1, 2, 3]
+
+   call s%method1()
+
+   if (s%arr(1) /= 2) error stop
+   if (s%arr(2) /= 4) error stop
+   if (s%arr(3) /= 6) error stop
+   print *, "PASS"
+end program class_101

--- a/integration_tests/class_102.f90
+++ b/integration_tests/class_102.f90
@@ -1,0 +1,66 @@
+! Test for https://github.com/lfortran/lfortran/issues/8303
+! Extended type with polymorphic dispatch through self%obj%method(wrap(1)%arr)
+! LLVM IR verification failed with type mismatch for allocatable array argument
+module class_102_mod
+
+   type, abstract :: AbsType
+   contains
+      procedure(method), deferred :: method
+   end type AbsType
+
+   abstract interface
+      subroutine method(self,arr)
+         import
+         class(AbsType),       intent(inout) :: self
+         real(8), allocatable, intent(inout) :: arr(:)
+      end subroutine method
+   end interface
+
+   type, extends(AbsType) :: MyType
+      class(AbsType), allocatable :: obj
+   contains
+      procedure :: method => implementation
+      procedure :: do_work
+   end type MyType
+
+   type :: Wrapper
+      real(8), allocatable :: arr(:)
+   end type Wrapper
+
+contains
+
+   subroutine implementation(self,arr)
+      class(MyType),        intent(inout) :: self
+      real(8), allocatable, intent(inout) :: arr(:)
+      integer :: i
+      do i = 1, size(arr)
+         arr(i) = arr(i) * 2.0d0
+      end do
+   end subroutine implementation
+
+   subroutine do_work(self,wrap)
+      class(MyType), intent(inout) :: self
+      type(Wrapper), intent(inout) :: wrap(:)
+      call self%obj%method(wrap(1)%arr)
+   end subroutine do_work
+
+end module class_102_mod
+
+program class_102
+   use class_102_mod
+   implicit none
+
+   type(MyType) :: obj
+   type(Wrapper) :: wrap(1)
+
+   allocate(MyType :: obj%obj)
+   allocate(wrap(1)%arr(3))
+   wrap(1)%arr = [1.0d0, 2.0d0, 3.0d0]
+
+   call obj%do_work(wrap)
+
+   if (abs(wrap(1)%arr(1) - 2.0d0) > 1.0d-10) error stop
+   if (abs(wrap(1)%arr(2) - 4.0d0) > 1.0d-10) error stop
+   if (abs(wrap(1)%arr(3) - 6.0d0) > 1.0d-10) error stop
+   print *, "PASS"
+end program class_102

--- a/integration_tests/class_103.f90
+++ b/integration_tests/class_103.f90
@@ -1,0 +1,33 @@
+! Test for https://github.com/lfortran/lfortran/issues/2925
+! Typed allocation of polymorphic arrays with data members
+! MRE from issue comment by difference-scheme (the data member variant)
+module class_103_m
+
+   type :: Base
+      real :: data = 2.0
+   end type Base
+
+   type, extends(Base) :: Extended
+   end type Extended
+
+contains
+
+   subroutine allocator(array)
+      class(Base), allocatable, intent(out) :: array(:)
+      allocate( Extended :: array(1) )
+   end subroutine allocator
+
+end module class_103_m
+
+program class_103
+   use class_103_m
+   implicit none
+   class(Base), allocatable :: arr(:)
+
+   call allocator(arr)
+
+   if (.not. allocated(arr)) error stop
+   if (size(arr) /= 1) error stop
+   if (abs(arr(1)%data - 2.0) > 1e-6) error stop
+   print *, "PASS"
+end program class_103

--- a/integration_tests/class_99.f90
+++ b/integration_tests/class_99.f90
@@ -1,0 +1,28 @@
+! Test for https://github.com/lfortran/lfortran/issues/6787
+! Abstract type-bound operator was rejected by semantic analysis
+! Error was: "add doesn't exist inside abstype type"
+module class_99_abstracted
+   type, abstract :: abstype
+   contains
+      private
+      procedure(addop), deferred :: add
+      generic, public :: operator(+) => add
+   end type abstype
+
+   abstract interface
+      function addop(a,b) result (r)
+         import :: abstype
+         class(abstype), intent(in) :: a, b
+         class(abstype), allocatable :: r
+      end function addop
+   end interface
+end module class_99_abstracted
+
+module class_99_test
+   use class_99_abstracted
+end module class_99_test
+
+program class_99
+  use class_99_test
+  print *, "PASS"
+end program class_99


### PR DESCRIPTION
## Summary
- Add integration tests for 5 class/OOP issues confirmed fixed on main but lacking test coverage
- Tests use exact MREs from the issue reports (bodies and comments)
- This is a focused subset of #9813 covering class/polymorphism bugs

Closes #2925
Closes #6787
Closes #6975
Closes #7640
Closes #8303

## Why
These issues are fixed on main but lack integration tests to prevent regressions. Each test is derived from the exact MRE in the issue.

## Changes
- [`integration_tests/class_99.f90`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/class_99.f90): #6787 - Abstract type-bound operator with deferred procedure and `generic, public :: operator(+) => add`. The bug was semantic analysis rejecting valid code with "add doesn't exist inside abstype type". Exact MRE from issue body.
- [`integration_tests/class_100.f90`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/class_100.f90): #6975 - `select type` with selector being a deferred function call returning `class(*), allocatable`. The bug was a segfault during compilation. Exact MRE from issue body.
- [`integration_tests/class_101.f90`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/class_101.f90): #7640 - Polymorphic deferred function on embedded object returning array gave wrong results (all zeros instead of doubled values). Extended MRE from issue comment by kmr-srbh, with runtime assertions. Note: existing `class_47.f90` (from #7670) uses `class(MyType)` (concrete), but this test uses `class(AbsType)` (abstract) per the issue MRE, which exercises vtable dispatch.
- [`integration_tests/class_102.f90`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/class_102.f90): #8303 - Extended type with polymorphic dispatch through `self%obj%method(wrap(1)%arr)` where arr is allocatable. LLVM IR verification failed with type mismatch. Extended from issue MRE with actual implementation and runtime assertions.
- [`integration_tests/class_103.f90`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/class_103.f90): #2925 - Typed allocation of polymorphic arrays (`allocate(Extended :: array(1))`) with data members. MRE from issue comment #10 by difference-scheme (the variant with `real :: data = 2.0` that caused segfault).
- [`integration_tests/CMakeLists.txt`](https://github.com/lfortran/lfortran/blob/4b543f59eb5550adf9c72d7d5c413dfc4c2d4a4c/integration_tests/CMakeLists.txt): register all 5 tests with labels `gfortran llvm`

## Fix attribution

| Issue | Fixed by | Merged | Description |
|-------|----------|--------|-------------|
| #2925 | #7282, #5791, #9462, #9509 | 2025-05-14 to 2026-01-16 | Incremental: semantics type-spec fix, ASR struct refactor, class array allocation |
| #6787 | #8008 | 2025-07-10 | Attribute flags overwrite fix in ast_symboltable_visitor.cpp (also fixes #8007) |
| #6975 | #8478, #8498, #5791 | 2025-07-22 to 2025-09-04 | Incremental: vtable implementation, type_info for select type, ASR struct refactor |
| #7640 | #7641, #7670 | 2025-06-09, 2025-06-11 | ClassProcedure return type fix + allocatable array member load for class |
| #8303 | #8478, #5791 | 2025-07-22, 2025-08-29 | Incremental: vtable implementation + ASR struct refactor |

## Tests

All 5 tests pass with both LLVM and gfortran backends.

## Verification

### Tests pass on current main (this branch = upstream/main + test files only)
```
$ scripts/lf.sh itest -b llvm -t class_99
1/1 Test #1734: class_99 .........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t class_100
1/1 Test #1735: class_100 ........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t class_101
1/1 Test #1736: class_101 ........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t class_102
1/1 Test #1737: class_102 ........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm -t class_103
1/1 Test #1738: class_103 ........................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b gfortran -t class_99
1/1 Test #1789: class_99 .........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t class_100
1/1 Test #1790: class_100 ........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t class_101
1/1 Test #1791: class_101 ........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t class_102
1/1 Test #1792: class_102 ........................   Passed    0.00 sec

$ scripts/lf.sh itest -b gfortran -t class_103
1/1 Test #1793: class_103 ........................   Passed    0.00 sec
```

### MRE source verification
| Issue | MRE source | Key detail |
|-------|-----------|------------|
| #2925 | Issue comment #10 | `allocate(Extended :: array(1))` with `real :: data = 2.0` member; runtime assertion on data value |
| #6787 | Issue body (exact) | `generic, public :: operator(+) => add` on abstract type with deferred procedure |
| #6975 | Issue body (exact) | `select type(obj => t%some_method())` where some_method is deferred returning `class(*)` |
| #7640 | Issue comment #1 | Concrete `MyType` extending abstract `AbsType`, runtime assertion on doubled array values |
| #8303 | Issue body (extended) | `self%obj%method(wrap(1)%arr)` with allocatable array; runtime assertion on doubled values |