### PR TITLE
test: uncomment select_type()  in `class_94.f90`

### DIFF
--- a/integration_tests/class_94.f90
+++ b/integration_tests/class_94.f90
@@ -34,7 +34,7 @@ contains
         integer :: i
 
         do i = 1, size(arr)
-             select type(arr)   !! TODO: fix this select type
+             select type(arr)
              type is (base_type)
                 arr(i)%value = arr(i)%value + 1
              type is (extended_type)


### PR DESCRIPTION
Closes #9548

All the tests in `class_94.f90` now work in `main`. 
So we can close #9548 now.