### PR TITLE
Fix nested_vars for procedure pointers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2232,6 +2232,7 @@ RUN(NAME nested_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME nested_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/nested_24.f90
+++ b/integration_tests/nested_24.f90
@@ -1,0 +1,27 @@
+module nested_24_mod
+  abstract interface
+    function iface(x)
+      integer, intent(in) :: x
+      integer :: iface
+    end function
+  end interface
+contains
+  function f(x)
+    integer, intent(in) :: x
+    integer :: f
+    f = x + 10
+  end function
+end module
+
+program nested_24
+  use nested_24_mod
+  implicit none
+  procedure(iface), pointer :: p => f
+  call sub()
+contains
+  subroutine sub()
+    if (p(1) /= 11) error stop
+    if (p(5) /= 15) error stop
+    print *, "ok"
+  end subroutine
+end program


### PR DESCRIPTION
When a procedure pointer variable initialized to a module function (e.g., procedure(iface), pointer :: p => f) was used in a contained subroutine, the nested_vars pass duplicated it into the context module but kept m_symbolic_value and m_type_declaration pointing to symbols in the program scope, causing ASR verify errors.

Clear the initialization expressions (m_symbolic_value/m_value) since the pass synchronizes values via assignments, and import m_type_declaration into the module scope as an ExternalSymbol.