### PR TITLE
Fix generic procedure name collision on import

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1766,6 +1766,7 @@ RUN(NAME interface_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME interface_29 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME interface_30 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME interface_31 LABELS gfortran llvm)
+RUN(NAME interface_32 LABELS gfortran llvm EXTRAFILES interface_32_module.f90 EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_interface_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_interface_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/interface_32.f90
+++ b/integration_tests/interface_32.f90
@@ -1,0 +1,29 @@
+module interface_32_clientmod
+
+   use interface_32_mymod
+   use interface_32_wrappermod, only: WrapperType
+
+contains
+
+   function init() result(wrap)
+      type(WrapperType) :: wrap
+      type(MyType)      :: obj
+      obj = MyType()
+      wrap = WrapperType(obj)
+   end function init
+
+end module interface_32_clientmod
+
+program interface_32
+   use interface_32_mymod
+   use interface_32_wrappermod
+   use interface_32_clientmod
+   implicit none
+
+   type(WrapperType) :: w
+
+   w = init()
+   if (w%obj%val /= 42) error stop
+   print *, "PASS"
+end program interface_32
+

--- a/integration_tests/interface_32_module.f90
+++ b/integration_tests/interface_32_module.f90
@@ -1,0 +1,40 @@
+module interface_32_mymod
+
+   type :: MyType
+      integer :: val = 0
+   end type MyType
+
+   interface MyType
+      procedure :: constructor
+   end interface MyType
+
+contains
+
+   function constructor() result(self)
+      type(MyType) :: self
+      self%val = 42
+   end function constructor
+
+end module interface_32_mymod
+
+module interface_32_wrappermod
+
+   use interface_32_mymod, only: MyType
+
+   type :: WrapperType
+      class(MyType), allocatable :: obj
+   end type WrapperType
+
+   interface WrapperType
+      procedure :: constructor
+   end interface WrapperType
+
+contains
+
+   function constructor(obj) result(self)
+      class(MyType), intent(in) :: obj
+      type(WrapperType)         :: self
+      allocate(self%obj, source=obj)
+   end function constructor
+
+end module interface_32_wrappermod

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -17375,6 +17375,16 @@ public:
             for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
                 ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                     ASRUtils::symbol_name(gp_ext->m_procs[i]));
+                if (m_proc != nullptr) {
+                    // Verify the resolved symbol refers to the same function
+                    // as the one in the source generic procedure, not a
+                    // different function with the same name from another module
+                    ASR::symbol_t* resolved = ASRUtils::symbol_get_past_external(m_proc);
+                    ASR::symbol_t* expected = ASRUtils::symbol_get_past_external(gp_ext->m_procs[i]);
+                    if (resolved != expected) {
+                        m_proc = nullptr;
+                    }
+                }
                 if( m_proc == nullptr ) {
                     are_all_present = false;
                     std::string proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);


### PR DESCRIPTION
When importing a generic procedure (e.g., a type-bound constructor interface) from a module, the proc resolution looked up the procedure name in the current scope. If a different function with the same name was already imported from another module, it would incorrectly use that function instead of importing the correct one.

Now we verify the resolved symbol matches the expected function from the source generic procedure. On mismatch, the correct function is imported via ExternalSymbol.

Fixes #10505.