### PR TITLE
Fix struct temp missing sub-expr visit

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1724,6 +1724,7 @@ RUN(NAME operator_overloading_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME custom_unary_operator_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/operator_overloading_23.f90
+++ b/integration_tests/operator_overloading_23.f90
@@ -1,0 +1,68 @@
+module operator_overloading_23_mod
+  implicit none
+  type :: string_t
+    character(len=:), allocatable :: s
+  end type
+  interface operator(.cat.)
+    pure function concat(strings) result(r)
+      import string_t
+      type(string_t), intent(in) :: strings(:)
+      type(string_t) :: r
+    end function
+  end interface
+
+  type :: diag_t
+    logical :: passed = .false.
+  end type
+  interface diag_t
+    pure function make_diag(test_passed, diagnostics_string) result(d)
+      import diag_t, string_t
+      logical, intent(in) :: test_passed
+      type(string_t), intent(in) :: diagnostics_string
+      type(diag_t) :: d
+    end function
+  end interface
+contains
+  pure function aggregate(diagnoses) result(d)
+    type(diag_t), intent(in) :: diagnoses(:)
+    type(diag_t) :: d
+    type(string_t) :: array(2)
+    d = diag_t( &
+      test_passed = all(diagnoses%passed), &
+      diagnostics_string = .cat. pack(array, mask = .not. diagnoses%passed) &
+    )
+  end function
+end module
+
+pure function concat(strings) result(r)
+  use operator_overloading_23_mod, only: string_t
+  type(string_t), intent(in) :: strings(:)
+  type(string_t) :: r
+  r%s = "ok"
+end function
+
+pure function make_diag(test_passed, diagnostics_string) result(d)
+  use operator_overloading_23_mod, only: diag_t, string_t
+  logical, intent(in) :: test_passed
+  type(string_t), intent(in) :: diagnostics_string
+  type(diag_t) :: d
+  d%passed = test_passed
+end function
+
+program operator_overloading_23
+  use operator_overloading_23_mod, only: diag_t, aggregate
+  implicit none
+  type(diag_t) :: diagnoses(2), result
+
+  diagnoses(1)%passed = .true.
+  diagnoses(2)%passed = .true.
+  result = aggregate(diagnoses)
+  if (.not. result%passed) error stop
+
+  diagnoses(1)%passed = .true.
+  diagnoses(2)%passed = .false.
+  result = aggregate(diagnoses)
+  if (result%passed) error stop
+
+  print *, "ok"
+end program

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -1368,6 +1368,7 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
                        ASRUtils::is_struct(*ASRUtils::expr_type(x_m_args[i].m_value)) &&
                        !ASR::is_a<ASR::Var_t>(
                             *ASRUtils::get_past_array_physical_cast(x_m_args[i].m_value)) ) {
+                visit_call_arg(x_m_args[i]);
                 ASR::expr_t* struct_var_temporary = create_and_allocate_temporary_variable_for_struct(
                     ASRUtils::get_past_array_physical_cast(x_m_args[i].m_value), name_hint, al, current_body,
                     current_scope, exprs_with_target, realloc_lhs);


### PR DESCRIPTION
In traverse_call_args, the array temporary branch calls visit_call_arg() to recursively simplify sub-expressions before creating a temporary, but the struct temporary branch was missing this step. This caused an assertion failure in the verifier when a struct call argument contained nested array expressions (e.g., a user-defined operator calling pack() with a StructInstanceMember array argument like diagnoses%passed), since those inner expressions were never simplified to Var nodes.