### PR TITLE
fix: show real values with decimals in interactive REPL

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -501,13 +501,15 @@ int prompt(bool verbose, CompilerOptions &cu)
             case (LCompilers::FortranEvaluator::EvalResult::real4) : {
                 if (verbose) std::cout << "Return type: real" << std::endl;
                 if (verbose) section("Result:");
-                std::cout << std::setprecision(8) << r.f32 << std::endl;
+                std::cout << std::showpoint << std::setprecision(8)
+                          << r.f32 << std::noshowpoint << std::endl;
                 break;
             }
             case (LCompilers::FortranEvaluator::EvalResult::real8) : {
                 if (verbose) std::cout << "Return type: real(8)" << std::endl;
                 if (verbose) section("Result:");
-                std::cout << std::setprecision(17) << r.f64 << std::endl;
+                std::cout << std::showpoint << std::setprecision(17)
+                          << r.f64 << std::noshowpoint << std::endl;
                 break;
             }
             case (LCompilers::FortranEvaluator::EvalResult::complex4) : {


### PR DESCRIPTION
## Summary
- print REPL `real` / `real(8)` evaluation results with `std::showpoint` so decimal output is explicit

Addresses #6097

## Why
Interactive REPL output currently prints real-valued expressions like `5.0` and implicit `f23` variables as `5` / `0`, which looks like integer output and is misleading.

**Stage:** Driver / interactive REPL frontend

## Changes
- [`src/bin/lfortran.cpp#L501-L513`](https://github.com/lfortran/lfortran/blob/38c5c490bfd2d40b30d4cc43aab4e54dfa8260a4/src/bin/lfortran.cpp#L501-L513): enable `showpoint` in real result printing branches and restore stream state afterward

## Tests
- REPL output checks in `--std=f23` mode for:
  - `5.0`
  - `foobar` (implicitly typed)
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build
$ printf '5.0\n' | ./lfortran/build/src/bin/lfortran --std=f23
...
5

$ printf 'foobar\n' | ./lfortran/build/src/bin/lfortran --std=f23
...
0
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/repl-real-output-format
$ scripts/lf.sh build
$ printf '5.0\n' | ./lfortran/build/src/bin/lfortran --std=f23
...
5.0000000

$ printf 'foobar\n' | ./lfortran/build/src/bin/lfortran --std=f23
...
0.0000000
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
