### PR TITLE
Fix segfault: where + maxval/minval

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1631,6 +1631,7 @@ RUN(NAME where_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME where_17 LABELS gfortran llvm)
 
 RUN(NAME forallloop_01 LABELS gfortran)
 RUN(NAME forall_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/where_17.f90
+++ b/integration_tests/where_17.f90
@@ -1,0 +1,28 @@
+program where_17
+    implicit none
+    integer :: nz(3), maxnz(3), minnz(3)
+    integer :: mx
+
+    nz = [480, 120, 1]
+
+    maxnz = 0
+    where (nz > 1)
+        maxnz = maxval(nz)
+    end where
+    if (maxnz(1) /= 480) error stop
+    if (maxnz(2) /= 480) error stop
+    if (maxnz(3) /= 0) error stop
+
+    minnz = 0
+    where (nz > 100)
+        minnz = minval(nz)
+    end where
+    if (minnz(1) /= 1) error stop
+    if (minnz(2) /= 1) error stop
+    if (minnz(3) /= 0) error stop
+
+    mx = maxnz(1)
+    if (mx /= 480) error stop
+
+    print *, mx
+end program where_17

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -62,6 +62,12 @@ class ArrayVarAddressReplacer: public ASR::BaseExprReplacer<ArrayVarAddressRepla
         ASR::BaseExprReplacer<ArrayVarAddressReplacer>::replace_FunctionCall(x);
     }
 
+    void replace_IntrinsicArrayFunction(ASR::IntrinsicArrayFunction_t* /*x*/) {
+        // Do not descend into intrinsic array functions (reductions like
+        // MaxVal, MinVal, Sum, etc.) because they operate on whole arrays
+        // and their array arguments must not be replaced with element accesses.
+    }
+
 };
 
 class ArrayVarAddressCollector: public ASR::CallReplacerOnExpressionsVisitor<ArrayVarAddressCollector> {


### PR DESCRIPTION
The array_op pass incorrectly descended into IntrinsicArrayFunction nodes (MaxVal, MinVal, Sum, etc.) and replaced their whole-array arguments with element accesses, e.g. maxval(nz) became maxval(nz(i)). This produced malformed ASR that caused a segfault in the later intrinsic_function pass.

Fix by adding replace_IntrinsicArrayFunction to ArrayVarAddressReplacer that skips descending into reduction arguments.

Fixes #10096.