### PR TITLE
ci: speedup using caching

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -41,10 +41,12 @@ jobs:
           fetch-depth: 0
           path: src
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@v2.0.2
         with:
-          micromamba-version: '1.5.10-0'
+          micromamba-version: '2.0.4-0'
           environment-file: src/ci/environment_linux.yml
+          cache-environment: true
+          cache-environment-key: env-debug-oos-${{ hashFiles('src/ci/environment_linux.yml') }}
           create-args: >-
             python=3.10
 
@@ -108,6 +110,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
+          cache-environment: true
+          cache-environment-key: env-release-${{ hashFiles('ci/environment_linux.yml') }}
           create-args: >-
             python=3.10
 
@@ -230,6 +234,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -248,6 +254,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -266,6 +274,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -283,6 +293,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -300,6 +312,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             llvmdev=21.1.0 
             python=${{ matrix.python-version }}
@@ -314,6 +328,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -328,6 +344,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-llvm-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=${{ matrix.python-version }}
             llvmdev=${{ matrix.llvm-version }}
@@ -346,8 +364,16 @@ jobs:
         if: matrix.llvm-version > 11
         run: micromamba install -y -n lf libunwind=1.7.2
 
-      - name: Setup WASI SDK
+      - name: Cache WASI SDK
         if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        id: cache-wasi-sdk
