### PR TITLE
Create a temporary for select type expr

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1609,6 +1609,7 @@ RUN(NAME select_type_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_23 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME select_type_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_25 LABELS gfortran llvm)
+RUN(NAME select_type_26 LABELS gfortran llvm)
 
 RUN(NAME program_02 LABELS gfortran llvm)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_type_26.f90
+++ b/integration_tests/select_type_26.f90
@@ -1,0 +1,67 @@
+module select_type_26_mod
+    implicit none
+
+    type, abstract :: base_getter
+    contains
+        procedure(get_iface), deferred :: get
+    end type base_getter
+
+    abstract interface
+        function get_iface(self, key) result(res)
+            import
+            class(base_getter), intent(in) :: self
+            character(*), intent(in) :: key
+            class(*), allocatable :: res
+        end function get_iface
+    end interface
+
+    type, abstract :: base_type
+    end type base_type
+
+    type, extends(base_type) :: my_type
+        integer :: val
+    end type my_type
+
+    type, extends(base_getter) :: my_getter
+    contains
+        procedure :: get => my_getter_get
+    end type my_getter
+
+contains
+
+    function my_getter_get(self, key) result(res)
+        class(my_getter), intent(in) :: self
+        character(*), intent(in) :: key
+        class(*), allocatable :: res
+        if (key == "base_type") then
+            allocate(res, source=my_type(42))
+        end if
+    end function my_getter_get
+
+    subroutine test_select_type_func_call(g, val)
+        class(base_getter), intent(in) :: g
+        integer, intent(out) :: val
+        val = 0
+        select type(obj => g%get("base_type"))
+        class is (base_type)
+            select type(obj)
+            type is (my_type)
+                val = obj%val
+            end select
+        end select
+    end subroutine test_select_type_func_call
+
+end module select_type_26_mod
+
+program select_type_26
+    use select_type_26_mod
+    implicit none
+
+    type(my_getter) :: g
+    integer :: val
+
+    call test_select_type_func_call(g, val)
+    print *, val
+    if (val /= 42) error stop
+
+end program select_type_26

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3197,6 +3197,26 @@ public:
         }
         visit_expr(*x.m_selector);
         ASR::expr_t* m_selector = ASRUtils::EXPR(tmp);
+        // When the selector is a function call, create a temporary variable
+        // to hold the result. The codegen expects Var or StructInstanceMember
+        // as the selector, not a FunctionCall.
+        if( ASR::is_a<ASR::FunctionCall_t>(*m_selector) ) {
+            ASR::ttype_t* selector_type = ASRUtils::expr_type(m_selector);
+            std::string tmp_name = current_scope->get_unique_name("~select_type_selector_tmp_");
+            ASR::symbol_t* type_decl = ASRUtils::get_struct_sym_from_struct_expr(m_selector);
+            ASR::symbol_t* tmp_sym = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(
+                al, x.base.base.loc, current_scope, s2c(al, tmp_name),
+                nullptr, 0, ASR::intentType::Local, nullptr, nullptr,
+                ASR::storage_typeType::Default, selector_type, type_decl,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false));
+            current_scope->add_symbol(tmp_name, tmp_sym);
+            ASR::expr_t* tmp_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, tmp_sym));
+            current_body->push_back(al, ASRUtils::STMT(ASRUtils::make_Assignment_t_util(
+                al, x.base.base.loc, tmp_var, m_selector, nullptr,
+                compiler_options.po.realloc_lhs_arrays, false)));
+            m_selector = tmp_var;
+        }
         Vec<ASR::stmt_t*> select_type_default;
         select_type_default.reserve(al, 1);
         Vec<ASR::type_stmt_t*> select_type_body;

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -185,6 +185,9 @@ ASR::symbol_t* get_struct_sym_from_struct_expr(ASR::expr_t* expression)
             // The symbol m_v has to be `Variable` or 'Function' for a Struct expression.
             if (ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(expression)->m_v))) {
                 ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(expression)->m_v));
+                if (var->m_type_declaration == nullptr) {
+                    return nullptr;
+                }
                 return ASRUtils::symbol_get_past_external(var->m_type_declaration);
             } else if (ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(expression)->m_v))) {
                 ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(expression)->m_v));
@@ -257,6 +260,9 @@ ASR::symbol_t* get_struct_sym_from_struct_expr(ASR::expr_t* expression)
         case ASR::exprType::FunctionCall: {
             ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(expression);
             ASR::Function_t* func = get_function(func_call->m_name);
+            if (func == nullptr || func->m_return_var == nullptr) {
+                return nullptr;
+            }
             return ASRUtils::get_struct_sym_from_struct_expr(func->m_return_var);
         }
         case ASR::exprType::StructConstant: {


### PR DESCRIPTION
The codegen expects Var or StructInstanceMember as the selector, not a FunctionCall. In this commit we make this transformation already in AST->ASR. It has the advantage that the bug fix is short. The disadvantage is that this transformation is lowering and we should not be lowering in AST->ASR. The right place for this is either an ASR pass, or possibly the backend if it needs to be extended to handle FunctionCall. So far all my solutions in ASR or LLVM were much more complex. So I am submitting this PR to get us unblocked and we can easily replace this code in ast_body_visitor.cpp with another solution in an ASR pass or LLVM and we can actually easily judge if it is more maitainable by comparing the code removed and code added. So this PR might be a good first step.

Fixes #10080.