### PR TITLE
rem: remove implicit deallocate before procedure call

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -172,10 +172,6 @@ public:
             } else {
                 if (tmp) {
                     ASR::stmt_t* tmp_stmt = ASRUtils::STMT(tmp);
-                    if (tmp_stmt->type == ASR::stmtType::SubroutineCall) {
-                        ASR::stmt_t* impl_decl = create_implicit_deallocate_subrout_call(tmp_stmt);
-                        if (impl_decl) body.push_back(al, impl_decl);
-                    }
                     body.push_back(al, tmp_stmt);
                 } else if (!tmp_vec.empty()) {
                     for (auto &x : tmp_vec) body.push_back(al, ASRUtils::STMT(x));
@@ -3748,81 +3744,6 @@ public:
         tmp = nullptr;
     }
 
-    ASR::stmt_t* create_implicit_deallocate_subrout_call(ASR::stmt_t* x) {
-        ASR::SubroutineCall_t* subrout_call = ASR::down_cast<ASR::SubroutineCall_t>(x);
-        const ASR::symbol_t* subrout_sym = ASRUtils::symbol_get_past_external(subrout_call->m_name);
-        if( ! ASR::is_a<ASR::Function_t>(*subrout_sym)
-            || ASR::down_cast<ASR::Function_t>(subrout_sym)->m_return_var != nullptr ) {
-            return nullptr;
-        }
-        ASR::Function_t* subrout = ASR::down_cast<ASR::Function_t>(subrout_sym);
-        Vec<ASR::expr_t*> del_syms;
-        del_syms.reserve(al, 1);
-        for( size_t i = 0; i < subrout_call->n_args; i++ ) {
-            if (!subrout_call->m_args[i].m_value) continue;
-            // Bounds check: call may have more args than definition (optional args)
-            if (i >= subrout->n_args) continue;
-            if (!subrout->m_args[i] || subrout->m_args[i]->type != ASR::exprType::Var) continue;
-
-            const ASR::Var_t* orig_arg_var = ASR::down_cast<ASR::Var_t>(subrout->m_args[i]);
-            const ASR::symbol_t* orig_sym = ASRUtils::symbol_get_past_external(orig_arg_var->m_v);
-            if (orig_sym->type != ASR::symbolType::Variable) continue;
-            ASR::Variable_t* orig_var = ASR::down_cast<ASR::Variable_t>(orig_sym);
-
-            if (orig_var->m_intent != ASR::intentType::Out) continue;
-            if (!ASRUtils::is_allocatable(orig_var->m_type) &&
-                !ASR::is_a<ASR::StructType_t>(*orig_var->m_type)) continue;
-
-            if( subrout_call->m_args[i].m_value &&
-                subrout_call->m_args[i].m_value->type == ASR::exprType::Var ) {
-                const ASR::Var_t* arg_var = ASR::down_cast<ASR::Var_t>(subrout_call->m_args[i].m_value);
-                const ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(arg_var->m_v);
-                if( sym->type == ASR::symbolType::Variable ) {
-                    ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                    if( ASR::is_a<ASR::Allocatable_t>(*var->m_type) &&
-                        ASR::is_a<ASR::Allocatable_t>(*orig_var->m_type) &&
-                        orig_var->m_intent == ASR::intentType::Out ) {
-                        del_syms.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x->base.loc, arg_var->m_v)));
-                    }
-                    // Check struct-type members
-                    if (ASR::is_a<ASR::StructType_t>(*ASRUtils::symbol_type(sym))
-                        && !ASRUtils::is_class_type(ASRUtils::symbol_type(sym))
-                        && ASR::down_cast<ASR::Variable_t>(orig_sym)->m_intent == ASR::intentType::Out) {
-                        ASR::Struct_t* struct_type = ASR::down_cast<ASR::Struct_t>(
-                            ASRUtils::symbol_get_past_external(var->m_type_declaration));
-                        while (struct_type) {
-                            SymbolTable* sym_table_of_struct = struct_type->m_symtab;
-                            for(auto struct_member : sym_table_of_struct->get_scope()){
-                                if(ASR::is_a<ASR::Variable_t>(*struct_member.second) &&
-                                    ASRUtils::is_allocatable(ASRUtils::symbol_type(struct_member.second))){
-                                    del_syms.push_back(al, ASRUtils::EXPR(
-                                        ASRUtils::getStructInstanceMember_t(al,subrout_call->m_args[i].m_value->base.loc,
-                                        (ASR::asr_t*)subrout_call->m_args[i].m_value,
-                                        const_cast<ASR::symbol_t*>(sym), struct_member.second, current_scope)));
-                                }
-                            }
-                            if (struct_type->m_parent) {
-                                struct_type = ASR::down_cast<ASR::Struct_t>(
-                                    ASRUtils::symbol_get_past_external(struct_type->m_parent));
-                            } else {
-                                struct_type = nullptr;
-                            }
-                        }
-                    }
-                }
-            }
-            // NOTE: StructInstanceMember actuals are NOT handled here because
-            // the pass_insert_deallocate pass adds deallocation at function entry
-            // for allocatable intent(out) dummies. Adding ImplicitDeallocate at
-            // the call site would cause double-free.
-        }
-        if( del_syms.size() == 0 ) {
-            return nullptr;
-        }
-        return ASRUtils::STMT(ASR::make_ImplicitDeallocate_t(al, x->base.loc,
-                    del_syms.p, del_syms.size()));
-    }
-
     void visit_Entry(const AST::Entry_t& /*x*/) {
         tmp = nullptr;
     }
@@ -3997,12 +3918,6 @@ public:
             ASR::stmt_t* tmp_stmt = nullptr;
             if (tmp != nullptr) {
                 tmp_stmt = ASRUtils::STMT(tmp);
-                if (tmp_stmt->type == ASR::stmtType::SubroutineCall) {
-                    ASR::stmt_t* impl_decl = create_implicit_deallocate_subrout_call(tmp_stmt);
-                    if (impl_decl != nullptr) {
-                        stmt_vector.push_back(impl_decl);
-                    }
-                }
                 if (tmp_stmt->type == ASR::stmtType::Assignment) {
                     // if it is an assignment to any of the entry function return variables, then
                     // make an assignment to return variable of master function

--- a/tests/reference/asr-allocate_01-f3446f6.json
+++ b/tests/reference/asr-allocate_01-f3446f6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_01-f3446f6.stdout",
-    "stdout_hash": "6b64573c9a7270e284b047447e5f8275ebf860a8a2eb9cd31bc9b181",
+    "stdout_hash": "1f75a71582d1df290fd46091ed77f00f6976eedbbc2f843d383bac13",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_01-f3446f6.stdout
+++ b/tests/reference/asr-allocate_01-f3446f6.stdout
@@ -1770,9 +1770,6 @@
                         )]
                         []
                     )
-                    (ImplicitDeallocate
-                        [(Var 2 c)]
-                    )
                     (SubroutineCall
                         2 sum
                         ()

--- a/tests/reference/asr-allocate_03-8219a72.json
+++ b/tests/reference/asr-allocate_03-8219a72.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allocate_03-8219a72.stdout",
-    "stdout_hash": "2d418eb98323810fa4115375e3ee62343ee5a144d25e46b4882e608a",
+    "stdout_hash": "6460edbd48ba3c986846b356562b73ea8cb6a0af6d999a728cfd4d51",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allocate_03-8219a72.stdout
+++ b/tests/reference/asr-allocate_03-8219a72.stdout
@@ -287,9 +287,6 @@
                                         )]
                                         []
                                     )
-                                    (ImplicitDeallocate
-                                        [(Var 4 x)]
-                                    )
                                     (SubroutineCall
                                         2 f
                                         ()
@@ -463,9 +460,6 @@
                                             ()
                                         )]
                                         []
-                                    )
-                                    (ImplicitDeallocate
-                                        [(Var 5 c)]
                                     )
                                     (SubroutineCall
                                         2 f
@@ -655,9 +649,6 @@
                         ()
                         .false.
                         .false.
-                    )
-                    (ImplicitDeallocate
-                        [(Var 2 c)]
                     )
                     (SubroutineCall
                         2 h

--- a/tests/reference/asr-derived_types_16_module-4aac273.json
+++ b/tests/reference/asr-derived_types_16_module-4aac273.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_16_module-4aac273.stdout",
-    "stdout_hash": "fe625074484bd3508e3f484755e135e4bc775dc153596296757c57f2",
+    "stdout_hash": "b5ee2cde36ba5d039eab1d13f4ff8246083c0077b5d73584afecd47c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_16_module-4aac273.stdout
+++ b/tests/reference/asr-derived_types_16_module-4aac273.stdout
@@ -100,9 +100,6 @@
                         ()
                         ()
                     )
