### PR TITLE
Fix nested subroutine local var intent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2315,6 +2315,7 @@ RUN(NAME nested_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME nested_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_25 LABELS gfortran llvm)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/nested_25.f90
+++ b/integration_tests/nested_25.f90
@@ -1,0 +1,19 @@
+module nested_25_mod
+contains
+    subroutine outer(i)
+        integer(4), intent(in) :: i
+    contains
+        subroutine inner()
+            integer(4) :: i
+            i = 1
+            if (i /= 1) error stop
+        end subroutine inner
+    end subroutine outer
+end module nested_25_mod
+
+program nested_25
+    use nested_25_mod
+    implicit none
+    call outer(5)
+    print *, "ok"
+end program nested_25

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1296,12 +1296,15 @@ public:
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
             std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
+            std::vector<std::string> current_procedure_args_copy = current_procedure_args;
+            current_procedure_args.clear();
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
             implicit_dictionary = implicit_dictionary_copy;
+            current_procedure_args = current_procedure_args_copy;
             default_storage_save = current_storage_save;
         }
         Vec<ASR::expr_t*> args;
@@ -1742,11 +1745,14 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
+            std::vector<std::string> current_procedure_args_copy = current_procedure_args;
+            current_procedure_args.clear();
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
+            current_procedure_args = current_procedure_args_copy;
             default_storage_save = current_storage_save;
         }
         // Convert and check arguments


### PR DESCRIPTION
The current_procedure_args from a parent function was leaking into nested (contained) subroutines/functions, causing local variables with the same name as a parent argument to be incorrectly assigned Unspecified intent instead of Local.  This led to the variable not being allocated in LLVM codegen, producing a null operand error.

Save and restore current_procedure_args around visit_program_unit calls for contained procedures in both visit_Subroutine and visit_Function.

Fixes #10446.