### PR TITLE
fix: make exit aliases quit interactive REPL

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -409,6 +409,20 @@ bool determine_completeness(std::string command)
     return complete;
 }
 
+static std::string trim_copy(const std::string &s) {
+    size_t start = s.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) return "";
+    size_t end = s.find_last_not_of(" \t\r\n");
+    return s.substr(start, end - start + 1);
+}
+
+static bool is_exit_command(const std::string &input) {
+    std::string normalized = LCompilers::to_lower(trim_copy(input));
+    return normalized == "exit" || normalized == "exit()"
+        || normalized == "quit" || normalized == "quit()"
+        || normalized == ":q" || normalized == ":quit";
+}
+
 int prompt(bool verbose, CompilerOptions &cu)
 {
     Terminal term(true, false);
@@ -431,6 +445,10 @@ int prompt(bool verbose, CompilerOptions &cu)
         std::string input = prompt0(term, ">>> ", history, iscomplete);
         if (input.size() == 1 && input[0] == CTRL_KEY('d')) {
             std::cout << std::endl;
+            std::cout << "Exiting." << std::endl;
+            return 0;
+        }
+        if (is_exit_command(input)) {
             std::cout << "Exiting." << std::endl;
             return 0;
         }


### PR DESCRIPTION
## Summary
- treat `exit`, `exit()`, `quit`, `quit()`, `:q`, and `:quit` as explicit REPL quit commands
- avoid sending these inputs through semantic analysis as regular Fortran code

Fixes #2148

## Why
In interactive mode, typing `exit` or `exit()` currently triggers semantic errors before the session exits on EOF. This is confusing and differs from standard REPL expectations.

**Stage:** Driver / interactive REPL frontend

## Changes
- [`src/bin/lfortran.cpp#L412-L424`](https://github.com/lfortran/lfortran/blob/2bb54ae0954a1beb74dc10d0276b82d81f47e446/src/bin/lfortran.cpp#L412-L424): add normalized exit-command detection helper
- [`src/bin/lfortran.cpp#L445-L454`](https://github.com/lfortran/lfortran/blob/2bb54ae0954a1beb74dc10d0276b82d81f47e446/src/bin/lfortran.cpp#L445-L454): short-circuit REPL loop and exit cleanly when exit aliases are entered

## Tests
- interactive REPL behavior checks via piped stdin for `exit` and `exit()`
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build
$ printf 'exit\n' | ./lfortran/build/src/bin/lfortran
...
semantic error: Variable 'exit' is not declared
...

$ printf 'exit()\n' | ./lfortran/build/src/bin/lfortran
...
semantic error: Function 'exit' not found (not user defined nor intrinsic)
...
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/repl-exit-command
$ scripts/lf.sh build
$ printf 'exit\n' | ./lfortran/build/src/bin/lfortran
...
Exiting.

$ printf 'exit()\n' | ./lfortran/build/src/bin/lfortran
...
Exiting.
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
