### PR TITLE
fix: get past external symbol in dimension expression in declaration

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -798,6 +798,7 @@ RUN(NAME arrays_99 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_100 LABELS gfortran llvm)
 RUN(NAME arrays_101 LABELS gfortran llvm)
 RUN(NAME arrays_102 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME arrays_103 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_103.f90
+++ b/integration_tests/arrays_103.f90
@@ -1,0 +1,45 @@
+module arrays_103_mod_1
+   implicit none
+   real(8), allocatable :: a(:,:)
+end module arrays_103_mod_1
+
+
+module arrays_103_mod_2
+   use arrays_103_mod_1
+   implicit none
+
+contains
+
+   subroutine automatic_array()
+      implicit none
+      real(8), dimension(size(a,1)) :: b
+      integer :: i
+
+      do i = 1, size(a,1)
+         b(i) = sum(a(i,:))
+      end do
+
+      if (any(b /= [10.0d0, 20.0d0, 30.0d0])) error stop
+
+   end subroutine automatic_array
+
+end module arrays_103_mod_2
+
+
+program arrays_103
+   use arrays_103_mod_1
+   use arrays_103_mod_2
+   implicit none
+   integer :: i, j
+
+   allocate(a(3,4))
+
+   do i = 1, 3
+      do j = 1, 4
+         a(i,j) = real(i*j, 8)
+      end do
+   end do
+
+   call automatic_array()
+
+end program arrays_103

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2421,7 +2421,7 @@ public:
             if  (ASR::is_a<ASR::Var_t>(*dim_expr_arrsize->m_v)){
                 ASR::Var_t* arr_var = ASR::down_cast<ASR::Var_t>(dim_expr_arrsize->m_v);
                 ASR::symbol_t* arr_sym = arr_var->m_v;
-                ASR::Variable_t* arr_variable = ASR::down_cast<ASR::Variable_t>(arr_sym);
+                ASR::Variable_t* arr_variable = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(arr_sym));
                 SymbolTable* symbol_scope = ASRUtils::symbol_parent_symtab(arr_sym);
                 if ((arr_variable->m_type->type == ASR::ttypeType::Allocatable) && !(in_Subroutine) && (symbol_scope->counter == current_scope->counter)) {
                     error = true;


### PR DESCRIPTION
Fixes #10115
