### PR TITLE
Handle dt calls in subroutine_from_function

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1743,6 +1743,7 @@ RUN(NAME operator_overloading_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_25 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_27 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME operator_overloading_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME custom_unary_operator_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_unary_operator_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/operator_overloading_28.f90
+++ b/integration_tests/operator_overloading_28.f90
@@ -1,0 +1,42 @@
+module module_operator_overloading_28
+  implicit none
+  private
+  public :: string_t
+
+  type string_t
+    character(len=:), allocatable :: s
+  contains
+    generic :: operator(==) => string_eq_string
+    procedure, private :: string_eq_string
+    procedure :: bracket
+  end type
+
+contains
+
+  elemental function string_eq_string(lhs, rhs) result(res)
+    class(string_t), intent(in) :: lhs
+    type(string_t), intent(in) :: rhs
+    logical :: res
+    res = lhs%s == rhs%s
+  end function
+
+  elemental function bracket(self) result(res)
+    class(string_t), intent(in) :: self
+    type(string_t) :: res
+    res%s = "[" // self%s // "]"
+  end function
+
+end module
+
+program operator_overloading_28
+  use module_operator_overloading_28, only : string_t
+  implicit none
+
+  type(string_t) :: arr(2), expected(2)
+  arr(1)%s = "ab"
+  arr(2)%s = "cd"
+  expected(1)%s = "[ab]"
+  expected(2)%s = "[cd]"
+  if (.not. all(arr%bracket() == expected)) error stop
+  print *, "PASS"
+end program

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -335,6 +335,9 @@ private :
                 && !ASRUtils::is_allocatable(function_return_t) 
                 &&  ASRUtils::get_string_type(function_return_t)->m_len_kind == ASR::ExpressionLength;
 
+        } else if (ASRUtils::is_array(function_return_t)) {
+            return ASRUtils::is_allocatable(return_slot_t)
+                && !ASRUtils::is_pointer(return_slot_t);
         } else if (   ASR::is_a<ASR::List_t> (*function_return_t)
                    || ASR::is_a<ASR::Dict_t> (*function_return_t)
                    || ASR::is_a<ASR::Set_t>  (*function_return_t)
@@ -385,28 +388,46 @@ public :
 
     void replace_FunctionCall(ASR::FunctionCall_t* x){
         traverse_functionCall_args(x->m_args, x->n_args);
-        if(PassUtils::is_non_primitive_return_type(x->m_type)){ // Arrays and structs are handled by the array_struct_temporary. No need to check for them here.
+        if (x->m_dt) {
+            ASR::expr_t** current_expr_copy = current_expr;
+            current_expr = &(x->m_dt);
+            replace_expr(x->m_dt);
+            current_expr = current_expr_copy;
+        }
+
+        ASR::Function_t* func = ASRUtils::get_function(x->m_name);
+        bool was_converted = func && Function__TO__ReturnType_MAP_.count(func) > 0;
+        if(PassUtils::is_non_primitive_return_type(x->m_type)
+            || PassUtils::is_aggregate_or_array_type(x->m_type)){
 
             // Create variable in current_scope to be holding the return.
+            // For converted functions (structs/arrays), pass the last arg as
+            // the sibling so create_var can extract the type_decl symbol.
+            ASR::expr_t* sibling_var = (was_converted && func->n_args > 0)
+                ? func->m_args[func->n_args - 1] : nullptr;
             ASR::expr_t* result_var = PassUtils::create_var(
                                             result_counter++,
                                             "return_slot", x->base.base.loc,
-                                            create_type_for_return_slot_var(x->m_type) , al, current_scope);
+                                            create_type_for_return_slot_var(x->m_type) , al, current_scope, sibling_var);
 
             /* Make Sure To Deallocate -- To Avoid Douple Allocation With Loops */
             if(ASRUtils::is_allocatable(ASRUtils::expr_type(result_var))) { insert_implicit_deallocate(result_var); }
-            
-            if(allocate_stmt_needed_for_return_slot(x->m_type, ASRUtils::expr_type(result_var))){
 
-                ASR::ttype_t* func_return_type {};
-                if(!ASRUtils::get_function(x->m_name)->m_return_var){ // FunctionCall to Modified Function (Currently Subroutine)
-                    func_return_type = Function__TO__ReturnType_MAP_[ASRUtils::get_function(x->m_name)];
-                } else {
-                    func_return_type = nullptr; // Doesn't matter to provide or not.
-                }
-                
+            bool alloc_needed = false;
+            if (ASRUtils::is_array(x->m_type) || PassUtils::is_non_primitive_return_type(x->m_type)) {
+                alloc_needed = allocate_stmt_needed_for_return_slot(
+                    x->m_type, ASRUtils::expr_type(result_var));
+            }
+            if(ASRUtils::is_array(x->m_type) && alloc_needed) {
+                insert_allocate_stmt_for_array(al, result_var, ASRUtils::EXPR((ASR::asr_t*)x), &pass_result);
+            } else if(PassUtils::is_non_primitive_return_type(x->m_type)
+                && alloc_needed){
+
+                // FunctionCall to modified function (currently subroutine)
+                ASR::ttype_t* alloc_type = was_converted ? Function__TO__ReturnType_MAP_[func] : nullptr;
+
                 AllocateVarBasedOnFuncCall::Allocate(
-                    al, x, ASR::down_cast<ASR::Var_t>(result_var),current_scope, pass_result, func_return_type);
+                    al, x, ASR::down_cast<ASR::Var_t>(result_var),current_scope, pass_result, alloc_type);
             }
             // Create new call args with `result_var` as last argument capturing return + Create a `subroutineCall`.
             Vec<ASR::call_arg_t> new_call_args;
@@ -529,7 +550,7 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
             return PassUtils::is_aggregate_or_array_type(m_value);
         }
 
-        void subroutine_call_from_function(const Location &loc, ASR::stmt_t &xx) {
+        bool subroutine_call_from_function(const Location &loc, ASR::stmt_t &xx) {
             ASR::expr_t* value = nullptr;
             ASR::expr_t* target = nullptr;
             bool is_pointer_return = false;
@@ -550,6 +571,21 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
             }
             ASR::FunctionCall_t* fc = ASR::down_cast<ASR::FunctionCall_t>(value);
 
+            // We skip the generic expression visitor on this statement, so
+            // ensure nested calls inside the function call arguments are still replaced.
+            for (size_t i = 0; i < fc->n_args; i++) {
+                ASR::expr_t** current_expr_copy = current_expr;
+                current_expr = &fc->m_args[i].m_value;
+                call_replacer();
+                current_expr = current_expr_copy;
+            }
+            if (fc->m_dt) {
+                ASR::expr_t** current_expr_copy = current_expr;
+                current_expr = &fc->m_dt;
+                call_replacer();
+                current_expr = current_expr_copy;
+            }
+
             ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external(fc->m_name);
             if(ASR::is_a<ASR::Function_t>(*func_sym)) {
                 ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(func_sym);
@@ -557,7 +593,7 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
                 if(ASR::is_a<ASR::FunctionType_t>(*func_type)){
                     ASR::FunctionType_t* func_type_type = ASR::down_cast<ASR::FunctionType_t>(func_type);
                     if (func_type_type->m_abi == ASR::abiType::BindC) {
-                        return; // Skip transformation for bind(C) functions
+                        return false; // Skip transformation for bind(C) functions
                     }
                 }
             }
@@ -637,25 +673,30 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
             } else {
                 remove_original_statement = true;
             }
+            return true;
         }
 
         void visit_Assignment(const ASR::Assignment_t &x) {
-            ASR::CallReplacerOnExpressionsVisitor \
-            <ReplaceFunctionCallWithSubroutineCallVisitor>::visit_Assignment(x);
             if(is_function_call_returning_aggregate_type(x.m_value)) {
                 ASR::Assignment_t& xx = const_cast<ASR::Assignment_t&>(x);
-                subroutine_call_from_function(x.base.base.loc, (ASR::stmt_t &)xx);
+                if (subroutine_call_from_function(x.base.base.loc, (ASR::stmt_t &)xx)) {
+                    return;
+                }
             }
+            ASR::CallReplacerOnExpressionsVisitor \
+            <ReplaceFunctionCallWithSubroutineCallVisitor>::visit_Assignment(x);
         }
 
         void visit_Associate(const ASR::Associate_t &x) {
-            ASR::CallReplacerOnExpressionsVisitor \
-            <ReplaceFunctionCallWithSubroutineCallVisitor>::visit_Associate(x);
             ASR::ttype_t* t = ASRUtils::extract_type(ASRUtils::expr_type(x.m_target));
             if(is_function_call_returning_aggregate_type(x.m_value) && ASR::is_a<ASR::StructType_t>(*t)) {
                 ASR::Associate_t& xx = const_cast<ASR::Associate_t&>(x);
-                subroutine_call_from_function(x.base.base.loc, (ASR::stmt_t &)xx);
+                if (subroutine_call_from_function(x.base.base.loc, (ASR::stmt_t &)xx)) {
+                    return;
+                }
             }
+            ASR::CallReplacerOnExpressionsVisitor \
+            <ReplaceFunctionCallWithSubroutineCallVisitor>::visit_Associate(x);
         }
 
     /**


### PR DESCRIPTION
Lower function-call rewrites to subroutine calls through m_dt and nested call arguments before statement replacement. This fixes cases like elemental type-bound calls inside overloaded comparisons (arr%bracket() == expected).