### PR TITLE
Fix chained user-defined operators with 'use ... only:' imports

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1740,6 +1740,7 @@ RUN(NAME custom_operator_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_operator_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_operator_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_operator_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME custom_operator_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/custom_operator_12.f90
+++ b/integration_tests/custom_operator_12.f90
@@ -1,0 +1,51 @@
+module custom_operator_12_m
+  implicit none
+
+  type :: operands_t
+    real :: actual, expected
+  end type
+
+  type :: result_t
+    logical :: passed
+  end type
+
+  interface operator(.approximates.)
+    module procedure approximates
+  end interface
+
+  interface operator(.within.)
+    module procedure within
+  end interface
+
+contains
+
+  elemental function approximates(actual, expected) result(operands)
+    real, intent(in) :: actual, expected
+    type(operands_t) :: operands
+    operands%actual = actual
+    operands%expected = expected
+  end function
+
+  elemental function within(operands, tolerance) result(res)
+    type(operands_t), intent(in) :: operands
+    real, intent(in) :: tolerance
+    type(result_t) :: res
+    res%passed = abs(operands%actual - operands%expected) <= tolerance
+  end function
+
+end module
+
+program custom_operator_12
+  use custom_operator_12_m, only: operator(.approximates.), operator(.within.), result_t
+  implicit none
+  type(result_t) :: r
+
+  ! Chained user-defined operators with "use ... only:" import
+  r = 1. .approximates. 2. .within. 3.
+  print *, r%passed
+  if (.not. r%passed) error stop
+
+  r = 1. .approximates. 2. .within. 0.5
+  print *, r%passed
+  if (r%passed) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -13911,10 +13911,18 @@ public:
         if (first_struct != nullptr && operator_sym == nullptr) {
             operator_sym = first_struct->m_symtab->resolve_symbol("~def_op~" + op);
             if (operator_sym == nullptr) {
-                diag.add(Diagnostic("`" + op
-                    + "` is not defined in the Struct: `" + first_struct->m_name
-                    + "`", Level::Error, Stage::Semantic, {Label("", {loc})}));
-                throw SemanticAbort();
+                // The operator is not type-bound; try resolving as a regular
+                // custom operator (with the "~~" prefix) in the current scope.
+                std::string prefixed_op = update_custom_op_name(op);
+                op_sym = current_scope->resolve_symbol(to_lower(prefixed_op));
+                operator_sym = ASRUtils::symbol_get_past_external(op_sym);
+                if (operator_sym == nullptr) {
+                    diag.add(Diagnostic("`" + op
+                        + "` is not defined in the Struct: `" + first_struct->m_name
+                        + "` or in the current scope",
+                        Level::Error, Stage::Semantic, {Label("", {loc})}));
+                    throw SemanticAbort();
+                }
             }
         }
 


### PR DESCRIPTION
When the first operand of a user-defined operator is a struct type, the semantic analyzer assumed the operator must be either in the current scope without the ~~ prefix or type-bound in the struct. It never fell back to looking for a regular custom operator (with ~~ prefix) in the current scope, causing a spurious error like:

  semantic error: `within` is not defined in the Struct: `operands_t`

Now, when the operator is not found in the struct's symtab, we also try resolving it as a regular custom operator in the current scope.