### PR TITLE
fix: keep decimal points in complex REPL results

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -513,13 +513,17 @@ int prompt(bool verbose, CompilerOptions &cu)
             case (LCompilers::FortranEvaluator::EvalResult::complex4) : {
                 if (verbose) std::cout << "Return type: complex" << std::endl;
                 if (verbose) section("Result:");
-                std::cout << std::setprecision(8) << "(" << r.c32.re << ", " << r.c32.im << ")" << std::endl;
+                std::cout << std::showpoint << std::setprecision(8)
+                          << "(" << r.c32.re << ", " << r.c32.im << ")"
+                          << std::noshowpoint << std::endl;
                 break;
             }
             case (LCompilers::FortranEvaluator::EvalResult::complex8) : {
                 if (verbose) std::cout << "Return type: complex(8)" << std::endl;
                 if (verbose) section("Result:");
-                std::cout << std::setprecision(17) << "(" << r.c64.re << ", " << r.c64.im << ")" << std::endl;
+                std::cout << std::showpoint << std::setprecision(17)
+                          << "(" << r.c64.re << ", " << r.c64.im << ")"
+                          << std::noshowpoint << std::endl;
                 break;
             }
             case (LCompilers::FortranEvaluator::EvalResult::boolean) : {


### PR DESCRIPTION
## Summary
- preserve decimal points in interactive REPL output for complex values

## Why
Complex REPL output currently drops decimal points for integral-looking components (for example `(1.5, 2)` and `(0, 0)`), which is inconsistent with input and with real-valued formatting improvements.

**Stage:** Driver / interactive REPL frontend

## Changes
- [`src/bin/lfortran.cpp#L513-L527`](https://github.com/lfortran/lfortran/blob/bdfc16e056c94988d3ea096f1850905792c6626f/src/bin/lfortran.cpp#L513-L527): use `showpoint` when printing `complex4` / `complex8` REPL results

## Tests
- REPL output checks with piped stdin:
  - `(1.5,2.0)`
  - `(0.0,0.0)`
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build
$ printf '(1.5,2.0)\n' | ./lfortran/build/src/bin/lfortran
...
(1.5, 2)

$ printf '(0.0,0.0)\n' | ./lfortran/build/src/bin/lfortran
...
(0, 0)
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/repl-complex-output-format
$ scripts/lf.sh build
$ printf '(1.5,2.0)\n' | ./lfortran/build/src/bin/lfortran
...
(1.5000000, 2.0000000)

$ printf '(0.0,0.0)\n' | ./lfortran/build/src/bin/lfortran
...
(0.0000000, 0.0000000)
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
