### PR TITLE
fix: use structural flag for unlimited polymorphic type checks

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1522,6 +1522,8 @@ RUN(NAME modules_63 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
 RUN(NAME modules_64 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME modules_65 LABELS gfortran llvm
         EXTRAFILES modules_65_base.f90 modules_65_child.f90 modules_65_worker.f90)
+RUN(NAME modules_66 LABELS gfortran llvm
+        EXTRAFILES modules_66_base.f90 modules_66_worker.f90)
 
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES
         associate_06_module.f90)

--- a/integration_tests/modules_66.f90
+++ b/integration_tests/modules_66.f90
@@ -1,0 +1,14 @@
+program modules_66
+    use modules_66_base, only: container_t
+    use modules_66_worker, only: extract_int
+    implicit none
+
+    type(container_t) :: c
+    integer :: r
+
+    allocate(c%item, source=42)
+    r = extract_int(c)
+    if (r /= 42) error stop
+
+    print *, "PASSED: modules_66"
+end program modules_66

--- a/integration_tests/modules_66_base.f90
+++ b/integration_tests/modules_66_base.f90
@@ -1,0 +1,8 @@
+module modules_66_base
+    implicit none
+
+    type :: container_t
+        class(*), allocatable :: item
+    end type container_t
+
+end module modules_66_base

--- a/integration_tests/modules_66_worker.f90
+++ b/integration_tests/modules_66_worker.f90
@@ -1,0 +1,19 @@
+module modules_66_worker
+    use modules_66_base, only: container_t
+    implicit none
+
+contains
+
+    function extract_int(c) result(res)
+        type(container_t), intent(in) :: c
+        integer :: res
+        res = -1
+        select type (x => c%item)
+        type is (integer)
+            res = x
+        class default
+            res = 0
+        end select
+    end function extract_int
+
+end module modules_66_worker

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6494,9 +6494,7 @@ public:
                         nullptr,
                         0,
                         true,
