### PR TITLE
Fix missing pass arg in proc ptr calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3453,6 +3453,7 @@ RUN(NAME separate_compilation_32 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_33 LABELS llvm EXTRAFILES separate_compilation_33a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_34 LABELS gfortran llvm EXTRAFILES separate_compilation_34a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_35 LABELS gfortran llvm EXTRAFILES separate_compilation_35a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_36 LABELS gfortran llvm EXTRAFILES separate_compilation_36a.f90 EXTRA_ARGS --separate-compilation)
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_36.f90
+++ b/integration_tests/separate_compilation_36.f90
@@ -1,0 +1,23 @@
+module separate_compilation_36b
+   use separate_compilation_36a
+   implicit none
+
+   type :: MyType
+      class(AbsType), allocatable :: obj
+   end type MyType
+
+contains
+
+   subroutine client()
+      class(MyType), allocatable :: arr(:,:)
+      associate( ob => arr(1,1)%obj )
+         call ob%ptr()
+      end associate
+   end subroutine client
+
+end module separate_compilation_36b
+
+program separate_compilation_36
+   implicit none
+   print *, "PASS"
+end program separate_compilation_36

--- a/integration_tests/separate_compilation_36a.f90
+++ b/integration_tests/separate_compilation_36a.f90
@@ -1,0 +1,15 @@
+module separate_compilation_36a
+   implicit none
+
+   type, abstract :: AbsType
+      procedure(intfc), pointer :: ptr => null()
+   end type AbsType
+
+   abstract interface
+      subroutine intfc(self)
+         import
+         class(AbsType), intent(in) :: self
+      end subroutine intfc
+   end interface
+
+end module separate_compilation_36a


### PR DESCRIPTION
When calling a procedure pointer component through a StructInstanceMember (e.g. ob%ptr()), the implicit pass (self) argument was not being forwarded to the callee, causing an LLVM verification error: 'Incorrect number of arguments passed to called function'.

The fix detects when the LLVM function type expects more parameters than were explicitly provided and inserts the parent object as the first (pass) argument.

Fixes #10384.