### PR TITLE
fix: use Fortran logical literals in REPL output

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -525,7 +525,7 @@ int prompt(bool verbose, CompilerOptions &cu)
             case (LCompilers::FortranEvaluator::EvalResult::boolean) : {
                 if (verbose) std::cout << "Return type: logical" << std::endl;
                 if (verbose) section("Result:");
-                std::cout << (r.b ? "True" : "False") << std::endl;
+                std::cout << (r.b ? ".true." : ".false.") << std::endl;
                 break;
             }
             case (LCompilers::FortranEvaluator::EvalResult::statement) : {


### PR DESCRIPTION
## Summary
- print REPL logical results in Fortran canonical form: `.true.` / `.false.`

## Why
Interactive mode currently prints logical values as `True` / `False`, which is inconsistent with Fortran syntax and with user-entered logical literals.

**Stage:** Driver / interactive REPL frontend

## Changes
- [`src/bin/lfortran.cpp#L525-L529`](https://github.com/lfortran/lfortran/blob/8bdb480391dd4a12ce3870ad825ecd51b7c826df/src/bin/lfortran.cpp#L525-L529): switch logical output formatting to `.true.` / `.false.`

## Tests
- REPL output checks with piped stdin:
  - `.true.`
  - `.false.`
- reference test sanity check: `interactive_parse_without_program_line`

## Verification

### Test fails on main
```bash
$ git -C lfortran switch --detach upstream/main
$ scripts/lf.sh build
$ printf '.true.\n' | ./lfortran/build/src/bin/lfortran
...
True

$ printf '.false.\n' | ./lfortran/build/src/bin/lfortran
...
False
```

### Test passes after fix
```bash
$ git -C lfortran switch fix/repl-logical-output-format
$ scripts/lf.sh build
$ printf '.true.\n' | ./lfortran/build/src/bin/lfortran
...
.true.

$ printf '.false.\n' | ./lfortran/build/src/bin/lfortran
...
.false.
```

```bash
$ scripts/lf.sh test -t interactive_parse_without_program_line -s
TESTS PASSED
```
