### PR TITLE
fix: remove kernel startup banner from stdout

### DIFF
--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -513,16 +513,9 @@ namespace LCompilers::LFortran {
                              std::move(interpreter),
                              xeus::make_xserver_shell_main,
                              std::move(hist),
-                             xeus::make_console_logger(xeus::xlogger::msg_type,
-                                                       xeus::make_file_logger(xeus::xlogger::content, "xeus.log")),
+                             xeus::make_file_logger(xeus::xlogger::content, "xeus.log"),
                              xeus::make_null_debugger,
                              debugger_config);
-
-        std::cout <<
-            "Starting xeus-fortran kernel...\n\n"
-            "If you want to connect to this kernel from an other client, you can use"
-            " the " + connection_filename + " file."
-            << std::endl;
 
         kernel.start();
 


### PR DESCRIPTION
## Summary
- remove the kernel startup banner printed to stdout from `run_kernel`
- switch kernel logger wiring to file logger only in this call site

## Why
Kernel startup should avoid unnecessary stdout banner text, especially when launched under notebook/front-end process managers that expect clean process output.

**Stage:** Interactive kernel driver

## Changes
- [`src/lfortran/fortran_kernel.cpp#L510-L520`](https://github.com/lfortran/lfortran/blob/a0926e9158df422afa18bd8d77aa4b702b6f5451/src/lfortran/fortran_kernel.cpp#L510-L520): remove explicit startup banner `std::cout` and keep file logger wiring

## Tests
- kernel startup probe using the existing local `jupyter_client` harness (`/tmp/kernel_ansi_check.py`)
- `scripts/lf.sh kernel-smoke`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build --with-xeus
$ /tmp/lf-kernel-venv/bin/python /tmp/kernel_ansi_check.py ./lfortran/build/src/bin/lfortran
xkernel::init
Before instantiating debugger
Debugger instantiated
Core instantiated
Starting xeus-fortran kernel...

If you want to connect to this kernel from an other client, you can use the /tmp/tmpq_elko9e.json file.
Run with XEUS 5.1.0
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/kernel-quiet-startup
$ scripts/lf.sh build --with-xeus
$ /tmp/lf-kernel-venv/bin/python /tmp/kernel_ansi_check.py ./lfortran/build/src/bin/lfortran
xkernel::init
Before instantiating debugger
Debugger instantiated
Core instantiated
Run with XEUS 5.1.0
```

```bash
$ scripts/lf.sh kernel-smoke
KERNEL_SMOKE_OK
```