-                    (ImplicitDeallocate
-                        [(Var 5 settings)]
-                    )
                     (SubroutineCall
                         5 get_command_line_settings
                         ()

--- a/tests/reference/asr-modules_29-dc71c55.json
+++ b/tests/reference/asr-modules_29-dc71c55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-dc71c55.stdout",
-    "stdout_hash": "652c496f5adc797204edcb432d61d8e2fd18729af483178040154d5a",
+    "stdout_hash": "5ff380958643eaa190ea580e59769560ce9c6bf06cdf571414f3c87c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-dc71c55.stdout
+++ b/tests/reference/asr-modules_29-dc71c55.stdout
@@ -1435,10 +1435,7 @@
                                     [(Var 6 self)
                                     (Var 6 table)
                                     (Var 6 error)]
-                                    [(ImplicitDeallocate
-                                        [(Var 6 error)]
-                                    )
-                                    (SubroutineCall
+                                    [(SubroutineCall
                                         4 new_dependencies
                                         ()
                                         [((StructInstanceMember

--- a/tests/reference/asr-modules_52-5261d38.json
+++ b/tests/reference/asr-modules_52-5261d38.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_52-5261d38.stdout",
-    "stdout_hash": "7e8975af469980db4d3bba626bc7747c2ad131a45406d3f05b7948b5",
+    "stdout_hash": "a7c1861ce379af0782577f4ddbb15bba4ef786267405e8b3468413ba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_52-5261d38.stdout
+++ b/tests/reference/asr-modules_52-5261d38.stdout
@@ -158,9 +158,6 @@
                                         )]
                                         []
                                     )
-                                    (ImplicitDeallocate
-                                        [(Var 3 table)]
-                                    )
                                     (SubroutineCall
                                         3 toml_parse@toml_parse_string
                                         3 toml_parse

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "ab82afd8e87b4d76095e94a3a1fd0b3e25cec953981268d268bf9494",
+    "stdout_hash": "1d0d47a8a83ac7ff85bce797ef786bf454f01bff22c48a14136ff9d7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -322,276 +322,247 @@ ifcont13:                                         ; preds = %ifcont11
   %97 = load i32*, i32** %96, align 8
   %98 = getelementptr inbounds i32, i32* %97, i32 %95
   store i32 3, i32* %98, align 4
-  %99 = load %array*, %array** %c, align 8
-  %100 = ptrtoint %array* %99 to i64
-  %101 = icmp eq i64 %100, 0
-  br i1 %101, label %merge_allocated15, label %check_data14
+  call void @h(%array** %c)
+  %99 = call i32 @g(%array** %c)
+  store i32 %99, i32* %r, align 4
+  %100 = load %array*, %array** %c, align 8
+  %101 = ptrtoint %array* %100 to i64
+  %102 = icmp eq i64 %101, 0
+  br i1 %102, label %merge_allocated15, label %check_data14
 
 check_data14:                                     ; preds = %ifcont13
-  %102 = getelementptr %array, %array* %99, i32 0, i32 0
-  %103 = load i32*, i32** %102, align 8
-  %104 = ptrtoint i32* %103 to i64
-  %105 = icmp ne i64 %104, 0
+  %103 = getelementptr %array, %array* %100, i32 0, i32 0
+  %104 = load i32*, i32** %103, align 8
+  %105 = ptrtoint i32* %104 to i64
+  %106 = icmp ne i64 %105, 0
   br label %merge_allocated15
 
 merge_allocated15:                                ; preds = %check_data14, %ifcont13
-  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %105, %check_data14 ]
-  br i1 %is_allocated16, label %then17, label %else18
+  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %106, %check_data14 ]
+  %107 = xor i1 %is_allocated16, true
+  br i1 %107, label %then17, label %ifcont18
 
 then17:                                           ; preds = %merge_allocated15
-  %106 = getelementptr %array, %array* %99, i32 0, i32 0
-  %107 = load i32*, i32** %106, align 8
-  %108 = bitcast i32* %107 to i8*
-  call void @_lfortran_free(i8* %108)
-  %109 = getelementptr %array, %array* %99, i32 0, i32 0
-  store i32* null, i32** %109, align 8
-  br label %ifcont19
-
-else18:                                           ; preds = %merge_allocated15
-  br label %ifcont19
-
-ifcont19:                                         ; preds = %else18, %then17
-  call void @h(%array** %c)
-  %110 = call i32 @g(%array** %c)
-  store i32 %110, i32* %r, align 4
-  %111 = load %array*, %array** %c, align 8
-  %112 = ptrtoint %array* %111 to i64
-  %113 = icmp eq i64 %112, 0
-  br i1 %113, label %merge_allocated21, label %check_data20
-
-check_data20:                                     ; preds = %ifcont19
-  %114 = getelementptr %array, %array* %111, i32 0, i32 0
-  %115 = load i32*, i32** %114, align 8
-  %116 = ptrtoint i32* %115 to i64
-  %117 = icmp ne i64 %116, 0
-  br label %merge_allocated21
-
-merge_allocated21:                                ; preds = %check_data20, %ifcont19
-  %is_allocated22 = phi i1 [ false, %ifcont19 ], [ %117, %check_data20 ]
-  %118 = xor i1 %is_allocated22, true
-  br i1 %118, label %then23, label %ifcont24
-
-then23:                                           ; preds = %merge_allocated21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont24:                                         ; preds = %merge_allocated21
-  %119 = getelementptr %array, %array* %111, i32 0, i32 2
-  %120 = load %dimension_descriptor*, %dimension_descriptor** %119, align 8
-  %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 0
-  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
-  %123 = load i32, i32* %122, align 4
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
-  %125 = load i32, i32* %124, align 4
-  %126 = sub i32 1, %123
-  %127 = add i32 %123, %125
-  %128 = sub i32 %127, 1
-  %129 = icmp slt i32 1, %123
-  %130 = icmp sgt i32 1, %128
-  %131 = or i1 %129, %130
-  br i1 %131, label %then25, label %ifcont26
+ifcont18:                                         ; preds = %merge_allocated15
+  %108 = getelementptr %array, %array* %100, i32 0, i32 2
+  %109 = load %dimension_descriptor*, %dimension_descriptor** %108, align 8
+  %110 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 0
+  %111 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 1
+  %112 = load i32, i32* %111, align 4
+  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 2
+  %114 = load i32, i32* %113, align 4
+  %115 = sub i32 1, %112
+  %116 = add i32 %112, %114
+  %117 = sub i32 %116, 1
+  %118 = icmp slt i32 1, %112
+  %119 = icmp sgt i32 1, %117
+  %120 = or i1 %118, %119
+  br i1 %120, label %then19, label %ifcont20
+
+then19:                                           ; preds = %ifcont18
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i32 1, i32 1, i32 %112, i32 %117)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont20:                                         ; preds = %ifcont18
+  %121 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 0
+  %122 = load i32, i32* %121, align 4
+  %123 = mul i32 %122, %115
+  %124 = add i32 0, %123
+  %125 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 1
+  %126 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 1
+  %127 = load i32, i32* %126, align 4
+  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 2
+  %129 = load i32, i32* %128, align 4
+  %130 = sub i32 1, %127
+  %131 = add i32 %127, %129
+  %132 = sub i32 %131, 1
+  %133 = icmp slt i32 1, %127
+  %134 = icmp sgt i32 1, %132
+  %135 = or i1 %133, %134
+  br i1 %135, label %then21, label %ifcont22
+
+then21:                                           ; preds = %ifcont20
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 1, i32 2, i32 %127, i32 %132)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont22:                                         ; preds = %ifcont20
+  %136 = getelementptr %dimension_descriptor, %dimension_descriptor* %125, i32 0, i32 0
+  %137 = load i32, i32* %136, align 4
+  %138 = mul i32 %137, %130
+  %139 = add i32 %124, %138
+  %140 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 2
+  %141 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 1
+  %142 = load i32, i32* %141, align 4
+  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 2
+  %144 = load i32, i32* %143, align 4
+  %145 = sub i32 1, %142
+  %146 = add i32 %142, %144
+  %147 = sub i32 %146, 1
+  %148 = icmp slt i32 1, %142
+  %149 = icmp sgt i32 1, %147
+  %150 = or i1 %148, %149
+  br i1 %150, label %then23, label %ifcont24
+
+then23:                                           ; preds = %ifcont22
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 1, i32 3, i32 %142, i32 %147)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont24:                                         ; preds = %ifcont22
+  %151 = getelementptr %dimension_descriptor, %dimension_descriptor* %140, i32 0, i32 0
+  %152 = load i32, i32* %151, align 4
+  %153 = mul i32 %152, %145
+  %154 = add i32 %139, %153
+  %155 = getelementptr %array, %array* %100, i32 0, i32 1
+  %156 = load i32, i32* %155, align 4
+  %157 = add i32 %154, %156
+  %158 = getelementptr %array, %array* %100, i32 0, i32 0
+  %159 = load i32*, i32** %158, align 8
+  %160 = getelementptr inbounds i32, i32* %159, i32 %157
+  %161 = load i32, i32* %160, align 4
+  %162 = icmp ne i32 %161, 8
+  br i1 %162, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i32 1, i32 1, i32 %123, i32 %128)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont26:                                         ; preds = %ifcont24
-  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
-  %133 = load i32, i32* %132, align 4
-  %134 = mul i32 %133, %126
-  %135 = add i32 0, %134
-  %136 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 1
-  %137 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 1
-  %138 = load i32, i32* %137, align 4
-  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 2
-  %140 = load i32, i32* %139, align 4
-  %141 = sub i32 1, %138
-  %142 = add i32 %138, %140
-  %143 = sub i32 %142, 1
-  %144 = icmp slt i32 1, %138
-  %145 = icmp sgt i32 1, %143
-  %146 = or i1 %144, %145
-  br i1 %146, label %then27, label %ifcont28
-
-then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i32 1, i32 2, i32 %138, i32 %143)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont28:                                         ; preds = %ifcont26
-  %147 = getelementptr %dimension_descriptor, %dimension_descriptor* %136, i32 0, i32 0
-  %148 = load i32, i32* %147, align 4
-  %149 = mul i32 %148, %141
-  %150 = add i32 %135, %149
-  %151 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %120, i32 2
-  %152 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 1
-  %153 = load i32, i32* %152, align 4
-  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 2
-  %155 = load i32, i32* %154, align 4
-  %156 = sub i32 1, %153
-  %157 = add i32 %153, %155
-  %158 = sub i32 %157, 1
-  %159 = icmp slt i32 1, %153
-  %160 = icmp sgt i32 1, %158
-  %161 = or i1 %159, %160
-  br i1 %161, label %then29, label %ifcont30
-
-then29:                                           ; preds = %ifcont28
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i32 1, i32 3, i32 %153, i32 %158)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont30:                                         ; preds = %ifcont28
-  %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %151, i32 0, i32 0
-  %163 = load i32, i32* %162, align 4
-  %164 = mul i32 %163, %156
-  %165 = add i32 %150, %164
-  %166 = getelementptr %array, %array* %111, i32 0, i32 1
-  %167 = load i32, i32* %166, align 4
-  %168 = add i32 %165, %167
-  %169 = getelementptr %array, %array* %111, i32 0, i32 0
-  %170 = load i32*, i32** %169, align 8
-  %171 = getelementptr inbounds i32, i32* %170, i32 %168
-  %172 = load i32, i32* %171, align 4
-  %173 = icmp ne i32 %172, 8
-  br i1 %173, label %then31, label %else32
-
-then31:                                           ; preds = %ifcont30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont33
+  br label %ifcont27
 
-else32:                                           ; preds = %ifcont30
-  br label %ifcont33
+else26:                                           ; preds = %ifcont24
+  br label %ifcont27
 
-ifcont33:                                         ; preds = %else32, %then31
-  %174 = alloca i64, align 8
-  %175 = load %array*, %array** %c, align 8
-  %176 = ptrtoint %array* %175 to i64
-  %177 = icmp eq i64 %176, 0
-  br i1 %177, label %merge_allocated35, label %check_data34
+ifcont27:                                         ; preds = %else26, %then25
+  %163 = alloca i64, align 8
+  %164 = load %array*, %array** %c, align 8
+  %165 = ptrtoint %array* %164 to i64
+  %166 = icmp eq i64 %165, 0
+  br i1 %166, label %merge_allocated29, label %check_data28
 
-check_data34:                                     ; preds = %ifcont33
-  %178 = getelementptr %array, %array* %175, i32 0, i32 0
-  %179 = load i32*, i32** %178, align 8
-  %180 = ptrtoint i32* %179 to i64
-  %181 = icmp ne i64 %180, 0
-  br label %merge_allocated35
+check_data28:                                     ; preds = %ifcont27
+  %167 = getelementptr %array, %array* %164, i32 0, i32 0
+  %168 = load i32*, i32** %167, align 8
+  %169 = ptrtoint i32* %168 to i64
+  %170 = icmp ne i64 %169, 0
+  br label %merge_allocated29
 
-merge_allocated35:                                ; preds = %check_data34, %ifcont33
-  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %181, %check_data34 ]
-  %182 = xor i1 %is_allocated36, true
-  br i1 %182, label %then37, label %ifcont38
+merge_allocated29:                                ; preds = %check_data28, %ifcont27
+  %is_allocated30 = phi i1 [ false, %ifcont27 ], [ %170, %check_data28 ]
+  %171 = xor i1 %is_allocated30, true
+  br i1 %171, label %then31, label %ifcont32
 
