### PR TITLE
fix: handle array dimensions for nested function calls having return types as allocatable arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -606,6 +606,7 @@ RUN(NAME functions_50 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_51 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_52 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_53 LABELS llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME functions_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --realloc-lhs-arrays)
 
 
 RUN(NAME common_01 LABELS gfortran)

--- a/integration_tests/functions_54.f90
+++ b/integration_tests/functions_54.f90
@@ -1,0 +1,40 @@
+module mod_functions_54
+    implicit none
+
+    type,public :: string
+        character(len=:),allocatable :: str
+    end type string
+
+    contains 
+    elemental function string_to_int(me) result(i)
+        class(string),intent(in) :: me
+        integer :: i
+        i = len(me%str)
+    end function string_to_int
+
+    function split(str,token) result(vals)
+        implicit none
+        character(len=*),intent(in)  :: str
+        character(len=*),intent(in)  :: token
+        type(string),dimension(:),allocatable :: vals
+        allocate(vals(1)) 
+        vals(1)%str = str
+    end function split
+
+    function parse_nums64(line) result(ints)
+        character(len=*),intent(in) :: line
+        integer(4),dimension(:), allocatable :: ints 
+        type(string),dimension(:),allocatable :: vals
+        ints = string_to_int(split(line, ' '))
+    end function parse_nums64
+end module mod_functions_54
+
+program functions_54 
+  use mod_functions_54
+  character(len=100) :: single_line
+  integer(4), allocatable :: results(:)
+  single_line = "10 20 30"
+  results = parse_nums64(single_line)
+  print *, results
+  if (results(1) /= 100) error stop
+end program functions_54

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3359,6 +3359,10 @@ ASR::asr_t* make_ArraySize_t_util(
                 }
                 return &(result->base);
             } else if( is_dimension_constant ) {
+                if( m_dims[dim - 1].m_length == nullptr ) {
+                    // For Deferred-shape allocatable return, calculate size at runtime
+                    return ASR::make_ArraySize_t(al, a_loc, a_v, a_dim, a_type, a_value);
+                }
                 LCOMPILERS_ASSERT(m_dims[dim - 1].m_length);
                 return &(m_dims[dim - 1].m_length->base);
             }


### PR DESCRIPTION
Fixes #6713 
Towards #5629 

Changes made:
- For nested function calls inside function arguments, add support for runtime array-dimension calculations.