### PR TITLE
ci: run LAPACK smoke tests across LLVM matrix, full suite on 11/21

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -532,7 +532,12 @@ jobs:
         if: ${{! (matrix.llvm-version == '7') }}
         run: |
             export PATH="$(pwd)/src/bin:$PATH"
-            RUNNER_OS="${{matrix.os}}" FC=lfortran ci/test_third_party_codes.sh
+            LAPACK_MODE="smoke"
+            if [[ "${{ matrix.llvm-version }}" == "11" || "${{ matrix.llvm-version }}" == "21" ]]; then
+                LAPACK_MODE="full"
+            fi
+            echo "Running LAPACK third-party mode: ${LAPACK_MODE}"
+            RUNNER_OS="${{matrix.os}}" FC=lfortran ci/test_third_party_codes.sh --lapack-mode "${LAPACK_MODE}"
 
   upload_tarball:
     name: Upload Tarball


### PR DESCRIPTION
## Summary
- add explicit LAPACK test mode support to `ci/test_third_party_codes.sh` (`--lapack-mode smoke|full`, default `full`)
- run reduced LAPACK smoke checks by default in Reference-LAPACK section
- keep full Reference-LAPACK suite (including ILP64) only when mode is `full`
- wire Exhaustive CI to use `full` only on LLVM 11 and LLVM 21, and `smoke` on all other LLVM versions

## Why
Reference-LAPACK full third-party testing in every LLVM matrix entry is very expensive. This keeps broad LLVM coverage with smoke tests while preserving full LAPACK coverage on LLVM 11 and 21.

**Stage:** CI / Third-party test orchestration

## Changes
- `.github/workflows/Exhaustive-Checks-CI.yml`: set LAPACK mode by LLVM version in the third-party step
- `ci/test_third_party_codes.sh`: add mode parsing + smoke/full selection for Reference-LAPACK testing

## Verification

### Script syntax
```bash
$ bash -n ci/test_third_party_codes.sh
# (passes with no output)
```

### LLVM mode mapping check
```bash
$ for v in 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21; do mode=smoke; if [[ "$v" == "11" || "$v" == "21" ]]; then mode=full; fi; printf "LLVM %s -> %s\n" "$v" "$mode"; done
LLVM 7 -> smoke
LLVM 8 -> smoke
LLVM 9 -> smoke
LLVM 10 -> smoke
LLVM 11 -> full
LLVM 12 -> smoke
LLVM 13 -> smoke
LLVM 14 -> smoke
LLVM 15 -> smoke
LLVM 16 -> smoke
LLVM 17 -> smoke
LLVM 18 -> smoke
LLVM 19 -> smoke
LLVM 20 -> smoke
LLVM 21 -> full
```

### Workflow wiring spot-check
```bash
$ rg -n "LAPACK_MODE|--lapack-mode" .github/workflows/Exhaustive-Checks-CI.yml ci/test_third_party_codes.sh
# confirms mode assignment in workflow and argument wiring into test_third_party_codes.sh
```
