### PR TITLE
Fix select rank(0) type mismatch for scalars

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -817,6 +817,7 @@ RUN(NAME select_rank_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME select_rank_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_rank_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_rank_14.f90
+++ b/integration_tests/select_rank_14.f90
@@ -1,0 +1,55 @@
+program select_rank_14
+    implicit none
+
+    integer :: s
+    integer :: a(3)
+    real :: r
+    real :: b(2)
+
+    s = 42
+    a = [10, 20, 30]
+    r = 3.14
+    b = [1.0, 2.0]
+
+    call check_int(s, 0)
+    call check_int(a, 1)
+    call check_real(r, 0)
+    call check_real(b, 1)
+
+contains
+
+    subroutine check_int(x, expected_rank)
+        integer, intent(in) :: x(..)
+        integer, intent(in) :: expected_rank
+        integer :: y
+
+        select rank (x)
+            rank (0)
+                if (expected_rank /= 0) error stop
+                y = x
+                if (y /= 42) error stop
+            rank (1)
+                if (expected_rank /= 1) error stop
+                y = x(1)
+                if (y /= 10) error stop
+        end select
+    end subroutine
+
+    subroutine check_real(x, expected_rank)
+        real, intent(in) :: x(..)
+        integer, intent(in) :: expected_rank
+        real :: y
+
+        select rank (x)
+            rank (0)
+                if (expected_rank /= 0) error stop
+                y = x
+                if (abs(y - 3.14) > 0.001) error stop
+            rank (1)
+                if (expected_rank /= 1) error stop
+                y = x(1)
+                if (abs(y - 1.0) > 0.001) error stop
+        end select
+    end subroutine
+
+end program

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1040,8 +1040,13 @@ public:
                 "the old physical type and new physical type must be different.");
         }
         if(check_external){
-            require(x.m_new == ASRUtils::extract_physical_type(x.m_type),
-                "Destination physical type conflicts with the physical type of target");
+            // For rank(0): AssumedRankArray → scalar, m_type is scalar so skip physical type check
+            bool is_rank0_scalar = (x.m_old == ASR::array_physical_typeType::AssumedRankArray
+                                    && !ASRUtils::is_array(x.m_type));
+            if (!is_rank0_scalar) {
+                require(x.m_new == ASRUtils::extract_physical_type(x.m_type),
+                    "Destination physical type conflicts with the physical type of target");
+            }
             require(x.m_old == ASRUtils::extract_physical_type(ASRUtils::expr_type(x.m_arg)),
                 "Old physical type conflicts with the physical type of argument " + std::to_string(x.m_old)
                 + " " + std::to_string(ASRUtils::extract_physical_type(ASRUtils::expr_type(x.m_arg))));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9902,7 +9902,16 @@ public:
         } else if (
             m_new == ASR::array_physical_typeType::DescriptorArray &&
             m_old == ASR::array_physical_typeType::AssumedRankArray) {
-            
+
+            if (!ASRUtils::is_array(m_type)) {
+                // rank(0): extract scalar value by loading the data pointer from the
+                // assumed-rank descriptor and dereferencing it.
+                llvm::Value* data_ptr = llvm_utils->CreateLoad2(
+                    data_type->getPointerTo(),
+                    arr_descr->get_pointer_to_data(arr_type, arg));
+                tmp = llvm_utils->CreateLoad2(data_type, data_ptr);
+            } else {
+
             llvm::Type* target_desc_type = llvm_utils->get_type_from_ttype_t_util(
                 m_arg,
                 ASRUtils::type_get_past_allocatable(
@@ -9951,6 +9960,7 @@ public:
             } else {
                 tmp = target_desc;
             }
+            } // end else (rank >= 1)
         } else if (
             m_new == ASR::array_physical_typeType::PointerArray &&
             m_old == ASR::array_physical_typeType::AssumedRankArray) {

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -433,6 +433,9 @@ class EditProcedureReplacer: public ASR::BaseExprReplacer<EditProcedureReplacer>
             (ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(x->m_arg)) ||
              ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x->m_arg))))) {
             *current_expr = x->m_arg;
+        } else if (x->m_old == ASR::array_physical_typeType::AssumedRankArray &&
+                   !ASRUtils::is_array(x->m_type)) {
+            // rank(0): AssumedRankArray → scalar, nothing to update
         } else {
             ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_pointer(
                   ASRUtils::type_get_past_allocatable(x->m_type)));


### PR DESCRIPTION
In a `select rank(rank(0))` block, the selector variable should behave as a scalar. Previously, using it directly in an assignment (`y = x`) caused a type mismatch because the semantic layer had no handling for the assumed-rank → scalar conversion.

Changes:
- semantics: insert ArrayPhysicalCast(AssumedRankArray → DescriptorArray, scalar_type) for rank(0) assumed-rank variables used as RHS values in assignments
- asr_verify: allow ArrayPhysicalCast where m_type is scalar when m_old is AssumedRankArray (rank-0 case)
- asr_to_llvm: handle rank(0) in ArrayPhysicalCastUtil by loading the data pointer from the assumed-rank descriptor and dereferencing it
- pass_array_by_data: skip the Array_t downcast for rank-0 scalar ArrayPhysicalCast nodes