### PR TITLE
fix: remove llvm_wasm labels from bindc_12 test

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1545,7 +1545,7 @@ RUN(NAME bindc_08 LABELS gfortran llvm EXTRAFILES bindc_08.c EXTRA_ARGS --reallo
 RUN(NAME bindc_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME bindc_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME bindc_11 LABELS gfortran llvm)
-RUN(NAME bindc_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME bindc_12 LABELS gfortran llvm)
 
 RUN(NAME case_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)


### PR DESCRIPTION
## Summary
- Remove `llvm_wasm llvm_wasm_emcc` labels from `bindc_12` test registration

Fixes #9911

## Why
`bindc_12.f90` calls `chdir()` which is a POSIX syscall unavailable in WASM/WASI. This causes test failures on LLVM 10 and LLVM 19 (the only versions that run `llvm_wasm` tests in exhaustive CI). Introduced in #9905.

## Changes
- [`integration_tests/CMakeLists.txt`](https://github.com/lfortran/lfortran/blob/2d7b691b1/integration_tests/CMakeLists.txt#L1548): Remove `llvm_wasm llvm_wasm_emcc` from `bindc_12` labels

## Verification

One-line change removing labels. The test itself is unchanged and continues to run with `gfortran` and `llvm` backends.