### PR TITLE
Fix array section stride in TBP calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -807,6 +807,7 @@ RUN(NAME arrays_100 LABELS gfortran llvm)
 RUN(NAME arrays_101 LABELS gfortran llvm)
 RUN(NAME arrays_102 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME arrays_103 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME arrays_104 LABELS gfortran llvm)
 
 # DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_104.f90
+++ b/integration_tests/arrays_104.f90
@@ -1,0 +1,65 @@
+! Test passing non-contiguous array sections to type-bound procedures.
+! The stride of the second dimension must reflect the original array's
+! leading dimension, not the extent of the section.
+module arrays_104_mod
+   implicit none
+
+   type :: MyType
+   contains
+      procedure :: method
+   end type MyType
+
+contains
+
+   subroutine method(self, a, b)
+      class(MyType), intent(in) :: self
+      real(8), intent(in) :: a(:,:)
+      real(8), intent(in) :: b(:)
+      integer :: i, j
+
+      do i = 1, size(a, 1)
+         do j = 1, size(a, 2)
+            if (abs(a(i, j) - real(j, 8)) > 1.0d-12) error stop
+         end do
+      end do
+
+      do i = 1, size(b)
+         if (abs(b(i) - 1.0d0) > 1.0d-12) error stop
+      end do
+   end subroutine method
+
+end module arrays_104_mod
+
+program arrays_104
+   use arrays_104_mod
+   implicit none
+
+   real(8) :: a(4, 4), b(4)
+   integer :: i, j, n, n2
+   class(MyType), allocatable :: obj
+
+   allocate(obj)
+
+   n = 3
+   n2 = 4
+
+   do j = 1, 4
+      do i = 1, 4
+         a(i, j) = real(j, 8)
+      end do
+   end do
+
+   b = 1.0d0
+
+   ! Verify directly
+   do i = 1, n
+      do j = 1, n2
+         if (abs(a(i, j) - real(j, 8)) > 1.0d-12) error stop
+      end do
+   end do
+
+   ! Pass non-contiguous section a(1:3, 1:4) from a 4x4 array
+   call obj%method(a(1:n, 1:n2), b(1:n))
+
+   print *, "PASS"
+end program arrays_104

--- a/src/libasr/pass/array_passed_in_function_call.cpp
+++ b/src/libasr/pass/array_passed_in_function_call.cpp
@@ -793,7 +793,7 @@ public:
         for( size_t i = 0; i < x_n_args; i++ ) {
             ASR::expr_t* arg_expr = x_m_args[i].m_value;
             if ( x_m_args[i].m_value && is_descriptor_array_casted_to_pointer_to_data(x_m_args[i].m_value) &&
-                 !is_func_bind_c && !ASRUtils::is_pointer(ASRUtils::expr_type(x_m_args[i].m_value)) &&
+                 !is_func_bind_c &&
                  !ASR::is_a<ASR::FunctionParam_t>(*ASRUtils::get_past_array_physical_cast(x_m_args[i].m_value)) 
                  && !ASRUtils::is_stringToArray_cast(ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr)->m_arg)) {
                 ASR::ArrayPhysicalCast_t* array_physical_cast = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr);


### PR DESCRIPTION
Remove the is_pointer check in the array_passed_in_function_call pass so
that pointer-typed temporaries (created by the array_struct_temporary
pass for array section arguments) go through the contiguity check.
Previously the check was skipped, causing non-contiguous sections like
a(1:n, 1:n2) from a larger array to be treated as contiguous, producing
wrong element access strides.

Fixes #10290.