### PR TITLE
Fix operator overload with class(*) args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2525,6 +2525,7 @@ RUN(NAME class_119 LABELS gfortran llvm)
 RUN(NAME class_120 LABELS gfortran llvm)
 RUN(NAME class_121 LABELS gfortran llvm)
 RUN(NAME class_122 LABELS gfortran llvm)
+RUN(NAME class_123 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_123.f90
+++ b/integration_tests/class_123.f90
@@ -1,0 +1,55 @@
+module class_123_mod
+   implicit none
+
+   type, abstract :: AbsType
+      integer :: val
+   contains
+      procedure(multintfc), deferred :: mult
+      generic :: operator(*) => mult
+   end type AbsType
+
+   abstract interface
+      function multintfc(a, b) result(r)
+         import
+         class(AbsType), intent(in) :: a
+         class(*),       intent(in) :: b
+         class(AbsType), allocatable :: r
+      end function multintfc
+   end interface
+
+   type, extends(AbsType) :: ConcreteType
+   contains
+      procedure :: mult => concrete_mult
+   end type ConcreteType
+
+contains
+
+   function concrete_mult(a, b) result(r)
+      class(ConcreteType), intent(in) :: a
+      class(*),            intent(in) :: b
+      class(AbsType), allocatable :: r
+      allocate(ConcreteType :: r)
+      select type (b)
+      type is (real(8))
+         r%val = int(a%val * b)
+      class default
+         r%val = 0
+      end select
+   end function concrete_mult
+
+   subroutine test(d)
+      class(AbsType), intent(in) :: d
+      class(AbsType), allocatable :: c
+      allocate(c, source = (d * 8.d0))
+      print *, c%val
+      if (c%val /= 40) error stop
+   end subroutine test
+
+end module class_123_mod
+
+program class_123
+   use class_123_mod
+   type(ConcreteType) :: obj
+   obj%val = 5
+   call test(obj)
+end program class_123

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1587,16 +1587,20 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                         ASR::ttype_t* right_arg_type2 = ASRUtils::type_get_past_allocatable_pointer(right_arg_type);
 
                         not_matching = not_matching || (!is_elemental &&
-                                       ((left_arg_type2->type != left_type2->type) ||
-                                       (right_arg_type2->type != right_type2->type)));
+                                       ((left_arg_type2->type != left_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) ||
+                                        (right_arg_type2->type != right_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))));
 
                         left_type2 = ASRUtils::type_get_past_array(left_type2);
                         left_arg_type2 = ASRUtils::type_get_past_array(left_arg_type2);
                         right_type2 = ASRUtils::type_get_past_array(right_type2);
                         right_arg_type2 = ASRUtils::type_get_past_array(right_arg_type2);
 
-                        if( !not_matching && (left_arg_type2->type == left_type2->type &&
-                                                right_arg_type2->type == right_type2->type) ) {
+                        if( !not_matching && ((left_arg_type2->type == left_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) &&
+                                               (right_arg_type2->type == right_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))) ) {
                             // If all are StructTypes then the Struct symbols should match
                             if (ASR::is_a<ASR::StructType_t>(*left_type2) &&
                                 ASR::is_a<ASR::StructType_t>(*right_type2) &&
@@ -2248,8 +2252,10 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
 
                         // Check for array type
                         not_matching = not_matching || (!is_elemental &&
-                                       ((left_arg_type2->type != left_type2->type) ||
-                                       (right_arg_type2->type != right_type2->type)));
+                                       ((left_arg_type2->type != left_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) ||
+                                        (right_arg_type2->type != right_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))));
 
                         // Get element type and compare
                         left_type2 = ASRUtils::type_get_past_array(left_type2);
@@ -2257,8 +2263,10 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                         right_type2 = ASRUtils::type_get_past_array(right_type2);
                         right_arg_type2 = ASRUtils::type_get_past_array(right_arg_type2);
 
-                        if( !not_matching && (left_arg_type2->type == left_type2->type &&
-                                                right_arg_type2->type == right_type2->type) ) {
+                        if( !not_matching && ((left_arg_type2->type == left_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) &&
+                                               (right_arg_type2->type == right_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))) ) {
                             // If all are StructTypes then the Struct symbols should match
                             if (ASR::is_a<ASR::StructType_t>(*left_type2) &&
                                 ASR::is_a<ASR::StructType_t>(*right_type2) &&
@@ -2406,8 +2414,10 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
 
                         // Check for array type
                         not_matching = not_matching || (!is_elemental &&
-                                       ((left_arg_type2->type != left_type2->type) ||
-                                       (right_arg_type2->type != right_type2->type)));
+                                       ((left_arg_type2->type != left_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) ||
+                                        (right_arg_type2->type != right_type2->type &&
+                                         !ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))));
 
                         // Get element type and compare
                         left_type2 = ASRUtils::type_get_past_array(left_type2);
@@ -2415,8 +2425,10 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                         right_type2 = ASRUtils::type_get_past_array(right_type2);
                         right_arg_type2 = ASRUtils::type_get_past_array(right_arg_type2);
 
-                        if ( !not_matching && (left_arg_type2->type == left_type2->type &&
-                                                right_arg_type2->type == right_type2->type) ) {
+                        if ( !not_matching && ((left_arg_type2->type == left_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(left_arg_type2)) &&
+                                               (right_arg_type2->type == right_type2->type ||
+                                                ASRUtils::is_unlimited_polymorphic_type(right_arg_type2))) ) {
                             if (ASR::is_a<ASR::StructType_t>(*left_type2)
                                 && ASR::is_a<ASR::StructType_t>(*right_type2)
                                 && ASR::is_a<ASR::StructType_t>(*left_arg_type2)


### PR DESCRIPTION
The operator overload resolution in use_overloaded() was failing to match overloaded operators when a formal parameter was `class(*)` (unlimited polymorphic) but the actual argument was a non-class type (e.g., real). The type enum comparison rejected the match because StructType != Real, even though `class(*)` should accept any type.

This caused an ICE (assertion failure) in find_conversion_candidate() when it received a StructType that was out of range for the type_priority array.

Fix: skip the type enum mismatch check when the formal parameter type is unlimited polymorphic, in all three use_overloaded() variants (binop, cmpop, logicalbinop).

Fixes #10379.