### PR TITLE
fix: submodule handling for empty and dependencies

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1020,6 +1020,7 @@ RUN(NAME submodule_25a LABELS gfortran llvm_submodule EXTRAFILES submodule_25b.f
 RUN(NAME submodule_26 LABELS gfortran llvm)
 RUN(NAME submodule_27a LABELS gfortran llvm_submodule EXTRAFILES submodule_27b.f90 submodule_27c.f90)
 RUN(NAME submodule_28 LABELS gfortran llvm)
+RUN(NAME submodule_29a LABELS gfortran llvm_submodule EXTRAFILES submodule_29b.f90 submodule_29c.f90 submodule_29d.f90)
 
 
 RUN(NAME floor_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran) # floor body

--- a/integration_tests/submodule_29a.f90
+++ b/integration_tests/submodule_29a.f90
@@ -1,0 +1,10 @@
+program submodule_29
+    use submodule_29_mod, only: greet
+    implicit none
+    integer :: x, y
+
+    x = 3
+    call greet(x, y)
+    if (y /= 15) error stop
+    print *, "ok"
+end program

--- a/integration_tests/submodule_29b.f90
+++ b/integration_tests/submodule_29b.f90
@@ -1,0 +1,11 @@
+module submodule_29_mod
+    implicit none
+    integer, parameter :: multiplier = 5
+
+    interface
+        module subroutine greet(x, y)
+            integer, intent(in) :: x
+            integer, intent(out) :: y
+        end subroutine
+    end interface
+end module

--- a/integration_tests/submodule_29c.f90
+++ b/integration_tests/submodule_29c.f90
@@ -1,0 +1,7 @@
+submodule(submodule_29_mod) submodule_29_child
+    implicit none
+contains
+    module procedure greet
+        y = x * multiplier
+    end procedure
+end submodule

--- a/integration_tests/submodule_29d.f90
+++ b/integration_tests/submodule_29d.f90
@@ -1,0 +1,9 @@
+submodule(submodule_29_mod:submodule_29_child) submodule_29_grandchild
+    implicit none
+contains
+    subroutine helper(x, y)
+        integer, intent(in) :: x
+        integer, intent(out) :: y
+        y = x + multiplier
+    end subroutine
+end submodule

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -311,6 +311,10 @@ public:
             if( !unsupported_sym_name.empty() ) {
                 throw LCompilersException("'" + unsupported_sym_name + "' is not supported yet for declaring with use.");
             }
+            current_module_dependencies.push_back(al, s2c(al, parent_name));
+            for (size_t i = 0; i < m->n_dependencies; i++) {
+                current_module_dependencies.push_back(al, m->m_dependencies[i]);
+            }
         } else {
             tmp0 = ASR::make_Module_t(al, x.base.base.loc,
                                                 /* a_symtab */ current_scope,

--- a/src/libasr/modfile.cpp
+++ b/src/libasr/modfile.cpp
@@ -136,6 +136,10 @@ std::string save_pycfile(const ASR::TranslationUnit_t &m, LCompilers::LocationMa
 
 inline bool load_serialised_asr(const std::string &s, std::string& asr_binary,
                                 LCompilers::LocationManager &lm, std::string& error_message) {
+    if (s.empty()) {
+        error_message = "Modfile is empty";
+        return false;
+    }
 #ifdef WITH_LFORTRAN_BINARY_MODFILES
     BinaryReader b(s);
 #else

--- a/tests/reference/asr-derived_types_05-35150cd.json
+++ b/tests/reference/asr-derived_types_05-35150cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_05-35150cd.stdout",
-    "stdout_hash": "045c13c65a2a20ec4d967d328d9f0c8825f4db8d424b325c37b2ff38",
+    "stdout_hash": "c2eda195a8d9c5b9fefbbf8d94eeade8abc99adaf6d7c31e8872c26a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_05-35150cd.stdout
+++ b/tests/reference/asr-derived_types_05-35150cd.stdout
@@ -801,7 +801,7 @@
                         })
                     stdlib_string_type_constructor
                     derived_types_05_stdlib_string_type
-                    []
+                    [derived_types_05_stdlib_string_type]
                     .false.
                     .false.
                     .false.

--- a/tests/reference/asr-submodule_02-9152b7b.json
+++ b/tests/reference/asr-submodule_02-9152b7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-9152b7b.stdout",
-    "stdout_hash": "5ab04b4b49f83340b592a5a6f0d66a2d10f82593621ea569e3c891fa",
+    "stdout_hash": "54a02b35a69801a8c9671804c6bf0233f8d31dfd226dd66143ea8307",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-9152b7b.stdout
+++ b/tests/reference/asr-submodule_02-9152b7b.stdout
@@ -767,7 +767,8 @@
                         })
                     points_a
                     points
-                    []
+                    [points
+                    stdlib_kinds_submodule_02]
                     .false.
                     .false.
                     .false.

--- a/tests/reference/asr-submodule_04-987b68b.json
+++ b/tests/reference/asr-submodule_04-987b68b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_04-987b68b.stdout",
-    "stdout_hash": "502f96e1d1ea86a45cfe6a2902a231c79adc58f8a99289f8f498fa6b",
+    "stdout_hash": "8e7ba169fa5f684376d1f52f9654ab7f36fb8ffdb6462bfd68e0aa65",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_04-987b68b.stdout
+++ b/tests/reference/asr-submodule_04-987b68b.stdout
@@ -263,7 +263,7 @@
                         })
                     submod_submodule_04
                     mod_submodule_04
-                    []
+                    [mod_submodule_04]
                     .false.
                     .false.
                     .false.


### PR DESCRIPTION
Part of https://github.com/lfortran/lfortran/pull/10305