-then37:                                           ; preds = %merge_allocated35
+then31:                                           ; preds = %merge_allocated29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([101 x i8], [101 x i8]* @112, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @111, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont38:                                         ; preds = %merge_allocated35
-  %183 = getelementptr %array, %array* %175, i32 0, i32 2
-  %184 = load %dimension_descriptor*, %dimension_descriptor** %183, align 8
-  %185 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 0
-  %186 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 1
-  %187 = load i32, i32* %186, align 4
-  %188 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 2
-  %189 = load i32, i32* %188, align 4
-  %190 = sub i32 1, %187
-  %191 = add i32 %187, %189
-  %192 = sub i32 %191, 1
-  %193 = icmp slt i32 1, %187
-  %194 = icmp sgt i32 1, %192
-  %195 = or i1 %193, %194
-  br i1 %195, label %then39, label %ifcont40
+ifcont32:                                         ; preds = %merge_allocated29
+  %172 = getelementptr %array, %array* %164, i32 0, i32 2
+  %173 = load %dimension_descriptor*, %dimension_descriptor** %172, align 8
+  %174 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 0
+  %175 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 1
+  %176 = load i32, i32* %175, align 4
+  %177 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 2
+  %178 = load i32, i32* %177, align 4
+  %179 = sub i32 1, %176
+  %180 = add i32 %176, %178
+  %181 = sub i32 %180, 1
+  %182 = icmp slt i32 1, %176
+  %183 = icmp sgt i32 1, %181
+  %184 = or i1 %182, %183
+  br i1 %184, label %then33, label %ifcont34
 
-then39:                                           ; preds = %ifcont38
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @113, i32 0, i32 0), i32 1, i32 1, i32 %187, i32 %192)
+then33:                                           ; preds = %ifcont32
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @113, i32 0, i32 0), i32 1, i32 1, i32 %176, i32 %181)
   call void @exit(i32 1)
   unreachable
 
-ifcont40:                                         ; preds = %ifcont38
-  %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 0
-  %197 = load i32, i32* %196, align 4
-  %198 = mul i32 %197, %190
-  %199 = add i32 0, %198
-  %200 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 1
-  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 1
-  %202 = load i32, i32* %201, align 4
-  %203 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 2
-  %204 = load i32, i32* %203, align 4
-  %205 = sub i32 1, %202
-  %206 = add i32 %202, %204
-  %207 = sub i32 %206, 1
-  %208 = icmp slt i32 1, %202
-  %209 = icmp sgt i32 1, %207
-  %210 = or i1 %208, %209
-  br i1 %210, label %then41, label %ifcont42
+ifcont34:                                         ; preds = %ifcont32
+  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 0
+  %186 = load i32, i32* %185, align 4
+  %187 = mul i32 %186, %179
+  %188 = add i32 0, %187
+  %189 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 1
+  %190 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 1
+  %191 = load i32, i32* %190, align 4
+  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 2
+  %193 = load i32, i32* %192, align 4
+  %194 = sub i32 1, %191
+  %195 = add i32 %191, %193
+  %196 = sub i32 %195, 1
+  %197 = icmp slt i32 1, %191
+  %198 = icmp sgt i32 1, %196
+  %199 = or i1 %197, %198
+  br i1 %199, label %then35, label %ifcont36
 
-then41:                                           ; preds = %ifcont40
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @116, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i32 1, i32 2, i32 %202, i32 %207)
+then35:                                           ; preds = %ifcont34
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @116, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i32 1, i32 2, i32 %191, i32 %196)
   call void @exit(i32 1)
   unreachable
 
-ifcont42:                                         ; preds = %ifcont40
-  %211 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 0
-  %212 = load i32, i32* %211, align 4
-  %213 = mul i32 %212, %205
-  %214 = add i32 %199, %213
-  %215 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 2
-  %216 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 1
-  %217 = load i32, i32* %216, align 4
-  %218 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 2
-  %219 = load i32, i32* %218, align 4
-  %220 = sub i32 1, %217
-  %221 = add i32 %217, %219
-  %222 = sub i32 %221, 1
-  %223 = icmp slt i32 1, %217
-  %224 = icmp sgt i32 1, %222
-  %225 = or i1 %223, %224
-  br i1 %225, label %then43, label %ifcont44
+ifcont36:                                         ; preds = %ifcont34
+  %200 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 0
+  %201 = load i32, i32* %200, align 4
+  %202 = mul i32 %201, %194
+  %203 = add i32 %188, %202
+  %204 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 2
+  %205 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 1
+  %206 = load i32, i32* %205, align 4
+  %207 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 2
+  %208 = load i32, i32* %207, align 4
+  %209 = sub i32 1, %206
+  %210 = add i32 %206, %208
+  %211 = sub i32 %210, 1
+  %212 = icmp slt i32 1, %206
+  %213 = icmp sgt i32 1, %211
+  %214 = or i1 %212, %213
+  br i1 %214, label %then37, label %ifcont38
 
-then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @117, i32 0, i32 0), i32 1, i32 3, i32 %217, i32 %222)
+then37:                                           ; preds = %ifcont36
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @117, i32 0, i32 0), i32 1, i32 3, i32 %206, i32 %211)
   call void @exit(i32 1)
   unreachable
 
-ifcont44:                                         ; preds = %ifcont42
-  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 0
-  %227 = load i32, i32* %226, align 4
-  %228 = mul i32 %227, %220
-  %229 = add i32 %214, %228
-  %230 = getelementptr %array, %array* %175, i32 0, i32 1
-  %231 = load i32, i32* %230, align 4
-  %232 = add i32 %229, %231
-  %233 = getelementptr %array, %array* %175, i32 0, i32 0
-  %234 = load i32*, i32** %233, align 8
-  %235 = getelementptr inbounds i32, i32* %234, i32 %232
-  %236 = load i32, i32* %235, align 4
-  %237 = alloca i32, align 4
-  store i32 %236, i32* %237, align 4
-  %238 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %174, i32 0, i32 0, i32* %237)
-  %239 = load i64, i64* %174, align 4
+ifcont38:                                         ; preds = %ifcont36
+  %215 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 0
+  %216 = load i32, i32* %215, align 4
+  %217 = mul i32 %216, %209
+  %218 = add i32 %203, %217
+  %219 = getelementptr %array, %array* %164, i32 0, i32 1
+  %220 = load i32, i32* %219, align 4
+  %221 = add i32 %218, %220
+  %222 = getelementptr %array, %array* %164, i32 0, i32 0
+  %223 = load i32*, i32** %222, align 8
+  %224 = getelementptr inbounds i32, i32* %223, i32 %221
+  %225 = load i32, i32* %224, align 4
+  %226 = alloca i32, align 4
+  store i32 %225, i32* %226, align 4
+  %227 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %163, i32 0, i32 0, i32* %226)
+  %228 = load i64, i64* %163, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %240 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %238, i8** %240, align 8
-  %241 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %239, i64* %241, align 4
-  %242 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %243 = load i8*, i8** %242, align 8
-  %244 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %245 = load i64, i64* %244, align 4
-  %246 = trunc i64 %245 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* %243, i32 %246, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
-  %247 = icmp eq i8* %238, null
-  br i1 %247, label %free_done, label %free_nonnull
+  %229 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %227, i8** %229, align 8
+  %230 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %228, i64* %230, align 4
+  %231 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %232 = load i8*, i8** %231, align 8
+  %233 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %234 = load i64, i64* %233, align 4
+  %235 = trunc i64 %234 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* %232, i32 %235, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
+  %236 = icmp eq i8* %227, null
+  br i1 %236, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont44
-  call void @_lfortran_free(i8* %238)
+free_nonnull:                                     ; preds = %ifcont38
+  call void @_lfortran_free(i8* %227)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont44
+free_done:                                        ; preds = %free_nonnull, %ifcont38
   call void @_lpython_free_argv()
   br label %return
 
@@ -602,28 +573,28 @@ FINALIZE_SYMTABLE_allocate_03:                    ; preds = %return
   br label %Finalize_Variable_c
 
 Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_allocate_03
-  %248 = load %array*, %array** %c, align 8
-  %249 = icmp ne %array* %248, null
-  br i1 %249, label %is_allocated.then, label %is_allocated.else
+  %237 = load %array*, %array** %c, align 8
+  %238 = icmp ne %array* %237, null
+  br i1 %238, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %Finalize_Variable_c
-  %250 = getelementptr %array, %array* %248, i32 0, i32 0
-  %251 = load i32*, i32** %250, align 8
-  %252 = icmp eq i32* %251, null
-  br i1 %252, label %free_done46, label %free_nonnull45
+  %239 = getelementptr %array, %array* %237, i32 0, i32 0
+  %240 = load i32*, i32** %239, align 8
+  %241 = icmp eq i32* %240, null
+  br i1 %241, label %free_done40, label %free_nonnull39
 
-free_nonnull45:                                   ; preds = %is_allocated.then
-  %253 = bitcast i32* %251 to i8*
-  call void @_lfortran_free(i8* %253)
-  br label %free_done46
+free_nonnull39:                                   ; preds = %is_allocated.then
+  %242 = bitcast i32* %240 to i8*
+  call void @_lfortran_free(i8* %242)
+  br label %free_done40
 
-free_done46:                                      ; preds = %free_nonnull45, %is_allocated.then
+free_done40:                                      ; preds = %free_nonnull39, %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %Finalize_Variable_c
   br label %is_allocated.ifcont
 
-is_allocated.ifcont:                              ; preds = %is_allocated.else, %free_done46
+is_allocated.ifcont:                              ; preds = %is_allocated.else, %free_done40
   ret i32 0
 }
 
@@ -1108,384 +1079,355 @@ else:                                             ; preds = %ifcont17
   br label %ifcont19
 
 ifcont19:                                         ; preds = %else, %then18
-  %137 = load %array*, %array** %x, align 8
-  %138 = ptrtoint %array* %137 to i64
-  %139 = icmp eq i64 %138, 0
-  br i1 %139, label %merge_allocated21, label %check_data20
+  call void @f(%array** %x)
+  %137 = alloca i64, align 8
+  %138 = load %array*, %array** %x, align 8
+  %139 = ptrtoint %array* %138 to i64
+  %140 = icmp eq i64 %139, 0
+  br i1 %140, label %merge_allocated21, label %check_data20
 
 check_data20:                                     ; preds = %ifcont19
-  %140 = getelementptr %array, %array* %137, i32 0, i32 0
-  %141 = load i32*, i32** %140, align 8
-  %142 = ptrtoint i32* %141 to i64
-  %143 = icmp ne i64 %142, 0
+  %141 = getelementptr %array, %array* %138, i32 0, i32 0
+  %142 = load i32*, i32** %141, align 8
+  %143 = ptrtoint i32* %142 to i64
+  %144 = icmp ne i64 %143, 0
   br label %merge_allocated21
 
 merge_allocated21:                                ; preds = %check_data20, %ifcont19
-  %is_allocated22 = phi i1 [ false, %ifcont19 ], [ %143, %check_data20 ]
-  br i1 %is_allocated22, label %then23, label %else24
+  %is_allocated22 = phi i1 [ false, %ifcont19 ], [ %144, %check_data20 ]
+  %145 = xor i1 %is_allocated22, true
+  br i1 %145, label %then23, label %ifcont24
 
 then23:                                           ; preds = %merge_allocated21
