### PR TITLE
Fix submodule nopass type-bound linker error

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -998,6 +998,7 @@ RUN(NAME submodule_20a LABELS gfortran llvm_submodule EXTRAFILES submodule_20b.f
 RUN(NAME submodule_21a LABELS gfortran llvm_submodule EXTRAFILES submodule_21b.f90 submodule_21c.f90)
 
 RUN(NAME submodule_22 LABELS gfortran llvm)
+RUN(NAME submodule_23a LABELS gfortran llvm_submodule EXTRAFILES submodule_23b.f90 submodule_23c.f90)
 
 
 

--- a/integration_tests/submodule_23a.f90
+++ b/integration_tests/submodule_23a.f90
@@ -1,0 +1,7 @@
+program submodule_23a
+  use submodule_23_mod, only: mytype
+  implicit none
+  type(mytype) :: obj
+  if (.not. obj%check([1, 2])) error stop
+  print *, "ok"
+end program

--- a/integration_tests/submodule_23b.f90
+++ b/integration_tests/submodule_23b.f90
@@ -1,0 +1,13 @@
+module submodule_23_mod
+  implicit none
+  type :: mytype
+  contains
+    procedure, nopass :: check
+  end type
+  interface
+    module function check(args) result(found)
+      integer, intent(in) :: args(:)
+      logical found
+    end function
+  end interface
+end module

--- a/integration_tests/submodule_23c.f90
+++ b/integration_tests/submodule_23c.f90
@@ -1,0 +1,7 @@
+submodule(submodule_23_mod) submodule_23_sub
+  implicit none
+contains
+  module procedure check
+    found = size(args) > 0
+  end procedure
+end submodule


### PR DESCRIPTION
The pass_array_by_data pass was renaming submodule functions (e.g. check -> check_integer____0) while calls through StructMethodDeclaration were intentionally left untransformed. This caused an undefined reference at link time because the call site used the original name but the definition had the mangled name.

Skip the pass_array_by_data transformation for functions that are bound to a Struct via StructMethodDeclaration, either in the same module or in a parent module (for submodules). This ensures the definition keeps the same calling convention and symbol name that the untransformed call site expects.