### PR TITLE
Fix ICE for procedure pointer with parametric return type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -612,6 +612,7 @@ RUN(NAME functions_51 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_52 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_53 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_54 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME functions_55 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 
 
 RUN(NAME common_01 LABELS gfortran)
@@ -2551,6 +2552,7 @@ RUN(NAME class_120 LABELS gfortran llvm)
 RUN(NAME class_121 LABELS gfortran llvm)
 RUN(NAME class_122 LABELS gfortran llvm)
 RUN(NAME class_123 LABELS gfortran llvm)
+RUN(NAME class_124 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_124.f90
+++ b/integration_tests/class_124.f90
@@ -1,0 +1,53 @@
+module abstypemod_124
+   implicit none
+
+   type :: AbsType
+      procedure(pintfc), pointer, nopass :: ptr => null()
+   end type AbsType
+
+   interface
+      function pintfc(n) result(nres)
+         integer, intent(in) :: n(:)
+         integer :: nres(size(n))
+      end function pintfc
+   end interface
+
+end module abstypemod_124
+
+module clientmod_124
+   use abstypemod_124, only: AbsType
+   implicit none
+
+contains
+
+   subroutine client(obj)
+      class(AbsType), intent(in) :: obj
+      integer, allocatable :: nres(:)
+      allocate(nres(3))
+      nres = obj%ptr(nres)
+   end subroutine client
+
+end module clientmod_124
+
+program class_124
+   use abstypemod_124, only: AbsType
+   use clientmod_124, only: client
+   implicit none
+
+   type(AbsType) :: obj
+   obj%ptr => double_it
+   call client(obj)
+   print *, "ok"
+
+contains
+
+   function double_it(n) result(nres)
+      integer, intent(in) :: n(:)
+      integer :: nres(size(n))
+      integer :: i
+      do i = 1, size(n)
+         nres(i) = n(i) * 2
+      end do
+   end function double_it
+
+end program class_124

--- a/integration_tests/functions_55.f90
+++ b/integration_tests/functions_55.f90
@@ -1,0 +1,53 @@
+! Test procedure pointer with parametric return type
+! The return type dimension depends on the argument via size(n)
+module functions_55_mod
+   implicit none
+
+   type :: WrapperType
+      procedure(op_interface), pointer, nopass :: op => null()
+   end type WrapperType
+
+   interface
+      function op_interface(n) result(res)
+         integer, intent(in) :: n(:)
+         integer :: res(size(n))
+      end function op_interface
+   end interface
+
+contains
+
+   subroutine apply_op(obj)
+      class(WrapperType), intent(in) :: obj
+      integer, allocatable :: arr(:)
+      allocate(arr(4))
+      arr = [1, 2, 3, 4]
+      arr = obj%op(arr)
+      if (arr(1) /= 2) error stop
+      if (arr(2) /= 4) error stop
+      if (arr(3) /= 6) error stop
+      if (arr(4) /= 8) error stop
+   end subroutine apply_op
+
+end module functions_55_mod
+
+program functions_55
+   use functions_55_mod, only: WrapperType, apply_op
+   implicit none
+
+   type(WrapperType) :: obj
+   obj%op => double_array
+   call apply_op(obj)
+   print *, "ok"
+
+contains
+
+   function double_array(n) result(res)
+      integer, intent(in) :: n(:)
+      integer :: res(size(n))
+      integer :: i
+      do i = 1, size(n)
+         res(i) = n(i) * 2
+      end do
+   end function double_array
+
+end program functions_55

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10035,6 +10035,31 @@ public:
         if (ASRUtils::symbol_parent_symtab(v)->get_counter() != current_scope->get_counter()) {
             ADD_ASR_DEPENDENCIES(current_scope, v, current_function_dependencies);
         }
+        // Resolve FunctionParam references in return type dimensions
+        if (return_type && ASRUtils::is_array(return_type)) {
+            ASR::call_arg_t* call_args;
+            size_t n_call_args;
+            if (is_dt_present) {
+                call_args = args.p + 1;
+                n_call_args = args.size() - 1;
+            } else {
+                call_args = args.p;
+                n_call_args = args.size();
+            }
+            ASR::dimension_t* m_dims = nullptr;
+            size_t n_dims = ASRUtils::extract_dimensions_from_ttype(return_type, m_dims);
+            ASRUtils::ReplaceFunctionParamWithArg r(al, call_args, n_call_args);
+            Vec<ASR::dimension_t> new_dims;
+            new_dims.reserve(al, n_dims);
+            for (size_t i = 0; i < n_dims; i++) {
+                ASR::dimension_t dim;
+                dim.loc = m_dims[i].loc;
+                dim.m_start = m_dims[i].m_start ? r.replace_FunctionParam_with_arg(m_dims[i].m_start) : nullptr;
+                dim.m_length = m_dims[i].m_length ? r.replace_FunctionParam_with_arg(m_dims[i].m_length) : nullptr;
+                new_dims.push_back(al, dim);
+            }
+            return_type = ASRUtils::duplicate_type(al, return_type, &new_dims);
+        }
         // TODO: Uncomment later
         // ASRUtils::set_absent_optional_arguments_to_null(args, ASR::down_cast<ASR::Function_t>(v), al);
         if( is_dt_present ) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -575,7 +575,8 @@ ASR::symbol_t* get_struct_sym_from_struct_expr(ASR::expr_t* expression)
         case ASR::exprType::PointerAssociated:
         case ASR::exprType::PointerToCPtr:
         case ASR::exprType::GetPointer:
-        case ASR::exprType::CLoc: {
+        case ASR::exprType::CLoc:
+        case ASR::exprType::FunctionParam: {
             return nullptr;
         }
         case ASR::exprType::UnionInstanceMember: {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7037,6 +7037,9 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
     ASR::Function_t* func = ASRUtils::get_function(a_name);
 
     for( size_t i = 0; i < n_args; i++ ) {
+        if( i + is_method >= func_type->n_arg_types ) {
+            break;
+        }
         if( a_args[i].m_value == nullptr ) {
             continue;
         }

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -976,6 +976,9 @@ bool set_allocation_size(
             }
             break;
         }
+        case ASR::exprType::FunctionParam: {
+            return false;
+        }
         default: {
             LCOMPILERS_ASSERT_MSG(false, "ASR::exprType::" + std::to_string(value->type)
                 + " not handled yet in set_allocation_size");

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -781,6 +781,36 @@ class EditProcedureCallsVisitor : public ASR::ASRPassBaseWalkVisitor<EditProcedu
                     }
                     orig_args[i].m_value = maybe_cast_class_arg_to_struct(
                         subrout_sym, (i + dt_implicitPass), orig_args[i].m_value);
+                    // The function parameter expects PointerArray but the actual
+                    // call arg may be DescriptorArray (e.g. a temp created by
+                    // subroutine_from_function). Add ArrayPhysicalCast.
+                    ASR::ttype_t* arg_type = ASRUtils::expr_type(orig_args[i].m_value);
+                    if (ASRUtils::is_array(arg_type)) {
+                        ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(
+                            ASRUtils::type_get_past_allocatable(
+                                ASRUtils::type_get_past_pointer(arg_type)));
+                        if (array_t->m_physical_type == ASR::array_physical_typeType::DescriptorArray) {
+                            ASR::FunctionType_t* ft = ASRUtils::get_FunctionType(subrout_sym);
+                            size_t param_idx = i + dt_implicitPass;
+                            if (param_idx < ft->n_arg_types &&
+                                    ASRUtils::is_array(ft->m_arg_types[param_idx])) {
+                                ASR::Array_t* param_array = ASR::down_cast<ASR::Array_t>(
+                                    ASRUtils::type_get_past_allocatable(
+                                        ASRUtils::type_get_past_pointer(ft->m_arg_types[param_idx])));
+                                if (param_array->m_physical_type == ASR::array_physical_typeType::PointerArray) {
+                                    ASR::expr_t* physical_cast = ASRUtils::EXPR(
+                                        ASRUtils::make_ArrayPhysicalCast_t_util(
+                                            al, orig_args[i].m_value->base.loc,
+                                            orig_args[i].m_value, array_t->m_physical_type,
+                                            ASR::array_physical_typeType::PointerArray,
+                                            ASRUtils::duplicate_type(al, arg_type, nullptr,
+                                                ASR::array_physical_typeType::PointerArray, true),
+                                            nullptr));
+                                    orig_args[i].m_value = physical_cast;
+                                }
+                            }
+                        }
+                    }
                     new_args.push_back(al, orig_args[i]);
                     continue;
                 }


### PR DESCRIPTION
Handle FunctionParam expressions in the array_struct_temporary pass and related utilities. The crash occurred when compiling abstract types with procedure pointers whose return type dimensions reference function parameters (e.g., dimension(size(n))).

Changes:
- Handle FunctionParam in get_struct_sym_from_struct_expr
- Handle FunctionParam in set_allocation_size
- Skip visit_ttype in ArgSimplifier::visit_FunctionCall to avoid simplifying expressions inside TypeParameter dimensions
- Resolve FunctionParam references in the return type when creating function calls from function type variables
- Add bounds check in Call_t_body to prevent OOB access when extra return argument is appended by subroutine_from_function pass

Fixes #10444.