-                        ASRUtils::symbol_name(v) == std::string("~unlimited_polymorphic_type")
-                        ? true
-                        : false));
+                        derived_type_name == "~unlimited_polymorphic_type"));
                     } else { 
                         diag.add(Diagnostic(
                             "Derived type `" + derived_type_name + "` is not defined",

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2123,7 +2123,7 @@ public:
                 continue;
             }
             char* aggregate_type_name = nullptr;
-            if (item.first != "~unlimited_polymorphic_type") {
+            if (!ASRUtils::is_unlimited_polymorphic_type(item.second)) {
                 LCOMPILERS_ASSERT(ASR::is_a<ASR::Variable_t>(*item.second));
                 ASR::Variable_t* dt_variable = ASR::down_cast<ASR::Variable_t>(item.second);
                 ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(item.second));
@@ -2226,7 +2226,7 @@ public:
                 continue;
             }
             char* aggregate_type_name = nullptr;
-            if (item.first != "~unlimited_polymorphic_type") {
+            if (!ASRUtils::is_unlimited_polymorphic_type(item.second)) {
                 LCOMPILERS_ASSERT(ASR::is_a<ASR::Variable_t>(*item.second));
                 ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(item.second);
                 ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(item.second));

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3926,9 +3926,13 @@ inline bool is_parent(ASR::Struct_t* a, ASR::Struct_t* b) {
 }
 
 inline bool is_derived_type_similar(ASR::Struct_t* a, ASR::Struct_t* b) {
+    auto is_upoly = [](ASR::Struct_t* s) {
+        return s->m_struct_signature != nullptr &&
+            ASR::down_cast<ASR::StructType_t>(
+                s->m_struct_signature)->m_is_unlimited_polymorphic;
+    };
     return a == b || is_parent(a, b) || is_parent(b, a) ||
-        (std::string(a->m_name) == "~unlimited_polymorphic_type" &&
-        std::string(b->m_name) == "~unlimited_polymorphic_type");
+        (is_upoly(a) && is_upoly(b));
 }
 
 // Helper: check if IntegerBinOp is identity (x+0, 0+x, x-0)
@@ -4539,8 +4543,12 @@ inline bool check_class_assignment_compatibility(ASR::symbol_t* target, ASR::sym
     if (ASR::is_a<ASR::Struct_t>(*target) && ASR::is_a<ASR::Struct_t>(*value)) {
         ASR::Struct_t* tar_struct = ASR::down_cast<ASR::Struct_t>(target);
         ASR::Struct_t* val_struct = ASR::down_cast<ASR::Struct_t>(value);
-        is_class_same = (target == value) || (std::string(tar_struct->m_name) == "~unlimited_polymorphic_type" && std::string(tar_struct->m_name) == "~unlimited_polymorphic_type");
-        is_class_same = is_class_same || ASRUtils::is_parent(tar_struct, val_struct);
+        bool tar_is_upoly = tar_struct->m_struct_signature != nullptr &&
+            ASR::down_cast<ASR::StructType_t>(
+                tar_struct->m_struct_signature)->m_is_unlimited_polymorphic;
+        is_class_same = (target == value)
+            || tar_is_upoly
+            || ASRUtils::is_parent(tar_struct, val_struct);
     }
     return is_class_same;
 }
@@ -4812,8 +4820,30 @@ static inline ASR::symbol_t* import_struct_type(Allocator& al, ASR::symbol_t* st
         return struct_sym;
     }
     std::string struct_name = ASRUtils::symbol_name(struct_sym);
-    if (struct_name == "~unlimited_polymorphic_type") {
-        return struct_sym;
+    ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(struct_sym);
+    if (struct_t->m_struct_signature != nullptr &&
+        ASR::down_cast<ASR::StructType_t>(
+            struct_t->m_struct_signature)->m_is_unlimited_polymorphic) {
+        // Unlimited polymorphic is a per-scope synthetic type that cannot
+        // be imported as an ExternalSymbol.  Find a local instance in the
+        // scope chain or create one so the modfile serializer never writes
+        // a dangling symtab reference from the foreign module.
+        ASR::symbol_t* local = scope->resolve_symbol(struct_name);
+        if (local != nullptr) {
+            return local;
+        }
+        SymbolTable* upt_symtab = al.make_new<SymbolTable>(scope);
+        ASR::asr_t* dtype = ASR::make_Struct_t(al, struct_sym->base.loc,
+            upt_symtab, s2c(al, struct_name), nullptr, nullptr, 0,
+            nullptr, 0, nullptr, 0, ASR::abiType::Source,
+            ASR::accessType::Public, false, true, nullptr, 0,
+            nullptr, nullptr);
+        ASR::symbol_t* new_sym = ASR::down_cast<ASR::symbol_t>(dtype);
+        ASR::ttype_t* sig = ASRUtils::make_StructType_t_util(
+            al, struct_sym->base.loc, new_sym, false);
+        ASR::down_cast<ASR::Struct_t>(new_sym)->m_struct_signature = sig;
+        scope->add_symbol(struct_name, new_sym);
+        return new_sym;
     }
 
     // Get the module that owns this struct
@@ -5922,34 +5952,29 @@ static inline ASR::Enum_t* get_Enum_from_symbol(ASR::symbol_t* s) {
     return ASR::down_cast<ASR::Enum_t>(enum_type_cand);
 }
 
-static inline bool is_unlimited_polymorphic_type(ASR::expr_t* expr)
-{
-    ASR::ttype_t* type = ASRUtils::extract_type(ASRUtils::expr_type(expr));
-    if ( !ASR::is_a<ASR::StructType_t>(*type) ) {
-        return false;
-    }
-    ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(type);
-    
-    if (!ASRUtils::is_class_type(type)) {
-        return false;
-    }
-
-    return (st->n_data_member_types == 0 && st->n_member_function_types == 0
-            && ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(
-                   ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(expr))))
-                   == std::string("~unlimited_polymorphic_type"));
+static inline bool is_unlimited_polymorphic_type(ASR::Struct_t* st) {
+    if (st->m_struct_signature == nullptr) return false;
+    return ASR::down_cast<ASR::StructType_t>(
+        st->m_struct_signature)->m_is_unlimited_polymorphic;
 }
 
 static inline bool is_unlimited_polymorphic_type(ASR::symbol_t* sym)
 {
-    return (ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(sym))
-            == std::string("~unlimited_polymorphic_type"));
+    sym = ASRUtils::symbol_get_past_external(sym);
+    if (!ASR::is_a<ASR::Struct_t>(*sym)) return false;
+    return is_unlimited_polymorphic_type(
+        ASR::down_cast<ASR::Struct_t>(sym));
 }
 
 inline bool is_unlimited_polymorphic_type(ASR::ttype_t* const t){
     if(!ASR::is_a<ASR::StructType_t>(*extract_type(t))) return false;
 
     return ASR::down_cast<ASR::StructType_t>(extract_type(t))->m_is_unlimited_polymorphic;
+}
+
+static inline bool is_unlimited_polymorphic_type(ASR::expr_t* expr)
+{
+    return is_unlimited_polymorphic_type(ASRUtils::expr_type(expr));
 }
 /// Check if type is a class + not unlimited-polymorphic one
 inline bool non_unlimited_polymorphic_class(ASR::ttype_t* const t){

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1478,7 +1478,7 @@ public:
 
     llvm::Type* get_llvm_struct_data_type(ASR::Struct_t* st, bool is_pointer) {
         std::string struct_name = (std::string)st->m_name;
-        if (struct_name == "~unlimited_polymorphic_type") {
+        if (ASRUtils::is_unlimited_polymorphic_type(st)) {
             if (!compiler_options.new_classes) {
                 if (is_pointer) {
                     return llvm::Type::getVoidTy(context)->getPointerTo();
@@ -7699,10 +7699,8 @@ public:
                 llvm::Value* struct_value = builder->CreateLoad(struct_type, casted_val_ptr);
                 builder->CreateStore(struct_value, llvm_target);
             } else if( is_target_class && is_value_class ) {
-                std::string value_struct_t_name = "";
                 ASR::Struct_t* value_struct_t = ASR::down_cast<ASR::Struct_t>(
                         ASRUtils::symbol_get_past_external(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(x.m_value))));
-                value_struct_t_name = value_struct_t->m_name;
                 LCOMPILERS_ASSERT(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(x.m_target))
                                   == ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(x.m_value)));
                 llvm::Type* value_llvm_type = llvm_utils->get_type_from_ttype_t_util(x.m_value,
@@ -7715,7 +7713,7 @@ public:
                 llvm::Value* value_class = llvm_utils->CreateLoad2(ptr_type, llvm_utils->create_gep2(value_llvm_type, llvm_value, 1));
                 builder->CreateStore(value_vtabid, llvm_utils->create_gep2(value_llvm_type, llvm_target, 0));
 
-                if ( value_struct_t_name == "~unlimited_polymorphic_type" ) {
+                if ( ASRUtils::is_unlimited_polymorphic_type(value_struct_t) ) {
                     // we need to cast `value_class` to `void*`
                     llvm::Type* void_ptr_type = llvm::Type::getVoidTy(context)->getPointerTo();
                     value_class = builder->CreateBitCast(value_class, void_ptr_type);


### PR DESCRIPTION
## Summary

- Replace ~15 scattered `"~unlimited_polymorphic_type"` string comparisons with the existing `StructType_t::m_is_unlimited_polymorphic` flag
- Fix serialization crash in `import_struct_type` where a foreign module's unlimited polymorphic symbol was returned as-is, causing a dangling symtab reference during modfile deserialization
- Fix copy-paste bug in `check_class_assignment_compatibility` that checked the target name twice instead of target vs value

Follow-up to #9897 (certik review comment about avoiding string special cases).

## Why

PR #9897 fixed a serialization crash for bounded polymorphic types (`class(base_t)`) by externalizing struct references. However, it added a string-based special case for `~unlimited_polymorphic_type` that returned the foreign symbol as-is. When a third module deserializes the second module's modfile, the foreign symbol's symtab ID is not in the local `id_symtab_map`, causing an assertion failure.

**Stage:** Semantics + Codegen (string cleanup)

## Changes

- [`src/libasr/asr_utils.h`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/src/libasr/asr_utils.h): Add `is_unlimited_polymorphic_type(Struct_t*)` overload; rewrite `symbol_t*` and `expr_t*` overloads to use structural flag; fix `import_struct_type` to create local unlimited poly type instead of returning foreign symbol; fix `is_derived_type_similar` and `check_class_assignment_compatibility`
- [`src/libasr/codegen/asr_to_llvm.cpp`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/src/libasr/codegen/asr_to_llvm.cpp): Replace 2 string comparisons with structural checks
- [`src/libasr/codegen/llvm_utils.cpp`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/src/libasr/codegen/llvm_utils.cpp): Replace 5 string comparisons with structural checks
- [`src/lfortran/semantics/ast_symboltable_visitor.cpp`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/src/lfortran/semantics/ast_symboltable_visitor.cpp): Replace 2 name-based checks with structural checks
- [`src/lfortran/semantics/ast_common_visitor.h`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/src/lfortran/semantics/ast_common_visitor.h): Simplify; one string check remains because `v` is a placeholder `ExternalSymbol_t` with null external at this creation point

## Tests

- [`integration_tests/modules_66.f90`](https://github.com/lfortran/lfortran/blob/ff97968bb51ce2dd8427120636984366fdc9d495/integration_tests/modules_66.f90): Three-module test with `class(*)` in external module, `select type` with `class default` in worker module, main program using worker -- triggers the serialization crash path

## Verification

### Test fails on main
```
$ git checkout upstream/main
$ cd integration_tests && lfortran --separate-compilation modules_66_base.f90 modules_66_worker.f90 modules_66.f90 -o /tmp/m66_test
LCOMPILERS_ASSERT failed: src/libasr/serialization.cpp
function read_symbol(), line number 133 at 
id_symtab_map.find(symtab_id) != id_symtab_map.end()
Aborted (core dumped)
```

### Test passes after fix
```
$ git checkout fix/unlimited-poly-import-struct
$ cd integration_tests && lfortran --separate-compilation modules_66_base.f90 modules_66_worker.f90 modules_66.f90 -o /tmp/m66_test && /tmp/m66_test
PASSED: modules_66

$ scripts/lf.sh itest -b llvm -t modules_66
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh test
TESTS PASSED
```