### PR TITLE
Add WITH_LIRIC option for AOT compilation via liric compat headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ endif()
 
 # LLVM
 set(WITH_LLVM no CACHE BOOL "Build with LLVM support")
+set(WITH_LIRIC no CACHE BOOL "Use liric as LLVM replacement (C++ compat headers)")
+set(LIRIC_DIR "" CACHE PATH "Path to liric source/build directory")
 set(WITH_TARGET_AARCH64 no CACHE BOOL "Enable target AARCH64")
 set(WITH_TARGET_X86 no CACHE BOOL "Enable target X86")
 set(WITH_TARGET_WASM no CACHE BOOL "Enable target WebAssembly")
@@ -215,7 +217,29 @@ if (WITH_UNWIND)
     set(HAVE_LFORTRAN_UNWIND yes)
 endif()
 
-if (WITH_LLVM)
+if (WITH_LIRIC)
+    add_compile_definitions(WITH_LIRIC)
+    if ("${LIRIC_DIR}" STREQUAL "")
+        message(FATAL_ERROR "WITH_LIRIC requires LIRIC_DIR to be set")
+    endif()
+    find_library(LIRIC_LIB liric
+        PATHS "${LIRIC_DIR}/build" "${LIRIC_DIR}/lib" "${LIRIC_DIR}"
+        NO_DEFAULT_PATH)
+    if (NOT LIRIC_LIB)
+        message(FATAL_ERROR "Could not find libliric in ${LIRIC_DIR}")
+    endif()
+    message(STATUS "Using liric: ${LIRIC_LIB}")
+    message(STATUS "Liric includes: ${LIRIC_DIR}/include")
+    add_library(p::llvm INTERFACE IMPORTED)
+    set_property(TARGET p::llvm PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+        "${LIRIC_DIR}/include")
+    set_property(TARGET p::llvm PROPERTY INTERFACE_COMPILE_OPTIONS
+        $<$<COMPILE_LANGUAGE:CXX>:${LFORTRAN_CXX_NO_RTTI_FLAG}>)
+    set_property(TARGET p::llvm PROPERTY INTERFACE_LINK_LIBRARIES
+        "${LIRIC_LIB}" stdc++)
+    set(HAVE_LFORTRAN_LLVM yes)
+    set(WITH_LLVM yes)
+elseif (WITH_LLVM)
     set(WITH_ZSTD yes CACHE BOOL "Detect (and require) libzstd for LLVM")
     set(USE_DYNAMIC_ZSTD no CACHE BOOL "Use dynamic ZSTD library (default: static)")
     if(WITH_ZSTD)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1505,7 +1505,7 @@ public:
         if (ASRUtils::is_unlimited_polymorphic_type(st)) {
             if (!compiler_options.new_classes) {
                 if (is_pointer) {
-                    return llvm::Type::getVoidTy(context)->getPointerTo();
+                    return llvm::Type::getInt8Ty(context)->getPointerTo();
                 } else {
                     return llvm::Type::getVoidTy(context);
                 }
@@ -4433,6 +4433,12 @@ public:
         std::vector<llvm::Constant*> arr_elements;
         size_t arr_const_size = (size_t) ASRUtils::get_fixed_size_of_array(arr_const->m_type);
         arr_elements.reserve(arr_const_size);
+        llvm::ArrayType* arr_type = nullptr;
+        llvm::Type* elem_type = type;
+        if (type->isArrayTy()) {
+            arr_type = llvm::cast<llvm::ArrayType>(type);
+            elem_type = arr_type->getElementType();
+        }
         int a_kind;
         for (size_t i = 0; i < arr_const_size; i++) {
             ASR::expr_t* elem = ASRUtils::fetch_ArrayConstant_value(al, arr_const, i);
@@ -4456,10 +4462,12 @@ public:
                     context, llvm::APInt(1, logical_const->m_value)));
             }
         }
-        llvm::ArrayType* arr_type = llvm::ArrayType::get(type, arr_const_size);
+        if (!arr_type) {
+            arr_type = llvm::ArrayType::get(elem_type, arr_const_size);
+        }
         llvm::Constant* initializer = nullptr;
         if (isNullValueArray(arr_elements)) {
-            initializer = llvm::ConstantArray::getNullValue(type);
+            initializer = llvm::ConstantArray::getNullValue(arr_type);
         } else {
             initializer = llvm::ConstantArray::get(arr_type, arr_elements);
         }
