### PR TITLE
integration_tests: use newunit for scratch I/O tests

### DIFF
--- a/integration_tests/file_49.f90
+++ b/integration_tests/file_49.f90
@@ -3,12 +3,13 @@
 ! Exact MRE from issue body
 program file_49
     implicit none
+    integer :: unit_no
     character :: q*12
-    open(42, status='scratch', form='unformatted')
-    write(42) 'Hello world!'
-    rewind 42
-    read(42) q
-    close(42)
+    open(newunit=unit_no, status='scratch', form='unformatted')
+    write(unit_no) 'Hello world!'
+    rewind unit_no
+    read(unit_no) q
+    close(unit_no)
     print *, q
     if (q /= 'Hello world!') error stop
 end program file_49

--- a/integration_tests/format_33.f90
+++ b/integration_tests/format_33.f90
@@ -1,10 +1,11 @@
 program format_33  
   implicit none ! file backspace.f90
   character(20):: string
-  open(42,status='scratch')
-  write(42,"(A)") 'Hello world'
-  backspace 42
-  read(42,"(A)") string
+  integer :: unit_no
+  open(newunit=unit_no, status='scratch')
+  write(unit_no, "(A)") 'Hello world'
+  backspace unit_no
+  read(unit_no, "(A)") string
   print "(A)", string
   if (string /= 'Hello world') error stop
 end program format_33

--- a/integration_tests/logical_testing.f90
+++ b/integration_tests/logical_testing.f90
@@ -3,7 +3,7 @@ program logicalStringInput
     integer, parameter :: n = 6
     logical :: x
     character(len=1) :: actual(n), expected(n)
-    integer :: ios, i
+    integer :: ios, i, unit_no
     character(len=20), dimension(n) :: inputs = [ &
         ".true.         ", ".false.        ", "true           ", "false          ", &
         "True           ", "False          " ]
@@ -12,18 +12,18 @@ program logicalStringInput
     expected = ['T', 'F', 'T', 'F', 'T', 'F']
 
     ! as suggested, using the scratch file over .txt file
-    open(unit=10, status="scratch")
+    open(newunit=unit_no, status="scratch")
 
     ! writing in the scratch file
     do i = 1, n
-        write(10, '(A)') trim(inputs(i))
+        write(unit_no, '(A)') trim(inputs(i))
     end do
 
-    rewind(10)
+    rewind(unit_no)
 
     ! reading
     do i = 1, n
-        read(10, *, iostat=ios) x
+        read(unit_no, *, iostat=ios) x
         if (ios /= 0) then
             print *, "Error reading logical at index", i
             stop 1
@@ -35,7 +35,7 @@ program logicalStringInput
         end if
     end do
 
-    close(10)
+    close(unit_no)
 
     ! array se check validation
     do i = 1, n

--- a/integration_tests/read_08.f90
+++ b/integration_tests/read_08.f90
@@ -1,20 +1,21 @@
 program read_08
     ! Test reading logical values with T/F format
     implicit none
+    integer :: unit_no
     logical :: val1, val2, val3, val4
 
-    open(10, status='scratch')
-    write(10, '(A)') 'T'
-    write(10, '(A)') 'F'
-    write(10, '(A)') 't'
-    write(10, '(A)') 'f'
-    rewind(10)
+    open(newunit=unit_no, status='scratch')
+    write(unit_no, '(A)') 'T'
+    write(unit_no, '(A)') 'F'
+    write(unit_no, '(A)') 't'
+    write(unit_no, '(A)') 'f'
+    rewind(unit_no)
 
-    read(10, *) val1
-    read(10, *) val2
-    read(10, *) val3
-    read(10, *) val4
-    close(10)
+    read(unit_no, *) val1
+    read(unit_no, *) val2
+    read(unit_no, *) val3
+    read(unit_no, *) val4
+    close(unit_no)
 
     if (.not. val1) error stop "Expected T to be .true."
     if (val2) error stop "Expected F to be .false."

--- a/integration_tests/read_10.f90
+++ b/integration_tests/read_10.f90
@@ -1,14 +1,14 @@
 program read_10
     implicit none
     integer :: vals(3)
-    integer :: i
+    integer :: i, unit_no
 
-    open(10, status='scratch')
-    write(10, *) 10, 20, 30
-    rewind(10)
+    open(newunit=unit_no, status='scratch')
+    write(unit_no, *) 10, 20, 30
+    rewind(unit_no)
 
-    read(10, *) (vals(i), i=1, 3)
-    close(10)
+    read(unit_no, *) (vals(i), i=1, 3)
+    close(unit_no)
 
     if (vals(1) /= 10) error stop "vals(1) should be 10"
     if (vals(2) /= 20) error stop "vals(2) should be 20"

--- a/integration_tests/read_11.f90
+++ b/integration_tests/read_11.f90
@@ -1,17 +1,17 @@
 program read_11
     implicit none
-    integer :: i, j, n
+    integer :: i, j, n, unit_no
     real :: a(3, 4)
 
     n = 4
-    open(10, status='scratch')
-    write(10, *) 1.0, 2.0, 3.0, 4.0
-    write(10, *) 5.0, 6.0, 7.0, 8.0
-    rewind(10)
+    open(newunit=unit_no, status='scratch')
+    write(unit_no, *) 1.0, 2.0, 3.0, 4.0
+    write(unit_no, *) 5.0, 6.0, 7.0, 8.0
+    rewind(unit_no)
 
-    read(10, *) (a(1,j), j = 1, n)
-    read(10, *) (a(2,j), j = 1, n)
-    close(10)
+    read(unit_no, *) (a(1,j), j = 1, n)
+    read(unit_no, *) (a(2,j), j = 1, n)
+    close(unit_no)
 
     if (abs(a(1,1) - 1.0) > 1e-6) error stop "a(1,1) should be 1.0"
     if (abs(a(1,2) - 2.0) > 1e-6) error stop "a(1,2) should be 2.0"


### PR DESCRIPTION
## Summary
Use `newunit=` instead of fixed literal unit numbers in scratch-file integration tests to avoid unit collisions in parallel or shared-runtime execution.

## Scope
- integration_tests/read_08.f90
- integration_tests/read_10.f90
- integration_tests/read_11.f90
- integration_tests/logical_testing.f90
- integration_tests/format_33.f90
- integration_tests/file_49.f90

## Why
Fixed units (for example 10, 42) can conflict when tests are executed in parallel contexts that share runtime process state. `newunit=` allocates a safe free unit and removes that flake class.

## Verification
- gfortran integration_tests/read_08.f90 && ./a.out
- gfortran integration_tests/read_10.f90 && ./a.out
- gfortran integration_tests/read_11.f90 && ./a.out
- gfortran integration_tests/logical_testing.f90 && ./a.out
- gfortran integration_tests/format_33.f90 && ./a.out
- gfortran integration_tests/file_49.f90 && ./a.out
- Parallel smoke for read_11: 24 concurrent runs all passed
