### PR TITLE
fix: string-unit read into allocatable variable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2711,6 +2711,7 @@ RUN(NAME read_38 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_39 LABELS gfortran llvm)
 RUN(NAME read_40 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_41 LABELS gfortran llvm)
+RUN(NAME read_42 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_42.f90
+++ b/integration_tests/read_42.f90
@@ -1,0 +1,29 @@
+program read_42
+  ! Internal (string-unit) reads into allocatable scalar and array variables.
+  ! These used to crash with SIGSEGV because the codegen passed the alloca
+  ! address (pointer-to-pointer) to the runtime instead of the allocated
+  ! data pointer.
+  implicit none
+  character(len=3) :: s3
+  character(len=7) :: s7
+  real, allocatable :: x
+  real, allocatable :: arr(:)
+
+  ! Test 1: allocatable scalar
+  s3 = "1.0"
+  allocate(x)
+  read(s3, fmt=*) x
+  if (abs(x - 1.0) > 1e-6) error stop "Test 1 failed: allocatable scalar read"
+  deallocate(x)
+
+  ! Test 2: allocatable array
+  s7 = "1, 2, 3"
+  allocate(arr(3))
+  read(s7, fmt=*) arr
+  if (abs(arr(1) - 1.0) > 1e-6) error stop "Test 2 failed: arr(1)"
+  if (abs(arr(2) - 2.0) > 1e-6) error stop "Test 2 failed: arr(2)"
+  if (abs(arr(3) - 3.0) > 1e-6) error stop "Test 2 failed: arr(3)"
+  deallocate(arr)
+
+  print *, "All tests passed."
+end program read_42


### PR DESCRIPTION
When reading from an internal string unit into an allocatable scalar or array, the codegen was passing the alloca address (pointer-to-pointer) to the runtime read function instead of the actual allocated data pointer, causing a SIGSEGV.

For allocatable scalars: dereference the alloca once to get the pointer to the allocated value before calling the runtime.

For allocatable arrays: load the descriptor pointer, then extract the data pointer from the descriptor struct and pass it to the runtime.

Also fix the LLVM function-type declarations to use the inner type (past allocatable) so the parameter type matches the actual runtime function signatures.

Fixes `read(string, *) x` and `read(string, *) arr` where `x` is 'real, allocatable' and arr is 'real, allocatable(:)'.