-  %144 = getelementptr %array, %array* %137, i32 0, i32 0
-  %145 = load i32*, i32** %144, align 8
-  %146 = bitcast i32* %145 to i8*
-  call void @_lfortran_free(i8* %146)
-  %147 = getelementptr %array, %array* %137, i32 0, i32 0
-  store i32* null, i32** %147, align 8
-  br label %ifcont25
-
-else24:                                           ; preds = %merge_allocated21
-  br label %ifcont25
-
-ifcont25:                                         ; preds = %else24, %then23
-  call void @f(%array** %x)
-  %148 = alloca i64, align 8
-  %149 = load %array*, %array** %x, align 8
-  %150 = ptrtoint %array* %149 to i64
-  %151 = icmp eq i64 %150, 0
-  br i1 %151, label %merge_allocated27, label %check_data26
-
-check_data26:                                     ; preds = %ifcont25
-  %152 = getelementptr %array, %array* %149, i32 0, i32 0
-  %153 = load i32*, i32** %152, align 8
-  %154 = ptrtoint i32* %153 to i64
-  %155 = icmp ne i64 %154, 0
-  br label %merge_allocated27
-
-merge_allocated27:                                ; preds = %check_data26, %ifcont25
-  %is_allocated28 = phi i1 [ false, %ifcont25 ], [ %155, %check_data26 ]
-  %156 = xor i1 %is_allocated28, true
-  br i1 %156, label %then29, label %ifcont30
-
-then29:                                           ; preds = %merge_allocated27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([101 x i8], [101 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @31, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont30:                                         ; preds = %merge_allocated27
-  %157 = getelementptr %array, %array* %149, i32 0, i32 2
-  %158 = load %dimension_descriptor*, %dimension_descriptor** %157, align 8
-  %159 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %158, i32 0
-  %160 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 1
-  %161 = load i32, i32* %160, align 4
-  %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 2
-  %163 = load i32, i32* %162, align 4
-  %164 = sub i32 1, %161
-  %165 = add i32 %161, %163
-  %166 = sub i32 %165, 1
-  %167 = icmp slt i32 1, %161
-  %168 = icmp sgt i32 1, %166
-  %169 = or i1 %167, %168
-  br i1 %169, label %then31, label %ifcont32
+ifcont24:                                         ; preds = %merge_allocated21
+  %146 = getelementptr %array, %array* %138, i32 0, i32 2
+  %147 = load %dimension_descriptor*, %dimension_descriptor** %146, align 8
+  %148 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %147, i32 0
+  %149 = getelementptr %dimension_descriptor, %dimension_descriptor* %148, i32 0, i32 1
+  %150 = load i32, i32* %149, align 4
+  %151 = getelementptr %dimension_descriptor, %dimension_descriptor* %148, i32 0, i32 2
+  %152 = load i32, i32* %151, align 4
+  %153 = sub i32 1, %150
+  %154 = add i32 %150, %152
+  %155 = sub i32 %154, 1
+  %156 = icmp slt i32 1, %150
+  %157 = icmp sgt i32 1, %155
+  %158 = or i1 %156, %157
+  br i1 %158, label %then25, label %ifcont26
 
-then31:                                           ; preds = %ifcont30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 1, i32 %161, i32 %166)
+then25:                                           ; preds = %ifcont24
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @34, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 1, i32 %150, i32 %155)
   call void @exit(i32 1)
   unreachable
 
-ifcont32:                                         ; preds = %ifcont30
-  %170 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 0
-  %171 = load i32, i32* %170, align 4
-  %172 = mul i32 %171, %164
-  %173 = add i32 0, %172
-  %174 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %158, i32 1
-  %175 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 1
-  %176 = load i32, i32* %175, align 4
-  %177 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 2
-  %178 = load i32, i32* %177, align 4
-  %179 = sub i32 1, %176
-  %180 = add i32 %176, %178
-  %181 = sub i32 %180, 1
-  %182 = icmp slt i32 1, %176
-  %183 = icmp sgt i32 1, %181
-  %184 = or i1 %182, %183
-  br i1 %184, label %then33, label %ifcont34
+ifcont26:                                         ; preds = %ifcont24
+  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %148, i32 0, i32 0
+  %160 = load i32, i32* %159, align 4
+  %161 = mul i32 %160, %153
+  %162 = add i32 0, %161
+  %163 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %147, i32 1
+  %164 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 1
+  %165 = load i32, i32* %164, align 4
+  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 2
+  %167 = load i32, i32* %166, align 4
+  %168 = sub i32 1, %165
+  %169 = add i32 %165, %167
+  %170 = sub i32 %169, 1
+  %171 = icmp slt i32 1, %165
+  %172 = icmp sgt i32 1, %170
+  %173 = or i1 %171, %172
+  br i1 %173, label %then27, label %ifcont28
 
-then33:                                           ; preds = %ifcont32
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0), i32 1, i32 2, i32 %176, i32 %181)
+then27:                                           ; preds = %ifcont26
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @35, i32 0, i32 0), i32 1, i32 2, i32 %165, i32 %170)
   call void @exit(i32 1)
   unreachable
 
-ifcont34:                                         ; preds = %ifcont32
-  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 0
-  %186 = load i32, i32* %185, align 4
-  %187 = mul i32 %186, %179
-  %188 = add i32 %173, %187
-  %189 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %158, i32 2
-  %190 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 1
-  %191 = load i32, i32* %190, align 4
-  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 2
-  %193 = load i32, i32* %192, align 4
-  %194 = sub i32 1, %191
-  %195 = add i32 %191, %193
-  %196 = sub i32 %195, 1
-  %197 = icmp slt i32 1, %191
-  %198 = icmp sgt i32 1, %196
-  %199 = or i1 %197, %198
-  br i1 %199, label %then35, label %ifcont36
+ifcont28:                                         ; preds = %ifcont26
+  %174 = getelementptr %dimension_descriptor, %dimension_descriptor* %163, i32 0, i32 0
+  %175 = load i32, i32* %174, align 4
+  %176 = mul i32 %175, %168
+  %177 = add i32 %162, %176
+  %178 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %147, i32 2
+  %179 = getelementptr %dimension_descriptor, %dimension_descriptor* %178, i32 0, i32 1
+  %180 = load i32, i32* %179, align 4
+  %181 = getelementptr %dimension_descriptor, %dimension_descriptor* %178, i32 0, i32 2
+  %182 = load i32, i32* %181, align 4
+  %183 = sub i32 1, %180
+  %184 = add i32 %180, %182
+  %185 = sub i32 %184, 1
+  %186 = icmp slt i32 1, %180
+  %187 = icmp sgt i32 1, %185
+  %188 = or i1 %186, %187
+  br i1 %188, label %then29, label %ifcont30
 
-then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0), i32 1, i32 3, i32 %191, i32 %196)
+then29:                                           ; preds = %ifcont28
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @37, i32 0, i32 0), i32 1, i32 3, i32 %180, i32 %185)
   call void @exit(i32 1)
   unreachable
 
-ifcont36:                                         ; preds = %ifcont34
-  %200 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 0
-  %201 = load i32, i32* %200, align 4
-  %202 = mul i32 %201, %194
-  %203 = add i32 %188, %202
-  %204 = getelementptr %array, %array* %149, i32 0, i32 1
-  %205 = load i32, i32* %204, align 4
-  %206 = add i32 %203, %205
-  %207 = getelementptr %array, %array* %149, i32 0, i32 0
-  %208 = load i32*, i32** %207, align 8
-  %209 = getelementptr inbounds i32, i32* %208, i32 %206
-  %210 = load i32, i32* %209, align 4
-  %211 = alloca i32, align 4
-  store i32 %210, i32* %211, align 4
-  %212 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %148, i32 0, i32 0, i32* %211)
-  %213 = load i64, i64* %148, align 4
-  %stringFormat_desc37 = alloca %string_descriptor, align 8
-  %214 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  store i8* %212, i8** %214, align 8
-  %215 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  store i64 %213, i64* %215, align 4
-  %216 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  %217 = load i8*, i8** %216, align 8
-  %218 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  %219 = load i64, i64* %218, align 4
-  %220 = trunc i64 %219 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %217, i32 %220, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  %221 = icmp eq i8* %212, null
-  br i1 %221, label %free_done39, label %free_nonnull38
+ifcont30:                                         ; preds = %ifcont28
+  %189 = getelementptr %dimension_descriptor, %dimension_descriptor* %178, i32 0, i32 0
+  %190 = load i32, i32* %189, align 4
+  %191 = mul i32 %190, %183
+  %192 = add i32 %177, %191
+  %193 = getelementptr %array, %array* %138, i32 0, i32 1
+  %194 = load i32, i32* %193, align 4
+  %195 = add i32 %192, %194
+  %196 = getelementptr %array, %array* %138, i32 0, i32 0
+  %197 = load i32*, i32** %196, align 8
+  %198 = getelementptr inbounds i32, i32* %197, i32 %195
+  %199 = load i32, i32* %198, align 4
+  %200 = alloca i32, align 4
+  store i32 %199, i32* %200, align 4
+  %201 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %137, i32 0, i32 0, i32* %200)
+  %202 = load i64, i64* %137, align 4
+  %stringFormat_desc31 = alloca %string_descriptor, align 8
+  %203 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
+  store i8* %201, i8** %203, align 8
+  %204 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
+  store i64 %202, i64* %204, align 4
+  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
+  %206 = load i8*, i8** %205, align 8
+  %207 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
+  %208 = load i64, i64* %207, align 4
+  %209 = trunc i64 %208 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %206, i32 %209, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  %210 = icmp eq i8* %201, null
+  br i1 %210, label %free_done33, label %free_nonnull32
 
-free_nonnull38:                                   ; preds = %ifcont36
-  call void @_lfortran_free(i8* %212)
-  br label %free_done39
+free_nonnull32:                                   ; preds = %ifcont30
+  call void @_lfortran_free(i8* %201)
+  br label %free_done33
 
-free_done39:                                      ; preds = %free_nonnull38, %ifcont36
-  %222 = load %array*, %array** %x, align 8
-  %223 = ptrtoint %array* %222 to i64
-  %224 = icmp eq i64 %223, 0
-  br i1 %224, label %merge_allocated41, label %check_data40
+free_done33:                                      ; preds = %free_nonnull32, %ifcont30
+  %211 = load %array*, %array** %x, align 8
+  %212 = ptrtoint %array* %211 to i64
+  %213 = icmp eq i64 %212, 0
+  br i1 %213, label %merge_allocated35, label %check_data34
 
-check_data40:                                     ; preds = %free_done39
-  %225 = getelementptr %array, %array* %222, i32 0, i32 0
-  %226 = load i32*, i32** %225, align 8
-  %227 = ptrtoint i32* %226 to i64
-  %228 = icmp ne i64 %227, 0
-  br label %merge_allocated41
+check_data34:                                     ; preds = %free_done33
+  %214 = getelementptr %array, %array* %211, i32 0, i32 0
+  %215 = load i32*, i32** %214, align 8
+  %216 = ptrtoint i32* %215 to i64
+  %217 = icmp ne i64 %216, 0
+  br label %merge_allocated35
 
