### PR TITLE
Fix DT format write with class args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2668,6 +2668,7 @@ RUN(NAME write_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME write_18 LABELS gfortran llvm)
+RUN(NAME write_19 LABELS gfortran llvm EXTRAFILES write_19_module.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME write_fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME write_fortran_02 LABELS gfortran llvm fortran)

--- a/integration_tests/write_19.f90
+++ b/integration_tests/write_19.f90
@@ -1,0 +1,8 @@
+program write_19
+   use write_19_mod, only: t
+   use write_19_io, only: print_it
+   implicit none
+   type(t) :: obj
+   call print_it(obj)
+   print *, "ok"
+end program

--- a/integration_tests/write_19_module.f90
+++ b/integration_tests/write_19_module.f90
@@ -1,0 +1,31 @@
+module write_19_mod
+   implicit none
+   type :: t
+      integer :: x = 42
+   contains
+      procedure, private :: write_t
+      generic :: write(formatted) => write_t
+   end type t
+contains
+   subroutine write_t(self, unit, iotype, v_list, iostat, iomsg)
+      class(t), intent(in) :: self
+      integer, intent(in) :: unit
+      character(*), intent(in) :: iotype
+      integer, intent(in) :: v_list(:)
+      integer, intent(out) :: iostat
+      character(*), intent(inout) :: iomsg
+      if (iotype /= 'DT') error stop
+      if (self%x /= 42) error stop
+      iostat = 0
+   end subroutine
+end module
+
+module write_19_io
+   use write_19_mod, only: t
+   implicit none
+contains
+   subroutine print_it(obj)
+      class(t), intent(in) :: obj
+      write(*,'(dt)') obj
+   end subroutine
+end module

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2012,7 +2012,7 @@ bool use_overloaded_file_read_write(std::string &read_write, Vec<ASR::expr_t*> a
     ASR::symbol_t* sym = curr_scope->resolve_symbol(read_write);
     ASR::expr_t* expr_dt = nullptr;
     if( sym == nullptr ) {
-        if( ASR::is_a<ASR::StructType_t>(*arg_type) && !ASRUtils::is_class_type(arg_type) ) {
+        if( ASR::is_a<ASR::StructType_t>(*arg_type) ) {
             ASR::Struct_t* arg_struct = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(args[0])));
             sym = arg_struct->m_symtab->resolve_symbol(read_write);
             expr_dt = args[0];


### PR DESCRIPTION
The use_overloaded_file_read_write function excluded class types (polymorphic arguments) from the struct symtab lookup for user-defined derived type I/O. This caused the overload to not be found, and the fallback code created StructInstanceMember nodes referencing symbols from external module symtabs, which crashed during modfile deserialization with:

  AssertFailed: id_symtab_map.find(symtab_id) != id_symtab_map.end()

Remove the !is_class_type() exclusion so class(t) is handled the same as type(t) for DT format resolution.

Fixes #10095.