### PR TITLE
Fix ExternalSymbol for nested scopes

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3521,6 +3521,7 @@ RUN(NAME separate_compilation_33 LABELS llvm EXTRAFILES separate_compilation_33a
 RUN(NAME separate_compilation_34 LABELS gfortran llvm EXTRAFILES separate_compilation_34a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_35 LABELS gfortran llvm EXTRAFILES separate_compilation_35a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_36 LABELS gfortran llvm EXTRAFILES separate_compilation_36a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_37 LABELS gfortran llvm EXTRAFILES separate_compilation_37a.f90 separate_compilation_37b.f90 EXTRA_ARGS --separate-compilation)
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_37.f90
+++ b/integration_tests/separate_compilation_37.f90
@@ -1,0 +1,5 @@
+program separate_compilation_37
+   use separate_compilation_37b
+   implicit none
+   print *, "PASS"
+end program separate_compilation_37

--- a/integration_tests/separate_compilation_37a.f90
+++ b/integration_tests/separate_compilation_37a.f90
@@ -1,0 +1,18 @@
+module separate_compilation_37a
+   implicit none
+
+   type, abstract :: AbsType1
+   contains
+      procedure(method), deferred :: method
+   end type AbsType1
+
+   abstract interface
+      function method(self, str) result(res)
+         import
+         class(AbsType1), intent(in)  :: self
+         character(*),    intent(in)  :: str
+         class(*),        allocatable :: res
+      end function method
+   end interface
+
+end module separate_compilation_37a

--- a/integration_tests/separate_compilation_37b.f90
+++ b/integration_tests/separate_compilation_37b.f90
@@ -1,0 +1,19 @@
+module separate_compilation_37b
+   use separate_compilation_37a, only: AbsType1
+   implicit none
+
+   type, abstract :: AbsType2
+   end type AbsType2
+
+contains
+
+   function get_obj() result(obj)
+      class(AbsType2), allocatable :: obj
+      class(AbsType1), allocatable :: c
+      select type( o => c%method('String') )
+      class is (AbsType2)
+         obj = o
+      end select
+   end function get_obj
+
+end module separate_compilation_37b

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3419,11 +3419,41 @@ public:
                 } else {
                     // Symbol not found in current scope; add an ExternalSymbol
                     // referencing the original struct from its owner scope.
+                    // Find the containing Module and build scope_names so that
+                    // deserialization can resolve this via find_scoped_symbol.
+                    ASR::Module_t* mod = ASRUtils::get_sym_module(type_decl);
+                    char* ext_module_name;
+                    char** scope_names_p = nullptr;
+                    size_t scope_names_n = 0;
+                    if (mod != nullptr) {
+                        ext_module_name = mod->m_name;
+                        // Build scope_names: path from module to type_decl's
+                        // parent scope (collected bottom-up, then reversed).
+                        Vec<char*> scope_names_vec;
+                        scope_names_vec.reserve(al, 4);
+                        const SymbolTable *s = ASRUtils::symbol_parent_symtab(type_decl);
+                        while (s != mod->m_symtab) {
+                            scope_names_vec.push_back(al,
+                                ASRUtils::symbol_name(
+                                    ASR::down_cast<ASR::symbol_t>(s->asr_owner)));
+                            s = s->parent;
+                        }
+                        // Reverse to get outermost-first order
+                        for (size_t i = 0; i < scope_names_vec.size() / 2; i++) {
+                            std::swap(scope_names_vec.p[i],
+                                scope_names_vec.p[scope_names_vec.size() - 1 - i]);
+                        }
+                        scope_names_p = scope_names_vec.p;
+                        scope_names_n = scope_names_vec.size();
+                    } else {
+                        ext_module_name = ASRUtils::symbol_name(
+                            ASRUtils::get_asr_owner(type_decl));
+                    }
                     type_decl = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(
                         al, x.base.base.loc, current_scope,
                         s2c(al, decl_name), type_decl,
-                        ASRUtils::symbol_name(ASRUtils::get_asr_owner(type_decl)),
-                        nullptr, 0, s2c(al, decl_name),
+                        ext_module_name,
+                        scope_names_p, scope_names_n, s2c(al, decl_name),
                         ASR::accessType::Public));
                     current_scope->add_symbol(decl_name, type_decl);
                 }

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -852,11 +852,22 @@ public:
             require(is_valid_owner,
                 "ExternalSymbol::m_external '" + std::string(x.m_name) + "' is not in a module or struct type, owner: " +
                 x_m_module_name);
-            require(x_m_module_name == asr_owner_name,
+            // m_module_name can be either the direct owner or the
+            // top-level module when scope_names provides the path.
+            bool name_matches = (x_m_module_name == asr_owner_name);
+            if (!name_matches && m != nullptr && x.n_scope_names > 0) {
+                name_matches = (x_m_module_name == std::string(m->m_name));
+            }
+            require(name_matches,
                 "ExternalSymbol::m_module_name `" + x_m_module_name
                 + "` must match external's module name `" + asr_owner_name + "`");
             ASR::symbol_t *s = nullptr;
             if( m != nullptr && ((ASR::symbol_t*) m == ASRUtils::get_asr_owner(x.m_external)) ) {
+                s = m->m_symtab->find_scoped_symbol(x.m_original_name, x.n_scope_names, x.m_scope_names);
+            } else if( m != nullptr && x.n_scope_names > 0
+                       && x_m_module_name == std::string(m->m_name) ) {
+                // m_module_name refers to the top-level module and
+                // scope_names encodes the path to the nested owner.
                 s = m->m_symtab->find_scoped_symbol(x.m_original_name, x.n_scope_names, x.m_scope_names);
             } else if( sm ) {
                 s = sm->m_symtab->resolve_symbol(std::string(x.m_original_name));


### PR DESCRIPTION
When a type like ~unlimited_polymorphic_type is defined inside a function nested within a module, the ExternalSymbol referencing it must use the module as m_module_name and encode the path through intermediate scopes (e.g. the function) in scope_names. Previously m_module_name was set to the immediate parent (e.g. "method"), which the deserializer could not find in the global scope during separate compilation.

Set scope_names correctly at ExternalSymbol creation time in visit_SelectType so that find_scoped_symbol can resolve the symbol directly. Update the verify pass to accept m_module_name referring to the top-level module when scope_names provides the nested path.

Fixes #10443.