### PR TITLE
Initial impl. of floating point exception trapping

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 #include <lfortran/utils.h>
 
@@ -128,6 +129,7 @@ namespace LCompilers::CommandLineInterface {
         bool disable_error_banner = false;
         bool disable_realloc_lhs = false;
         bool old_classes = false;
+        std::string fpe_traps_str;
 
         // Standard options compatible with gfortran, gcc or clang
         // We follow the established conventions
@@ -151,6 +153,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_option("-W", opts.linker_flags, "Linker flags")->allow_extra_args(false);
         app.add_option("-f", opts.f_flags, "All `-f*` flags (only -fPIC & -fdefault-integer-8 supported for now)")->allow_extra_args(false);
         app.add_option("-O", opts.O_flags, "Optimization level (ignored for now)")->allow_extra_args(false);
+        app.add_option("--fpe-trap", fpe_traps_str, "Enable floating point exception trapping. Comma-separated list of: invalid, zero, overflow, underflow, inexact, denormal");
 
         // LFortran specific options
         // Warning-related flags
@@ -417,6 +420,29 @@ namespace LCompilers::CommandLineInterface {
                 throw lc::LCompilersException(
                     "The flag `-f" + f_flag + "` is not supported"
                 );
+            }
+        }
+
+        // Parse and validate --fpe-trap values, build bitmask
+        if (!fpe_traps_str.empty()) {
+            std::string token;
+            std::istringstream stream(fpe_traps_str);
+            while (std::getline(stream, token, ',')) {
+                // Trim whitespace
+                token.erase(0, token.find_first_not_of(" \t"));
+                token.erase(token.find_last_not_of(" \t") + 1);
+                if (token == "invalid")        compiler_options.fpe_traps |= lc::LCOMPILERS_FE_INVALID;
+                else if (token == "zero")      compiler_options.fpe_traps |= lc::LCOMPILERS_FE_ZERO;
+                else if (token == "overflow")  compiler_options.fpe_traps |= lc::LCOMPILERS_FE_OVERFLOW;
+                else if (token == "underflow") compiler_options.fpe_traps |= lc::LCOMPILERS_FE_UNDERFLOW;
+                else if (token == "inexact")   compiler_options.fpe_traps |= lc::LCOMPILERS_FE_INEXACT;
+                else if (token == "denormal")  compiler_options.fpe_traps |= lc::LCOMPILERS_FE_DENORMAL;
+                else {
+                    throw lc::LCompilersException(
+                        "Invalid --fpe-trap value '" + token + "'. "
+                        "Valid values are: invalid, zero, overflow, underflow, inexact, denormal"
+                    );
+                }
             }
         }
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5150,6 +5150,22 @@ public:
             }
             builder->CreateCall(fn, args);
         }