-merge_allocated41:                                ; preds = %check_data40, %free_done39
-  %is_allocated42 = phi i1 [ false, %free_done39 ], [ %228, %check_data40 ]
-  %229 = xor i1 %is_allocated42, true
-  br i1 %229, label %then43, label %ifcont44
+merge_allocated35:                                ; preds = %check_data34, %free_done33
+  %is_allocated36 = phi i1 [ false, %free_done33 ], [ %217, %check_data34 ]
+  %218 = xor i1 %is_allocated36, true
+  br i1 %218, label %then37, label %ifcont38
 
-then43:                                           ; preds = %merge_allocated41
+then37:                                           ; preds = %merge_allocated35
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont44:                                         ; preds = %merge_allocated41
-  %230 = getelementptr %array, %array* %222, i32 0, i32 2
-  %231 = load %dimension_descriptor*, %dimension_descriptor** %230, align 8
-  %232 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 0
-  %233 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 1
-  %234 = load i32, i32* %233, align 4
-  %235 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 2
-  %236 = load i32, i32* %235, align 4
-  %237 = sub i32 1, %234
-  %238 = add i32 %234, %236
-  %239 = sub i32 %238, 1
-  %240 = icmp slt i32 1, %234
-  %241 = icmp sgt i32 1, %239
-  %242 = or i1 %240, %241
-  br i1 %242, label %then45, label %ifcont46
+ifcont38:                                         ; preds = %merge_allocated35
+  %219 = getelementptr %array, %array* %211, i32 0, i32 2
+  %220 = load %dimension_descriptor*, %dimension_descriptor** %219, align 8
+  %221 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %220, i32 0
+  %222 = getelementptr %dimension_descriptor, %dimension_descriptor* %221, i32 0, i32 1
+  %223 = load i32, i32* %222, align 4
+  %224 = getelementptr %dimension_descriptor, %dimension_descriptor* %221, i32 0, i32 2
+  %225 = load i32, i32* %224, align 4
+  %226 = sub i32 1, %223
+  %227 = add i32 %223, %225
+  %228 = sub i32 %227, 1
+  %229 = icmp slt i32 1, %223
+  %230 = icmp sgt i32 1, %228
+  %231 = or i1 %229, %230
+  br i1 %231, label %then39, label %ifcont40
+
+then39:                                           ; preds = %ifcont38
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %223, i32 %228)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont40:                                         ; preds = %ifcont38
+  %232 = getelementptr %dimension_descriptor, %dimension_descriptor* %221, i32 0, i32 0
+  %233 = load i32, i32* %232, align 4
+  %234 = mul i32 %233, %226
+  %235 = add i32 0, %234
+  %236 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %220, i32 1
+  %237 = getelementptr %dimension_descriptor, %dimension_descriptor* %236, i32 0, i32 1
+  %238 = load i32, i32* %237, align 4
+  %239 = getelementptr %dimension_descriptor, %dimension_descriptor* %236, i32 0, i32 2
+  %240 = load i32, i32* %239, align 4
+  %241 = sub i32 1, %238
+  %242 = add i32 %238, %240
+  %243 = sub i32 %242, 1
+  %244 = icmp slt i32 1, %238
+  %245 = icmp sgt i32 1, %243
+  %246 = or i1 %244, %245
+  br i1 %246, label %then41, label %ifcont42
+
+then41:                                           ; preds = %ifcont40
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1, i32 2, i32 %238, i32 %243)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont42:                                         ; preds = %ifcont40
+  %247 = getelementptr %dimension_descriptor, %dimension_descriptor* %236, i32 0, i32 0
+  %248 = load i32, i32* %247, align 4
+  %249 = mul i32 %248, %241
+  %250 = add i32 %235, %249
+  %251 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %220, i32 2
+  %252 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 1
+  %253 = load i32, i32* %252, align 4
+  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 2
+  %255 = load i32, i32* %254, align 4
+  %256 = sub i32 1, %253
+  %257 = add i32 %253, %255
+  %258 = sub i32 %257, 1
+  %259 = icmp slt i32 1, %253
+  %260 = icmp sgt i32 1, %258
+  %261 = or i1 %259, %260
+  br i1 %261, label %then43, label %ifcont44
+
+then43:                                           ; preds = %ifcont42
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 3, i32 %253, i32 %258)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont44:                                         ; preds = %ifcont42
+  %262 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 0
+  %263 = load i32, i32* %262, align 4
+  %264 = mul i32 %263, %256
+  %265 = add i32 %250, %264
+  %266 = getelementptr %array, %array* %211, i32 0, i32 1
+  %267 = load i32, i32* %266, align 4
+  %268 = add i32 %265, %267
+  %269 = getelementptr %array, %array* %211, i32 0, i32 0
+  %270 = load i32*, i32** %269, align 8
+  %271 = getelementptr inbounds i32, i32* %270, i32 %268
+  %272 = load i32, i32* %271, align 4
+  %273 = icmp ne i32 %272, 99
+  br i1 %273, label %then45, label %else46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %234, i32 %239)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont46:                                         ; preds = %ifcont44
-  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %232, i32 0, i32 0
-  %244 = load i32, i32* %243, align 4
-  %245 = mul i32 %244, %237
-  %246 = add i32 0, %245
-  %247 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 1
-  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 1
-  %249 = load i32, i32* %248, align 4
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 2
-  %251 = load i32, i32* %250, align 4
-  %252 = sub i32 1, %249
-  %253 = add i32 %249, %251
-  %254 = sub i32 %253, 1
-  %255 = icmp slt i32 1, %249
-  %256 = icmp sgt i32 1, %254
-  %257 = or i1 %255, %256
-  br i1 %257, label %then47, label %ifcont48
-
-then47:                                           ; preds = %ifcont46
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1, i32 2, i32 %249, i32 %254)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont48:                                         ; preds = %ifcont46
-  %258 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 0
-  %259 = load i32, i32* %258, align 4
-  %260 = mul i32 %259, %252
-  %261 = add i32 %246, %260
-  %262 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %231, i32 2
-  %263 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 1
-  %264 = load i32, i32* %263, align 4
-  %265 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 2
-  %266 = load i32, i32* %265, align 4
-  %267 = sub i32 1, %264
-  %268 = add i32 %264, %266
-  %269 = sub i32 %268, 1
-  %270 = icmp slt i32 1, %264
-  %271 = icmp sgt i32 1, %269
-  %272 = or i1 %270, %271
-  br i1 %272, label %then49, label %ifcont50
-
-then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 3, i32 %264, i32 %269)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont50:                                         ; preds = %ifcont48
-  %273 = getelementptr %dimension_descriptor, %dimension_descriptor* %262, i32 0, i32 0
-  %274 = load i32, i32* %273, align 4
-  %275 = mul i32 %274, %267
-  %276 = add i32 %261, %275
-  %277 = getelementptr %array, %array* %222, i32 0, i32 1
-  %278 = load i32, i32* %277, align 4
-  %279 = add i32 %276, %278
-  %280 = getelementptr %array, %array* %222, i32 0, i32 0
-  %281 = load i32*, i32** %280, align 8
-  %282 = getelementptr inbounds i32, i32* %281, i32 %279
-  %283 = load i32, i32* %282, align 4
-  %284 = icmp ne i32 %283, 99
-  br i1 %284, label %then51, label %else52
-
-then51:                                           ; preds = %ifcont50
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont53
+  br label %ifcont47
 
-else52:                                           ; preds = %ifcont50
-  br label %ifcont53
+else46:                                           ; preds = %ifcont44
+  br label %ifcont47
 
-ifcont53:                                         ; preds = %else52, %then51
-  %285 = load %array*, %array** %x, align 8
-  %286 = ptrtoint %array* %285 to i64
-  %287 = icmp eq i64 %286, 0
-  br i1 %287, label %merge_allocated55, label %check_data54
+ifcont47:                                         ; preds = %else46, %then45
+  %274 = load %array*, %array** %x, align 8
+  %275 = ptrtoint %array* %274 to i64
+  %276 = icmp eq i64 %275, 0
+  br i1 %276, label %merge_allocated49, label %check_data48
 
-check_data54:                                     ; preds = %ifcont53
-  %288 = getelementptr %array, %array* %285, i32 0, i32 0
-  %289 = load i32*, i32** %288, align 8
-  %290 = ptrtoint i32* %289 to i64
-  %291 = icmp ne i64 %290, 0
-  br label %merge_allocated55
+check_data48:                                     ; preds = %ifcont47
+  %277 = getelementptr %array, %array* %274, i32 0, i32 0
+  %278 = load i32*, i32** %277, align 8
+  %279 = ptrtoint i32* %278 to i64
+  %280 = icmp ne i64 %279, 0
+  br label %merge_allocated49
 
-merge_allocated55:                                ; preds = %check_data54, %ifcont53
-  %is_allocated56 = phi i1 [ false, %ifcont53 ], [ %291, %check_data54 ]
-  %292 = xor i1 %is_allocated56, true
-  br i1 %292, label %then57, label %ifcont58
+merge_allocated49:                                ; preds = %check_data48, %ifcont47
+  %is_allocated50 = phi i1 [ false, %ifcont47 ], [ %280, %check_data48 ]
+  %281 = xor i1 %is_allocated50, true
+  br i1 %281, label %then51, label %ifcont52
 
-then57:                                           ; preds = %merge_allocated55
+then51:                                           ; preds = %merge_allocated49
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont58:                                         ; preds = %merge_allocated55
-  %293 = getelementptr %array, %array* %285, i32 0, i32 2
-  %294 = load %dimension_descriptor*, %dimension_descriptor** %293, align 8
-  %295 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 0
-  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 1
-  %297 = load i32, i32* %296, align 4
-  %298 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 2
-  %299 = load i32, i32* %298, align 4
-  %300 = sub i32 1, %297
-  %301 = add i32 %297, %299
-  %302 = sub i32 %301, 1
-  %303 = icmp slt i32 1, %297
-  %304 = icmp sgt i32 1, %302
-  %305 = or i1 %303, %304
-  br i1 %305, label %then59, label %ifcont60
+ifcont52:                                         ; preds = %merge_allocated49
+  %282 = getelementptr %array, %array* %274, i32 0, i32 2
+  %283 = load %dimension_descriptor*, %dimension_descriptor** %282, align 8
+  %284 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %283, i32 0
+  %285 = getelementptr %dimension_descriptor, %dimension_descriptor* %284, i32 0, i32 1
+  %286 = load i32, i32* %285, align 4
+  %287 = getelementptr %dimension_descriptor, %dimension_descriptor* %284, i32 0, i32 2
+  %288 = load i32, i32* %287, align 4
+  %289 = sub i32 1, %286
+  %290 = add i32 %286, %288
+  %291 = sub i32 %290, 1
+  %292 = icmp slt i32 1, %286
+  %293 = icmp sgt i32 1, %291
+  %294 = or i1 %292, %293
+  br i1 %294, label %then53, label %ifcont54
 
-then59:                                           ; preds = %ifcont58
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1, i32 1, i32 %297, i32 %302)
+then53:                                           ; preds = %ifcont52
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1, i32 1, i32 %286, i32 %291)
   call void @exit(i32 1)
   unreachable
 
