### PR TITLE
Fix procedure pointer intent in methods

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2381,6 +2381,7 @@ RUN(NAME class_107 LABELS gfortran llvm)
 RUN(NAME class_108 LABELS gfortran llvm)
 RUN(NAME class_109 LABELS gfortran llvm)
 RUN(NAME class_110 LABELS gfortran llvm EXTRAFILES class_110_module.f90)
+RUN(NAME class_111 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_111.f90
+++ b/integration_tests/class_111.f90
@@ -1,0 +1,47 @@
+module class_111_mod
+
+   type :: MyType
+      procedure(factory), pointer, nopass :: val => null()
+   contains
+      procedure :: get
+   end type MyType
+
+   abstract interface
+      subroutine factory()
+      end subroutine factory
+   end interface
+
+contains
+
+   recursive subroutine get(self, key, val)
+      class(MyType),               intent(in)  :: self
+      character(*),                intent(in)  :: key
+      procedure(factory), pointer, intent(out) :: val
+      val => self%val
+   end subroutine get
+
+end module class_111_mod
+
+program class_111
+
+   use class_111_mod
+
+   character(*),       parameter :: key = 'test'
+   procedure(factory), pointer   :: val
+
+   type(MyType) :: obj
+
+   obj%val => my_factory
+   call obj%get(key, val)
+
+   if (.not. associated(val)) error stop
+   if (.not. associated(val, my_factory)) error stop
+
+   print *, "PASS"
+
+contains
+
+   subroutine my_factory()
+   end subroutine my_factory
+
+end program class_111

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16257,9 +16257,10 @@ public:
                                     bool pass_by_value = true;
                                     if ( ASR::is_a<ASR::Function_t>(*func_subrout) ) {
                                         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(func_subrout);
-                                        if ( ASR::is_a<ASR::Var_t>(*func->m_args[i]) ){
+                                        size_t arg_idx = i + is_method;
+                                        if ( arg_idx < func->n_args && ASR::is_a<ASR::Var_t>(*func->m_args[arg_idx]) ){
                                             ASR::symbol_t* func_var_sym = ASRUtils::symbol_get_past_external(
-                                                ASR::down_cast<ASR::Var_t>(func->m_args[i])->m_v);
+                                                ASR::down_cast<ASR::Var_t>(func->m_args[arg_idx])->m_v);
                                             if ( ASR::is_a<ASR::Variable_t>(*func_var_sym) ) {
                                                 ASR::Variable_t* func_variable = ASR::down_cast<ASR::Variable_t>(func_var_sym);
                                                 if ( func_variable->m_intent == ASRUtils::intent_inout || func_variable->m_intent == ASRUtils::intent_out ) {


### PR DESCRIPTION
When calling a type-bound procedure with a procedure pointer argument that has intent(out), the LLVM codegen incorrectly used the raw caller argument index to look up the formal parameter's intent. For method calls, this index must be offset by one to account for the implicit `self` parameter, which is passed separately via x.m_dt.

This caused the codegen to check the wrong formal parameter's intent, resulting in procedure pointer arguments being passed by value instead of by reference, triggering an LLVM verification error: "Call parameter type does not match function signature".

Fixes #10066.