### PR TITLE
Fix false error for zero-length arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -995,6 +995,8 @@ RUN(NAME submodule_18a LABELS gfortran llvm_submodule EXTRAFILES submodule_18b.f
 RUN(NAME submodule_19a LABELS gfortran llvm_submodule EXTRAFILES submodule_19b.f90 submodule_19c.f90)
 RUN(NAME submodule_20a LABELS gfortran llvm_submodule EXTRAFILES submodule_20b.f90 submodule_20c.f90)
 
+RUN(NAME submodule_22 LABELS gfortran llvm)
+
 
 
 RUN(NAME floor_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran) # floor body

--- a/integration_tests/submodule_22.f90
+++ b/integration_tests/submodule_22.f90
@@ -1,0 +1,34 @@
+module submodule_22_mod
+  implicit none
+
+  interface
+    pure module function separated_values(separator, mold) result(format_string)
+      character(len=*), intent(in) :: separator
+      class(*), intent(in) :: mold(..)
+      character(len=:), allocatable :: format_string
+    end function
+  end interface
+
+end module submodule_22_mod
+
+submodule(submodule_22_mod) submodule_22_sub
+  implicit none
+contains
+  pure module function separated_values(separator, mold) result(format_string)
+    character(len=*), intent(in) :: separator
+    class(*), intent(in) :: mold(..)
+    character(len=:), allocatable :: format_string
+    format_string = "(*(G25.20,:,'" // separator // "'))"
+  end function
+end submodule submodule_22_sub
+
+program submodule_22
+  use submodule_22_mod
+  implicit none
+  character(len=100) :: output
+  real, parameter :: vals(*) = [1.0, 2.0, 3.0]
+
+  write(output, fmt=separated_values(separator=",", mold=[real::])) vals
+  if (len_trim(output) == 0) error stop
+  print *, trim(output)
+end program submodule_22

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8686,11 +8686,18 @@ public:
                         ASR::Array_t* arr_lhs = ASR::down_cast<ASR::Array_t>(arg_type);
                         int lhs_ele = 1;
                         int rhs_ele = 1;
+                        bool rhs_size_known = true;
                         for (size_t i = 0; i < arr_rhs->n_dims; i++) {
                             std::int64_t rhs_dim = ASRUtils::extract_dim_value_int(arr_rhs->m_dims[i].m_length);
                             if( rhs_dim != -1 ){
                                 rhs_ele *= rhs_dim;
+                            } else {
+                                rhs_size_known = false;
+                                break;
                             }
+                        }
+                        if ( arr_rhs->n_dims == 0 ) {
+                            rhs_size_known = false;
                         }
                         for (size_t i = 0; i < arr_lhs->n_dims; i++) {
                             std::int64_t lhs_dim = ASRUtils::extract_dim_value_int(arr_lhs->m_dims[i].m_length);
@@ -8701,7 +8708,7 @@ public:
                                 break;
                             }
                         }
-                        if( lhs_ele < rhs_ele ){
+                        if( rhs_size_known && lhs_ele < rhs_ele ){
                             diag.add(Diagnostic("Array passed into function has `" + std::to_string(lhs_ele) +
                                 "` elements but function expects `" + std::to_string(rhs_ele) + "`.",
                                 Level::Error, Stage::Semantic, {Label("", {args.p[i].loc})}));


### PR DESCRIPTION
Skip the array element count check when the function parameter has unknown dimensions (e.g., assumed-rank). Previously, unknown dimensions defaulted to size 1, causing a spurious error when passing zero-length arrays like [real::] to assumed-rank parameters.