@@ -4677,7 +4685,7 @@ public:
                 }
             llvm_symtab[h] = ptr;
         } else if( x.m_type->type == ASR::ttypeType::CPtr ) {
-            llvm::Type* void_ptr = llvm::Type::getVoidTy(context)->getPointerTo();
+            llvm::Type* void_ptr = llvm::Type::getInt8Ty(context)->getPointerTo();
             llvm::Constant *ptr = module->getOrInsertGlobal(llvm_var_name,
                 void_ptr);
             if (!external) {
@@ -4732,7 +4740,7 @@ public:
             }
             if (!is_class) {
                 if( x.m_type_declaration && ASRUtils::is_c_ptr(x.m_type_declaration) ) {
-                    llvm::Type* void_ptr = llvm::Type::getVoidTy(context)->getPointerTo();
+                    llvm::Type* void_ptr = llvm::Type::getInt8Ty(context)->getPointerTo();
                     llvm::Constant *ptr = module->getOrInsertGlobal(llvm_var_name,
                         void_ptr);
                     if (!external) {
@@ -6634,9 +6642,9 @@ public:
             F->setSubprogram(SP);
             debug_current_scope = SP;
         }
-        proc_return = llvm::BasicBlock::Create(context, "return");
         llvm::BasicBlock *BB = llvm::BasicBlock::Create(context,
                 ".entry", F);
+        proc_return = llvm::BasicBlock::Create(context, "return");
         builder->SetInsertPoint(BB);
         if (compiler_options.emit_debug_info) debug_emit_loc(x);
         declare_args(x, *F);
@@ -6928,7 +6936,7 @@ public:
             tmp = llvm_utils->CreateLoad2(elem_type->getPointerTo(), arr_descr->get_pointer_to_data(elem_type, tmp));
         }
         tmp = builder->CreateBitCast(tmp,
-                    llvm::Type::getVoidTy(context)->getPointerTo());
+                    llvm::Type::getInt8Ty(context)->getPointerTo());
     }
 
 
@@ -7009,7 +7017,7 @@ public:
             tmp = llvm_utils->get_string_data(ASRUtils::get_string_type(x.m_arg), tmp);
         }
         tmp = builder->CreateBitCast(tmp,
-                    llvm::Type::getVoidTy(context)->getPointerTo());
+                    llvm::Type::getInt8Ty(context)->getPointerTo());
     }
 
 
@@ -8079,7 +8087,7 @@ public:
 
                 if ( ASRUtils::is_unlimited_polymorphic_type(value_struct_t) ) {
                     // we need to cast `value_class` to `void*`
-                    llvm::Type* void_ptr_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                    llvm::Type* void_ptr_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                     value_class = builder->CreateBitCast(value_class, void_ptr_type);
                 }
                 builder->CreateStore(value_class, llvm_utils->create_gep2(value_llvm_type, llvm_target, 1));
