### PR TITLE
Fix overloaded assign with struct op result

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1762,6 +1762,7 @@ RUN(NAME custom_operator_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_operator_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_operator_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME custom_operator_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME custom_operator_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/custom_operator_13.f90
+++ b/integration_tests/custom_operator_13.f90
@@ -1,0 +1,41 @@
+module custom_operator_13_mod
+  implicit none
+
+  type :: string_t
+    character(len=:), allocatable :: s
+  contains
+    procedure :: cat_sc
+    procedure, pass(rhs) :: assign_to_char
+    generic :: operator(//) => cat_sc
+    generic :: assignment(=) => assign_to_char
+  end type
+
+contains
+
+  elemental function cat_sc(lhs, rhs) result(res)
+    class(string_t), intent(in) :: lhs
+    character(len=*), intent(in) :: rhs
+    type(string_t) :: res
+    res%s = lhs%s // rhs
+  end function
+
+  pure subroutine assign_to_char(lhs, rhs)
+    character(len=:), intent(out), allocatable :: lhs
+    class(string_t), intent(in) :: rhs
+    lhs = rhs%s
+  end subroutine
+
+end module
+
+program custom_operator_13
+  use custom_operator_13_mod
+  implicit none
+
+  type(string_t) :: x
+  character(len=:), allocatable :: result
+
+  x%s = "hello"
+  result = x // " world"
+  if (result /= "hello world") error stop
+  print *, result
+end program

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -678,6 +678,16 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
 
         void visit_Assignment(const ASR::Assignment_t &x) {
             if(is_function_call_returning_aggregate_type(x.m_value)) {
+                if (x.m_overloaded) {
+                    // User-defined assignment(=) where the RHS is a function
+                    // call returning an aggregate type. The array_struct_temporary
+                    // pass has already created a temp for the function result
+                    // and wired the m_overloaded SubroutineCall to use it.
+                    // Just emit the overloaded call and drop this Assignment.
+                    pass_result.push_back(al, x.m_overloaded);
+                    remove_original_statement = true;
+                    return;
+                }
                 ASR::Assignment_t& xx = const_cast<ASR::Assignment_t&>(x);
                 if (subroutine_call_from_function(x.base.base.loc, (ASR::stmt_t &)xx)) {
                     return;


### PR DESCRIPTION
The subroutine_from_function pass crashed with a check_equal_type(str, StructType) assertion when a user-defined assignment(=) with pass(rhs) received a FunctionCall returning a StructType as m_value.

When m_overloaded is set on such an Assignment, the array_struct_temporary pass has already created a temporary for the struct result and wired the overloaded SubroutineCall to use it. Emit that SubroutineCall directly instead of trying to make the character target a return slot for the struct- returning function.