### PR TITLE
fix: add support for association of polymorphic pointer variable to character variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -820,6 +820,8 @@ RUN(NAME pointer_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_03 LABELS gfortran llvm)
 RUN(NAME pointer_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section_assignment LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/pointer_05.f90
+++ b/integration_tests/pointer_05.f90
@@ -13,9 +13,11 @@ program pointer_05
     type is (integer)
       print *, "Integer=", p
       if (p /= 42) error stop
+      p = 52
     type is (real)
       print *, "Real=", p
       if (abs(p - 5.5) > 1e-6) error stop
+      p = 6.5
     class default
       print *, "Unknown"
       error stop
@@ -26,11 +28,18 @@ program pointer_05
     type is (integer)
       print *, "Integer=", p
       if (p /= 42) error stop
+      p = 52
     type is (real)
       print *, "Real=", p
       if (abs(p - 5.5) > 1e-6) error stop
+      p = 6.5
     class default
       print *, "Unknown"
       error stop
   end select
+  
+  print *, r 
+  print *, i
+  if (abs(r - 6.5) > 1e-6) error stop
+  if (i /= 52) error stop
 end program pointer_05

--- a/integration_tests/pointer_06.f90
+++ b/integration_tests/pointer_06.f90
@@ -1,0 +1,19 @@
+program a
+  implicit none
+  ! Declare an unlimited polymorphic pointer
+  class(*), pointer :: ptr
+  character(5), target :: t
+  t = 'abcde'
+  ptr => t
+  select type (p => ptr)
+    type is (character(*))
+      print *, p
+      if (p /= 'abcde') error stop
+      p = 'vwxyz'
+    class default
+      print *, "Unknown"
+      error stop
+  end select
+  print *, t
+  if (t /= 'vwxyz') error stop
+end program a

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3173,6 +3173,14 @@ public:
                                                        type_stmt_type->m_vartype, false, false, m_dims,
                                                        nullptr,
                                                        type_declaration, ASR::abiType::Source);
+                        // Convert AssumedLength to DeferredLength for select type associate statements
+                        if (ASRUtils::is_character(*selector_type)) {
+                            ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(
+                                ASRUtils::extract_type(selector_type));
+                            if (str_type->m_len_kind == ASR::string_length_kindType::AssumedLength) {
+                                str_type->m_len_kind = ASR::string_length_kindType::DeferredLength;
+                            }
+                        }
                         selector_ttype = selector_variable ? selector_variable->m_type : nullptr;
                         if (selector_ttype) {
                             ASR::ttype_t* view_type = make_typed_selector_view_type(


### PR DESCRIPTION
Fixes #9923 
Towards #8029 

Changes made:
- For strings declared inside select type block associates, change it's type from AssumedLength to DeferredLength.
- Add support for association of character variables to polymorphic class pointer variables, and vice-versa.
- Update tests for #9700  to make them more robust, by checking for variable value change using associate alias variable