### PR TITLE
feat: add fixed/free form magics in kernel mode

### DIFF
--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -120,8 +120,36 @@ namespace LCompilers::LFortran {
         std::string code0;
         CompilerOptions cu;
         try {
-            if (startswith(code, "%%showast")) {
-                code0 = code.substr(code.find("\n")+1);
+            std::string code_eval = code;
+            if (startswith(code_eval, "%%fixed_form")) {
+                e.compiler_options.fixed_form = true;
+                size_t newline_pos = code_eval.find("\n");
+                if (newline_pos == std::string::npos) {
+                    publish_stream("stdout", "Fixed-form mode enabled.");
+                    nl::json result;
+                    result["status"] = "ok";
+                    result["payload"] = nl::json::array();
+                    result["user_expressions"] = nl::json::object();
+                    cb(result);
+                    return;
+                }
+                code_eval = code_eval.substr(newline_pos + 1);
+            } else if (startswith(code_eval, "%%free_form")) {
+                e.compiler_options.fixed_form = false;
+                size_t newline_pos = code_eval.find("\n");
+                if (newline_pos == std::string::npos) {
+                    publish_stream("stdout", "Free-form mode enabled.");
+                    nl::json result;
+                    result["status"] = "ok";
+                    result["payload"] = nl::json::array();
+                    result["user_expressions"] = nl::json::object();
+                    cb(result);
+                    return;
+                }
+                code_eval = code_eval.substr(newline_pos + 1);
+            }
+            if (startswith(code_eval, "%%showast")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -150,8 +178,8 @@ namespace LCompilers::LFortran {
                 cb(result);
                 return;
             }
-            if (startswith(code, "%%showasr")) {
-                code0 = code.substr(code.find("\n")+1);
+            if (startswith(code_eval, "%%showasr")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -180,8 +208,8 @@ namespace LCompilers::LFortran {
                 cb(result);
                 return;
             }
-            if (startswith(code, "%%showllvm")) {
-                code0 = code.substr(code.find("\n")+1);
+            if (startswith(code_eval, "%%showllvm")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -212,8 +240,8 @@ namespace LCompilers::LFortran {
                 cb(result);
                 return;
             }
-            if (startswith(code, "%%showasm")) {
-                code0 = code.substr(code.find("\n")+1);
+            if (startswith(code_eval, "%%showasm")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -244,8 +272,8 @@ namespace LCompilers::LFortran {
                 cb(result);
                 return;
             }
-            if (startswith(code, "%%showcpp")) {
-                code0 = code.substr(code.find("\n")+1);
+            if (startswith(code_eval, "%%showcpp")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -274,8 +302,8 @@ namespace LCompilers::LFortran {
                 cb(result);
                 return;
             }
-            if (startswith(code, "%%showfmt")) {
-                code0 = code.substr(code.find("\n")+1);
+            if (startswith(code_eval, "%%showfmt")) {
+                code0 = code_eval.substr(code_eval.find("\n")+1);
                 LocationManager lm;
                 {
                     LocationManager::FileLocations fl;
@@ -306,7 +334,7 @@ namespace LCompilers::LFortran {
             }
 
             RedirectStdout s(std_out);
-            code0 = code;
+            code0 = code_eval;
             LocationManager lm;
             {
                 LocationManager::FileLocations fl;


### PR DESCRIPTION
## Summary
- add `%%fixed_form` and `%%free_form` kernel magics to toggle evaluator parsing mode
- allow these magics to act as mode toggles without forcing a parse error on `%` tokens

Addresses #511

## Why
Notebook cells starting with `%%fixed_form` currently fail immediately with a `%` syntax error. This prevents fixed-form workflows in kernel mode.

**Stage:** Interactive kernel frontend

## Changes
- [`src/lfortran/fortran_kernel.cpp#L123-L150`](https://github.com/lfortran/lfortran/blob/e53852028fee512785d2004dec378c1b48c0e549/src/lfortran/fortran_kernel.cpp#L123-L150): add `%%fixed_form` / `%%free_form` handling and mode toggles
- [`src/lfortran/fortran_kernel.cpp#L151-L337`](https://github.com/lfortran/lfortran/blob/e53852028fee512785d2004dec378c1b48c0e549/src/lfortran/fortran_kernel.cpp#L151-L337): route subsequent magic/default handling through the potentially transformed `code_eval`

## Tests
- kernel execution via local `jupyter_client` harness:
  - `%%fixed_form`
  - `%%free_form`
- `scripts/lf.sh kernel-smoke`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build --with-xeus
$ /tmp/lf-kernel-venv/bin/python /tmp/kernel_exec.py ./lfortran/build/src/bin/lfortran '[]' $'%%fixed_form\n      continue'
SHELL_STATUS=error
SHELL_ENAME=CompilerError
SHELL_EVALUE=syntax error: Token '%' is unexpected here
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/kernel-fixed-form-magic
$ scripts/lf.sh build --with-xeus
$ /tmp/lf-kernel-venv/bin/python /tmp/kernel_exec.py ./lfortran/build/src/bin/lfortran '[]' $'%%fixed_form'
SHELL_STATUS=ok
STREAM_STDOUT=Fixed-form mode enabled.

$ /tmp/lf-kernel-venv/bin/python /tmp/kernel_exec.py ./lfortran/build/src/bin/lfortran '[]' $'%%free_form'
SHELL_STATUS=ok
STREAM_STDOUT=Free-form mode enabled.
```

```bash
$ scripts/lf.sh kernel-smoke
KERNEL_SMOKE_OK
```
