### PR TITLE
Fix PDT structure constructor type mismatch

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1939,6 +1939,7 @@ RUN(NAME pdt_12 LABELS llvm)
 RUN(NAME pdt_13 LABELS llvm EXTRA_ARGS --separate-compilation)
 RUN(NAME pdt_14 LABELS llvm EXTRA_ARGS --separate-compilation)
 RUN(NAME pdt_15 LABELS gfortran llvm)
+RUN(NAME pdt_16 LABELS gfortran llvm)
 
 RUN(NAME derived_types_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_02 LABELS gfortran llvm)

--- a/integration_tests/pdt_16.f90
+++ b/integration_tests/pdt_16.f90
@@ -1,0 +1,25 @@
+program pdt_16
+    ! Test PDT structure constructor with default kind parameter.
+    ! Both keyword and positional argument forms must work.
+    implicit none
+    integer, parameter :: sp = kind(1.)
+
+    type :: operands_t(k)
+        integer, kind :: k = sp
+        real(k) :: actual, expected
+    end type
+
+    type(operands_t) :: op1, op2
+
+    ! Keyword arguments (kind parameter uses default)
+    op1 = operands_t(actual=1.0, expected=2.0)
+    if (abs(op1%actual - 1.0) > 1e-6) error stop
+    if (abs(op1%expected - 2.0) > 1e-6) error stop
+
+    ! Positional arguments (kind parameter given explicitly)
+    op2 = operands_t(4, 3.0, 4.0)
+    if (abs(op2%actual - 3.0) > 1e-6) error stop
+    if (abs(op2%expected - 4.0) > 1e-6) error stop
+
+    print *, "ok"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8314,6 +8314,53 @@ public:
         Vec<ASR::call_arg_t> vals;
         visit_expr_list(m_args, n_args, vals);
         visit_kwargs(vals, kwargs, n_kwargs, loc, v, diag);
+
+        // For PDTs with kind parameters, resolve to the instantiated type
+        // and re-cast args to concrete member types (not sentinel types).
+        ASR::symbol_t* v_orig = ASRUtils::symbol_get_past_external(v);
+        ASR::Struct_t* struct_type = ASR::down_cast<ASR::Struct_t>(v_orig);
+        if (struct_type->n_kind_params > 0) {
+            std::string pdt_name = struct_type->m_name;
+            std::vector<int64_t> kind_vals;
+            for (size_t i = 0; i < struct_type->n_kind_params; i++) {
+                std::string kp_name(struct_type->m_kind_params[i]);
+                ASR::symbol_t* kp_sym = struct_type->m_symtab->get_symbol(kp_name);
+                ASR::Variable_t* kp_var = ASR::down_cast<ASR::Variable_t>(kp_sym);
+                int64_t kind_val = ASR::down_cast<ASR::IntegerConstant_t>(
+                    ASRUtils::expr_value(kp_var->m_symbolic_value))->m_n;
+                kind_vals.push_back(kind_val);
+            }
+            Vec<ASR::dimension_t> dims;
+            dims.reserve(al, 0);
+            ASR::symbol_t* type_declaration = nullptr;
+            instantiate_pdt_by_values(loc, pdt_name, kind_vals,
+                false, false, dims, type_declaration,
+                ASR::abiType::Source, false);
+            if (type_declaration) {
+                v = type_declaration;
+            }
+
+            // Re-cast args to the instantiated member types
+            ASR::symbol_t* v_inst = ASRUtils::symbol_get_past_external(v);
+            ASR::Struct_t* inst_struct = ASR::down_cast<ASR::Struct_t>(v_inst);
+            for (size_t i = 0; i < vals.size() && i < inst_struct->n_members; i++) {
+                if (vals[i].m_value == nullptr) continue;
+                std::string member_name(inst_struct->m_members[i]);
+                ASR::symbol_t* inst_member_sym =
+                    inst_struct->m_symtab->get_symbol(member_name);
+                if (inst_member_sym) {
+                    ASR::ttype_t* inst_member_type =
+                        ASRUtils::type_get_past_allocatable(
+                            ASRUtils::symbol_type(inst_member_sym));
+                    ASR::ttype_t* arg_type =
+                        ASRUtils::type_get_past_allocatable(
+                            ASRUtils::expr_type(vals[i].m_value));
+                    ImplicitCastRules::set_converted_value(al, loc,
+                        &vals.p[i].m_value, arg_type, inst_member_type, diag);
+                }
+            }
+        }
+
         ASR::ttype_t* der = ASRUtils::make_StructType_t_util(al, loc, v, true);
 
         // Ensure all values are constant before creating StructConstant


### PR DESCRIPTION
The structure constructor for parameterized derived types (PDTs) used the template symbol (e.g. operands_t) instead of the monomorphized instantiation (e.g. operands_t_4), causing a type mismatch on assignment to a variable declared with the default kind.

Resolve the PDT to its instantiated symbol inside
create_DerivedTypeConstructor by collecting default kind parameter values and calling instantiate_pdt_by_values.  Also re-cast constructor arguments from sentinel types (Real 1000) to concrete types (Real 4) so LLVM codegen produces correct stores.

Fixes #10482.