### PR TITLE
fix: raise semantic error for procedure pointer

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2422,6 +2422,41 @@ public:
             if (ASRUtils::is_derived_type_similar(target_struct, value_struct)) {
                 tmp = ASRUtils::make_Associate_t_util(al, x.base.base.loc, target, value);
             }
+        } else if (ASR::is_a<ASR::FunctionType_t>(*target_type) && ASR::is_a<ASR::FunctionType_t>(*value_type)) {
+            ASR::FunctionType_t* target_func_type = ASR::down_cast<ASR::FunctionType_t>(target_type);
+            ASR::FunctionType_t* value_func_type = ASR::down_cast<ASR::FunctionType_t>(value_type);
+            
+            bool target_is_sub = (target_func_type->m_return_var_type == nullptr);
+            bool value_is_sub = (value_func_type->m_return_var_type == nullptr);
+            
+            if (target_is_sub != value_is_sub) {
+                std::string value_name = "";
+                if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*value) || 
+                    ASR::is_a<ASR::IntrinsicImpureFunction_t>(*value)) {
+                    value_name = "intrinsic function";
+                } else if (ASR::is_a<ASR::Var_t>(*value)) {
+                    ASR::symbol_t* value_sym = ASR::down_cast<ASR::Var_t>(value)->m_v;
+                    value_name = ASRUtils::symbol_name(value_sym);
+                } else if (ASR::is_a<ASR::FunctionCall_t>(*value)) {
+                    ASR::FunctionCall_t* fc = ASR::down_cast<ASR::FunctionCall_t>(value);
+                    if (fc->m_name) {
+                        value_name = ASRUtils::symbol_name(fc->m_name);
+                    }
+                }
+                if (value_name.empty()) {
+                    value_name = "unknown";
+                }
+                std::string expected_type = target_is_sub ? "a subroutine" : "a function";
+                diag.add(Diagnostic(
+                    "Interface mismatch in procedure pointer assignment at (1): '" + value_name + "' is not " + expected_type,
+                    Level::Error, Stage::Semantic, {
+                        Label("(1)",{x.base.base.loc})
+                    }));
+                throw SemanticAbort();
+            }            
+            if (ASRUtils::types_equal(target_type, value_type, target, value)) {
+                tmp = ASRUtils::make_Associate_t_util(al, x.base.base.loc, target, value);
+            }
         } else if (ASRUtils::types_equal(target_type, value_type, target, value)) {
             tmp = ASRUtils::make_Associate_t_util(al, x.base.base.loc, target, value);
         }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7512,6 +7512,16 @@ public:
                 }
             }
         } else if (sym_type->m_type == AST::decl_typeType::TypeProcedure) {
+            if (!sym_type->m_name) {
+                Location &attr_loc = sym_type->base.base.loc;
+                diag.add(Diagnostic(
+                    "Procedure declarations without an explicit interface (procedure()) are not yet supported. "
+                    "Please use procedure(interface_name) or declare an interface block.",
+                    Level::Error, Stage::Semantic, {
+                        Label("",{attr_loc})
+                    }));
+                throw SemanticAbort();
+            }
             std::string func_name = to_lower(sym_type->m_name);
             ASR::symbol_t *v = current_scope->resolve_symbol(func_name);
             if( !v ) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1190,7 +1190,7 @@ public:
                     LCOMPILERS_ASSERT(type);
 
                     if(type && type->m_type == AST::decl_typeType::TypeProcedure &&
-                           type->m_name == sym_name) {
+                           type->m_name && type->m_name == sym_name) {
                         procedure_decl_indices.push_back(al, i);
                         continue;
                     }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -165,23 +165,23 @@ contains
         integer, save :: slash_y/2/
     end subroutine slash_init_warning_paths
 
+    function dummy_func() result(r)
+        integer :: r
+        r = 42
+    end function dummy_func
 
+    subroutine dummy_sub()
+       print *, "dummy subroutine"
+    end subroutine dummy_sub
 
+    subroutine proc_ptr_error_tests()
+        implicit none
+        procedure(), pointer :: pf1
+        pf1 => dummy_sub
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        procedure(sub_test), pointer :: pf2
+        pf2 => dummy_func
+    end subroutine proc_ptr_error_tests
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "409c56187aa2009ef1bc4577f047f06f479e48f9e1a423ae7b9f7b8e",
+    "infile_hash": "c47b072fac3d2369df0a78d0c126deabce23e55831e9bc4f8f983e62",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "ca6b1c775f0919ea1e78f97dbdb6f9db3d0c7a011565803d028f982c",
+    "stderr_hash": "acfff02c94452c8719975cca06be5ecaa12c8933218554cb06b17fee",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -70,6 +70,12 @@ warning: non-standard Fortran 77-style initialization (extension)
 165 |         integer, save :: slash_y/2/
     |                          ^^^^^^^^^^ Use modern syntax instead: integer :: slash_y = 2
 
+semantic error: Procedure declarations without an explicit interface (procedure()) are not yet supported. Please use procedure(interface_name) or declare an interface block.
+   --> tests/errors/continue_compilation_1.f90:179:9
+    |
+179 |         procedure(), pointer :: pf1
+    |         ^^^^^^^^^^^ 
+
 semantic error: Defined assignment procedure must not return a value
    --> tests/errors/continue_compilation_1.f90:141:5 - 145:32
     |
@@ -121,6 +127,12 @@ semantic error: Interface 'missing_global_interface' is referenced but not defin
    |
 25 |     procedure(missing_global_interface), pointer :: p => null()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Referenced here
+
+semantic error: Interface 'sub_test' is referenced but not defined
+   --> tests/errors/continue_compilation_1.f90:182:9
+    |
+182 |         procedure(sub_test), pointer :: pf2
+    |         ^^^^^^^^^^^^^^^^^^^ Referenced here
 
 semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
    --> tests/errors/continue_compilation_1.f90:210:5 - 212:49
@@ -356,6 +368,18 @@ semantic error: Character intrinsic 'len_trim' with class(*) argument must be in
     |
 138 |         print *, len_trim(generic)
     |                  ^^^^^^^^^^^^^^^^^ invalid use of character intrinsic with polymorphic argument
+
+semantic error: Variable 'pf1' is not declared
+   --> tests/errors/continue_compilation_1.f90:180:9
+    |
+180 |         pf1 => dummy_sub
+    |         ^^^ 'pf1' is undeclared
+
+semantic error: Interface mismatch in procedure pointer assignment at (1): 'dummy_func' is not a subroutine
+   --> tests/errors/continue_compilation_1.f90:183:9
+    |
+183 |         pf2 => dummy_func
+    |         ^^^^^^^^^^^^^^^^^ (1)
 
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:268:14


### PR DESCRIPTION
Closes #10131 

Description for the fix :

`ast_body_visitor` -  Added check for function to subroutine and vice versa
`ast_common_visitor` - Check for `procedure()` without `interface`
`continue_compilation` - add tests


i am not sure about the changes in `continue_compilation` please let me know if any fix is required.