### PR TITLE
docs: clarify conda installation and binary path (Fixes #10012)

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -27,10 +27,10 @@ When installing LFortran using Conda, multiple copies of the `lfortran`
 executable may be present in different locations (for example, in the package
 cache). Only the executable inside the active Conda environment should be used.
 
-The correct executable is typically located at:
+After activating a conda environment, the correct executable is typically located at:
 `$CONDA_PREFIX/bin/lfortran`
 
-To verify which executable is being used, run:
+To verify which executable is being used, activate a conda environment and run:
 `which lfortran`
 
 Other copies located in package directories may not run correctly and can be ignored.


### PR DESCRIPTION
This PR addresses #10012 by adding a note to help users identify the correct lfortran binary path after a Conda installation. It uses $CONDA_PREFIX and 'which lfortran' for verification.


 Fixes #10012.