### PR TITLE
Fix proc pointer codegen in separate compilation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3595,6 +3595,7 @@ RUN(NAME separate_compilation_41 LABELS gfortran llvm EXTRAFILES separate_compil
 
 RUN(NAME separate_compilation_42 LABELS llvm EXTRA_ARGS --separate-compilation)
 
+RUN(NAME separate_compilation_43 LABELS gfortran llvm EXTRAFILES separate_compilation_43a.f90 separate_compilation_43b.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_43.f90
+++ b/integration_tests/separate_compilation_43.f90
@@ -1,0 +1,6 @@
+program separate_compilation_43
+    use separate_compilation_43b_module
+    implicit none
+
+    print *, "ok"
+end program separate_compilation_43

--- a/integration_tests/separate_compilation_43a.f90
+++ b/integration_tests/separate_compilation_43a.f90
@@ -1,0 +1,15 @@
+module separate_compilation_43a_module
+    implicit none
+
+    type, abstract :: AbsType
+        procedure(pintfc), pointer :: ptr => null()
+    end type AbsType
+
+    abstract interface
+        subroutine pintfc(self)
+            import
+            class(AbsType), intent(in) :: self
+        end subroutine pintfc
+    end interface
+
+end module separate_compilation_43a_module

--- a/integration_tests/separate_compilation_43b.f90
+++ b/integration_tests/separate_compilation_43b.f90
@@ -1,0 +1,18 @@
+module separate_compilation_43b_module
+    use separate_compilation_43a_module
+    implicit none
+
+    type :: MyType
+        class(AbsType), allocatable :: obj
+    contains
+        procedure :: method
+    end type MyType
+
+contains
+
+    subroutine method(self)
+        class(MyType), intent(in) :: self
+        call self%obj%ptr()
+    end subroutine method
+
+end module separate_compilation_43b_module

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18420,13 +18420,6 @@ public:
         if( x.m_dt && ASR::is_a<ASR::StructInstanceMember_t>(*x.m_dt) &&
             ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(x.m_name)) &&
             ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(x.m_name))) ) {
-            uint64_t ptr_loads_copy = ptr_loads;
-            ptr_loads = 1;
-            this->visit_expr(*x.m_dt);
-            ptr_loads = ptr_loads_copy;
-            llvm::Type* func_ptr_type = llvm_utils->get_type_from_ttype_t_util(x.m_dt, ASRUtils::symbol_type(x.m_name), module.get());
-            llvm::Value* callee = llvm_utils->CreateLoad2(func_ptr_type, tmp);
-
             ASR::Function_t* func = nullptr;
             if (ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(x.m_name))) {
                 ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(
@@ -18437,6 +18430,13 @@ public:
                 func = ASR::down_cast<ASR::Function_t>(
                     ASRUtils::symbol_get_past_external(x.m_name));
             }
+
+            uint64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 1;
+            this->visit_expr(*x.m_dt);
+            ptr_loads = ptr_loads_copy;
+            llvm::Type* func_ptr_type = llvm_utils->get_function_type(*func, module.get())->getPointerTo();
+            llvm::Value* callee = llvm_utils->CreateLoad2(func_ptr_type, tmp);
             bool will_prepend_self = (func && func->n_args > x.n_args);
             args = convert_call_args(x, will_prepend_self);
             llvm::FunctionType* fntype = llvm_utils->get_function_type(*func, module.get());


### PR DESCRIPTION
When calling a procedure pointer member loaded from a separately
compiled module (e.g. call self%obj%ptr()), the LLVM codegen crashed
because get_type_from_ttype_t_util tried to extract the FunctionType
from the StructInstanceMember expression (x.m_dt), which doesn't
directly carry a FunctionType.

Fix by computing the Function_t from the procedure pointer variable's
type_declaration before generating the function pointer type, and using
get_function_type directly instead of get_type_from_ttype_t_util.

Fixes #10489.