+        // Enable floating point exception trapping if requested
+        if (compiler_options.fpe_traps != 0) {
+            if (compiler_options.emit_debug_info) debug_emit_loc(x);
+            llvm::Function *fpe_fn = module->getFunction("_lfortran_enable_fpe_traps");
+            if(!fpe_fn) {
+                llvm::FunctionType *fpe_function_type = llvm::FunctionType::get(
+                    llvm::Type::getVoidTy(context), {
+                        llvm::Type::getInt32Ty(context)
+                    }, false);
+                fpe_fn = llvm::Function::Create(fpe_function_type,
+                    llvm::Function::ExternalLinkage, "_lfortran_enable_fpe_traps", module.get());
+            }
+            llvm::Value *mask_val = llvm::ConstantInt::get(context,
+                llvm::APInt(32, compiler_options.fpe_traps));
+            builder->CreateCall(fpe_fn, {mask_val});
+        }
         // Set runtime color preference based on compiler option (only when enabled)
         if (compiler_options.use_runtime_colors) {
             if (compiler_options.emit_debug_info) debug_emit_loc(x);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1,3 +1,6 @@
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,6 +16,9 @@
 #include <limits.h>
 #include <stdint.h>
 #include <stddef.h>  /* ptrdiff_t */
+#if !defined(COMPILE_TO_WASM)
+#include <fenv.h>
+#endif
 
 #define PI 3.14159265358979323846
 // Enum for float format types to avoid string comparison
@@ -100,6 +106,7 @@ static int _lfortran_use_runtime_colors = 0;  // disabled by default
 #ifdef HAVE_LFORTRAN_LINK
 // For dl_iterate_phdr() functionality
 #  include <link.h>
+#ifndef _GNU_SOURCE
 struct dl_phdr_info {
     ElfW(Addr) dlpi_addr;
     const char *dlpi_name;
@@ -108,6 +115,7 @@ struct dl_phdr_info {
 };
 extern int dl_iterate_phdr (int (*__callback) (struct dl_phdr_info *,
     size_t, void *), void *__data);
+#endif
 #endif
 
 #ifdef HAVE_LFORTRAN_UNWIND
@@ -8211,6 +8219,97 @@ LFORTRAN_API int32_t _lfortran_get_command_status() {
 }
 
 // << Command line arguments << ------------------------------------------------
+
+// >> Floating point exception trapping >> -------------------------------------
+// These constants must match the LCOMPILERS_FE_* values in utils.h
+#define LCOMPILERS_FE_INVALID   1
+#define LCOMPILERS_FE_ZERO      2
+#define LCOMPILERS_FE_OVERFLOW  4
+#define LCOMPILERS_FE_UNDERFLOW 8
+#define LCOMPILERS_FE_INEXACT   16
+#define LCOMPILERS_FE_DENORMAL  32
+
+LFORTRAN_API void _lfortran_enable_fpe_traps(int32_t trap_mask) {
+#if defined(COMPILE_TO_WASM)
+    fprintf(stderr, "Warning: --fpe-trap is not supported on WASM\n");
+    (void)trap_mask;
+#elif defined(__linux__)
+    int excepts = 0;
+    if (trap_mask & LCOMPILERS_FE_INVALID)   excepts |= FE_INVALID;
+    if (trap_mask & LCOMPILERS_FE_ZERO)      excepts |= FE_DIVBYZERO;
+    if (trap_mask & LCOMPILERS_FE_OVERFLOW)  excepts |= FE_OVERFLOW;
+    if (trap_mask & LCOMPILERS_FE_UNDERFLOW) excepts |= FE_UNDERFLOW;
+    if (trap_mask & LCOMPILERS_FE_INEXACT)   excepts |= FE_INEXACT;
+    // denormal: Linux feenableexcept doesn't have a separate flag;
+    // on x86, we handle it via MXCSR below
+    if (excepts) {
+        feenableexcept(excepts);
+    }
+#if defined(__x86_64__) || defined(__i386__)
+    if (trap_mask & LCOMPILERS_FE_DENORMAL) {
+        // Enable denormal-operand exception in SSE MXCSR (bit 8)
+        unsigned int mxcsr;
+        __asm__ __volatile__("stmxcsr %0" : "=m"(mxcsr));
+        mxcsr &= ~(1u << 8);  // Clear DM (Denormals-Are-Zeros mask) to unmask
+        __asm__ __volatile__("ldmxcsr %0" : : "m"(mxcsr));
+    }
+#endif
+#elif defined(__APPLE__)
+#if defined(__x86_64__) || defined(__i386__)
+    // macOS x86_64: manipulate x87 control word and SSE MXCSR
+    fenv_t env;
+    fegetenv(&env);
+    // x87 control word: bits 0-5 are exception masks (1=masked, 0=unmasked)
+    if (trap_mask & LCOMPILERS_FE_INVALID)   env.__control &= ~FE_INVALID;
+    if (trap_mask & LCOMPILERS_FE_ZERO)      env.__control &= ~FE_DIVBYZERO;
+    if (trap_mask & LCOMPILERS_FE_OVERFLOW)  env.__control &= ~FE_OVERFLOW;
+    if (trap_mask & LCOMPILERS_FE_UNDERFLOW) env.__control &= ~FE_UNDERFLOW;
+    if (trap_mask & LCOMPILERS_FE_INEXACT)   env.__control &= ~FE_INEXACT;
+    // SSE MXCSR: bits 7-12 are exception masks
+    if (trap_mask & LCOMPILERS_FE_INVALID)   env.__mxcsr &= ~(1u << 7);   // Invalid
+    if (trap_mask & LCOMPILERS_FE_ZERO)      env.__mxcsr &= ~(1u << 9);   // Divide-by-zero
+    if (trap_mask & LCOMPILERS_FE_OVERFLOW)  env.__mxcsr &= ~(1u << 10);  // Overflow
+    if (trap_mask & LCOMPILERS_FE_UNDERFLOW) env.__mxcsr &= ~(1u << 11);  // Underflow
+    if (trap_mask & LCOMPILERS_FE_INEXACT)   env.__mxcsr &= ~(1u << 12);  // Inexact (Precision)
+    if (trap_mask & LCOMPILERS_FE_DENORMAL)  env.__mxcsr &= ~(1u << 8);   // Denormal
+    fesetenv(&env);
+#elif defined(__aarch64__)
+    // macOS ARM64: manipulate FPCR register
+    // FPCR trap enable bits: 8=IOE(invalid), 9=DZE(divbyzero), 10=OFE(overflow),
+    //                        11=UFE(underflow), 12=IXE(inexact), 15=IDE(input denormal)
+    uint64_t fpcr;
+    __asm__ __volatile__("mrs %0, fpcr" : "=r"(fpcr));
+    if (trap_mask & LCOMPILERS_FE_INVALID)   fpcr |= (1ULL << 8);   // IOE - Invalid Operation
+    if (trap_mask & LCOMPILERS_FE_ZERO)      fpcr |= (1ULL << 9);   // DZE - Division by Zero
+    if (trap_mask & LCOMPILERS_FE_OVERFLOW)  fpcr |= (1ULL << 10);  // OFE - Overflow
+    if (trap_mask & LCOMPILERS_FE_UNDERFLOW) fpcr |= (1ULL << 11);  // UFE - Underflow
+    if (trap_mask & LCOMPILERS_FE_INEXACT)   fpcr |= (1ULL << 12);  // IXE - Inexact
+    if (trap_mask & LCOMPILERS_FE_DENORMAL)  fpcr |= (1ULL << 15);  // IDE - Input Denormal
+    __asm__ __volatile__("msr fpcr, %0" : : "r"(fpcr));
+#else
+    fprintf(stderr, "Warning: --fpe-trap is not supported on this Apple architecture\n");
+    (void)trap_mask;
+#endif
+#elif defined(_WIN32)
+    unsigned int cw = 0;
+    // _controlfp: second arg = mask of bits to change
+    // Clearing a bit in the control word UNMASKS (enables) that exception
+    unsigned int disable_mask = 0;
+    if (trap_mask & LCOMPILERS_FE_INVALID)   disable_mask |= _EM_INVALID;
+    if (trap_mask & LCOMPILERS_FE_ZERO)      disable_mask |= _EM_ZERODIVIDE;
+    if (trap_mask & LCOMPILERS_FE_OVERFLOW)  disable_mask |= _EM_OVERFLOW;
+    if (trap_mask & LCOMPILERS_FE_UNDERFLOW) disable_mask |= _EM_UNDERFLOW;
+    if (trap_mask & LCOMPILERS_FE_INEXACT)   disable_mask |= _EM_INEXACT;
+    if (trap_mask & LCOMPILERS_FE_DENORMAL)  disable_mask |= _EM_DENORMAL;
+    if (disable_mask) {
+        _controlfp_s(&cw, ~disable_mask & _MCW_EM, disable_mask);
+    }
+#else
+    fprintf(stderr, "Warning: --fpe-trap is not supported on this platform\n");
+    (void)trap_mask;
+#endif
+}
+// << Floating point exception trapping << -------------------------------------
 
 // Initial setup
 LFORTRAN_API void _lpython_call_initial_functions(int32_t argc_1, char *argv_1[]) {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -67,6 +67,7 @@ typedef double _Complex double_complex_t;
     }
 #endif
 
+LFORTRAN_API void _lfortran_enable_fpe_traps(int32_t trap_mask);
 LFORTRAN_API double _lfortran_sum(int n, double *v);
 LFORTRAN_API void _lfortran_random_number(int n, double *v);
 LFORTRAN_API void _lfortran_init_random_clock();

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -145,6 +145,7 @@ struct CompilerOptions {
     bool descriptor_index_64 = false; // Use 64-bit indices in array descriptors (implied by -fdefault-integer-8)
     bool wasm_html = false;
     bool time_report = false;
+    int32_t fpe_traps = 0; // Bitmask of LCOMPILERS_FE_* flags
     std::string emcc_embed;
     std::vector<std::string> import_paths;
     Platform platform;
@@ -155,6 +156,14 @@ struct CompilerOptions {
 bool present(Vec<char*> &v, const char* name);
 bool present(char** const v, size_t n, const std::string name);
 int initialize();
+
+// Floating point exception trap flags (bitmask)
+const int32_t LCOMPILERS_FE_INVALID   = 1;
+const int32_t LCOMPILERS_FE_ZERO      = 2;
+const int32_t LCOMPILERS_FE_OVERFLOW  = 4;
+const int32_t LCOMPILERS_FE_UNDERFLOW = 8;
+const int32_t LCOMPILERS_FE_INEXACT   = 16;
+const int32_t LCOMPILERS_FE_DENORMAL  = 32;
 
 } // namespace LCompilers
 

--- a/tests/fpe_trap_test.f90
+++ b/tests/fpe_trap_test.f90
@@ -1,0 +1,25 @@
+! How to test:
+
+! $ lfortran tests/fpe_trap_test.f90 --fpe-trap invalid -g
+! Floating point exception (core dumped)
+! $ gdb fpe_trap_test.out
+! [...]
+! (gdb) run
+! [...]
+! Program received signal SIGFPE, Arithmetic exception.
+! test_fpe () at tests/fpe_trap_test.f90:18
+! 18        y = 0.0 / x       ! traps here
+!
+
+program test_fpe
+  implicit none
+  real :: x, y
+  call get_zero(x)
+  y = 0.0 / x       ! traps here
+  print *, "y = ", y
+contains
+  subroutine get_zero(val)
+    real, intent(out) :: val
+    val = 0.0
+  end subroutine
+end program


### PR DESCRIPTION
Add a new --fpe-trap compiler option that enables hardware floating point exception trapping at program startup, similar to GFortran's -ffpe-trap.

The option accepts a comma-separated list of exception types:
  invalid, zero, overflow, underflow, inexact, denormal

Example usage:
  lfortran --fpe-trap invalid,zero,overflow program.f90

Implementation details:
- Add fpe_traps field to CompilerOptions (utils.h)
- Register --fpe-trap CLI option with comma-separated validation
- Add _lfortran_enable_fpe_traps() runtime function that configures hardware FPE traps using a bitmask encoding
- Emit call to the runtime function in LLVM codegen (visit_Program) when --fpe-trap is specified
- Cross-platform support:
  - Linux: feenableexcept() + MXCSR for denormals
  - macOS x86_64: fenv_t manipulation + MXCSR
  - macOS ARM64: FPCR register via inline asm
  - Windows: _controlfp_s()
  - WASM: warning (not supported)

Fixes #10179.