### PR TITLE
fix: use local ExternalSymbol for type_declaration on call temporaries

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3232,6 +3232,7 @@ RUN(NAME separate_compilation_27 LABELS gfortran llvm_submodule EXTRAFILES separ
 RUN(NAME separate_compilation_28 LABELS gfortran llvm EXTRAFILES separate_compilation_28a.f90 separate_compilation_28b.f90 EXTRA_ARGS --implicit-interface)
 RUN(NAME separate_compilation_29 LABELS gfortran llvm EXTRAFILES separate_compilation_29a.f90 separate_compilation_29b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_30 LABELS gfortran llvm EXTRAFILES separate_compilation_30a.f90 separate_compilation_30b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_31 LABELS gfortran llvm EXTRAFILES separate_compilation_31a.f90 separate_compilation_31b.f90 EXTRA_ARGS --separate-compilation)
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_30.f90
+++ b/integration_tests/separate_compilation_30.f90
@@ -1,6 +1,6 @@
-program separate_compilation_31
-    use separate_compilation_31b_module, only: client
+program separate_compilation_30
+    use separate_compilation_30b_module, only: client
     implicit none
 
     type(client) :: x
-end program separate_compilation_31
+end program separate_compilation_30

--- a/integration_tests/separate_compilation_30a.f90
+++ b/integration_tests/separate_compilation_30a.f90
@@ -1,4 +1,4 @@
-module separate_compilation_31a_module
+module separate_compilation_30a_module
     implicit none
     private
 
@@ -24,4 +24,4 @@ contains
         self%obj = obj
     end function constructor
 
-end module separate_compilation_31a_module
+end module separate_compilation_30a_module

--- a/integration_tests/separate_compilation_30b.f90
+++ b/integration_tests/separate_compilation_30b.f90
@@ -1,5 +1,5 @@
-module separate_compilation_31b_module
-    use separate_compilation_31a_module, only: abstype, mytype
+module separate_compilation_30b_module
+    use separate_compilation_30a_module, only: abstype, mytype
     implicit none
     private
 
@@ -30,4 +30,4 @@ contains
         arr = mytype(ints, obj)
     end subroutine method
 
-end module separate_compilation_31b_module
+end module separate_compilation_30b_module

--- a/integration_tests/separate_compilation_31.f90
+++ b/integration_tests/separate_compilation_31.f90
@@ -1,0 +1,4 @@
+program separate_compilation_31
+    use separate_compilation_31b_module, only: get_my_obj
+    implicit none
+end program separate_compilation_31

--- a/integration_tests/separate_compilation_31a.f90
+++ b/integration_tests/separate_compilation_31a.f90
@@ -1,0 +1,21 @@
+module separate_compilation_31a_module
+    implicit none
+
+    type, abstract :: AbsType
+    end type AbsType
+
+    type :: MyType
+    end type MyType
+
+    interface MyType
+        procedure :: constructor
+    end interface MyType
+
+contains
+
+    function constructor(obj) result(self)
+        class(AbsType), intent(in) :: obj
+        type(MyType) :: self
+    end function constructor
+
+end module separate_compilation_31a_module

--- a/integration_tests/separate_compilation_31b.f90
+++ b/integration_tests/separate_compilation_31b.f90
@@ -1,0 +1,16 @@
+module separate_compilation_31b_module
+    use separate_compilation_31a_module, only: AbsType, MyType
+    implicit none
+
+contains
+
+    function get_my_obj() result(myobj)
+        class(MyType), allocatable :: myobj
+        myobj = MyType(get_obj())
+    end function get_my_obj
+
+    function get_obj() result(obj)
+        class(AbsType), allocatable :: obj
+    end function get_obj
+
+end module separate_compilation_31b_module

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9056,8 +9056,9 @@ public:
                     ASR::symbol_t* type_declaration = nullptr;
                     ASR::ttype_t* ret_type_base = ASRUtils::extract_type(ret_type);
                     if (ASR::is_a<ASR::StructType_t>(*ret_type_base)) {
-                        type_declaration = ASRUtils::symbol_get_past_external(
-                            ASRUtils::get_struct_sym_from_struct_expr(val));
+                        type_declaration = ASRUtils::import_struct_type(al,
+                            ASRUtils::get_struct_sym_from_struct_expr(val),
+                            current_scope);
                     }
                     ASR::symbol_t* tmp_sym =
                         ASR::down_cast<ASR::symbol_t>(


### PR DESCRIPTION
The previous commit (b4eb10eb2) used symbol_get_past_external() to set m_type_declaration on lowered call temporaries, which resolved to the actual Struct symbol in the foreign module's symbol table. When the module was serialized to a modfile, the foreign symtab ID was written, causing an assertion failure during deserialization in separate compilation (id_symtab_map lookup failed).

Use import_struct_type() instead, which finds or creates an ExternalSymbol in the current module's scope, ensuring m_type_declaration always references a symbol within the serialized module's own symbol table hierarchy.

Fixes #10020.