+        uses: actions/cache@v4
+        with:
+          path: ~/ext/wasi-sdk
+          key: wasi-sdk-21.0-linux
+
+      - name: Setup WASI SDK
+        if: (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')) && steps.cache-wasi-sdk.outputs.cache-hit != 'true'
         shell: bash -e -l {0}
         run: |
           mkdir -p $HOME/ext
@@ -359,8 +385,16 @@ jobs:
           echo $WASI_SDK_PATH
           $WASI_SDK_PATH/bin/clang --version
 
-      - name: Install wasmtime
+      - name: Cache wasmtime
         if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        id: cache-wasmtime
+        uses: actions/cache@v4
+        with:
+          path: ~/wasmtime-v19.0.2-x86_64-linux
+          key: wasmtime-v19.0.2-x86_64-linux
+
+      - name: Install wasmtime
+        if: (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')) && steps.cache-wasmtime.outputs.cache-hit != 'true'
         shell: bash -e -l {0}
         run: |
           cd $HOME
@@ -369,8 +403,16 @@ jobs:
           export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
           wasmtime --version
 
-      - name: Setup Emscripten SDK
+      - name: Cache Emscripten SDK
         if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        id: cache-emsdk
+        uses: actions/cache@v4
+        with:
+          path: ~/ext/emsdk
+          key: emsdk-4.0.13-3.1.35
+
+      - name: Setup Emscripten SDK
+        if: (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')) && steps.cache-emsdk.outputs.cache-hit != 'true'
         shell: bash -e -l {0}
         run: |
           mkdir -p $HOME/ext
@@ -574,6 +616,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
+          cache-environment: true
+          cache-environment-key: env-tarball-${{ hashFiles('ci/environment_linux.yml') }}
           create-args: >-
             python=3.10
 
@@ -609,6 +653,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
+          cache-environment: true
+          cache-environment-key: env-no-llvm-${{ hashFiles('ci/environment_linux.yml') }}
           create-args: >-
             python=3.10
 
@@ -633,6 +679,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
+          cache-environment: true
+          cache-environment-key: env-mlir-${{ hashFiles('ci/environment_linux_llvm.yml') }}
           create-args: >-
             python=3.10
             mlir=19.1.6
@@ -685,6 +733,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_docs_linux.yml
+          cache-environment: true
+          cache-environment-key: env-docs-${{ hashFiles('ci/environment_docs_linux.yml') }}
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment.yml
+          cache-environment: true
+          cache-environment-key: env-${{ runner.os }}-${{ matrix.llvm-version }}-${{ hashFiles('ci/environment.yml') }}
           create-args: >-
             llvmdev=${{ matrix.llvm-version }}
 
@@ -264,9 +266,17 @@ jobs:
             ./run_tests.py -b fortran -j1
             ./run_tests.py -b fortran -f -j1
 
-      - name: Test GFortran, Debug Build, Fortran, OpenMP, C/C++ backend, Upload Tarball, CPP Build, WASM - Test C/C++ Backend
-        shell: bash -e -l {0}
+      - name: Cache Kokkos
         if: contains(matrix.os, 'ubuntu') && contains(matrix.llvm-version, '11')
+        id: cache-kokkos
+        uses: actions/cache@v4
+        with:
+          path: ~/ext/kokkos
+          key: kokkos-3.1.01-ubuntu
+
+      - name: Build Kokkos
+        shell: bash -e -l {0}
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.llvm-version, '11') && steps.cache-kokkos.outputs.cache-hit != 'true'
         run: |
             mkdir build-kokkos
             cd build-kokkos
@@ -277,10 +287,15 @@ jobs:
             cd build
             export LFORTRAN_KOKKOS_DIR=$HOME/ext/kokkos
             cmake -DCMAKE_INSTALL_PREFIX=$LFORTRAN_KOKKOS_DIR -DKokkos_ENABLE_OPENMP=On -DKokkos_ARCH_HSW=On ..
-            make
+            make -j$(nproc)
             make install
             cd ../../..
 
+      - name: Test GFortran, Debug Build, Fortran, OpenMP, C/C++ backend, Upload Tarball, CPP Build, WASM - Test C/C++ Backend
+        shell: bash -e -l {0}
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.llvm-version, '11')
+        run: |
+            export LFORTRAN_KOKKOS_DIR=$HOME/ext/kokkos
             cd integration_tests
             ./run_tests.py -b cpp c c_nopragma
             ./run_tests.py -b cpp c c_nopragma -f
@@ -332,13 +347,15 @@ jobs:
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
+          cache-environment: true
+          cache-environment-key: env-wasm-${{ hashFiles('ci/environment_linux.yml') }}
           create-args: >-
             python=3.10
 
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache
-          key: ${{ github.job }}-${{ matrix.os }}
+          key: ${{ github.job }}-ubuntu-latest
 
       - name : Remove existing node
         shell: bash -e -l {0}
@@ -347,7 +364,15 @@ jobs:
             node -v
             sudo rm -rf /usr/local/bin/node /usr/local/bin/npm
 
+      - name: Cache Emscripten SDK
+        id: cache-emsdk
+        uses: actions/cache@v4
+        with:
+          path: ~/ext/emsdk
+          key: emsdk-4.0.13-3.1.35-node-18.20.3
+
       - name: Setup Emscripten SDK
+        if: steps.cache-emsdk.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           set -ex

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -53,7 +53,7 @@ else # Linux or macOS
 fi
 
 cmake -G$LFORTRAN_CMAKE_GENERATOR -DCMAKE_VERBOSE_MAKEFILE=ON -DWITH_LSP=yes -DWITH_LLVM=yes -DWITH_XEUS=yes -DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_RUNTIME_STACKTRACE=$ENABLE_RUNTIME_STACKTRACE ..
-cmake --build . --target install
+cmake --build . --target install -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 ./src/lfortran/tests/test_lfortran
 ./src/bin/lfortran < ../src/bin/example_input.txt
 ctest --output-on-failure


### PR DESCRIPTION
# CI Performance Improvements

## 1. Parallel build in `ci/build.sh`

The `cmake --build . --target install` command was running single-threaded (no `-j` flag). Added `-j$(nproc)` with cross-platform fallbacks for macOS and a default of 4 cores.

**Estimated savings:** 5–15 minutes per job.

## 2. Micromamba environment caching

Added `cache-environment: true` and unique `cache-environment-key` to all 13 `setup-micromamba` invocations across both `Quick-Checks-CI.yml` and `Exhaustive-Checks-CI.yml`. This uses the action's built-in caching to store and restore the entire conda environment (including LLVM) between runs, avoiding fresh package downloads and solves on every CI run.

Also upgraded the `debug_outOfSource` job from the outdated `setup-micromamba@v1.8.0` to `v2.0.2` for consistency.

**Estimated savings:** 3–5 minutes per job.

## 3. Caching for Emscripten, WASI SDK, wasmtime, and Kokkos

Added `actions/cache@v4` with version-pinned cache keys for external SDKs and tools that were previously downloaded and built from source on every run:

- **Emscripten SDK** — cached in `build_to_wasm_and_upload` (Quick-Checks) and LLVM 10/19 (Exhaustive)
- **Kokkos** — cached in the C/C++ backend test step (Quick-Checks); also parallelized the Kokkos build with `make -j$(nproc)`
- **WASI SDK** — cached in Exhaustive LLVM 10/19
- **wasmtime** — cached in Exhaustive LLVM 10/19

Download/install steps are conditionally skipped on cache hits.

**Estimated savings:** 5–10 minutes per job.

## Files changed

- `ci/build.sh`
- `.github/workflows/Quick-Checks-CI.yml`
- `.github/workflows/Exhaustive-Checks-CI.yml`
