### PR TITLE
fix: restore legacy kernel CLI invocation paths

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2452,7 +2452,7 @@ int main_app(int argc, char *argv[]) {
             opts.arg_fmt_indent, opts.arg_fmt_indent_unit, compiler_options);
     }
 
-    if (kernel) {
+    if (kernel || !opts.arg_kernel_f.empty()) {
 #ifdef HAVE_LFORTRAN_XEUS
         return LCompilers::LFortran::run_kernel(opts.arg_kernel_f);
 #else

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -55,6 +55,8 @@ namespace LCompilers::CommandLineInterface {
         std::string skip_pass;
         std::string arg_backend = "llvm";
         std::string arg_kernel_f;
+        std::string arg_kernel_legacy_f;
+        bool arg_interactive_legacy = false;
         std::string linker{""};
         std::string linker_path{""};
         bool print_targets = false;


### PR DESCRIPTION
## Summary
- restore compatibility for legacy kernel invocation via `--interactive --kernel <connection_file>`
- allow parent compiler options (for example `-I`) after `kernel -f ...` using subcommand fallthrough
- emit deprecation warnings that point to supported modern forms

## Why
Recent parser changes made common interactive/kernel invocations fail at argument parsing. This broke existing kernelspecs and command lines that still use legacy flags or place global options after the `kernel` subcommand.

**Stage:** Command-line parser / driver

## Changes
- [`src/bin/lfortran_command_line_parser.h#L57-L60`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran_command_line_parser.h#L57-L60): track legacy `--kernel` and `--interactive` parse state
- [`src/bin/lfortran_command_line_parser.cpp#L259-L264`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran_command_line_parser.cpp#L259-L264): add deprecated legacy option aliases
- [`src/bin/lfortran_command_line_parser.cpp#L292-L295`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran_command_line_parser.cpp#L292-L295): enable `kernel` subcommand fallthrough for parent options
- [`src/bin/lfortran_command_line_parser.cpp#L327-L333`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran_command_line_parser.cpp#L327-L333): normalize legacy `--kernel` value into `arg_kernel_f`
- [`src/bin/lfortran_command_line_parser.cpp#L354-L363`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran_command_line_parser.cpp#L354-L363): emit deprecation warnings for legacy flags
- [`src/bin/lfortran.cpp#L2455-L2458`](https://github.com/lfortran/lfortran/blob/55f7f82547b144356cfea8707aa836165516806f/src/bin/lfortran.cpp#L2455-L2458): enter kernel mode when legacy `--kernel` option is used

## Tests
- parser compatibility checks for both legacy and subcommand forms against a valid kernel connection file
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build --with-xeus
$ timeout 3 ./lfortran/build/src/bin/lfortran --interactive --kernel /tmp/lfortran-cli-compat-conn.json
The following arguments were not expected: --kernel --interactive
Run with --help for more information.

$ timeout 3 ./lfortran/build/src/bin/lfortran kernel -f /tmp/lfortran-cli-compat-conn.json -I /tmp
The following arguments were not expected: /tmp -I
Run with --help for more information.
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/kernel-cli-legacy-compat
$ scripts/lf.sh build --with-xeus
$ timeout 3 ./lfortran/build/src/bin/lfortran --interactive --kernel /tmp/lfortran-cli-compat-conn.json
warning: `--interactive` is deprecated; launch REPL with `lfortran` or use `--interactive-parse` for parser mode.
warning: `--kernel` is deprecated; use `kernel -f <connection_file>`.
xkernel::init
Core instantiated
Starting xeus-fortran kernel...

$ timeout 3 ./lfortran/build/src/bin/lfortran kernel -f /tmp/lfortran-cli-compat-conn.json -I /tmp
xkernel::init
Core instantiated
Starting xeus-fortran kernel...
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