-ifcont60:                                         ; preds = %ifcont58
-  %306 = getelementptr %dimension_descriptor, %dimension_descriptor* %295, i32 0, i32 0
-  %307 = load i32, i32* %306, align 4
-  %308 = mul i32 %307, %300
-  %309 = add i32 0, %308
-  %310 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 1
-  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 1
-  %312 = load i32, i32* %311, align 4
-  %313 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 2
-  %314 = load i32, i32* %313, align 4
-  %315 = sub i32 1, %312
-  %316 = add i32 %312, %314
-  %317 = sub i32 %316, 1
-  %318 = icmp slt i32 1, %312
-  %319 = icmp sgt i32 1, %317
-  %320 = or i1 %318, %319
-  br i1 %320, label %then61, label %ifcont62
+ifcont54:                                         ; preds = %ifcont52
+  %295 = getelementptr %dimension_descriptor, %dimension_descriptor* %284, i32 0, i32 0
+  %296 = load i32, i32* %295, align 4
+  %297 = mul i32 %296, %289
+  %298 = add i32 0, %297
+  %299 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %283, i32 1
+  %300 = getelementptr %dimension_descriptor, %dimension_descriptor* %299, i32 0, i32 1
+  %301 = load i32, i32* %300, align 4
+  %302 = getelementptr %dimension_descriptor, %dimension_descriptor* %299, i32 0, i32 2
+  %303 = load i32, i32* %302, align 4
+  %304 = sub i32 1, %301
+  %305 = add i32 %301, %303
+  %306 = sub i32 %305, 1
+  %307 = icmp slt i32 1, %301
+  %308 = icmp sgt i32 1, %306
+  %309 = or i1 %307, %308
+  br i1 %309, label %then55, label %ifcont56
 
-then61:                                           ; preds = %ifcont60
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 1, i32 2, i32 %312, i32 %317)
+then55:                                           ; preds = %ifcont54
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i32 1, i32 2, i32 %301, i32 %306)
   call void @exit(i32 1)
   unreachable
 
-ifcont62:                                         ; preds = %ifcont60
-  %321 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 0
-  %322 = load i32, i32* %321, align 4
-  %323 = mul i32 %322, %315
-  %324 = add i32 %309, %323
-  %325 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %294, i32 2
-  %326 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 1
-  %327 = load i32, i32* %326, align 4
-  %328 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 2
-  %329 = load i32, i32* %328, align 4
-  %330 = sub i32 1, %327
-  %331 = add i32 %327, %329
-  %332 = sub i32 %331, 1
-  %333 = icmp slt i32 1, %327
-  %334 = icmp sgt i32 1, %332
-  %335 = or i1 %333, %334
-  br i1 %335, label %then63, label %ifcont64
+ifcont56:                                         ; preds = %ifcont54
+  %310 = getelementptr %dimension_descriptor, %dimension_descriptor* %299, i32 0, i32 0
+  %311 = load i32, i32* %310, align 4
+  %312 = mul i32 %311, %304
+  %313 = add i32 %298, %312
+  %314 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %283, i32 2
+  %315 = getelementptr %dimension_descriptor, %dimension_descriptor* %314, i32 0, i32 1
+  %316 = load i32, i32* %315, align 4
+  %317 = getelementptr %dimension_descriptor, %dimension_descriptor* %314, i32 0, i32 2
+  %318 = load i32, i32* %317, align 4
+  %319 = sub i32 1, %316
+  %320 = add i32 %316, %318
+  %321 = sub i32 %320, 1
+  %322 = icmp slt i32 1, %316
+  %323 = icmp sgt i32 1, %321
+  %324 = or i1 %322, %323
+  br i1 %324, label %then57, label %ifcont58
 
-then63:                                           ; preds = %ifcont62
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 3, i32 %327, i32 %332)
+then57:                                           ; preds = %ifcont56
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1, i32 3, i32 %316, i32 %321)
   call void @exit(i32 1)
   unreachable
 
-ifcont64:                                         ; preds = %ifcont62
-  %336 = getelementptr %dimension_descriptor, %dimension_descriptor* %325, i32 0, i32 0
-  %337 = load i32, i32* %336, align 4
-  %338 = mul i32 %337, %330
-  %339 = add i32 %324, %338
-  %340 = getelementptr %array, %array* %285, i32 0, i32 1
-  %341 = load i32, i32* %340, align 4
-  %342 = add i32 %339, %341
-  %343 = getelementptr %array, %array* %285, i32 0, i32 0
-  %344 = load i32*, i32** %343, align 8
-  %345 = getelementptr inbounds i32, i32* %344, i32 %342
-  store i32 8, i32* %345, align 4
+ifcont58:                                         ; preds = %ifcont56
+  %325 = getelementptr %dimension_descriptor, %dimension_descriptor* %314, i32 0, i32 0
+  %326 = load i32, i32* %325, align 4
+  %327 = mul i32 %326, %319
+  %328 = add i32 %313, %327
+  %329 = getelementptr %array, %array* %274, i32 0, i32 1
+  %330 = load i32, i32* %329, align 4
+  %331 = add i32 %328, %330
+  %332 = getelementptr %array, %array* %274, i32 0, i32 0
+  %333 = load i32*, i32** %332, align 8
+  %334 = getelementptr inbounds i32, i32* %333, i32 %331
+  store i32 8, i32* %334, align 4
   store i32 0, i32* %r, align 4
   br label %return
 
-return:                                           ; preds = %ifcont64
+return:                                           ; preds = %ifcont58
   br label %FINALIZE_SYMTABLE_g
 
 FINALIZE_SYMTABLE_g:                              ; preds = %return
-  %346 = load i32, i32* %r, align 4
-  ret i32 %346
+  %335 = load i32, i32* %r, align 4
+  ret i32 %335
 }
 
 define void @h(%array** %c) {
@@ -1569,378 +1511,349 @@ else11:                                           ; preds = %merge_allocated8
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %27 = load %array*, %array** %c, align 8
-  %28 = ptrtoint %array* %27 to i64
-  %29 = icmp eq i64 %28, 0
-  br i1 %29, label %merge_allocated14, label %check_data13
+  call void @f(%array** %c)
+  %27 = alloca i64, align 8
+  %28 = load %array*, %array** %c, align 8
+  %29 = ptrtoint %array* %28 to i64
+  %30 = icmp eq i64 %29, 0
+  br i1 %30, label %merge_allocated14, label %check_data13
 
 check_data13:                                     ; preds = %ifcont12
-  %30 = getelementptr %array, %array* %27, i32 0, i32 0
-  %31 = load i32*, i32** %30, align 8
-  %32 = ptrtoint i32* %31 to i64
-  %33 = icmp ne i64 %32, 0
+  %31 = getelementptr %array, %array* %28, i32 0, i32 0
+  %32 = load i32*, i32** %31, align 8
+  %33 = ptrtoint i32* %32 to i64
+  %34 = icmp ne i64 %33, 0
   br label %merge_allocated14
 
 merge_allocated14:                                ; preds = %check_data13, %ifcont12
-  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %33, %check_data13 ]
-  br i1 %is_allocated15, label %then16, label %else17
+  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %34, %check_data13 ]
+  %35 = xor i1 %is_allocated15, true
+  br i1 %35, label %then16, label %ifcont17
 
 then16:                                           ; preds = %merge_allocated14
-  %34 = getelementptr %array, %array* %27, i32 0, i32 0
-  %35 = load i32*, i32** %34, align 8
-  %36 = bitcast i32* %35 to i8*
-  call void @_lfortran_free(i8* %36)
-  %37 = getelementptr %array, %array* %27, i32 0, i32 0
-  store i32* null, i32** %37, align 8
-  br label %ifcont18
-
-else17:                                           ; preds = %merge_allocated14
-  br label %ifcont18
-
-ifcont18:                                         ; preds = %else17, %then16
-  call void @f(%array** %c)
-  %38 = alloca i64, align 8
-  %39 = load %array*, %array** %c, align 8
-  %40 = ptrtoint %array* %39 to i64
-  %41 = icmp eq i64 %40, 0
-  br i1 %41, label %merge_allocated20, label %check_data19
-
-check_data19:                                     ; preds = %ifcont18
-  %42 = getelementptr %array, %array* %39, i32 0, i32 0
-  %43 = load i32*, i32** %42, align 8
-  %44 = ptrtoint i32* %43 to i64
-  %45 = icmp ne i64 %44, 0
-  br label %merge_allocated20
-
-merge_allocated20:                                ; preds = %check_data19, %ifcont18
-  %is_allocated21 = phi i1 [ false, %ifcont18 ], [ %45, %check_data19 ]
-  %46 = xor i1 %is_allocated21, true
-  br i1 %46, label %then22, label %ifcont23
-
-then22:                                           ; preds = %merge_allocated20
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([101 x i8], [101 x i8]* @62, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont23:                                         ; preds = %merge_allocated20
-  %47 = getelementptr %array, %array* %39, i32 0, i32 2
-  %48 = load %dimension_descriptor*, %dimension_descriptor** %47, align 8
-  %49 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 0
-  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 1
-  %51 = load i32, i32* %50, align 4
-  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 2
-  %53 = load i32, i32* %52, align 4
-  %54 = sub i32 1, %51
-  %55 = add i32 %51, %53
-  %56 = sub i32 %55, 1
-  %57 = icmp slt i32 1, %51
-  %58 = icmp sgt i32 1, %56
-  %59 = or i1 %57, %58
-  br i1 %59, label %then24, label %ifcont25
+ifcont17:                                         ; preds = %merge_allocated14
+  %36 = getelementptr %array, %array* %28, i32 0, i32 2
+  %37 = load %dimension_descriptor*, %dimension_descriptor** %36, align 8
+  %38 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 0
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
+  %40 = load i32, i32* %39, align 4
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
+  %42 = load i32, i32* %41, align 4
+  %43 = sub i32 1, %40
+  %44 = add i32 %40, %42
+  %45 = sub i32 %44, 1
+  %46 = icmp slt i32 1, %40
+  %47 = icmp sgt i32 1, %45
+  %48 = or i1 %46, %47
+  br i1 %48, label %then18, label %ifcont19
 
-then24:                                           ; preds = %ifcont23
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @64, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @63, i32 0, i32 0), i32 1, i32 1, i32 %51, i32 %56)
+then18:                                           ; preds = %ifcont17
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @64, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @63, i32 0, i32 0), i32 1, i32 1, i32 %40, i32 %45)
   call void @exit(i32 1)
   unreachable
 
-ifcont25:                                         ; preds = %ifcont23
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %49, i32 0, i32 0
-  %61 = load i32, i32* %60, align 4
-  %62 = mul i32 %61, %54
-  %63 = add i32 0, %62
-  %64 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 1
-  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 1
-  %66 = load i32, i32* %65, align 4
-  %67 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 2
-  %68 = load i32, i32* %67, align 4
-  %69 = sub i32 1, %66
-  %70 = add i32 %66, %68
-  %71 = sub i32 %70, 1
-  %72 = icmp slt i32 1, %66
-  %73 = icmp sgt i32 1, %71
-  %74 = or i1 %72, %73
-  br i1 %74, label %then26, label %ifcont27
+ifcont19:                                         ; preds = %ifcont17
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
+  %50 = load i32, i32* %49, align 4
+  %51 = mul i32 %50, %43
+  %52 = add i32 0, %51
+  %53 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 1
+  %54 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 1
+  %55 = load i32, i32* %54, align 4
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 2
+  %57 = load i32, i32* %56, align 4
+  %58 = sub i32 1, %55
+  %59 = add i32 %55, %57
+  %60 = sub i32 %59, 1
+  %61 = icmp slt i32 1, %55
+  %62 = icmp sgt i32 1, %60
+  %63 = or i1 %61, %62
+  br i1 %63, label %then20, label %ifcont21
 
