### PR TITLE
CI: Initial Julienne test

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -137,6 +137,20 @@ time_section "🧪 Testing splpak" '
   rm -rf splpak
 '
 
+time_section "🧪 Testing Julienne" '
+  git clone https://github.com/certik/julienne.git
+  cd julienne
+  export PATH="$(pwd)/../src/bin:$PATH"
+  micromamba install -c conda-forge fpm
+
+  git checkout -t origin/lf2
+  git checkout 04dffa762ab0f5259d41ac6071c7395c6c404c98
+  fpm test --compiler=lfortran --flag --cpp --flag --separate-compilation --flag --realloc-lhs-arrays idiomatic_assertion_failure_test
+
+  print_success "Done with Julienne"
+  cd ..
+'
+
 time_section "🧪 Testing fortran-regex" '
   git clone https://github.com/perazz/fortran-regex.git
   cd fortran-regex


### PR DESCRIPTION
It builds all tests and runs one that does not fail. The main test is the `driver` but it does not run yet. Also the `lf2` branch has several lines commented out, which we should either fix in LFortran or create a proper workaround that is equivalent.