### PR TITLE
fix: add missing file_ends entries in kernel evaluation paths

### DIFF
--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -129,6 +129,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 diag::Diagnostics diagnostics;
                 Result<std::string>
@@ -159,6 +160,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 diag::Diagnostics diagnostics;
                 Result<std::string>
@@ -189,6 +191,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 LCompilers::PassManager lpm;
                 lpm.use_default_passes();
@@ -221,6 +224,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 LCompilers::PassManager lpm;
                 lpm.use_default_passes();
@@ -253,6 +257,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 diag::Diagnostics diagnostics;
                 Result<std::string>
@@ -283,6 +288,7 @@ namespace LCompilers::LFortran {
                     std::ofstream out("input");
                     out << code0;
                     lm.files.push_back(fl);
+                    lm.file_ends.push_back(code0.size());
                 }
                 diag::Diagnostics diagnostics;
                 Result<std::string>
@@ -314,6 +320,7 @@ namespace LCompilers::LFortran {
                 std::ofstream out("input");
                 out << code0;
                 lm.files.push_back(fl);
+                lm.file_ends.push_back(code0.size());
             }
             LCompilers::PassManager lpm;
             lpm.use_default_passes();


### PR DESCRIPTION
## Summary

Every `lm.files.push_back()` must be paired with `lm.file_ends.push_back()` or `LocationManager::bisection()` will index out of bounds when rendering diagnostics. The Jupyter kernel had 7 sites missing the `file_ends` entry.

**Stage:** Driver (kernel frontend)

## Changes

- [`src/lfortran/fortran_kernel.cpp`](https://github.com/lfortran/lfortran/blob/d516b6283/src/lfortran/fortran_kernel.cpp): add `lm.file_ends.push_back(code0.size())` after each `lm.files.push_back(fl)` in all 7 kernel evaluation paths

## Why

`LocationManager` uses `bisection(file_ends, out_pos)` to map error positions back to source files. When `files` and `file_ends` vectors are out of sync, any diagnostic (e.g. a syntax error in a Jupyter cell) causes an out-of-bounds access. Every other call site in the codebase (`lfortran.cpp`, `lfortran_accessor.cpp`, tests, passes) pairs these correctly -- the kernel was the only place missing it.