### PR TITLE
Fix block external symbol resolution

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3566,10 +3566,10 @@ RUN(NAME separate_compilation_34 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_35 LABELS gfortran llvm EXTRAFILES separate_compilation_35a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_36 LABELS gfortran llvm EXTRAFILES separate_compilation_36a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_37 LABELS gfortran llvm EXTRAFILES separate_compilation_37a.f90 separate_compilation_37b.f90 EXTRA_ARGS --separate-compilation)
-
 RUN(NAME separate_compilation_38 LABELS gfortran llvm EXTRAFILES separate_compilation_38a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_39 LABELS llvm EXTRAFILES separate_compilation_39a.f90 separate_compilation_39b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_40 LABELS llvm EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_41 LABELS gfortran llvm EXTRAFILES separate_compilation_41a.f90 separate_compilation_41b.f90 separate_compilation_41c.f90 EXTRA_ARGS --separate-compilation)
 
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc

--- a/integration_tests/separate_compilation_41.f90
+++ b/integration_tests/separate_compilation_41.f90
@@ -1,0 +1,6 @@
+program separate_compilation_41
+   use separate_compilation_41c
+   implicit none
+
+   print *, "PASS"
+end program separate_compilation_41

--- a/integration_tests/separate_compilation_41a.f90
+++ b/integration_tests/separate_compilation_41a.f90
@@ -1,0 +1,21 @@
+module separate_compilation_41a
+   implicit none
+
+   type :: innertype
+   contains
+      procedure :: method
+   end type innertype
+
+   type :: outertype
+      class(innertype), allocatable :: inner
+   end type outertype
+
+contains
+
+   subroutine method(self, n, arr)
+      class(innertype), intent(in) :: self
+      integer, intent(in) :: n
+      real(8), intent(in) :: arr(n:, :)
+   end subroutine method
+
+end module separate_compilation_41a

--- a/integration_tests/separate_compilation_41b.f90
+++ b/integration_tests/separate_compilation_41b.f90
@@ -1,0 +1,22 @@
+module separate_compilation_41b
+   use separate_compilation_41a, only: outertype
+   implicit none
+
+   type :: wrapper
+      class(outertype), allocatable :: outer
+   end type wrapper
+
+contains
+
+   subroutine client(self, n, arr)
+      class(wrapper), intent(in) :: self
+      integer, intent(in) :: n
+      real(8), intent(in) :: arr(n:, :)
+
+      select type (outer => self%outer)
+      class is (outertype)
+         call self%outer%inner%method(n, arr)
+      end select
+   end subroutine client
+
+end module separate_compilation_41b

--- a/integration_tests/separate_compilation_41c.f90
+++ b/integration_tests/separate_compilation_41c.f90
@@ -1,0 +1,4 @@
+module separate_compilation_41c
+   use separate_compilation_41b
+   implicit none
+end module separate_compilation_41c

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -345,6 +345,13 @@ public:
         BaseWalkVisitor<FixExternalSymbolsVisitor>::visit_AssociateBlock(x);
         current_scope = current_scope_copy;
     }
+
+    void visit_Block(const Block_t& x) {
+        SymbolTable* current_scope_copy = current_scope;
+        current_scope = x.m_symtab;
+        BaseWalkVisitor<FixExternalSymbolsVisitor>::visit_Block(x);
+        current_scope = current_scope_copy;
+    }
     /**
      * Searches for an enum containing a specific enumerator across all loaded
      * modules.  When multiple modules define an enum with the same name (e.g.


### PR DESCRIPTION
Track block scopes while fixing ExternalSymbol references loaded from modfiles so separate compilation can resolve symbols introduced in select type blocks.

Add a separate compilation regression test covering nested polymorphic components with a type-bound procedure imported through another module.

Fixes #10468.