### PR TITLE
chore: pin the version of binutils for LLVM 22 build

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -322,7 +322,7 @@ jobs:
             llvm-openmp=14.0.4
             make=4.3
             openmpi=5.0.10
-            binutils
+            binutils=2.45.1
             zstd-static=1.5.7
 
       - uses: mamba-org/setup-micromamba@v2.0.2


### PR DESCRIPTION
Addresses https://github.com/lfortran/lfortran/pull/10475#discussion_r2899919462

(Same version as that present in `conda list`)