### PR TITLE
CI: use the latest main of Julienne

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -138,7 +138,7 @@ time_section "🧪 Testing splpak" '
 '
 
 time_section "🧪 Testing Julienne" '
-  git clone https://github.com/certik/julienne.git
+  git clone https://github.com/BerkeleyLab/julienne.git
   cd julienne
   export PATH="$(pwd)/../src/bin:$PATH"
   micromamba install -c conda-forge fpm


### PR DESCRIPTION
This is now using the latest main, no workarounds needed. For now the main tests do not run yet, but it fully compiles and builds, which is what this PR is testing.