### PR TITLE
Fix double free in struct constructor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1617,6 +1617,7 @@ RUN(NAME select_type_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_25 LABELS gfortran llvm)
 RUN(NAME select_type_26 LABELS gfortran llvm)
 RUN(NAME select_type_27 LABELS gfortran llvm)
+RUN(NAME select_type_28 LABELS gfortran llvm)
 
 RUN(NAME program_02 LABELS gfortran llvm)
 RUN(NAME program_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_type_28.f90
+++ b/integration_tests/select_type_28.f90
@@ -1,0 +1,51 @@
+! Test struct constructor with class member inside select type
+! Verifies no double free when constructing a struct from a
+! select type associated variable
+module select_type_28_type1mod
+
+   type :: Type1
+   end type Type1
+
+contains
+
+   function get_Type1() result(res)
+      class(*), allocatable :: res
+      res = Type1()
+   end function get_Type1
+
+end module select_type_28_type1mod
+
+module select_type_28_type2mod
+
+   use select_type_28_type1mod
+
+   type :: Type2
+      class(Type1), allocatable :: field
+   end type Type2
+
+contains
+
+   function get_Type2() result(res)
+      class(*), allocatable :: res
+      select type( obj => get_Type1() )
+      class is (Type1)
+         res = Type2(obj)
+      end select
+   end function get_Type2
+
+end module select_type_28_type2mod
+
+program select_type_28
+
+   use select_type_28_type2mod
+
+   class(Type2), allocatable :: res
+
+   select type( obj => get_Type2() )
+   class is (Type2)
+      res = obj
+   end select
+
+   print *, "PASS"
+
+end program select_type_28

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -736,7 +736,8 @@ namespace LCompilers {
                             x_m_args_i, cast_kind, casted_type, nullptr, nullptr));
                     }
                     ASR::stmt_t* assign;
-                    if (ASRUtils::is_pointer(ASRUtils::expr_type(x_m_args_i))) {
+                    if (ASRUtils::is_pointer(ASRUtils::expr_type(x_m_args_i)) &&
+                        ASRUtils::is_pointer(ASRUtils::expr_type(derived_ref))) {
                         assign = ASRUtils::STMT(ASRUtils::make_Associate_t_util(replacer->al,
                                                     x->base.base.loc, derived_ref, x_m_args_i));
                     } else {


### PR DESCRIPTION
When lowering StructConstructor to member-wise assignments, an Associate (shallow pointer copy) was used whenever the source argument was a pointer type. This caused a double free when a select type associated variable was used as a class allocatable member in a struct constructor, since both the temporary struct and the selector pointed to the same memory and both got finalized.

Only use Associate when both the target member and the source value are pointers. When the target is allocatable, always use Assignment to perform a deep copy.

Fixes #10140.