### PR TITLE
Fix class(*) allocatable assignment

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2398,6 +2398,7 @@ RUN(NAME class_108 LABELS gfortran llvm)
 RUN(NAME class_109 LABELS gfortran llvm)
 RUN(NAME class_110 LABELS gfortran llvm EXTRAFILES class_110_module.f90)
 RUN(NAME class_111 LABELS gfortran llvm)
+RUN(NAME class_112 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_112.f90
+++ b/integration_tests/class_112.f90
@@ -1,0 +1,37 @@
+program class_112
+   implicit none
+
+   integer, parameter :: i = 4
+   real, parameter :: r = 3.14
+   logical, parameter :: l = .true.
+   class(*), allocatable :: obj
+
+   obj = i
+   select type(obj)
+      type is (integer)
+         print *, obj
+         if (obj /= 4) error stop
+      class default
+         error stop
+   end select
+
+   obj = r
+   select type(obj)
+      type is (real)
+         print *, obj
+         if (abs(obj - 3.14) > 1.0e-6) error stop
+      class default
+         error stop
+   end select
+
+   obj = l
+   select type(obj)
+      type is (logical)
+         print *, obj
+         if (obj .neqv. .true.) error stop
+      class default
+         error stop
+   end select
+
+   print *, "All tests passed."
+end program class_112

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8847,10 +8847,13 @@ public:
                 llvm_utils->deepcopy(x.m_value, value, target,
                     asr_target_type, asr_value_type, module.get());
             } else {
-                struct_api->store_intrinsic_type_vptr(asr_value_type,
-                    ASRUtils::extract_kind_from_ttype_t(asr_value_type), target, module.get());
                 llvm::Type* target_llvm_type = llvm_utils->get_type_from_ttype_t_util(
                     x.m_target, ASRUtils::extract_type(asr_target_type), module.get());
+                if (ASRUtils::is_allocatable(asr_target_type)) {
+                    target = llvm_utils->CreateLoad2(target_llvm_type->getPointerTo(), target);
+                }
+                struct_api->store_intrinsic_type_vptr(asr_value_type,
+                    ASRUtils::extract_kind_from_ttype_t(asr_value_type), target, module.get());
                 llvm::Type* value_llvm_type = llvm_utils->get_type_from_ttype_t_util(
                     x.m_value, ASRUtils::extract_type(asr_value_type), module.get());
                 target = llvm_utils->create_gep2(target_llvm_type, target, 1);


### PR DESCRIPTION
When assigning a non-polymorphic value (e.g. integer) to an allocatable class(*) target, the LLVM codegen did not dereference the extra pointer level from the Allocatable wrapper before calling create_gep2, causing a type mismatch assertion failure.

Add a load to strip the allocatable indirection before accessing the unlimited polymorphic struct fields.

Fixes #10119.