### PR TITLE
Fix class(*) intrinsic scalar store

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2404,6 +2404,9 @@ RUN(NAME class_108 LABELS gfortran llvm)
 RUN(NAME class_109 LABELS gfortran llvm)
 RUN(NAME class_110 LABELS gfortran llvm EXTRAFILES class_110_module.f90)
 RUN(NAME class_111 LABELS gfortran llvm)
+RUN(NAME class_112 LABELS gfortran llvm)
+RUN(NAME class_113 LABELS gfortran llvm)
+RUN(NAME class_114 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_112.f90
+++ b/integration_tests/class_112.f90
@@ -1,0 +1,37 @@
+program class_112
+   implicit none
+
+   integer, parameter :: i = 4
+   real, parameter :: r = 3.14
+   logical, parameter :: l = .true.
+   class(*), allocatable :: obj
+
+   obj = i
+   select type(obj)
+      type is (integer)
+         print *, obj
+         if (obj /= 4) error stop
+      class default
+         error stop
+   end select
+
+   obj = r
+   select type(obj)
+      type is (real)
+         print *, obj
+         if (abs(obj - 3.14) > 1.0e-6) error stop
+      class default
+         error stop
+   end select
+
+   obj = l
+   select type(obj)
+      type is (logical)
+         print *, obj
+         if (obj .neqv. .true.) error stop
+      class default
+         error stop
+   end select
+
+   print *, "All tests passed."
+end program class_112

--- a/integration_tests/class_113.f90
+++ b/integration_tests/class_113.f90
@@ -1,0 +1,27 @@
+program class_113
+   implicit none
+   integer :: i
+   real :: r
+   class(*), allocatable :: obj
+
+   i = 77
+   obj = i
+   select type(obj)
+      type is (integer)
+         print *, obj
+         if (obj /= 77) error stop
+      class default
+         error stop
+   end select
+
+   r = 1.5
+   obj = r
+   select type(obj)
+      type is (real(4))
+         if (abs(obj - 1.5) > 1.0e-5) error stop
+      class default
+         error stop
+   end select
+
+   print *, "All tests passed."
+end program class_113

--- a/integration_tests/class_114.f90
+++ b/integration_tests/class_114.f90
@@ -1,0 +1,21 @@
+program main
+
+   integer,  parameter :: i = 4
+
+   select type (obj => unlimited_polymorphic(i))
+   type is (integer)
+      print *, obj
+      if (obj /= 4) error stop
+   class default
+      error stop
+   end select
+
+contains
+
+   function unlimited_polymorphic(i) result(res)
+      integer,  intent(in) :: i
+      class(*), allocatable :: res
+      res = i
+   end function unlimited_polymorphic
+
+end program main

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8899,6 +8899,15 @@ public:
                 target = llvm_utils->create_gep2(target_llvm_type, target, 1);
                 target = llvm_utils->CreateLoad2(llvm_utils->i8_ptr, target);
                 target = builder->CreateBitCast(target, value_llvm_type->getPointerTo());
+                // With ptr_loads=0, variables produce a pointer while
+                // constants produce a value directly.  deepcopy for scalar
+                // intrinsic types expects a loaded value, so load only when
+                // the LLVM value is actually a pointer.
+                if (!ASRUtils::is_array(asr_value_type) &&
+                        !ASRUtils::is_character(*asr_value_type) &&
+                        value->getType()->isPointerTy()) {
+                    value = llvm_utils->CreateLoad2(value_llvm_type, value);
+                }
                 llvm_utils->deepcopy(x.m_value, value, target,
                     asr_target_type, asr_value_type, module.get());
             }


### PR DESCRIPTION
Load the value from pointer only when the LLVM value is actually a pointer. With ptr_loads=0, variables produce a pointer while constants (e.g. complex literals) produce a value directly. The previous code unconditionally loaded, which caused LLVM verification failures for complex constants.

Fixes #10121. Fixes #10119.