### PR TITLE
Fix pass(rhs) operator overloading

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1727,6 +1727,7 @@ RUN(NAME operator_overloading_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME custom_unary_operator_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/operator_overloading_24.f90
+++ b/integration_tests/operator_overloading_24.f90
@@ -1,0 +1,52 @@
+module operator_overloading_24_mod
+  implicit none
+
+  type :: string_t
+    character(len=:), allocatable :: s
+  contains
+    procedure, private :: string_t_eq_string_t
+    procedure, private :: string_t_eq_character
+    procedure, private, pass(rhs) :: character_eq_string_t
+    generic :: operator(==) => string_t_eq_string_t, string_t_eq_character, character_eq_string_t
+  end type
+
+contains
+
+  elemental logical function string_t_eq_string_t(lhs, rhs)
+    class(string_t), intent(in) :: lhs, rhs
+    string_t_eq_string_t = lhs%s == rhs%s
+  end function
+
+  elemental logical function string_t_eq_character(lhs, rhs)
+    class(string_t), intent(in) :: lhs
+    character(len=*), intent(in) :: rhs
+    string_t_eq_character = lhs%s == rhs
+  end function
+
+  elemental logical function character_eq_string_t(lhs, rhs)
+    character(len=*), intent(in) :: lhs
+    class(string_t), intent(in) :: rhs
+    character_eq_string_t = lhs == rhs%s
+  end function
+
+end module
+
+program operator_overloading_24
+  use operator_overloading_24_mod, only: string_t
+  implicit none
+
+  ! string_t == string_t
+  if (.not. (string_t("abc") == string_t("abc"))) error stop
+  if (string_t("abc") == string_t("xyz")) error stop
+
+  ! string_t == character
+  if (.not. (string_t("abc") == "abc")) error stop
+  if (string_t("abc") == "xyz") error stop
+
+  ! character == string_t (pass(rhs))
+  if (.not. ("abc" == string_t("abc"))) error stop
+  if ("abc" == string_t("xyz")) error stop
+
+  print *, "All tests passed."
+
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2077,12 +2077,23 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
         right_struct = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(right)));
     }
     bool found = false;
-    if (is_op_overloaded(op, intrinsic_op_name, curr_scope, left_struct)) {
+    // Try left_struct first; if not found, try right_struct (for pass(rhs) operators)
+    ASR::Struct_t* active_struct = left_struct;
+    bool pass_right = false;
+    bool op_overloaded_found = is_op_overloaded(op, intrinsic_op_name, curr_scope, left_struct);
+    if (!op_overloaded_found && right_struct != nullptr) {
+        op_overloaded_found = is_op_overloaded(op, intrinsic_op_name, curr_scope, right_struct);
+        if (op_overloaded_found) {
+            active_struct = right_struct;
+            pass_right = true;
+        }
+    }
+    if (op_overloaded_found) {
         ASR::symbol_t* sym = curr_scope->resolve_symbol(intrinsic_op_name);
         ASR::symbol_t* orig_sym = ASRUtils::symbol_get_past_external(sym);
         ASR::symbol_t* orig_sym2 = nullptr;
-        if ( left_struct != nullptr) {
-            ASR::Struct_t* temp_struct = left_struct;
+        if ( active_struct != nullptr) {
+            ASR::Struct_t* temp_struct = active_struct;
             while (temp_struct) {
                 if (temp_struct->m_symtab->get_symbol(intrinsic_op_name) != nullptr) {
                     orig_sym2 = temp_struct->m_symtab->get_symbol(intrinsic_op_name);
@@ -2117,9 +2128,9 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
             ASR::symbol_t* orig_proc = ASRUtils::symbol_get_past_external(op_overloading_procs[i]);
             if ( ASR::is_a<ASR::StructMethodDeclaration_t>(*op_overloading_procs[i]) ) {
                 ASR::StructMethodDeclaration_t* cp = ASR::down_cast<ASR::StructMethodDeclaration_t>(op_overloading_procs[i]);
-                if (cp->m_parent_symtab->get_counter() != left_struct->m_symtab->get_counter()) {
+                if (cp->m_parent_symtab->get_counter() != active_struct->m_symtab->get_counter()) {
                     // It may be overided in the derived class
-                    ASR::Struct_t* temp_struct = left_struct;
+                    ASR::Struct_t* temp_struct = active_struct;
                     while (temp_struct->m_parent) {
                         if (temp_struct->m_symtab->get_symbol(cp->m_name) != nullptr) {
                             cp = ASR::down_cast<ASR::StructMethodDeclaration_t>(temp_struct->m_symtab->get_symbol(cp->m_name));
@@ -2188,14 +2199,20 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                             a_args.reserve(al, 1);
                             ASR::call_arg_t left_call_arg, right_call_arg;
                             ASR::expr_t* self_arg = nullptr;
-                            if (i < n_interface_proc) {
+                            if (i < n_interface_proc || pass_right) {
+                                // For interface procs or pass(rhs) class procs,
+                                // both args go in a_args in proper order
                                 left_call_arg.loc = left->base.loc, left_call_arg.m_value = left;
                                 a_args.push_back(al, left_call_arg);
+                                right_call_arg.loc = right->base.loc, right_call_arg.m_value = right;
+                                a_args.push_back(al, right_call_arg);
+                            } else {
+                                // pass(lhs) or default: self_arg is left, right is the regular argument
+                                right_call_arg.loc = right->base.loc, right_call_arg.m_value = right;
+                                a_args.push_back(al, right_call_arg);
                             }
-                            right_call_arg.loc = right->base.loc, right_call_arg.m_value = right;
-                            a_args.push_back(al, right_call_arg);
                             std::string func_name = to_lower(func->m_name);
-                            if (i >= n_interface_proc) {
+                            if (i >= n_interface_proc && !pass_right) {
                                 ASR::symbol_t* mem_ext = import_class_procedure(al, loc, orig_proc, curr_scope);
                                 matched_func_name = ASRUtils::symbol_name(mem_ext);
                                 self_arg = left;
@@ -2207,7 +2224,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                             }
                             ASR::symbol_t* a_name = curr_scope->resolve_symbol(matched_func_name);
                             if( a_name == nullptr ) {
-                                if (i >= n_interface_proc) {
+                                if (i >= n_interface_proc && !pass_right) {
                                     err("Unable to resolve matched function for operator overloading, " + matched_func_name, loc);
                                 } else {
                                     a_name = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(


### PR DESCRIPTION
When a comparison operator like == was defined as a type-bound procedure with pass(rhs), and the left operand was a non-struct type (e.g., character), the operator was not found because use_overloaded only checked left_struct for type-bound operators.

Fix by also checking right_struct when left_struct does not have the operator. For pass(rhs) class procedures, both arguments are passed as regular arguments (no self_arg) to avoid codegen issues with m_dt expecting a struct expression.