### PR TITLE
Add --infer CLI flag and interactive default mode plumbing

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -164,6 +164,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--fixed-form", compiler_options.fixed_form, "Use fixed form Fortran source parsing")->group(group_language_options);
         app.add_flag("--fixed-form-infer", opts.fixed_form_infer, "Use heuristics to infer if a file is in fixed form")->group(group_language_options);
         app.add_option("--std", opts.arg_standard, "Select standard conformance (lf, f23, legacy)")->group(group_language_options);
+        app.add_flag("--infer", opts.arg_infer, "Enable infer mode")->group(group_language_options);
         app.add_flag("--implicit-typing", compiler_options.implicit_typing, "Allow implicit typing")->group(group_language_options);
         app.add_flag("--disable-implicit-typing", opts.disable_implicit_typing, "Disable implicit typing")->group(group_language_options);
         app.add_flag("--implicit-interface", compiler_options.implicit_interface, "Allow implicit interface")->group(group_language_options);
@@ -337,6 +338,10 @@ namespace LCompilers::CommandLineInterface {
             }
         }
 
+        if (opts.arg_infer && !opts.arg_standard.empty()) {
+            throw lc::LCompilersException("Cannot use --infer and --std at the same time");
+        }
+
         if (opts.arg_standard == "" || opts.arg_standard == "lf") {
             // The default LFortran behavior, do nothing
         } else if (opts.arg_standard == "f23") {
@@ -434,6 +439,13 @@ namespace LCompilers::CommandLineInterface {
                 }
             }
         }
+
+        // Interactive mode defaults to infer mode (`lfortran` with no input file),
+        // unless an explicit mode is selected.
+        if (!opts.arg_infer && opts.arg_standard.empty() && opts.arg_files.empty()) {
+            opts.arg_infer = true;
+        }
+        compiler_options.infer_mode = opts.arg_infer;
 
         if (opts.disable_style_suggestions && style_suggestions) {
             throw lc::LCompilersException("Cannot use --no-style-suggestions and --style-suggestions at the same time");

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -29,6 +29,7 @@ namespace LCompilers::CommandLineInterface {
         std::vector<std::string> arg_files;
         std::string arg_file;
         std::string arg_standard;
+        bool arg_infer = false;
         bool arg_version = false;
         // see parser.prescan function for what 'prescanning' does
         bool show_prescan = false;

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -126,6 +126,7 @@ struct CompilerOptions {
     bool bounds_checking = true;
     std::string error_format = "human";
     bool new_parser = false;
+    bool infer_mode = false;
     bool implicit_typing = false;
     bool implicit_interface = false;
     bool implicit_argument_casting = false;

--- a/tests/errors/infer_mode_conflict_01.f90
+++ b/tests/errors/infer_mode_conflict_01.f90
@@ -1,0 +1,2 @@
+program infer_mode_conflict_01
+end program infer_mode_conflict_01

--- a/tests/infer_mode_smoke_01.f90
+++ b/tests/infer_mode_smoke_01.f90
@@ -1,0 +1,2 @@
+program infer_mode_smoke_01
+end program infer_mode_smoke_01

--- a/tests/reference/run-infer_mode_conflict_01-0752705.json
+++ b/tests/reference/run-infer_mode_conflict_01-0752705.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-infer_mode_conflict_01-0752705",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/infer_mode_conflict_01.f90",
+    "infile_hash": "f1d7b5c4f9ac34c2e5fd3d9f2689daa8b1d1d926ddd8ffa9f509ac6b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-infer_mode_conflict_01-0752705.stderr",
+    "stderr_hash": "5244456f590a25462bb39f97303aa64543b89a0f01722cec1505de6f",
+    "returncode": 1
+}

--- a/tests/reference/run-infer_mode_conflict_01-0752705.stderr
+++ b/tests/reference/run-infer_mode_conflict_01-0752705.stderr
@@ -1,0 +1,1 @@
+Cannot use --infer and --std at the same time

--- a/tests/reference/run-infer_mode_smoke_01-f9a09d6.json
+++ b/tests/reference/run-infer_mode_smoke_01-f9a09d6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-infer_mode_smoke_01-f9a09d6",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/infer_mode_smoke_01.f90",
+    "infile_hash": "27f38709d506bc21c86a5e43a27e790423a9c88fe6f19eaaf8d6ebf4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3394,6 +3394,16 @@ filename = "implicit_typing2.f90"
 asr_implicit_typing = true
 
 [[test]]
+filename = "infer_mode_smoke_01.f90"
+run = true
+options = "--infer"
+
+[[test]]
+filename = "errors/infer_mode_conflict_01.f90"
+run = true
+options = "--infer --std=f23"
+
+[[test]]
 filename = "allow_implicit_interface.f90"
 asr_implicit_interface = true
 


### PR DESCRIPTION
## Summary
- add a first-class `--infer` CLI flag (`Language Options`)
- add mode resolution plumbing so `lfortran` (no input files) defaults to infer mode unless a mode is explicitly selected
- reject conflicting mode selection: `--infer` together with `--std=...`
- add focused regression tests for infer CLI acceptance and mode-conflict diagnostics

Fixes #10155
Part of #10162
Related to #312
Related to #6097

## Why
Step 1 of the infer-mode rollout needs CLI/mode plumbing before parser/semantics changes. This PR establishes explicit mode selection behavior and a guardrail for conflicting mode flags.

## Changes
- `src/bin/lfortran_command_line_parser.cpp`
  - adds `--infer`
  - adds `--infer` + `--std` conflict diagnostic
  - sets interactive default mode to infer when no files are passed
  - stores selected mode in `compiler_options.infer_mode`
- `src/bin/lfortran_command_line_parser.h`
  - adds `arg_infer`
- `src/libasr/utils.h`
  - adds `CompilerOptions::infer_mode`
- `tests/tests.toml`
  - adds new CLI-focused run tests
- `tests/infer_mode_smoke_01.f90`
- `tests/errors/infer_mode_conflict_01.f90`
- reference updates:
  - `tests/reference/run-infer_mode_smoke_01-f9a09d6.json`
  - `tests/reference/run-infer_mode_conflict_01-0752705.json`
  - `tests/reference/run-infer_mode_conflict_01-0752705.stderr`

## Verification
### Behavior fails on `upstream/main`
```bash
$ git -C lfortran checkout upstream/main
$ scripts/lf.sh build
$ scripts/lf.sh run lfortran/tests/expr5.f90 --infer
=== LLVM: 11 (micromamba env: lf-llvm11) ===
Using LLVM: 11
Compiling: lfortran/tests/expr5.f90
The following argument was not expected: --infer
Run with --help for more information.
```

### Behavior passes on this branch
```bash
$ git -C lfortran checkout fix/infer-cli-mode
$ scripts/lf.sh build
$ scripts/lf.sh run lfortran/integration_tests/print_01.f90 --infer
=== LLVM: 11 (micromamba env: lf-llvm11) ===
Using LLVM: 11
Compiling: lfortran/integration_tests/print_01.f90
Running: /tmp/lfortran_run_39981
25    1    3    25    50
25    1    3    25    50
```

### Tests added/updated
```bash
$ scripts/lf.sh test -t infer_mode_smoke_01 -s
infer_mode_smoke_01.f90 * run ✓

$ scripts/lf.sh test -t infer_mode_conflict_01 -s
errors/infer_mode_conflict_01.f90 * run ✓
```

### Existing test spot-check
```bash
$ scripts/lf.sh test -t implicit_typing1 -s
implicit_typing1.f90 * run ✓
implicit_typing1.f90 * asr ✓
errors/implicit_typing1.f90 * asr ✓
```
