### PR TITLE
fix: skip leading spaces in complex list reads

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2709,6 +2709,7 @@ RUN(NAME read_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_38 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_39 LABELS gfortran llvm)
 RUN(NAME read_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME read_41 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_41.f90
+++ b/integration_tests/read_41.f90
@@ -1,0 +1,27 @@
+program read_41
+  ! List-directed internal read of complex with leading whitespace.
+  ! The Fortran standard requires leading blanks to be ignored.
+  implicit none
+  complex :: z
+  character(len=:), allocatable :: s
+
+  ! No leading space
+  s = "(1.0,0.0)"
+  read(s, *) z
+  if (abs(real(z) - 1.0) > 1e-6) error stop "Test 1 real part failed"
+  if (abs(aimag(z) - 0.0) > 1e-6) error stop "Test 1 imag part failed"
+
+  ! One leading space
+  s = " (1.0,0.0)"
+  read(s, *) z
+  if (abs(real(z) - 1.0) > 1e-6) error stop "Test 2 real part failed"
+  if (abs(aimag(z) - 0.0) > 1e-6) error stop "Test 2 imag part failed"
+
+  ! Multiple leading spaces
+  s = "   (2.5,-3.0)"
+  read(s, *) z
+  if (abs(real(z) - 2.5) > 1e-6) error stop "Test 3 real part failed"
+  if (abs(aimag(z) - (-3.0)) > 1e-6) error stop "Test 3 imag part failed"
+
+  print *, "All tests passed."
+end program read_41

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -14152,8 +14152,8 @@ public:
                                    ASRUtils::type_get_past_allocatable_pointer(type)))) {
                         ASR::Complex_t* complex_type = ASR::down_cast<ASR::Complex_t>(ASRUtils::type_get_past_array(
                                 ASRUtils::type_get_past_allocatable_pointer(type)));
-                        fmt = complex_type->m_kind == 4 ? LCompilers::create_global_string_ptr(context, *module, *builder, "(%f, %f)")
-                                                       : LCompilers::create_global_string_ptr(context, *module, *builder, "(%lf, %lf)");
+                        fmt = complex_type->m_kind == 4 ? LCompilers::create_global_string_ptr(context, *module, *builder, " (%f,%f)")
+                                                       : LCompilers::create_global_string_ptr(context, *module, *builder, " (%lf,%lf)");
                     }
                     llvm::Value *src_data, *src_len;
                     std::tie(src_data, src_len) = llvm_utils->get_string_length_data(


### PR DESCRIPTION
sscanf format "(%f,%f)" requires '(' to be the next character in the input. Add a leading space to the format so sscanf skips any whitespace before '(' in list-directed complex reads.

Fixes: read(s, *) z where s has leading whitespace before the opening parenthesis.