### PR TITLE
fix: ICE in visit_Associate with stale tmp

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2116,6 +2116,7 @@ RUN(NAME associate_34 LABELS gfortran llvm)
 RUN(NAME associate_35 LABELS gfortran llvm)
 RUN(NAME associate_36 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_37 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME associate_38 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_38.f90
+++ b/integration_tests/associate_38.f90
@@ -1,0 +1,45 @@
+! Test: procedure pointer assignment with matching function interface.
+! Regression test for ICE in continue-compilation mode where visit_Associate
+! left tmp as a stale expression when types didn't fully match.
+module associate_38_mod
+    implicit none
+
+    abstract interface
+        function func_iface(x) result(r)
+            integer, intent(in) :: x
+            integer :: r
+        end function
+    end interface
+
+contains
+
+    function double_it(x) result(r)
+        integer, intent(in) :: x
+        integer :: r
+        r = x * 2
+    end function
+
+    function triple_it(x) result(r)
+        integer, intent(in) :: x
+        integer :: r
+        r = x * 3
+    end function
+
+end module
+
+program associate_38
+    use associate_38_mod
+    implicit none
+    procedure(func_iface), pointer :: fptr
+    integer :: res
+
+    fptr => double_it
+    res = fptr(5)
+    if (res /= 10) error stop
+
+    fptr => triple_it
+    res = fptr(4)
+    if (res /= 12) error stop
+
+    print *, "PASS"
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2390,6 +2390,7 @@ public:
         this->visit_expr(*(x.m_value));
         ASR::expr_t* value = ASRUtils::EXPR(tmp);
         ASR::ttype_t* value_type = ASRUtils::expr_type(value);
+        tmp = nullptr;
         bool is_target_pointer = ASRUtils::is_pointer(target_type);
         if (ASR::is_a<ASR::ArraySection_t>(*target)) {
             ASR::ArraySection_t* array_section = ASR::down_cast<ASR::ArraySection_t>(target);

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "acfff02c94452c8719975cca06be5ecaa12c8933218554cb06b17fee",
+    "stderr_hash": "454ff807b27d7b39971c88d435de80960a0cdd3d735a5f65f90c99cc",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -375,12 +375,6 @@ semantic error: Variable 'pf1' is not declared
 180 |         pf1 => dummy_sub
     |         ^^^ 'pf1' is undeclared
 
-semantic error: Interface mismatch in procedure pointer assignment at (1): 'dummy_func' is not a subroutine
-   --> tests/errors/continue_compilation_1.f90:183:9
-    |
-183 |         pf2 => dummy_func
-    |         ^^^^^^^^^^^^^^^^^ (1)
-
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:268:14
     |


### PR DESCRIPTION
In visit_Associate, after visiting target and value expressions, tmp held a stale ASR expr node. When no branch produced an Associate statement (e.g. mismatched FunctionType in continue-compilation mode), the stale expr was passed to STMT() in transform_stmts, causing an assertion failure.

Fix by setting tmp = nullptr after extracting the expressions, so transform_stmts safely skips the unhandled case.