### PR TITLE
chore: ignore generated root-level test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,13 @@ src/lfortran/tests/subroutines_args32
 src/lfortran/tests/print32
 src/lfortran/tests/print_integer
 src/lfortran/tests/cmp32
+cmp32
+print32
+print_integer
+subroutines32
+subroutines_args32
+write32
+write32.asm
 src/lfortran/tests/x
 src/lfortran/tests/ref_pickle.txt.new
 src/server/lsp_language_server.cpp


### PR DESCRIPTION
## Summary
- ignore root-level generated artifacts produced by local test workflows
- keep existing `src/lfortran/tests/*` ignores unchanged
- avoid dirty worktree noise after running local test/debug binaries

Fixes #3456

## Changes
- `.gitignore`: add root-level ignores for
  - `cmp32`
  - `print32`
  - `print_integer`
  - `subroutines32`
  - `subroutines_args32`
  - `write32`
  - `write32.asm`

## Verification

### Fresh clean build
```bash
$ scripts/lf.sh build --clean
... BUILD COMPLETE ...
LFortran version: 0.60.0-222-g26da2ae3b
```
