### PR TITLE
Fix ICE on inherited generic binding

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2458,6 +2458,7 @@ RUN(NAME class_118 LABELS gfortran llvm)
 RUN(NAME class_119 LABELS gfortran llvm)
 RUN(NAME class_120 LABELS gfortran llvm)
 RUN(NAME class_121 LABELS gfortran llvm)
+RUN(NAME class_122 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_122.f90
+++ b/integration_tests/class_122.f90
@@ -1,0 +1,38 @@
+module class_122_mod
+   implicit none
+
+   type :: parent_t
+      integer :: val
+   contains
+      procedure, non_overridable :: get_val_impl
+   end type
+
+   type, extends(parent_t) :: child_t
+   contains
+      generic :: get_val => get_val_impl
+   end type
+
+contains
+
+   function get_val_impl(self) result(v)
+      class(parent_t), intent(in) :: self
+      integer :: v
+      v = self%val
+   end function
+
+   subroutine test_sub(obj)
+      class(child_t), intent(in) :: obj
+      integer :: v
+      v = obj%get_val_impl()
+      print *, v
+      if (v /= 42) error stop
+   end subroutine
+
+end module class_122_mod
+
+program class_122
+   use class_122_mod
+   type(child_t) :: c
+   c%val = 42
+   call test_sub(c)
+end program class_122

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18319,6 +18319,7 @@ public:
                     ASRUtils::symbol_get_past_external(struct_type_t->m_parent));
                 s_class_proc = struct_type_t->m_symtab->get_symbol(proc_sym_name);
             }
+            s_class_proc = ASRUtils::symbol_get_past_external(s_class_proc);
             ASR::StructMethodDeclaration_t* class_proc = ASR::down_cast<ASR::StructMethodDeclaration_t>(s_class_proc);
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(
                 ASRUtils::symbol_get_past_external(class_proc->m_proc));
@@ -18527,6 +18528,7 @@ public:
                     ASRUtils::symbol_get_past_external(struct_type_t->m_parent));
                 s_class_proc = struct_type_t->m_symtab->get_symbol(proc_sym_name);
             }
+            s_class_proc = ASRUtils::symbol_get_past_external(s_class_proc);
             ASR::StructMethodDeclaration_t* class_proc = ASR::down_cast<ASR::StructMethodDeclaration_t>(s_class_proc);
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(
                 ASRUtils::symbol_get_past_external(class_proc->m_proc));


### PR DESCRIPTION
When a child type has a generic binding that resolves to a non_overridable procedure inherited from a parent type, the symbol lookup in the child's symtab returns an ExternalSymbol pointing to the parent's StructMethodDeclaration. The codegen was missing symbol_get_past_external() before downcasting, causing an assertion failure. Apply the resolution in both
visit_RuntimePolymorphicSubroutineCall and
visit_RuntimePolymorphicFunctionCall.