-then26:                                           ; preds = %ifcont25
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @65, i32 0, i32 0), i32 1, i32 2, i32 %66, i32 %71)
+then20:                                           ; preds = %ifcont19
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @66, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @65, i32 0, i32 0), i32 1, i32 2, i32 %55, i32 %60)
   call void @exit(i32 1)
   unreachable
 
-ifcont27:                                         ; preds = %ifcont25
-  %75 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 0
-  %76 = load i32, i32* %75, align 4
-  %77 = mul i32 %76, %69
-  %78 = add i32 %63, %77
-  %79 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %48, i32 2
-  %80 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 1
-  %81 = load i32, i32* %80, align 4
-  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 2
-  %83 = load i32, i32* %82, align 4
-  %84 = sub i32 1, %81
-  %85 = add i32 %81, %83
-  %86 = sub i32 %85, 1
-  %87 = icmp slt i32 1, %81
-  %88 = icmp sgt i32 1, %86
-  %89 = or i1 %87, %88
-  br i1 %89, label %then28, label %ifcont29
+ifcont21:                                         ; preds = %ifcont19
+  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %53, i32 0, i32 0
+  %65 = load i32, i32* %64, align 4
+  %66 = mul i32 %65, %58
+  %67 = add i32 %52, %66
+  %68 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 2
+  %69 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 1
+  %70 = load i32, i32* %69, align 4
+  %71 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 2
+  %72 = load i32, i32* %71, align 4
+  %73 = sub i32 1, %70
+  %74 = add i32 %70, %72
+  %75 = sub i32 %74, 1
+  %76 = icmp slt i32 1, %70
+  %77 = icmp sgt i32 1, %75
+  %78 = or i1 %76, %77
+  br i1 %78, label %then22, label %ifcont23
 
-then28:                                           ; preds = %ifcont27
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0), i32 1, i32 3, i32 %81, i32 %86)
+then22:                                           ; preds = %ifcont21
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([163 x i8], [163 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @67, i32 0, i32 0), i32 1, i32 3, i32 %70, i32 %75)
   call void @exit(i32 1)
   unreachable
 
-ifcont29:                                         ; preds = %ifcont27
-  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %79, i32 0, i32 0
-  %91 = load i32, i32* %90, align 4
-  %92 = mul i32 %91, %84
-  %93 = add i32 %78, %92
-  %94 = getelementptr %array, %array* %39, i32 0, i32 1
-  %95 = load i32, i32* %94, align 4
-  %96 = add i32 %93, %95
-  %97 = getelementptr %array, %array* %39, i32 0, i32 0
-  %98 = load i32*, i32** %97, align 8
-  %99 = getelementptr inbounds i32, i32* %98, i32 %96
-  %100 = load i32, i32* %99, align 4
-  %101 = alloca i32, align 4
-  store i32 %100, i32* %101, align 4
-  %102 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %38, i32 0, i32 0, i32* %101)
-  %103 = load i64, i64* %38, align 4
+ifcont23:                                         ; preds = %ifcont21
+  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %68, i32 0, i32 0
+  %80 = load i32, i32* %79, align 4
+  %81 = mul i32 %80, %73
+  %82 = add i32 %67, %81
+  %83 = getelementptr %array, %array* %28, i32 0, i32 1
+  %84 = load i32, i32* %83, align 4
+  %85 = add i32 %82, %84
+  %86 = getelementptr %array, %array* %28, i32 0, i32 0
+  %87 = load i32*, i32** %86, align 8
+  %88 = getelementptr inbounds i32, i32* %87, i32 %85
+  %89 = load i32, i32* %88, align 4
+  %90 = alloca i32, align 4
+  store i32 %89, i32* %90, align 4
+  %91 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %90)
+  %92 = load i64, i64* %27, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %104 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %102, i8** %104, align 8
-  %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %103, i64* %105, align 4
-  %106 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %107 = load i8*, i8** %106, align 8
-  %108 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %109 = load i64, i64* %108, align 4
-  %110 = trunc i64 %109 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* %107, i32 %110, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 1)
-  %111 = icmp eq i8* %102, null
-  br i1 %111, label %free_done, label %free_nonnull
+  %93 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %91, i8** %93, align 8
+  %94 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %92, i64* %94, align 4
+  %95 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %96 = load i8*, i8** %95, align 8
+  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %98 = load i64, i64* %97, align 4
+  %99 = trunc i64 %98 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* %96, i32 %99, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i32 1)
+  %100 = icmp eq i8* %91, null
+  br i1 %100, label %free_done, label %free_nonnull
 
-free_nonnull:                                     ; preds = %ifcont29
-  call void @_lfortran_free(i8* %102)
+free_nonnull:                                     ; preds = %ifcont23
+  call void @_lfortran_free(i8* %91)
   br label %free_done
 
-free_done:                                        ; preds = %free_nonnull, %ifcont29
-  %112 = load %array*, %array** %c, align 8
-  %113 = ptrtoint %array* %112 to i64
-  %114 = icmp eq i64 %113, 0
-  br i1 %114, label %merge_allocated31, label %check_data30
+free_done:                                        ; preds = %free_nonnull, %ifcont23
+  %101 = load %array*, %array** %c, align 8
+  %102 = ptrtoint %array* %101 to i64
+  %103 = icmp eq i64 %102, 0
+  br i1 %103, label %merge_allocated25, label %check_data24
 
-check_data30:                                     ; preds = %free_done
-  %115 = getelementptr %array, %array* %112, i32 0, i32 0
-  %116 = load i32*, i32** %115, align 8
-  %117 = ptrtoint i32* %116 to i64
-  %118 = icmp ne i64 %117, 0
-  br label %merge_allocated31
+check_data24:                                     ; preds = %free_done
+  %104 = getelementptr %array, %array* %101, i32 0, i32 0
+  %105 = load i32*, i32** %104, align 8
+  %106 = ptrtoint i32* %105 to i64
+  %107 = icmp ne i64 %106, 0
+  br label %merge_allocated25
 
-merge_allocated31:                                ; preds = %check_data30, %free_done
-  %is_allocated32 = phi i1 [ false, %free_done ], [ %118, %check_data30 ]
-  %119 = xor i1 %is_allocated32, true
-  br i1 %119, label %then33, label %ifcont34
+merge_allocated25:                                ; preds = %check_data24, %free_done
+  %is_allocated26 = phi i1 [ false, %free_done ], [ %107, %check_data24 ]
+  %108 = xor i1 %is_allocated26, true
+  br i1 %108, label %then27, label %ifcont28
 
-then33:                                           ; preds = %merge_allocated31
+then27:                                           ; preds = %merge_allocated25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont34:                                         ; preds = %merge_allocated31
-  %120 = getelementptr %array, %array* %112, i32 0, i32 2
-  %121 = load %dimension_descriptor*, %dimension_descriptor** %120, align 8
-  %122 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %121, i32 0
-  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 1
-  %124 = load i32, i32* %123, align 4
-  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 2
-  %126 = load i32, i32* %125, align 4
-  %127 = sub i32 1, %124
-  %128 = add i32 %124, %126
-  %129 = sub i32 %128, 1
-  %130 = icmp slt i32 1, %124
-  %131 = icmp sgt i32 1, %129
-  %132 = or i1 %130, %131
-  br i1 %132, label %then35, label %ifcont36
+ifcont28:                                         ; preds = %merge_allocated25
+  %109 = getelementptr %array, %array* %101, i32 0, i32 2
+  %110 = load %dimension_descriptor*, %dimension_descriptor** %109, align 8
+  %111 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %110, i32 0
+  %112 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 1
+  %113 = load i32, i32* %112, align 4
+  %114 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 2
+  %115 = load i32, i32* %114, align 4
+  %116 = sub i32 1, %113
+  %117 = add i32 %113, %115
+  %118 = sub i32 %117, 1
+  %119 = icmp slt i32 1, %113
+  %120 = icmp sgt i32 1, %118
+  %121 = or i1 %119, %120
+  br i1 %121, label %then29, label %ifcont30
+
+then29:                                           ; preds = %ifcont28
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 1, i32 1, i32 %113, i32 %118)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont30:                                         ; preds = %ifcont28
+  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 0
+  %123 = load i32, i32* %122, align 4
+  %124 = mul i32 %123, %116
+  %125 = add i32 0, %124
+  %126 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %110, i32 1
+  %127 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 1
+  %128 = load i32, i32* %127, align 4
+  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 2
+  %130 = load i32, i32* %129, align 4
+  %131 = sub i32 1, %128
+  %132 = add i32 %128, %130
+  %133 = sub i32 %132, 1
+  %134 = icmp slt i32 1, %128
+  %135 = icmp sgt i32 1, %133
+  %136 = or i1 %134, %135
+  br i1 %136, label %then31, label %ifcont32
+
+then31:                                           ; preds = %ifcont30
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 2, i32 %128, i32 %133)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont32:                                         ; preds = %ifcont30
+  %137 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 0
+  %138 = load i32, i32* %137, align 4
+  %139 = mul i32 %138, %131
+  %140 = add i32 %125, %139
+  %141 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %110, i32 2
+  %142 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 1
+  %143 = load i32, i32* %142, align 4
+  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 2
+  %145 = load i32, i32* %144, align 4
+  %146 = sub i32 1, %143
+  %147 = add i32 %143, %145
+  %148 = sub i32 %147, 1
+  %149 = icmp slt i32 1, %143
+  %150 = icmp sgt i32 1, %148
+  %151 = or i1 %149, %150
+  br i1 %151, label %then33, label %ifcont34
+
+then33:                                           ; preds = %ifcont32
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 3, i32 %143, i32 %148)
+  call void @exit(i32 1)
+  unreachable
+
+ifcont34:                                         ; preds = %ifcont32
+  %152 = getelementptr %dimension_descriptor, %dimension_descriptor* %141, i32 0, i32 0
+  %153 = load i32, i32* %152, align 4
+  %154 = mul i32 %153, %146
+  %155 = add i32 %140, %154
+  %156 = getelementptr %array, %array* %101, i32 0, i32 1
+  %157 = load i32, i32* %156, align 4
+  %158 = add i32 %155, %157
+  %159 = getelementptr %array, %array* %101, i32 0, i32 0
+  %160 = load i32*, i32** %159, align 8
+  %161 = getelementptr inbounds i32, i32* %160, i32 %158
+  %162 = load i32, i32* %161, align 4
+  %163 = icmp ne i32 %162, 99
+  br i1 %163, label %then35, label %else36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0), i32 1, i32 1, i32 %124, i32 %129)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont36:                                         ; preds = %ifcont34
-  %133 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 0
-  %134 = load i32, i32* %133, align 4
-  %135 = mul i32 %134, %127
-  %136 = add i32 0, %135
-  %137 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %121, i32 1
-  %138 = getelementptr %dimension_descriptor, %dimension_descriptor* %137, i32 0, i32 1
-  %139 = load i32, i32* %138, align 4
-  %140 = getelementptr %dimension_descriptor, %dimension_descriptor* %137, i32 0, i32 2
-  %141 = load i32, i32* %140, align 4
-  %142 = sub i32 1, %139
-  %143 = add i32 %139, %141
-  %144 = sub i32 %143, 1
-  %145 = icmp slt i32 1, %139
-  %146 = icmp sgt i32 1, %144
-  %147 = or i1 %145, %146
-  br i1 %147, label %then37, label %ifcont38
-
-then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i32 1, i32 2, i32 %139, i32 %144)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont38:                                         ; preds = %ifcont36
-  %148 = getelementptr %dimension_descriptor, %dimension_descriptor* %137, i32 0, i32 0
-  %149 = load i32, i32* %148, align 4
-  %150 = mul i32 %149, %142
-  %151 = add i32 %136, %150
-  %152 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %121, i32 2
-  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 1
-  %154 = load i32, i32* %153, align 4
-  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 2
-  %156 = load i32, i32* %155, align 4
-  %157 = sub i32 1, %154
-  %158 = add i32 %154, %156
-  %159 = sub i32 %158, 1
-  %160 = icmp slt i32 1, %154
-  %161 = icmp sgt i32 1, %159
-  %162 = or i1 %160, %161
-  br i1 %162, label %then39, label %ifcont40
-
-then39:                                           ; preds = %ifcont38
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i32 1, i32 3, i32 %154, i32 %159)
-  call void @exit(i32 1)
-  unreachable
-
-ifcont40:                                         ; preds = %ifcont38
-  %163 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 0
-  %164 = load i32, i32* %163, align 4
-  %165 = mul i32 %164, %157
-  %166 = add i32 %151, %165
-  %167 = getelementptr %array, %array* %112, i32 0, i32 1
-  %168 = load i32, i32* %167, align 4
-  %169 = add i32 %166, %168
-  %170 = getelementptr %array, %array* %112, i32 0, i32 0
-  %171 = load i32*, i32** %170, align 8
-  %172 = getelementptr inbounds i32, i32* %171, i32 %169
-  %173 = load i32, i32* %172, align 4
-  %174 = icmp ne i32 %173, 99
-  br i1 %174, label %then41, label %else42
-
-then41:                                           ; preds = %ifcont40
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
   call void @exit(i32 1)
