### PR TITLE
fix: prevent double-wrap of m_dt in SubrCall

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2730,6 +2730,7 @@ RUN(NAME procedure_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME procedure_27 LABELS gfortran llvm)
 
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_27.f90
+++ b/integration_tests/procedure_27.f90
@@ -1,0 +1,57 @@
+! Test procedure pointer component in a derived type with allocatable
+! character component, accessed via a class (polymorphic) dummy argument.
+! This triggered a GEP type mismatch in codegen when the subroutine_from_function
+! pass incorrectly double-wrapped the m_dt StructInstanceMember expression.
+module procedure_27_mod
+  implicit none
+
+  type :: result_t
+    logical :: passed = .false.
+  end type
+
+  abstract interface
+    function result_fn_i() result(r)
+      import result_t
+      type(result_t) :: r
+    end function
+  end interface
+
+  type :: desc_t
+    character(len=:), allocatable :: text
+    procedure(result_fn_i), pointer, nopass :: get_result => null()
+  contains
+    procedure :: run
+  end type
+
+contains
+
+  function make_pass() result(r)
+    type(result_t) :: r
+    r%passed = .true.
+  end function
+
+  subroutine run(self)
+    class(desc_t), intent(in) :: self
+    type(result_t) :: res
+    if (associated(self%get_result)) then
+      res = self%get_result()
+      if (.not. res%passed) error stop
+    end if
+  end subroutine
+
+end module
+
+program procedure_27
+  use procedure_27_mod
+  implicit none
+  type(desc_t) :: d
+
+  ! Test with null procedure pointer (should not call)
+  call d%run()
+
+  ! Test with assigned procedure pointer
+  d%get_result => make_pass
+  call d%run()
+
+  print *, "ok"
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7317,7 +7317,8 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
 
     if( a_dt && ASR::is_a<ASR::Variable_t>(
         *ASRUtils::symbol_get_past_external(a_name)) &&
-        ASR::is_a<ASR::FunctionType_t>(*ASRUtils::symbol_type(a_name)) ) {
+        ASR::is_a<ASR::FunctionType_t>(*ASRUtils::symbol_type(a_name)) &&
+        !ASR::is_a<ASR::StructInstanceMember_t>(*a_dt) ) {
         a_dt = ASRUtils::EXPR(ASR::make_StructInstanceMember_t(al, a_loc,
             a_dt, a_name, ASRUtils::duplicate_type(al, ASRUtils::symbol_type(a_name)), nullptr));
     }


### PR DESCRIPTION
When a FunctionCall returning a struct via a procedure pointer component (e.g., `self%get_result()`) was lowered to a SubroutineCall by the subroutine_from_function pass, make_SubroutineCall_t_util unconditionally wrapped a_dt in a StructInstanceMember node. If a_dt was already a StructInstanceMember (as it is for procedure pointer components), this created a double nesting, causing a GEP type mismatch assertion failure in LLVM codegen.

Add a guard to skip the wrapping when a_dt is already a StructInstanceMember.