### PR TITLE
fix: add character allocation argument validation

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2263,12 +2263,12 @@ public:
                     AST::FuncCallOrArray_t* func_call_t =
                         AST::down_cast<AST::FuncCallOrArray_t>(x.m_args[i].m_start);
                     if( to_lower(std::string(func_call_t->m_func)) == "character" ) {
-                        LCOMPILERS_ASSERT(func_call_t->n_args == 1 ||
-                                          func_call_t->n_keywords <= 2);
-                        if( func_call_t->m_args[0].m_end ) {
+                        if (func_call_t->n_args > 0 && func_call_t->n_args <= 2
+                            && func_call_t->m_args[0].m_end) {
                             visit_expr(*func_call_t->m_args[0].m_end);
                             new_arg.m_len_expr = ASRUtils::EXPR(tmp);
                         } else {
+                            LCOMPILERS_ASSERT(func_call_t->n_keywords <= 2);
                             for( size_t i = 0; i < func_call_t->n_keywords; i++ ) {
                                 if( to_lower(std::string(func_call_t->m_keywords[i].m_arg)) == "len" ) {
                                     visit_expr(*func_call_t->m_keywords[i].m_value);


### PR DESCRIPTION
Resolves #9859

Timings on macOS 26.2 Apple M4 16GB RAM

### GFortran (build only)
```
fpm --compiler=gfortran build  41.92s user 1.91s system 98% cpu 44.370 total
```

### LFortran Release (build only)
```
fpm --compiler=lfortran build --flag   16.79s user 0.74s system 99% cpu 17.638 total
```

2.5x faster than GFortran.

### LFortran Release (build & test)
```
fpm --compiler=lfortran test --flag   97.55s user 4.14s system 99% cpu 1:42.55 total
```

### LFortran Debug (build only)
```
fpm --compiler=lfortran build --flag   62.76s user 0.99s system 99% cpu 1:03.93 total
```

### LFortran Debug (build & test)
```
fpm --compiler=lfortran test --flag   180.50s user 5.28s system 99% cpu 3:07.42 total
```