### PR TITLE
Fix intrinsic // in associate with op

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2054,6 +2054,7 @@ RUN(NAME associate_30 LABELS gfortran llvm)
 RUN(NAME associate_31 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_32 LABELS llvm)
 RUN(NAME associate_33 LABELS gfortran llvm)
+RUN(NAME associate_34 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_34.f90
+++ b/integration_tests/associate_34.f90
@@ -1,0 +1,38 @@
+! Test: intrinsic // inside associate when user-defined operator(//) is in scope
+module associate_34_mod
+  implicit none
+
+  type :: string_t
+    character(len=:), allocatable :: s
+  end type
+
+  interface operator(//)
+    elemental module function char_cat_string(lhs, rhs) result(res)
+      character(len=*), intent(in) :: lhs
+      type(string_t), intent(in) :: rhs
+      type(string_t) :: res
+    end function
+  end interface
+
+end module
+
+submodule (associate_34_mod) associate_34_sub
+  implicit none
+contains
+  elemental module function char_cat_string(lhs, rhs) result(res)
+    character(len=*), intent(in) :: lhs
+    type(string_t), intent(in) :: rhs
+    type(string_t) :: res
+    res%s = lhs // rhs%s
+  end function
+end submodule
+
+program associate_34
+  use associate_34_mod
+  implicit none
+  character(len=:), allocatable :: a
+  a = "world"
+  associate(str => a)
+    if ("hello " // str /= "hello world") error stop
+  end associate
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -14244,9 +14244,9 @@ public:
         ASR::ttype_t *left_type_ = ASRUtils::expr_type(left);
         ASR::ttype_t *right_type_ = ASRUtils::expr_type(right);
         ASR::ttype_t *left_type = ASRUtils::type_get_past_array(
-            ASRUtils::type_get_past_allocatable(left_type_));
+            ASRUtils::type_get_past_allocatable_pointer(left_type_));
         ASR::ttype_t *right_type = ASRUtils::type_get_past_array(
-            ASRUtils::type_get_past_allocatable(right_type_));
+            ASRUtils::type_get_past_allocatable_pointer(right_type_));
 
         if( ASR::is_a<ASR::String_t>(*left_type) &&
             ASR::is_a<ASR::String_t>(*right_type) ) { // CreateIntrinisc `stringConcat`


### PR DESCRIPTION
When a user-defined operator(//) is in scope for non-character types, intrinsic string concatenation inside an associate block failed because associate variables have a Pointer type wrapper that was not stripped when checking operand types.

Use type_get_past_allocatable_pointer instead of type_get_past_allocatable in visit_StrOp so the Pointer wrapper is also removed before the String_t type check.