### PR TITLE
Fix private function name clash across modules

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1640,6 +1640,8 @@ RUN(NAME modules_68 LABELS gfortran llvm)
 RUN(NAME modules_69 LABELS gfortran llvm)
 RUN(NAME modules_70 LABELS gfortran llvm)
 RUN(NAME modules_71 LABELS gfortran llvm)
+RUN(NAME modules_72 LABELS gfortran llvm
+        EXTRAFILES modules_72_stypemod.f90 modules_72_otypemod.f90)
 
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES
         associate_06_module.f90)

--- a/integration_tests/modules_72.f90
+++ b/integration_tests/modules_72.f90
@@ -1,0 +1,16 @@
+program modules_72
+    use modules_72_stypemod, only: SomeType
+    use modules_72_otypemod, only: OtherType
+    implicit none
+
+    type(SomeType) :: s
+    type(OtherType) :: o
+
+    s = SomeType()
+    if (s%x /= 10) error stop
+
+    o = OtherType()
+    if (o%y /= 20) error stop
+
+    print *, "PASSED: modules_72"
+end program modules_72

--- a/integration_tests/modules_72_otypemod.f90
+++ b/integration_tests/modules_72_otypemod.f90
@@ -1,0 +1,20 @@
+module modules_72_otypemod
+    use modules_72_stypemod
+    implicit none
+
+    type :: OtherType
+        integer :: y = 0
+    end type OtherType
+
+    interface OtherType
+        procedure :: constructor
+    end interface OtherType
+
+contains
+
+    function constructor() result(self)
+        type(OtherType) :: self
+        self%y = 20
+    end function constructor
+
+end module modules_72_otypemod

--- a/integration_tests/modules_72_stypemod.f90
+++ b/integration_tests/modules_72_stypemod.f90
@@ -1,0 +1,20 @@
+module modules_72_stypemod
+    implicit none
+    private
+
+    type, public :: SomeType
+        integer :: x = 0
+    end type SomeType
+
+    interface SomeType
+        procedure :: constructor
+    end interface SomeType
+
+contains
+
+    function constructor() result(self)
+        type(SomeType) :: self
+        self%x = 10
+    end function constructor
+
+end module modules_72_stypemod

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2035,8 +2035,26 @@ public:
 
         if (parent_scope->get_symbol(sym_name) != nullptr) {
             ASR::symbol_t *f1 = parent_scope->get_symbol(sym_name);
-            if (ASR::is_a<ASR::ExternalSymbol_t>(*f1) && in_submodule) {
-                parent_scope->erase_symbol(sym_name);
+            if (ASR::is_a<ASR::ExternalSymbol_t>(*f1)) {
+                if (in_submodule) {
+                    parent_scope->erase_symbol(sym_name);
+                } else {
+                    ASR::symbol_t *orig = ASRUtils::symbol_get_past_external(f1);
+                    bool is_private_orig = false;
+                    if (ASR::is_a<ASR::Function_t>(*orig)) {
+                        is_private_orig = ASR::down_cast<ASR::Function_t>(
+                            orig)->m_access == ASR::accessType::Private;
+                    }
+                    if (is_private_orig) {
+                        parent_scope->erase_symbol(sym_name);
+                    } else {
+                        diag.add(diag::Diagnostic(
+                            "Function already defined",
+                            diag::Level::Error, diag::Stage::Semantic, {
+                                diag::Label("", {tmp->loc})}));
+                        throw SemanticAbort();
+                    }
+                }
             } else if (ASR::is_a<ASR::Function_t>(*f1)) {
                 ASR::Function_t* f2 = ASR::down_cast<ASR::Function_t>(f1);
                 if (ASRUtils::get_FunctionType(f2)->m_abi == ASR::abiType::ExternalUndefined ||


### PR DESCRIPTION
When a module with default private access defines a function used as a specific procedure in a public generic interface, and another module uses it and defines its own function with the same name, LFortran incorrectly reported 'Function already defined'.

The private function was imported as an ExternalSymbol (needed indirectly by the public generic), but the function definition handler only allowed ExternalSymbol replacement in submodule context. Now it also allows replacement when the ExternalSymbol references a private function from another module, matching standard Fortran semantics.

Fixes #10492.