-  br label %ifcont43
+  br label %ifcont37
 
-else42:                                           ; preds = %ifcont40
-  br label %ifcont43
+else36:                                           ; preds = %ifcont34
+  br label %ifcont37
 
-ifcont43:                                         ; preds = %else42, %then41
-  %175 = load %array*, %array** %c, align 8
-  %176 = ptrtoint %array* %175 to i64
-  %177 = icmp eq i64 %176, 0
-  br i1 %177, label %merge_allocated45, label %check_data44
+ifcont37:                                         ; preds = %else36, %then35
+  %164 = load %array*, %array** %c, align 8
+  %165 = ptrtoint %array* %164 to i64
+  %166 = icmp eq i64 %165, 0
+  br i1 %166, label %merge_allocated39, label %check_data38
 
-check_data44:                                     ; preds = %ifcont43
-  %178 = getelementptr %array, %array* %175, i32 0, i32 0
-  %179 = load i32*, i32** %178, align 8
-  %180 = ptrtoint i32* %179 to i64
-  %181 = icmp ne i64 %180, 0
-  br label %merge_allocated45
+check_data38:                                     ; preds = %ifcont37
+  %167 = getelementptr %array, %array* %164, i32 0, i32 0
+  %168 = load i32*, i32** %167, align 8
+  %169 = ptrtoint i32* %168 to i64
+  %170 = icmp ne i64 %169, 0
+  br label %merge_allocated39
 
-merge_allocated45:                                ; preds = %check_data44, %ifcont43
-  %is_allocated46 = phi i1 [ false, %ifcont43 ], [ %181, %check_data44 ]
-  %182 = xor i1 %is_allocated46, true
-  br i1 %182, label %then47, label %ifcont48
+merge_allocated39:                                ; preds = %check_data38, %ifcont37
+  %is_allocated40 = phi i1 [ false, %ifcont37 ], [ %170, %check_data38 ]
+  %171 = xor i1 %is_allocated40, true
+  br i1 %171, label %then41, label %ifcont42
 
-then47:                                           ; preds = %merge_allocated45
+then41:                                           ; preds = %merge_allocated39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([100 x i8], [100 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
-ifcont48:                                         ; preds = %merge_allocated45
-  %183 = getelementptr %array, %array* %175, i32 0, i32 2
-  %184 = load %dimension_descriptor*, %dimension_descriptor** %183, align 8
-  %185 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 0
-  %186 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 1
-  %187 = load i32, i32* %186, align 4
-  %188 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 2
-  %189 = load i32, i32* %188, align 4
-  %190 = sub i32 1, %187
-  %191 = add i32 %187, %189
-  %192 = sub i32 %191, 1
-  %193 = icmp slt i32 1, %187
-  %194 = icmp sgt i32 1, %192
-  %195 = or i1 %193, %194
-  br i1 %195, label %then49, label %ifcont50
+ifcont42:                                         ; preds = %merge_allocated39
+  %172 = getelementptr %array, %array* %164, i32 0, i32 2
+  %173 = load %dimension_descriptor*, %dimension_descriptor** %172, align 8
+  %174 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 0
+  %175 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 1
+  %176 = load i32, i32* %175, align 4
+  %177 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 2
+  %178 = load i32, i32* %177, align 4
+  %179 = sub i32 1, %176
+  %180 = add i32 %176, %178
+  %181 = sub i32 %180, 1
+  %182 = icmp slt i32 1, %176
+  %183 = icmp sgt i32 1, %181
+  %184 = or i1 %182, %183
+  br i1 %184, label %then43, label %ifcont44
 
-then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 1, i32 1, i32 %187, i32 %192)
+then43:                                           ; preds = %ifcont42
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i32 1, i32 1, i32 %176, i32 %181)
   call void @exit(i32 1)
   unreachable
 
-ifcont50:                                         ; preds = %ifcont48
-  %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %185, i32 0, i32 0
-  %197 = load i32, i32* %196, align 4
-  %198 = mul i32 %197, %190
-  %199 = add i32 0, %198
-  %200 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 1
-  %201 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 1
-  %202 = load i32, i32* %201, align 4
-  %203 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 2
-  %204 = load i32, i32* %203, align 4
-  %205 = sub i32 1, %202
-  %206 = add i32 %202, %204
-  %207 = sub i32 %206, 1
-  %208 = icmp slt i32 1, %202
-  %209 = icmp sgt i32 1, %207
-  %210 = or i1 %208, %209
-  br i1 %210, label %then51, label %ifcont52
+ifcont44:                                         ; preds = %ifcont42
+  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %174, i32 0, i32 0
+  %186 = load i32, i32* %185, align 4
+  %187 = mul i32 %186, %179
+  %188 = add i32 0, %187
+  %189 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 1
+  %190 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 1
+  %191 = load i32, i32* %190, align 4
+  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 2
+  %193 = load i32, i32* %192, align 4
+  %194 = sub i32 1, %191
+  %195 = add i32 %191, %193
+  %196 = sub i32 %195, 1
+  %197 = icmp slt i32 1, %191
+  %198 = icmp sgt i32 1, %196
+  %199 = or i1 %197, %198
+  br i1 %199, label %then45, label %ifcont46
 
-then51:                                           ; preds = %ifcont50
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i32 1, i32 2, i32 %202, i32 %207)
+then45:                                           ; preds = %ifcont44
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i32 1, i32 2, i32 %191, i32 %196)
   call void @exit(i32 1)
   unreachable
 
-ifcont52:                                         ; preds = %ifcont50
-  %211 = getelementptr %dimension_descriptor, %dimension_descriptor* %200, i32 0, i32 0
-  %212 = load i32, i32* %211, align 4
-  %213 = mul i32 %212, %205
-  %214 = add i32 %199, %213
-  %215 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %184, i32 2
-  %216 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 1
-  %217 = load i32, i32* %216, align 4
-  %218 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 2
-  %219 = load i32, i32* %218, align 4
-  %220 = sub i32 1, %217
-  %221 = add i32 %217, %219
-  %222 = sub i32 %221, 1
-  %223 = icmp slt i32 1, %217
-  %224 = icmp sgt i32 1, %222
-  %225 = or i1 %223, %224
-  br i1 %225, label %then53, label %ifcont54
+ifcont46:                                         ; preds = %ifcont44
+  %200 = getelementptr %dimension_descriptor, %dimension_descriptor* %189, i32 0, i32 0
+  %201 = load i32, i32* %200, align 4
+  %202 = mul i32 %201, %194
+  %203 = add i32 %188, %202
+  %204 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %173, i32 2
+  %205 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 1
+  %206 = load i32, i32* %205, align 4
+  %207 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 2
+  %208 = load i32, i32* %207, align 4
+  %209 = sub i32 1, %206
+  %210 = add i32 %206, %208
+  %211 = sub i32 %210, 1
+  %212 = icmp slt i32 1, %206
+  %213 = icmp sgt i32 1, %211
+  %214 = or i1 %212, %213
+  br i1 %214, label %then47, label %ifcont48
 
-then53:                                           ; preds = %ifcont52
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 1, i32 3, i32 %217, i32 %222)
+then47:                                           ; preds = %ifcont46
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([162 x i8], [162 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i32 1, i32 3, i32 %206, i32 %211)
   call void @exit(i32 1)
   unreachable
 
-ifcont54:                                         ; preds = %ifcont52
-  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %215, i32 0, i32 0
-  %227 = load i32, i32* %226, align 4
-  %228 = mul i32 %227, %220
-  %229 = add i32 %214, %228
-  %230 = getelementptr %array, %array* %175, i32 0, i32 1
-  %231 = load i32, i32* %230, align 4
-  %232 = add i32 %229, %231
-  %233 = getelementptr %array, %array* %175, i32 0, i32 0
-  %234 = load i32*, i32** %233, align 8
-  %235 = getelementptr inbounds i32, i32* %234, i32 %232
-  store i32 8, i32* %235, align 4
+ifcont48:                                         ; preds = %ifcont46
+  %215 = getelementptr %dimension_descriptor, %dimension_descriptor* %204, i32 0, i32 0
+  %216 = load i32, i32* %215, align 4
+  %217 = mul i32 %216, %209
+  %218 = add i32 %203, %217
+  %219 = getelementptr %array, %array* %164, i32 0, i32 1
+  %220 = load i32, i32* %219, align 4
+  %221 = add i32 %218, %220
+  %222 = getelementptr %array, %array* %164, i32 0, i32 0
+  %223 = load i32*, i32** %222, align 8
+  %224 = getelementptr inbounds i32, i32* %223, i32 %221
+  store i32 8, i32* %224, align 4
   br label %return
 
-return:                                           ; preds = %ifcont54
+return:                                           ; preds = %ifcont48
   br label %FINALIZE_SYMTABLE_h
 
 FINALIZE_SYMTABLE_h:                              ; preds = %return


### PR DESCRIPTION
This removes `ImplicitDeallocate` before a procedure call because we already deallocate `intent(out)` arguments at function entries.