### PR TITLE
fix: array constructor lower bound starts at 1

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2052,6 +2052,7 @@ RUN(NAME associate_29 LABELS gfortran llvm)
 RUN(NAME associate_30 LABELS gfortran llvm)
 RUN(NAME associate_31 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_32 LABELS llvm)
+RUN(NAME associate_33 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_33.f90
+++ b/integration_tests/associate_33.f90
@@ -1,0 +1,20 @@
+program associate_33
+! Test: associate with lbound/ubound without DIM (array result)
+implicit none
+
+real(8), allocatable :: a(:,:,:,:)
+
+allocate( a(-3:14,1,1,1) )
+
+associate (lb => lbound(a), ub => ubound(a))
+    if (lb(1) /= -3) error stop
+    if (lb(2) /= 1) error stop
+    if (lb(3) /= 1) error stop
+    if (lb(4) /= 1) error stop
+    if (ub(1) /= 14) error stop
+    if (ub(2) /= 1) error stop
+    if (ub(3) /= 1) error stop
+    if (ub(4) /= 1) error stop
+end associate
+
+end program associate_33

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -6745,7 +6745,7 @@ inline ASR::asr_t* make_ArrayConstructor_t_util(Allocator &al, const Location &a
         dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
             al, a_loc, n_args, ASRUtils::TYPE(ASR::make_Integer_t(al, a_loc, 4))));
         dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-            al, a_loc, 0, ASRUtils::TYPE(ASR::make_Integer_t(al, a_loc, 4))));
+            al, a_loc, 1, ASRUtils::TYPE(ASR::make_Integer_t(al, a_loc, 4))));
         dims.push_back(al, dim);
         a_type = ASRUtils::make_Array_t_util(al, dim.loc,
             a_type, dims.p, dims.size(), ASR::abiType::Source,


### PR DESCRIPTION
When `lbound(a)` or `ubound(a)` is called without a DIM argument, the result is a rank-1 array whose lower bound is 1 (per the Fortran standard). The array constructor utility was incorrectly setting m_start to 0, causing the returned array to be indexed from 0, so e.g. lb(1) would return lbound(a,2) instead of lbound(a,1).

Fixes associate construct with lbound/ubound selectors.

Fixes #10217.