### PR TITLE
fix: accept --connection-file in kernel subcommand

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -284,7 +284,8 @@ namespace LCompilers::CommandLineInterface {
 
         // kernel
         kernel = app.add_subcommand("kernel", "Run in Jupyter kernel mode.");
-        kernel->add_option("-f", opts.arg_kernel_f, "The kernel connection file")->required();
+        kernel->add_option("-f,--connection-file", opts.arg_kernel_f,
+            "The kernel connection file")->required();
 
         // mod
         mod = app.add_subcommand("mod", "Fortran mod file utilities.");


### PR DESCRIPTION
## Summary
- add `--connection-file` as a long option alias for kernel subcommand `-f`

## Why
Kernel subcommand currently requires only `-f`, which is brittle for wrappers and scripts that prefer explicit long option names.

**Stage:** Command-line parser / kernel subcommand

## Changes
- [`src/bin/lfortran_command_line_parser.cpp#L286-L288`](https://github.com/lfortran/lfortran/blob/84d079c6e0cd4efef8115133282cf4191aa52395/src/bin/lfortran_command_line_parser.cpp#L286-L288): support `-f,--connection-file` for kernel connection path

## Tests
- CLI kernel invocation with long option:
  - `lfortran kernel --connection-file <file>`
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build --with-xeus
$ timeout 3 ./lfortran/build/src/bin/lfortran kernel --connection-file /tmp/lfortran-cli-compat-conn.json
-f is required
Run with --help for more information.
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/kernel-connection-file-option
$ scripts/lf.sh build --with-xeus
$ timeout 3 ./lfortran/build/src/bin/lfortran kernel --connection-file /tmp/lfortran-cli-compat-conn.json
xkernel::init
Core instantiated
Starting xeus-fortran kernel...
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