@@ -10666,7 +10674,7 @@ public:
             if (change_symtab) {
                 llvm::Type* src_type = llvm_utils->get_type_from_ttype_t_util(x.m_selector, expr_type(x.m_selector), module.get());
                 llvm::Value* llvm_selector_new = llvm_utils->create_gep2(src_type, llvm_selector, 1);
-                llvm_selector_new = llvm_utils->CreateLoad2(llvm::Type::getVoidTy(context)->getPointerTo(),llvm_selector_new);
+                llvm_selector_new = llvm_utils->CreateLoad2(llvm::Type::getInt8Ty(context)->getPointerTo(),llvm_selector_new);
                 llvm_selector_new = builder->CreateBitCast(llvm_selector_new, ctx.block_type->getPointerTo());
                 uint32_t h = get_hash((ASR::asr_t*)ASR::down_cast<ASR::Variable_t>(current_scope->resolve_symbol(selector_var_name)));
                 llvm_symtab[h] = llvm_selector_new;
@@ -11511,10 +11519,16 @@ public:
         if (ASR::is_a<ASR::ArrayItem_t>(*(x.m_source))) {
             source = llvm_utils->CreateLoad2(type, source);
         }
-        llvm::Value *ftarget = builder->CreateSIToFP(target,
-                type);
-        llvm::Value *fsource = builder->CreateSIToFP(source,
-                type);
+        llvm::Value *ftarget = target;
+        llvm::Value *fsource = source;
+        if (ftarget->getType() != type) {
+            if (ftarget->getType()->isIntegerTy()) ftarget = builder->CreateSIToFP(ftarget, type);
+            else if (ftarget->getType()->isFloatingPointTy()) ftarget = builder->CreateFPCast(ftarget, type);
+        }
+        if (fsource->getType() != type) {
+            if (fsource->getType()->isIntegerTy()) fsource = builder->CreateSIToFP(fsource, type);
+            else if (fsource->getType()->isFloatingPointTy()) fsource = builder->CreateFPCast(fsource, type);
+        }
         std::string func_name = a_kind == 4 ? "llvm.copysign.f32" : "llvm.copysign.f64";
         llvm::Function *fn_copysign = module->getFunction(func_name);
         if (!fn_copysign) {
@@ -12926,7 +12940,7 @@ public:
                 break;
             }
             case (ASR::cast_kindType::UnsignedIntegerToCPtr) : {
-                tmp = builder->CreateIntToPtr(tmp, llvm::Type::getVoidTy(context)->getPointerTo());
+                tmp = builder->CreateIntToPtr(tmp, llvm::Type::getInt8Ty(context)->getPointerTo());
                 break;
             }
             case (ASR::cast_kindType::ComplexToComplex) : {
@@ -16534,7 +16548,7 @@ public:
                                     // Local variable of type
                                     // CPtr is a void**, so we
                                     // have to load it
-                                    llvm::Type* cptr_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                                    llvm::Type* cptr_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                                     tmp = llvm_utils->CreateLoad2(cptr_type, tmp);
                                 }
                             } else if ( x_abi == ASR::abiType::BindC && orig_arg != nullptr ) {
@@ -16550,7 +16564,8 @@ public:
                                                     // tmp is {float, float}*
                                                     // type_fx2 is i64
                                                     llvm::Type* type_fx2 = llvm::Type::getInt64Ty(context);
-                                                    tmp = llvm_utils->CreateLoad2(type_fx2, tmp);
+                                                    llvm::Value* c32_as_i64_ptr = builder->CreateBitCast(tmp, type_fx2->getPointerTo());
+                                                    tmp = llvm_utils->CreateLoad2(type_fx2, c32_as_i64_ptr);
                                                 } else if (compiler_options.platform == Platform::macOS_ARM) {
                                                     // tmp is {float, float}*
                                                     // type_fx2 is [2 x float]
@@ -16562,7 +16577,8 @@ public:
                                                     // tmp is {float, float}*
                                                     // type_fx2 is <2 x float>
                                                     llvm::Type* type_fx2 = FIXED_VECTOR_TYPE::get(llvm::Type::getFloatTy(context), 2);
-                                                    tmp = llvm_utils->CreateLoad2(type_fx2, tmp);
+                                                    llvm::Value* c32_as_vec2_ptr = builder->CreateBitCast(tmp, type_fx2->getPointerTo());
+                                                    tmp = llvm_utils->CreateLoad2(type_fx2, c32_as_vec2_ptr);
                                                 }
                                             } else {
                                                 LCOMPILERS_ASSERT(c_kind == 8)
@@ -16580,7 +16596,7 @@ public:
                                             // Local variable or Dummy out argument
                                             // of type CPtr is a void**, so we
                                             // have to load it
-                                            llvm::Type* cptr_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                                            llvm::Type* cptr_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                                             tmp = llvm_utils->CreateLoad2(cptr_type, tmp);
                                         }
                                     } else {
@@ -16882,7 +16898,7 @@ public:
                     case (ASR::ttypeType::StructType) :
                         break;
                     case (ASR::ttypeType::CPtr) :
-                        target_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                        target_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                         break;
                     case ASR::ttypeType::Allocatable:
                     case (ASR::ttypeType::Pointer) : {
@@ -17615,7 +17631,7 @@ public:
                         builder->CreateBitCast(
                             llvm_utils->CreateLoad2(wrapped_struct_llvm_type->getPointerTo(),
                                                     llvm_utils->create_gep2(dt_type, dt, 1)),
-                            llvm::Type::getVoidTy(context)->getPointerTo()),
+                            llvm::Type::getInt8Ty(context)->getPointerTo()),
                         polymorphic_addr);
                     llvm::Value* type_id_addr = llvm_utils->create_gep2(_type, abstract_, 0);
                     if (ASR::is_a<ASR::StructType_t>(*arg_type)) {
@@ -17648,7 +17664,7 @@ public:
                 llvm::Value* polymorphic_data_addr = llvm_utils->create_gep2(array_data_type, polymorphic_data, 1);
                 llvm::Value* dt_data = llvm_utils->CreateLoad2(dt_array_data_type->getPointerTo(), arr_descr->get_pointer_to_data(arg_expr, arg_type, dt, module.get()));
                 builder->CreateStore(
-                    builder->CreateBitCast(dt_data, llvm::Type::getVoidTy(context)->getPointerTo()),
+                    builder->CreateBitCast(dt_data, llvm::Type::getInt8Ty(context)->getPointerTo()),
                     polymorphic_data_addr);
                 llvm::Value* type_id_addr = llvm_utils->create_gep2(array_data_type, polymorphic_data, 0);
                 builder->CreateStore(
@@ -17662,7 +17678,7 @@ public:
                 llvm::Value* abstract_ = llvm_utils->CreateAlloca(_type);
                 llvm::Value* polymorphic_addr = llvm_utils->create_gep2(_type, abstract_, 1);
                 builder->CreateStore(
-                    builder->CreateBitCast(dt, llvm::Type::getVoidTy(context)->getPointerTo()),
+                    builder->CreateBitCast(dt, llvm::Type::getInt8Ty(context)->getPointerTo()),
                     polymorphic_addr);
                 llvm::Value* type_id_addr = llvm_utils->create_gep2(_type, abstract_, 0);
                 if (ASR::is_a<ASR::StructType_t>(*arg_type) && !ASRUtils::is_class_type(arg_type)) {

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -21,9 +21,11 @@ namespace llvm {
     class GlobalVariable;
     class TargetMachine;
     class DataLayout;
+#ifndef WITH_LIRIC
     namespace orc {
         class KaleidoscopeJIT;
     }
+#endif
 }
 
 namespace mlir {
@@ -63,7 +65,9 @@ public:
 class LLVMEvaluator
 {
 private:
+#ifndef WITH_LIRIC
     std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit;
+#endif
     std::unique_ptr<llvm::LLVMContext> context;
     std::string target_triple;
     llvm::TargetMachine *TM;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -253,7 +253,7 @@ namespace LCompilers {
                 break;
             }
             case ASR::ttypeType::CPtr: {
-                llvm_mem_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                llvm_mem_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                 break;
             }
             default:
@@ -390,7 +390,7 @@ namespace LCompilers {
                 std::vector<llvm::Type*> member_types;
                 member_types.push_back(getIntType(8));
                 if( der_type_name == "~unlimited_polymorphic_type_polymorphic" ) {
-                    member_types.push_back(llvm::Type::getVoidTy(context)->getPointerTo());
+                    member_types.push_back(llvm::Type::getInt8Ty(context)->getPointerTo());
                 } else {
                     member_types.push_back(getStructType(der_type, module, true));
                 }
@@ -503,7 +503,7 @@ namespace LCompilers {
                 break;
             }
             case ASR::ttypeType::CPtr: {
-                el_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                el_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                 break;
             }
             case ASR::ttypeType::StructType: {
@@ -836,7 +836,7 @@ namespace LCompilers {
                 break;
             }
             case (ASR::ttypeType::CPtr) : {
-                type = llvm::Type::getVoidTy(context)->getPointerTo();
+                type = llvm::Type::getInt8Ty(context)->getPointerTo();
                 break;
             }
             case (ASR::ttypeType::Tuple) : {
@@ -1116,7 +1116,7 @@ namespace LCompilers {
                     return_type = llvm::Type::getInt1Ty(context);
                     break;
                 case (ASR::ttypeType::CPtr) :
-                    return_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                    return_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                     break;
                 case (ASR::ttypeType::Pointer) : {
                     return_type = get_type_from_ttype_t_util(x.m_return_var, ASRUtils::get_contained_type(return_var_type0), module)->getPointerTo();
@@ -1466,7 +1466,7 @@ namespace LCompilers {
             }
             case (ASR::ttypeType::CPtr) : {
                 a_kind = 8;
-                llvm_type = llvm::Type::getVoidTy(context)->getPointerTo();
+                llvm_type = llvm::Type::getInt8Ty(context)->getPointerTo();
                 break;
             }
             case (ASR::ttypeType::EnumType) : {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -1213,9 +1213,9 @@ if(get_struct_sym(member_variable) == struct_sym /*recursive declaration*/){cont
             // Free consecutive structs inserted into array's single class structure `{VTable*, underlying_struct*}
             if(is_class_type){
                 auto const class_type_llvm = llvm_utils_->getClassType(struct_sym);
-                auto const struct_type_llvm = llvm_utils_->getStructType(struct_sym, llvm_utils_->module);
-                auto const allocated_cosecutive_structs = builder_->CreateLoad(struct_type_llvm->getPointerTo(),
-                                                             llvm_utils_->CreateGEP2(class_type_llvm, data_ptr, 1));
+                auto const consecutive_field_ptr = llvm_utils_->CreateGEP2(class_type_llvm, data_ptr, 1);
+                auto const consecutive_field_type = consecutive_field_ptr->getType()->getPointerElementType();
+                auto const allocated_cosecutive_structs = builder_->CreateLoad(consecutive_field_type, consecutive_field_ptr);
                 llvm_utils_->lfortran_free(allocated_cosecutive_structs);
                 // deallocate class wrapper 
                 llvm_utils_->lfortran_free(data_ptr);


### PR DESCRIPTION
## Summary

- Add `WITH_LIRIC` / `LIRIC_DIR` CMake options to build lfortran with liric as the backend instead of LLVM ORC JIT
- Fix `void*` → `i8*` pointer type in codegen (liric doesn't support void pointer types)
- Fix ArrayConstant initializer type mismatch when type is already an ArrayType
- Fix copysign codegen to handle float/int operands correctly (avoid unconditional SIToFP)
- Fix complex32 BindC ABI: add explicit bitcast before type-punned load
- Fix polymorphic class field: use getPointerElementType() instead of hardcoded struct type
- Move `proc_return` block creation after `.entry` block to maintain correct block ordering

## Why

Liric provides a fast C11 JIT/AOT backend (~47x faster compile than LLVM on the LL corpus).
This PR enables building lfortran with `cmake -DWITH_LIRIC=ON -DLIRIC_DIR=/path/to/liric`
as a drop-in replacement for the LLVM ORC JIT, using liric's C++ compat headers that
provide the same `llvm::` namespace API backed by liric's native compiler.

## Changes

- [`CMakeLists.txt`]: Add `WITH_LIRIC`/`LIRIC_DIR` options, create `p::llvm` interface target pointing to liric
- [`src/libasr/codegen/asr_to_llvm.cpp`]: void* → i8*, ArrayConstant fix, copysign fix, block ordering fix
- [`src/libasr/codegen/evaluator.cpp`]: Guard KaleidoscopeJIT with `#ifndef WITH_LIRIC`, set `LIRIC_POLICY=ir`
- [`src/libasr/codegen/evaluator.h`]: Guard KaleidoscopeJIT declaration
- [`src/libasr/codegen/llvm_utils.cpp`]: void* → i8* in all CPtr/polymorphic paths
- [`src/libasr/codegen/llvm_utils.h`]: Fix polymorphic class free to use getPointerElementType()

## Test plan

- [ ] Build with `cmake -DWITH_LIRIC=ON -DLIRIC_DIR=<path>` and verify compilation succeeds
- [ ] Run `LIRIC_POLICY=direct lfortran --jit test.f90` and `LIRIC_POLICY=ir lfortran --jit test.f90`
- [ ] Verify AOT: `lfortran test.f90 -o test && ./test` produces correct output
- [ ] Run bench_matrix ll_jit lane to confirm ~47x speedup maintained