### PR TITLE
CI: migrate integration tests for llvm* backend to quick checks

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -436,30 +436,6 @@ jobs:
 
             cmake --build . -j16 --target install
 
-      # LLVM 10-19 all work in exactly the same way, so the test is identical
-      - name: Test Linux LLVM 8-16
-        if: ${{(contains(matrix.llvm-version, '8') || contains(matrix.llvm-version, '9') || contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '11') || contains(matrix.llvm-version, '12') || contains(matrix.llvm-version, '13') || contains(matrix.llvm-version, '14') || contains(matrix.llvm-version, '15') || contains(matrix.llvm-version, '16'))}}
-        shell: bash -e -l {0}
-        run: |
-            cd integration_tests
-            ./run_tests.py -b llvm -sc
-            ./run_tests.py -b llvm llvmImplicit
-            ./run_tests.py -b llvm llvmImplicit -f -nf16
-            ./run_tests.py -b llvm_submodule
-            ./run_tests.py -b llvm_submodule -sc
-
-      - name: Test Linux LLVM 17-21
-        if: ${{(contains(matrix.llvm-version, '17') || contains(matrix.llvm-version, '18') || contains(matrix.llvm-version, '19') || contains(matrix.llvm-version, '20') || contains(matrix.llvm-version, '21'))}}
-        shell: bash -e -l {0}
-        run: |
-            ctest --output-on-failure
-            cd integration_tests
-            ./run_tests.py -b llvm -sc
-            ./run_tests.py -b llvm llvmImplicit
-            ./run_tests.py -b llvm llvmImplicit -f
-            ./run_tests.py -b llvm_submodule
-            ./run_tests.py -b llvm_submodule -sc
-
       - name: Check SciPy Build and Test Run - Test SciPy
         shell: bash -e -x -l {0}
         if: contains(matrix.os, 'ubuntu') && contains(matrix.llvm-version, '11')

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -67,9 +67,16 @@ if [[ $WIN != "1" ]]; then
     ctest -L llvm -j${NPROC}
     cd ..
 
-    ./run_tests.py -b llvm llvm2 llvm_rtlib llvm_nopragma llvm_integer_8
+    ./run_tests.py -b llvm llvm2 llvm_rtlib llvm_nopragma llvm_integer_8 llvmImplicit
+    ./run_tests.py -b llvm -sc
     ./run_tests.py -b llvm2 llvm_rtlib llvm_nopragma llvm_integer_8 -f
-    ./run_tests.py -b llvm -f -nf16
+    if [[ $LFORTRAN_LLVM_VERSION == "11" ]]; then
+        ./run_tests.py -b llvm llvmImplicit -f -nf16
+    else
+        ./run_tests.py -b llvm llvmImplicit -f
+    fi
+    ./run_tests.py -b llvm_submodule
+    ./run_tests.py -b llvm_submodule -sc
     cd ..
 
     pip install src/server/tests tests/server


### PR DESCRIPTION
Towards #10056
With this integration tests will run only in quick checks (So LLVM 11 and 21 only, not for all llvm). Is that fine?