### PR TITLE
Fix select rank(0) for derived types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -818,6 +818,7 @@ RUN(NAME select_rank_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME select_rank_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_14 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME select_rank_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_rank_15.f90
+++ b/integration_tests/select_rank_15.f90
@@ -1,0 +1,36 @@
+program select_rank_15
+    implicit none
+
+    type :: my_type
+        integer :: value
+    end type
+
+    type(my_type) :: s
+    type(my_type) :: a(3)
+
+    s = my_type(42)
+    a = [my_type(10), my_type(20), my_type(30)]
+
+    call check_struct(s, 0)
+    call check_struct(a, 1)
+
+contains
+
+    subroutine check_struct(x, expected_rank)
+        type(my_type), intent(in) :: x(..)
+        integer, intent(in) :: expected_rank
+        type(my_type) :: y
+
+        select rank (x)
+            rank (0)
+                if (expected_rank /= 0) error stop
+                y = x
+                if (y%value /= 42) error stop
+            rank (1)
+                if (expected_rank /= 1) error stop
+                y = x(1)
+                if (y%value /= 10) error stop
+        end select
+    end subroutine
+
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7083,8 +7083,12 @@ public:
                 if (v && ASRUtils::symbol_get_past_external(v) && ASR::is_a<ASR::Union_t>(*ASRUtils::symbol_get_past_external(v))) {    
                     type = ASRUtils::get_union_type(al, loc, ASRUtils::symbol_get_past_external(v));
                 }
-                type = ASRUtils::make_Array_t_util(
-                    al, loc, type, dims.p, dims.size(), abi, is_argument);
+                if (is_assumed_rank) {
+                    type = ASRUtils::TYPE(ASR::make_Array_t(al, loc, type, nullptr, 0, ASR::array_physical_typeType::AssumedRankArray));
+                } else {
+                    type = ASRUtils::make_Array_t_util(
+                        al, loc, type, dims.p, dims.size(), abi, is_argument);
+                }
                 if (is_pointer) {
                     type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                         type));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9921,12 +9921,16 @@ public:
             m_old == ASR::array_physical_typeType::AssumedRankArray) {
 
             if (!ASRUtils::is_array(m_type)) {
-                // rank(0): extract scalar value by loading the data pointer from the
-                // assumed-rank descriptor and dereferencing it.
+                // rank(0): extract scalar value from the assumed-rank descriptor.
                 llvm::Value* data_ptr = llvm_utils->CreateLoad2(
                     data_type->getPointerTo(),
                     arr_descr->get_pointer_to_data(arr_type, arg));
-                tmp = llvm_utils->CreateLoad2(data_type, data_ptr);
+                if (ASRUtils::is_struct(*m_type)) {
+                    // For struct types, return the pointer (deepcopy needs a pointer)
+                    tmp = data_ptr;
+                } else {
+                    tmp = llvm_utils->CreateLoad2(data_type, data_ptr);
+                }
             } else {
 
             llvm::Type* target_desc_type = llvm_utils->get_type_from_ttype_t_util(


### PR DESCRIPTION
Extend the rank(0) assumed-rank scalar fix (23b93757) to handle user-defined derived types (StructType):

- semantics: mark assumed-rank struct variables with AssumedRankArray physical type instead of DescriptorArray
- asr_to_llvm: for rank(0) struct types, return the data pointer directly instead of loading the value (deepcopy expects a pointer)