### PR TITLE
code-refactor: optimize llvm backend to reduce memory leaks inside do-loops

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -520,6 +520,7 @@ RUN(NAME doloop_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --us
 RUN(NAME doloop_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --use-loop-variable-after-loop)
 RUN(NAME doloop_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME doloop_18 LABELS gfortran llvm)
+RUN(NAME doloop_19 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 
 RUN(NAME cycle_and_exit1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME cycle_and_exit2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/doloop_19.f90
+++ b/integration_tests/doloop_19.f90
@@ -1,0 +1,39 @@
+! This code intends to check stack memory leaks inside do-loop.
+
+program do_loop_19
+
+    implicit none
+    integer :: isum, i, j, ans
+    integer,dimension(:,:),allocatable :: price2
+    integer,dimension(:,:,:),allocatable :: perimeter
+
+    integer, parameter :: NTOTAL = 3
+    allocate(price2(NTOTAL, NTOTAL))
+
+    if (.not. allocated(perimeter)) then
+        allocate(perimeter(4, NTOTAL, NTOTAL)); perimeter = 0
+    end if
+
+    do i = 1, NTOTAL
+        do j = 1, NTOTAL
+            call go()
+            price2(i,j) = compute_n_sides()
+            print *,"i", i, j
+        end do
+    end do
+    ans = sum(price2)
+    print *,ans
+    if (ans /= 324) error stop
+    
+
+    contains
+        recursive subroutine go()
+            perimeter = 1     
+        end subroutine go
+
+        function compute_n_sides() result(iper)
+            integer :: iper
+            iper = count(perimeter==1)
+        end function compute_n_sides
+
+end program do_loop_19

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -19910,7 +19910,7 @@ public:
             args.push_back(serialization_info);
 
             // Create and Push a pointer to int64 to store the result size in
-            llvm::Value *result_size_ptr = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt64Ty(context));
+            llvm::Value *result_size_ptr = llvm_utils->CreateAlloca(llvm::Type::getInt64Ty(context));
             args.push_back(result_size_ptr);
 
             // Check unallocated arguments

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -20082,7 +20082,11 @@ public:
             // Load result size
             llvm::Value *result_size = llvm_utils->CreateLoad2(llvm::Type::getInt64Ty(context), result_size_ptr);
 
-            tmp = llvm_utils->create_string_descriptor(tmp, result_size,"stringFormat_desc");
+            llvm::Value* str_fmt_desc = llvm_utils->CreateAlloca(
+                llvm_utils->string_descriptor, nullptr, "stringFormat_desc");
+            builder->CreateStore(tmp, llvm_utils->CreateGEP2(llvm_utils->string_descriptor, str_fmt_desc, 0));
+            builder->CreateStore(result_size, llvm_utils->CreateGEP2(llvm_utils->string_descriptor, str_fmt_desc, 1));
+            tmp = str_fmt_desc;
         } else {
             throw CodeGenError("Only FormatFortran string formatting implemented so far.");
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5374,7 +5374,7 @@ public:
         llvm::Type* llvm_data_type = llvm_utils->get_el_type(expr, asr_data_type, module.get());
         llvm::Value* ptr_ = nullptr;
         if( is_malloc_array_type && !is_list && !is_data_only ) {
-            ptr_ = llvm_utils->CreateAlloca(*builder, type_, nullptr, "arr_desc");
+            ptr_ = llvm_utils->CreateAlloca(type_, nullptr, "arr_desc");
             if(ASRUtils::is_character(*m_type)){
                 llvm::Value* str_desc = create_and_setup_string_for_array(m_type, nullptr, false, "arr_desc_str_desc");
                 builder->CreateStore(str_desc, arr_descr->get_pointer_to_data(type_, ptr_));

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -493,14 +493,21 @@ namespace LCompilers {
             }
         }
 
+        llvm::Value* alloc_dim_des_at_entry(llvm::IRBuilder<>* builder,
+                llvm::LLVMContext& context, llvm::StructType* dim_des, int n_dims) {
+            llvm::BasicBlock& entry_block = builder->GetInsertBlock()->getParent()->getEntryBlock();
+            llvm::IRBuilder<> builder0(context);
+            builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
+            llvm::Value* llvm_ndims = builder0.CreateAlloca(llvm::Type::getInt32Ty(context));
+            builder0.CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), llvm_ndims);
+            return builder0.CreateAlloca(dim_des,
+                builder0.CreateLoad(llvm::Type::getInt32Ty(context), llvm_ndims));
+        }
+
         void SimpleCMODescriptor::fill_dimension_descriptor(llvm::Type* type, llvm::Value* arr, int n_dims) {
             unsigned index_bit_width = index_type->getIntegerBitWidth();
             llvm::Value* dim_des_val = llvm_utils->create_gep2(type, arr, 2);
-            llvm::Value* llvm_ndims = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt32Ty(context));
-            builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), llvm_ndims);
-            llvm::Value* dim_des_first;
-            dim_des_first = llvm_utils->CreateAlloca(*builder, dim_des,
-                                    llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), llvm_ndims));
+            llvm::Value* dim_des_first = alloc_dim_des_at_entry(builder, context, dim_des, n_dims);
 
             // If unallocated, set lower bound and size to 1.
             // This is for entering the loop array_op pass generates to check if array is allocated in ArrayItem at runtime.
@@ -519,10 +526,7 @@ namespace LCompilers {
             llvm::Value* offset_val = llvm_utils->create_gep2(type, arr, 1);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)), offset_val);
             llvm::Value* dim_des_val = this->get_pointer_to_dimension_descriptor_array(type, arr, false);
-            llvm::Value* llvm_ndims = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt32Ty(context), nullptr);
-            builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), llvm_ndims);
-            llvm::Value* dim_des_first = llvm_utils->CreateAlloca(*builder, dim_des,
-                                                            llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), llvm_ndims));
+            llvm::Value* dim_des_first = alloc_dim_des_at_entry(builder, context, dim_des, n_dims);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), get_rank(type, arr, true));
             builder->CreateStore(dim_des_first, dim_des_val);
             dim_des_val = llvm_utils->CreateLoad2(dim_des->getPointerTo(), dim_des_val);
@@ -557,10 +561,7 @@ namespace LCompilers {
             llvm::Value* offset_val = llvm_utils->create_gep2(type, arr, 1);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)), offset_val);
             llvm::Value* dim_des_val = llvm_utils->create_gep2(type, arr, 2);
-            llvm::Value* llvm_ndims = llvm_utils->CreateAlloca(*builder, llvm::Type::getInt32Ty(context), nullptr);
-            builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), llvm_ndims);
-            llvm::Value* dim_des_first = llvm_utils->CreateAlloca(*builder, dim_des,
-                                                               llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), llvm_ndims));
+            llvm::Value* dim_des_first = alloc_dim_des_at_entry(builder, context, dim_des, n_dims);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)), get_rank(type, arr, true));
             builder->CreateStore(dim_des_first, dim_des_val);
             dim_des_val = llvm_utils->CreateLoad2(dim_des->getPointerTo(), dim_des_val);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -26,6 +26,15 @@ namespace LCompilers {
                 llvm::IRBuilder<> &builder, llvm::Value* arg_size);
         llvm::Value* lfortran_realloc(llvm::LLVMContext &context, llvm::Module &module,
                 llvm::IRBuilder<> &builder, llvm::Value* ptr, llvm::Value* arg_size);
+        /*
+        Allocates dimension descriptor temporaries (llvm_ndims, dim_des_first)
+        in the function entry block instead of body.
+        This helps to not allocate each descriptor repeatedly for inner-loop bodies
+        in-case of nested do-loops, which helps to save stack memory. 
+        Rather, these temporaries are allocated only once at entry block.
+        */
+        llvm::Value* alloc_dim_des_at_entry(llvm::IRBuilder<>* builder,
+                llvm::LLVMContext& context, llvm::StructType* dim_des, int n_dims);
 
         /*
         * This function checks whether the

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "e8a46cf58bc49c274481252a11898bcb7ce4d008a248764dd61a4d3a",
+    "stdout_hash": "f0c388fc3fcf9350017c196fee468d7f0c3ee6e872eab95961349545",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
+%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 
 @0 = private unnamed_addr constant [4 x i8] c"arr\00", align 1
 @1 = private unnamed_addr constant [22 x i8] c"tests/allocate_02.f90\00", align 1
@@ -15,20 +15,20 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %2 = alloca i32, align 4
+  store i32 1, i32* %2, align 4
+  %3 = load i32, i32* %2, align 4
+  %4 = alloca %dimension_descriptor, i32 %3, align 8
+  %arr_desc = alloca %array, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %arr = alloca %array*, align 8
   store %array* null, %array** %arr, align 8
-  %arr_desc = alloca %array, align 8
-  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 1, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
+  %5 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 1
   store i32 1, i32* %6, align 4
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
+  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 2
   store i32 1, i32* %7, align 4
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
+  store %dimension_descriptor* %4, %dimension_descriptor** %5, align 8
   %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
   store i32 1, i32* %8, align 4
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "e574095952a96f07be4830d1aa27603c6e42fefb063df1d463c71a08",
+    "stdout_hash": "bdb8af511b5b2935d5e273ad0671880190032bb09a9286b3d0554fa1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "a8a5ba3d47415d2fca76af12bb7e78dcd04acf86e8852e621bf6a44e",
+    "stdout_hash": "24e250ee009aab2378c21ff8aa7abb5e33993f4745e28484d1ee8ded",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "bdb8af511b5b2935d5e273ad0671880190032bb09a9286b3d0554fa1",
+    "stdout_hash": "a8a5ba3d47415d2fca76af12bb7e78dcd04acf86e8852e621bf6a44e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -2,8 +2,8 @@
 source_filename = "LFortran"
 
 %string_descriptor = type <{ i8*, i64 }>
-%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
+%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 
 @0 = private unnamed_addr constant [2 x i8] c"c\00", align 1
 @1 = private unnamed_addr constant [43 x i8] c"tests/../integration_tests/allocate_03.f90\00", align 1
@@ -235,20 +235,20 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = alloca i64, align 8
+  %3 = alloca i32, align 4
+  store i32 3, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  %arr_desc = alloca %array, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca %array*, align 8
   store %array* null, %array** %c, align 8
-  %arr_desc = alloca %array, align 8
-  %3 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %4 = alloca i32, align 4
-  store i32 3, i32* %4, align 4
-  %5 = load i32, i32* %4, align 4
-  %6 = alloca %dimension_descriptor, i32 %5, align 8
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %6, i32 0, i32 1
+  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
   store i32 1, i32* %7, align 4
-  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %6, i32 0, i32 2
+  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
   store i32 1, i32* %8, align 4
-  store %dimension_descriptor* %6, %dimension_descriptor** %3, align 8
+  store %dimension_descriptor* %5, %dimension_descriptor** %6, align 8
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
   store i32 3, i32* %9, align 4
   %10 = getelementptr %array, %array* %arr_desc, i32 0, i32 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -234,109 +234,110 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca %array*, align 8
   store %array* null, %array** %c, align 8
   %arr_desc = alloca %array, align 8
-  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 3, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
-  store i32 1, i32* %6, align 4
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
+  %3 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %4 = alloca i32, align 4
+  store i32 3, i32* %4, align 4
+  %5 = load i32, i32* %4, align 4
+  %6 = alloca %dimension_descriptor, i32 %5, align 8
+  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %6, i32 0, i32 1
   store i32 1, i32* %7, align 4
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
-  %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
-  store i32 3, i32* %8, align 4
-  %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %9, align 8
+  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %6, i32 0, i32 2
+  store i32 1, i32* %8, align 4
+  store %dimension_descriptor* %6, %dimension_descriptor** %3, align 8
+  %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
+  store i32 3, i32* %9, align 4
+  %10 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
+  store i32* null, i32** %10, align 8
   store %array* %arr_desc, %array** %c, align 8
   %r = alloca i32, align 4
   %stat = alloca i32, align 4
   store i32 1, i32* %stat, align 4
-  %10 = load %array*, %array** %c, align 8
-  %11 = ptrtoint %array* %10 to i64
-  %12 = icmp eq i64 %11, 0
-  br i1 %12, label %merge_allocated, label %check_data
+  %11 = load %array*, %array** %c, align 8
+  %12 = ptrtoint %array* %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %13 = getelementptr %array, %array* %10, i32 0, i32 0
-  %14 = load i32*, i32** %13, align 8
-  %15 = ptrtoint i32* %14 to i64
-  %16 = icmp ne i64 %15, 0
+  %14 = getelementptr %array, %array* %11, i32 0, i32 0
+  %15 = load i32*, i32** %14, align 8
+  %16 = ptrtoint i32* %15 to i64
+  %17 = icmp ne i64 %16, 0
   br label %merge_allocated
 
 merge_allocated:                                  ; preds = %check_data, %.entry
-  %is_allocated = phi i1 [ false, %.entry ], [ %16, %check_data ]
+  %is_allocated = phi i1 [ false, %.entry ], [ %17, %check_data ]
   br i1 %is_allocated, label %then, label %ifcont
 
 then:                                             ; preds = %merge_allocated
-  %17 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %18 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %19 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %18, i32 0, i32 0
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @163, i32 0, i32 0), i8** %20, align 8
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 1
-  store i32 8, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 2
-  store i32 14, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 3
-  store i32 8, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 4
-  store i32 23, i32* %24, align 4
-  %25 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([53 x i8], [53 x i8]* @164, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
-  %26 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %18, i32 0, i32 0
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 2
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 0
-  store i1 true, i1* %29, align 1
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 1
-  store i8* %25, i8** %30, align 8
-  store { i8*, i32, i32, i32, i32 }* %27, { i8*, i32, i32, i32, i32 }** %28, align 8
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 3
-  store i32 1, i32* %31, align 4
-  %32 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %17, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @165, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
+  %18 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %19 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %20 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
+  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @163, i32 0, i32 0), i8** %21, align 8
+  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 1
+  store i32 8, i32* %22, align 4
+  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 2
+  store i32 14, i32* %23, align 4
+  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 3
+  store i32 8, i32* %24, align 4
+  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 4
+  store i32 23, i32* %25, align 4
+  %26 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([53 x i8], [53 x i8]* @164, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
+  %27 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
+  %28 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
+  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 2
+  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 0
+  store i1 true, i1* %30, align 1
+  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 1
+  store i8* %26, i8** %31, align 8
+  store { i8*, i32, i32, i32, i32 }* %28, { i8*, i32, i32, i32, i32 }** %29, align 8
+  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 3
+  store i32 1, i32* %32, align 4
+  %33 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %33, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @165, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %merge_allocated
-  %33 = load %array*, %array** %c, align 8
-  %34 = getelementptr %array, %array* %33, i32 0, i32 1
-  store i32 0, i32* %34, align 4
-  %35 = getelementptr %array, %array* %33, i32 0, i32 2
-  %36 = load %dimension_descriptor*, %dimension_descriptor** %35, align 8
-  %37 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %36, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 0
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 1
-  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 2
-  store i32 1, i32* %38, align 4
+  %34 = load %array*, %array** %c, align 8
+  %35 = getelementptr %array, %array* %34, i32 0, i32 1
+  store i32 0, i32* %35, align 4
+  %36 = getelementptr %array, %array* %34, i32 0, i32 2
+  %37 = load %dimension_descriptor*, %dimension_descriptor** %36, align 8
+  %38 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 0
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
   store i32 1, i32* %39, align 4
-  store i32 3, i32* %40, align 4
-  %41 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %36, i32 1
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 0
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 1
-  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %41, i32 0, i32 2
-  store i32 3, i32* %42, align 4
-  store i32 1, i32* %43, align 4
-  store i32 3, i32* %44, align 4
-  %45 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %36, i32 2
-  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %45, i32 0, i32 0
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %45, i32 0, i32 1
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %45, i32 0, i32 2
-  store i32 9, i32* %46, align 4
-  store i32 1, i32* %47, align 4
-  store i32 3, i32* %48, align 4
-  %49 = getelementptr %array, %array* %33, i32 0, i32 0
-  %50 = call i8* @_lfortran_malloc(i64 108)
-  %51 = bitcast i8* %50 to i32*
-  store i32* %51, i32** %49, align 8
+  store i32 1, i32* %40, align 4
+  store i32 3, i32* %41, align 4
+  %42 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 1
+  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %42, i32 0, i32 0
+  %44 = getelementptr %dimension_descriptor, %dimension_descriptor* %42, i32 0, i32 1
+  %45 = getelementptr %dimension_descriptor, %dimension_descriptor* %42, i32 0, i32 2
+  store i32 3, i32* %43, align 4
+  store i32 1, i32* %44, align 4
+  store i32 3, i32* %45, align 4
+  %46 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 2
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
+  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
+  store i32 9, i32* %47, align 4
+  store i32 1, i32* %48, align 4
+  store i32 3, i32* %49, align 4
+  %50 = getelementptr %array, %array* %34, i32 0, i32 0
+  %51 = call i8* @_lfortran_malloc(i64 108)
+  %52 = bitcast i8* %51 to i32*
+  store i32* %52, i32** %50, align 8
   store i32 0, i32* %stat, align 4
-  %52 = load i32, i32* %stat, align 4
-  %53 = icmp ne i32 %52, 0
-  br i1 %53, label %then1, label %else
+  %53 = load i32, i32* %stat, align 4
+  %54 = icmp ne i32 %53, 0
+  br i1 %54, label %then1, label %else
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @166, i32 0, i32 0))
@@ -347,413 +348,413 @@ else:                                             ; preds = %ifcont
   br label %ifcont2
 
 ifcont2:                                          ; preds = %else, %then1
-  %54 = load %array*, %array** %c, align 8
-  %55 = ptrtoint %array* %54 to i64
-  %56 = icmp eq i64 %55, 0
-  br i1 %56, label %merge_allocated4, label %check_data3
+  %55 = load %array*, %array** %c, align 8
+  %56 = ptrtoint %array* %55 to i64
+  %57 = icmp eq i64 %56, 0
+  br i1 %57, label %merge_allocated4, label %check_data3
 
 check_data3:                                      ; preds = %ifcont2
-  %57 = getelementptr %array, %array* %54, i32 0, i32 0
-  %58 = load i32*, i32** %57, align 8
-  %59 = ptrtoint i32* %58 to i64
-  %60 = icmp ne i64 %59, 0
+  %58 = getelementptr %array, %array* %55, i32 0, i32 0
+  %59 = load i32*, i32** %58, align 8
+  %60 = ptrtoint i32* %59 to i64
+  %61 = icmp ne i64 %60, 0
   br label %merge_allocated4
 
 merge_allocated4:                                 ; preds = %check_data3, %ifcont2
-  %is_allocated5 = phi i1 [ false, %ifcont2 ], [ %60, %check_data3 ]
-  %61 = xor i1 %is_allocated5, true
-  br i1 %61, label %then6, label %ifcont7
+  %is_allocated5 = phi i1 [ false, %ifcont2 ], [ %61, %check_data3 ]
+  %62 = xor i1 %is_allocated5, true
+  br i1 %62, label %then6, label %ifcont7
 
 then6:                                            ; preds = %merge_allocated4
-  %62 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %63 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %64 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %63, i32 0, i32 0
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %64, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @169, i32 0, i32 0), i8** %65, align 8
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %64, i32 0, i32 1
-  store i32 10, i32* %66, align 4
-  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %64, i32 0, i32 2
-  store i32 5, i32* %67, align 4
-  %68 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %64, i32 0, i32 3
-  store i32 10, i32* %68, align 4
-  %69 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %64, i32 0, i32 4
-  store i32 14, i32* %69, align 4
-  %70 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
-  %71 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %62, i32 0, i32 0
-  %72 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %63, i32 0, i32 0
-  %73 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %71, i32 0, i32 2
-  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %71, i32 0, i32 0
-  store i1 true, i1* %74, align 1
-  %75 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %71, i32 0, i32 1
-  store i8* %70, i8** %75, align 8
-  store { i8*, i32, i32, i32, i32 }* %72, { i8*, i32, i32, i32, i32 }** %73, align 8
-  %76 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %71, i32 0, i32 3
-  store i32 1, i32* %76, align 4
-  %77 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %62, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0))
+  %63 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %64 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %65 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %64, i32 0, i32 0
+  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @169, i32 0, i32 0), i8** %66, align 8
+  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 1
+  store i32 10, i32* %67, align 4
+  %68 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 2
+  store i32 5, i32* %68, align 4
+  %69 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 3
+  store i32 10, i32* %69, align 4
+  %70 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 4
+  store i32 14, i32* %70, align 4
+  %71 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
+  %72 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %63, i32 0, i32 0
+  %73 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %64, i32 0, i32 0
+  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 2
+  %75 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 0
+  store i1 true, i1* %75, align 1
+  %76 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 1
+  store i8* %71, i8** %76, align 8
+  store { i8*, i32, i32, i32, i32 }* %73, { i8*, i32, i32, i32, i32 }** %74, align 8
+  %77 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 3
+  store i32 1, i32* %77, align 4
+  %78 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %63, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont7:                                          ; preds = %merge_allocated4
-  %78 = getelementptr %array, %array* %54, i32 0, i32 2
-  %79 = load %dimension_descriptor*, %dimension_descriptor** %78, align 8
-  %80 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %79, i32 0
-  %81 = getelementptr %dimension_descriptor, %dimension_descriptor* %80, i32 0, i32 1
-  %82 = load i32, i32* %81, align 4
-  %83 = getelementptr %dimension_descriptor, %dimension_descriptor* %80, i32 0, i32 2
-  %84 = load i32, i32* %83, align 4
-  %85 = sub i32 1, %82
-  %86 = add i32 %82, %84
-  %87 = sub i32 %86, 1
-  %88 = icmp slt i32 1, %82
-  %89 = icmp sgt i32 1, %87
-  %90 = or i1 %88, %89
-  br i1 %90, label %then8, label %ifcont9
+  %79 = getelementptr %array, %array* %55, i32 0, i32 2
+  %80 = load %dimension_descriptor*, %dimension_descriptor** %79, align 8
+  %81 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %80, i32 0
+  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 1
+  %83 = load i32, i32* %82, align 4
+  %84 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 2
+  %85 = load i32, i32* %84, align 4
+  %86 = sub i32 1, %83
+  %87 = add i32 %83, %85
+  %88 = sub i32 %87, 1
+  %89 = icmp slt i32 1, %83
+  %90 = icmp sgt i32 1, %88
+  %91 = or i1 %89, %90
+  br i1 %91, label %then8, label %ifcont9
 
 then8:                                            ; preds = %ifcont7
-  %91 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %92 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %93 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %92, i32 0, i32 0
-  %94 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @173, i32 0, i32 0), i8** %94, align 8
-  %95 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 1
-  store i32 10, i32* %95, align 4
-  %96 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 2
-  store i32 5, i32* %96, align 4
-  %97 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 3
-  store i32 10, i32* %97, align 4
-  %98 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 4
-  store i32 14, i32* %98, align 4
-  %99 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
-  %100 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %91, i32 0, i32 0
-  %101 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %92, i32 0, i32 0
-  %102 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 2
-  %103 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 0
-  store i1 true, i1* %103, align 1
-  %104 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 1
-  store i8* %99, i8** %104, align 8
-  store { i8*, i32, i32, i32, i32 }* %101, { i8*, i32, i32, i32, i32 }** %102, align 8
-  %105 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 3
-  store i32 1, i32* %105, align 4
-  %106 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %91, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i32 1, i32 1, i32 %82, i32 %87)
+  %92 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %93 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %94 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %93, i32 0, i32 0
+  %95 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %94, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @173, i32 0, i32 0), i8** %95, align 8
+  %96 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %94, i32 0, i32 1
+  store i32 10, i32* %96, align 4
+  %97 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %94, i32 0, i32 2
+  store i32 5, i32* %97, align 4
+  %98 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %94, i32 0, i32 3
+  store i32 10, i32* %98, align 4
+  %99 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %94, i32 0, i32 4
+  store i32 14, i32* %99, align 4
+  %100 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
+  %101 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %92, i32 0, i32 0
+  %102 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %93, i32 0, i32 0
+  %103 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %101, i32 0, i32 2
+  %104 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %101, i32 0, i32 0
+  store i1 true, i1* %104, align 1
+  %105 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %101, i32 0, i32 1
+  store i8* %100, i8** %105, align 8
+  store { i8*, i32, i32, i32, i32 }* %102, { i8*, i32, i32, i32, i32 }** %103, align 8
+  %106 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %101, i32 0, i32 3
+  store i32 1, i32* %106, align 4
+  %107 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %92, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i32 1, i32 1, i32 %83, i32 %88)
   call void @exit(i32 1)
   unreachable
 
 ifcont9:                                          ; preds = %ifcont7
-  %107 = getelementptr %dimension_descriptor, %dimension_descriptor* %80, i32 0, i32 0
-  %108 = load i32, i32* %107, align 4
-  %109 = mul i32 %108, %85
-  %110 = add i32 0, %109
-  %111 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %79, i32 1
-  %112 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 1
-  %113 = load i32, i32* %112, align 4
-  %114 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 2
-  %115 = load i32, i32* %114, align 4
-  %116 = sub i32 1, %113
-  %117 = add i32 %113, %115
-  %118 = sub i32 %117, 1
-  %119 = icmp slt i32 1, %113
-  %120 = icmp sgt i32 1, %118
-  %121 = or i1 %119, %120
-  br i1 %121, label %then10, label %ifcont11
+  %108 = getelementptr %dimension_descriptor, %dimension_descriptor* %81, i32 0, i32 0
+  %109 = load i32, i32* %108, align 4
+  %110 = mul i32 %109, %86
+  %111 = add i32 0, %110
+  %112 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %80, i32 1
+  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %112, i32 0, i32 1
+  %114 = load i32, i32* %113, align 4
+  %115 = getelementptr %dimension_descriptor, %dimension_descriptor* %112, i32 0, i32 2
+  %116 = load i32, i32* %115, align 4
+  %117 = sub i32 1, %114
+  %118 = add i32 %114, %116
+  %119 = sub i32 %118, 1
+  %120 = icmp slt i32 1, %114
+  %121 = icmp sgt i32 1, %119
+  %122 = or i1 %120, %121
+  br i1 %122, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  %122 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %123 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %124 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %123, i32 0, i32 0
-  %125 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %124, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @177, i32 0, i32 0), i8** %125, align 8
-  %126 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %124, i32 0, i32 1
-  store i32 10, i32* %126, align 4
-  %127 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %124, i32 0, i32 2
-  store i32 5, i32* %127, align 4
-  %128 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %124, i32 0, i32 3
-  store i32 10, i32* %128, align 4
-  %129 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %124, i32 0, i32 4
-  store i32 14, i32* %129, align 4
-  %130 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @178, i32 0, i32 0))
-  %131 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %122, i32 0, i32 0
-  %132 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %123, i32 0, i32 0
-  %133 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %131, i32 0, i32 2
-  %134 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %131, i32 0, i32 0
-  store i1 true, i1* %134, align 1
-  %135 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %131, i32 0, i32 1
-  store i8* %130, i8** %135, align 8
-  store { i8*, i32, i32, i32, i32 }* %132, { i8*, i32, i32, i32, i32 }** %133, align 8
-  %136 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %131, i32 0, i32 3
-  store i32 1, i32* %136, align 4
-  %137 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %122, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @179, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0), i32 1, i32 2, i32 %113, i32 %118)
+  %123 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %124 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %125 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %124, i32 0, i32 0
+  %126 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %125, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @177, i32 0, i32 0), i8** %126, align 8
+  %127 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %125, i32 0, i32 1
+  store i32 10, i32* %127, align 4
+  %128 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %125, i32 0, i32 2
+  store i32 5, i32* %128, align 4
+  %129 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %125, i32 0, i32 3
+  store i32 10, i32* %129, align 4
+  %130 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %125, i32 0, i32 4
+  store i32 14, i32* %130, align 4
+  %131 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @178, i32 0, i32 0))
+  %132 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %123, i32 0, i32 0
+  %133 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %124, i32 0, i32 0
+  %134 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %132, i32 0, i32 2
+  %135 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %132, i32 0, i32 0
+  store i1 true, i1* %135, align 1
+  %136 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %132, i32 0, i32 1
+  store i8* %131, i8** %136, align 8
+  store { i8*, i32, i32, i32, i32 }* %133, { i8*, i32, i32, i32, i32 }** %134, align 8
+  %137 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %132, i32 0, i32 3
+  store i32 1, i32* %137, align 4
+  %138 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %123, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %138, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @179, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0), i32 1, i32 2, i32 %114, i32 %119)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %138 = getelementptr %dimension_descriptor, %dimension_descriptor* %111, i32 0, i32 0
-  %139 = load i32, i32* %138, align 4
-  %140 = mul i32 %139, %116
-  %141 = add i32 %110, %140
-  %142 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %79, i32 2
-  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %142, i32 0, i32 1
-  %144 = load i32, i32* %143, align 4
-  %145 = getelementptr %dimension_descriptor, %dimension_descriptor* %142, i32 0, i32 2
-  %146 = load i32, i32* %145, align 4
-  %147 = sub i32 1, %144
-  %148 = add i32 %144, %146
-  %149 = sub i32 %148, 1
-  %150 = icmp slt i32 1, %144
-  %151 = icmp sgt i32 1, %149
-  %152 = or i1 %150, %151
-  br i1 %152, label %then12, label %ifcont13
+  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %112, i32 0, i32 0
+  %140 = load i32, i32* %139, align 4
+  %141 = mul i32 %140, %117
+  %142 = add i32 %111, %141
+  %143 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %80, i32 2
+  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %143, i32 0, i32 1
+  %145 = load i32, i32* %144, align 4
+  %146 = getelementptr %dimension_descriptor, %dimension_descriptor* %143, i32 0, i32 2
+  %147 = load i32, i32* %146, align 4
+  %148 = sub i32 1, %145
+  %149 = add i32 %145, %147
+  %150 = sub i32 %149, 1
+  %151 = icmp slt i32 1, %145
+  %152 = icmp sgt i32 1, %150
+  %153 = or i1 %151, %152
+  br i1 %153, label %then12, label %ifcont13
 
 then12:                                           ; preds = %ifcont11
-  %153 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %154 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %155 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %154, i32 0, i32 0
-  %156 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %155, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @181, i32 0, i32 0), i8** %156, align 8
-  %157 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %155, i32 0, i32 1
-  store i32 10, i32* %157, align 4
-  %158 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %155, i32 0, i32 2
-  store i32 5, i32* %158, align 4
-  %159 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %155, i32 0, i32 3
-  store i32 10, i32* %159, align 4
-  %160 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %155, i32 0, i32 4
-  store i32 14, i32* %160, align 4
-  %161 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @182, i32 0, i32 0))
-  %162 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %153, i32 0, i32 0
-  %163 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %154, i32 0, i32 0
-  %164 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 0, i32 2
-  %165 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 0, i32 0
-  store i1 true, i1* %165, align 1
-  %166 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 0, i32 1
-  store i8* %161, i8** %166, align 8
-  store { i8*, i32, i32, i32, i32 }* %163, { i8*, i32, i32, i32, i32 }** %164, align 8
-  %167 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 0, i32 3
-  store i32 1, i32* %167, align 4
-  %168 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %153, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %168, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @183, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @180, i32 0, i32 0), i32 1, i32 3, i32 %144, i32 %149)
+  %154 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %155 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %156 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %155, i32 0, i32 0
+  %157 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %156, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @181, i32 0, i32 0), i8** %157, align 8
+  %158 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %156, i32 0, i32 1
+  store i32 10, i32* %158, align 4
+  %159 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %156, i32 0, i32 2
+  store i32 5, i32* %159, align 4
+  %160 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %156, i32 0, i32 3
+  store i32 10, i32* %160, align 4
+  %161 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %156, i32 0, i32 4
+  store i32 14, i32* %161, align 4
+  %162 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @182, i32 0, i32 0))
+  %163 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %154, i32 0, i32 0
+  %164 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %155, i32 0, i32 0
+  %165 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %163, i32 0, i32 2
+  %166 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %163, i32 0, i32 0
+  store i1 true, i1* %166, align 1
+  %167 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %163, i32 0, i32 1
+  store i8* %162, i8** %167, align 8
+  store { i8*, i32, i32, i32, i32 }* %164, { i8*, i32, i32, i32, i32 }** %165, align 8
+  %168 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %163, i32 0, i32 3
+  store i32 1, i32* %168, align 4
+  %169 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %154, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %169, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @183, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @180, i32 0, i32 0), i32 1, i32 3, i32 %145, i32 %150)
   call void @exit(i32 1)
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %169 = getelementptr %dimension_descriptor, %dimension_descriptor* %142, i32 0, i32 0
-  %170 = load i32, i32* %169, align 4
-  %171 = mul i32 %170, %147
-  %172 = add i32 %141, %171
-  %173 = getelementptr %array, %array* %54, i32 0, i32 1
-  %174 = load i32, i32* %173, align 4
-  %175 = add i32 %172, %174
-  %176 = getelementptr %array, %array* %54, i32 0, i32 0
-  %177 = load i32*, i32** %176, align 8
-  %178 = getelementptr inbounds i32, i32* %177, i32 %175
-  store i32 3, i32* %178, align 4
+  %170 = getelementptr %dimension_descriptor, %dimension_descriptor* %143, i32 0, i32 0
+  %171 = load i32, i32* %170, align 4
+  %172 = mul i32 %171, %148
+  %173 = add i32 %142, %172
+  %174 = getelementptr %array, %array* %55, i32 0, i32 1
+  %175 = load i32, i32* %174, align 4
+  %176 = add i32 %173, %175
+  %177 = getelementptr %array, %array* %55, i32 0, i32 0
+  %178 = load i32*, i32** %177, align 8
+  %179 = getelementptr inbounds i32, i32* %178, i32 %176
+  store i32 3, i32* %179, align 4
   call void @h(%array** %c)
-  %179 = call i32 @g(%array** %c)
-  store i32 %179, i32* %r, align 4
-  %180 = load %array*, %array** %c, align 8
-  %181 = ptrtoint %array* %180 to i64
-  %182 = icmp eq i64 %181, 0
-  br i1 %182, label %merge_allocated15, label %check_data14
+  %180 = call i32 @g(%array** %c)
+  store i32 %180, i32* %r, align 4
+  %181 = load %array*, %array** %c, align 8
+  %182 = ptrtoint %array* %181 to i64
+  %183 = icmp eq i64 %182, 0
+  br i1 %183, label %merge_allocated15, label %check_data14
 
 check_data14:                                     ; preds = %ifcont13
-  %183 = getelementptr %array, %array* %180, i32 0, i32 0
-  %184 = load i32*, i32** %183, align 8
-  %185 = ptrtoint i32* %184 to i64
-  %186 = icmp ne i64 %185, 0
+  %184 = getelementptr %array, %array* %181, i32 0, i32 0
+  %185 = load i32*, i32** %184, align 8
+  %186 = ptrtoint i32* %185 to i64
+  %187 = icmp ne i64 %186, 0
   br label %merge_allocated15
 
 merge_allocated15:                                ; preds = %check_data14, %ifcont13
-  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %186, %check_data14 ]
-  %187 = xor i1 %is_allocated16, true
-  br i1 %187, label %then17, label %ifcont18
+  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %187, %check_data14 ]
+  %188 = xor i1 %is_allocated16, true
+  br i1 %188, label %then17, label %ifcont18
 
 then17:                                           ; preds = %merge_allocated15
-  %188 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %189 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %190 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %189, i32 0, i32 0
-  %191 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @185, i32 0, i32 0), i8** %191, align 8
-  %192 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 1
-  store i32 13, i32* %192, align 4
-  %193 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 2
-  store i32 9, i32* %193, align 4
-  %194 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 3
-  store i32 13, i32* %194, align 4
-  %195 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 4
-  store i32 18, i32* %195, align 4
-  %196 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @186, i32 0, i32 0))
-  %197 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %188, i32 0, i32 0
-  %198 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %189, i32 0, i32 0
-  %199 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 2
-  %200 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 0
-  store i1 true, i1* %200, align 1
-  %201 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 1
-  store i8* %196, i8** %201, align 8
-  store { i8*, i32, i32, i32, i32 }* %198, { i8*, i32, i32, i32, i32 }** %199, align 8
-  %202 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 3
-  store i32 1, i32* %202, align 4
-  %203 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %188, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %203, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @184, i32 0, i32 0))
+  %189 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %190 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %191 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %190, i32 0, i32 0
+  %192 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %191, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @185, i32 0, i32 0), i8** %192, align 8
+  %193 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %191, i32 0, i32 1
+  store i32 13, i32* %193, align 4
+  %194 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %191, i32 0, i32 2
+  store i32 9, i32* %194, align 4
+  %195 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %191, i32 0, i32 3
+  store i32 13, i32* %195, align 4
+  %196 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %191, i32 0, i32 4
+  store i32 18, i32* %196, align 4
+  %197 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @186, i32 0, i32 0))
+  %198 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %189, i32 0, i32 0
+  %199 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %190, i32 0, i32 0
+  %200 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %198, i32 0, i32 2
+  %201 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %198, i32 0, i32 0
+  store i1 true, i1* %201, align 1
+  %202 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %198, i32 0, i32 1
+  store i8* %197, i8** %202, align 8
+  store { i8*, i32, i32, i32, i32 }* %199, { i8*, i32, i32, i32, i32 }** %200, align 8
+  %203 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %198, i32 0, i32 3
+  store i32 1, i32* %203, align 4
+  %204 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %189, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %204, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @184, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %merge_allocated15
-  %204 = getelementptr %array, %array* %180, i32 0, i32 2
-  %205 = load %dimension_descriptor*, %dimension_descriptor** %204, align 8
-  %206 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %205, i32 0
-  %207 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 1
-  %208 = load i32, i32* %207, align 4
-  %209 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 2
-  %210 = load i32, i32* %209, align 4
-  %211 = sub i32 1, %208
-  %212 = add i32 %208, %210
-  %213 = sub i32 %212, 1
-  %214 = icmp slt i32 1, %208
-  %215 = icmp sgt i32 1, %213
-  %216 = or i1 %214, %215
-  br i1 %216, label %then19, label %ifcont20
+  %205 = getelementptr %array, %array* %181, i32 0, i32 2
+  %206 = load %dimension_descriptor*, %dimension_descriptor** %205, align 8
+  %207 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %206, i32 0
+  %208 = getelementptr %dimension_descriptor, %dimension_descriptor* %207, i32 0, i32 1
+  %209 = load i32, i32* %208, align 4
+  %210 = getelementptr %dimension_descriptor, %dimension_descriptor* %207, i32 0, i32 2
+  %211 = load i32, i32* %210, align 4
+  %212 = sub i32 1, %209
+  %213 = add i32 %209, %211
+  %214 = sub i32 %213, 1
+  %215 = icmp slt i32 1, %209
+  %216 = icmp sgt i32 1, %214
+  %217 = or i1 %215, %216
+  br i1 %217, label %then19, label %ifcont20
 
 then19:                                           ; preds = %ifcont18
-  %217 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %218 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %219 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %218, i32 0, i32 0
-  %220 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %219, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @189, i32 0, i32 0), i8** %220, align 8
-  %221 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %219, i32 0, i32 1
-  store i32 13, i32* %221, align 4
-  %222 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %219, i32 0, i32 2
-  store i32 9, i32* %222, align 4
-  %223 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %219, i32 0, i32 3
-  store i32 13, i32* %223, align 4
-  %224 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %219, i32 0, i32 4
-  store i32 18, i32* %224, align 4
-  %225 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @190, i32 0, i32 0))
-  %226 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %217, i32 0, i32 0
-  %227 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %218, i32 0, i32 0
-  %228 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %226, i32 0, i32 2
-  %229 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %226, i32 0, i32 0
-  store i1 true, i1* %229, align 1
-  %230 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %226, i32 0, i32 1
-  store i8* %225, i8** %230, align 8
-  store { i8*, i32, i32, i32, i32 }* %227, { i8*, i32, i32, i32, i32 }** %228, align 8
-  %231 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %226, i32 0, i32 3
-  store i32 1, i32* %231, align 4
-  %232 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %217, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %232, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @191, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @188, i32 0, i32 0), i32 1, i32 1, i32 %208, i32 %213)
+  %218 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %219 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %220 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %219, i32 0, i32 0
+  %221 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %220, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @189, i32 0, i32 0), i8** %221, align 8
+  %222 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %220, i32 0, i32 1
+  store i32 13, i32* %222, align 4
+  %223 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %220, i32 0, i32 2
+  store i32 9, i32* %223, align 4
+  %224 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %220, i32 0, i32 3
+  store i32 13, i32* %224, align 4
+  %225 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %220, i32 0, i32 4
+  store i32 18, i32* %225, align 4
+  %226 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @190, i32 0, i32 0))
+  %227 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %218, i32 0, i32 0
+  %228 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %219, i32 0, i32 0
+  %229 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %227, i32 0, i32 2
+  %230 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %227, i32 0, i32 0
+  store i1 true, i1* %230, align 1
+  %231 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %227, i32 0, i32 1
+  store i8* %226, i8** %231, align 8
+  store { i8*, i32, i32, i32, i32 }* %228, { i8*, i32, i32, i32, i32 }** %229, align 8
+  %232 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %227, i32 0, i32 3
+  store i32 1, i32* %232, align 4
+  %233 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %218, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %233, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @191, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @188, i32 0, i32 0), i32 1, i32 1, i32 %209, i32 %214)
   call void @exit(i32 1)
   unreachable
 
 ifcont20:                                         ; preds = %ifcont18
-  %233 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 0
-  %234 = load i32, i32* %233, align 4
-  %235 = mul i32 %234, %211
-  %236 = add i32 0, %235
-  %237 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %205, i32 1
-  %238 = getelementptr %dimension_descriptor, %dimension_descriptor* %237, i32 0, i32 1
-  %239 = load i32, i32* %238, align 4
-  %240 = getelementptr %dimension_descriptor, %dimension_descriptor* %237, i32 0, i32 2
-  %241 = load i32, i32* %240, align 4
-  %242 = sub i32 1, %239
-  %243 = add i32 %239, %241
-  %244 = sub i32 %243, 1
-  %245 = icmp slt i32 1, %239
-  %246 = icmp sgt i32 1, %244
-  %247 = or i1 %245, %246
-  br i1 %247, label %then21, label %ifcont22
+  %234 = getelementptr %dimension_descriptor, %dimension_descriptor* %207, i32 0, i32 0
+  %235 = load i32, i32* %234, align 4
+  %236 = mul i32 %235, %212
+  %237 = add i32 0, %236
+  %238 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %206, i32 1
+  %239 = getelementptr %dimension_descriptor, %dimension_descriptor* %238, i32 0, i32 1
+  %240 = load i32, i32* %239, align 4
+  %241 = getelementptr %dimension_descriptor, %dimension_descriptor* %238, i32 0, i32 2
+  %242 = load i32, i32* %241, align 4
+  %243 = sub i32 1, %240
+  %244 = add i32 %240, %242
+  %245 = sub i32 %244, 1
+  %246 = icmp slt i32 1, %240
+  %247 = icmp sgt i32 1, %245
+  %248 = or i1 %246, %247
+  br i1 %248, label %then21, label %ifcont22
 
 then21:                                           ; preds = %ifcont20
-  %248 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %249 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %250 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %249, i32 0, i32 0
-  %251 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %250, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @193, i32 0, i32 0), i8** %251, align 8
-  %252 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %250, i32 0, i32 1
-  store i32 13, i32* %252, align 4
-  %253 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %250, i32 0, i32 2
-  store i32 9, i32* %253, align 4
-  %254 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %250, i32 0, i32 3
-  store i32 13, i32* %254, align 4
-  %255 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %250, i32 0, i32 4
-  store i32 18, i32* %255, align 4
-  %256 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @194, i32 0, i32 0))
-  %257 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %248, i32 0, i32 0
-  %258 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %249, i32 0, i32 0
-  %259 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %257, i32 0, i32 2
-  %260 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %257, i32 0, i32 0
-  store i1 true, i1* %260, align 1
-  %261 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %257, i32 0, i32 1
-  store i8* %256, i8** %261, align 8
-  store { i8*, i32, i32, i32, i32 }* %258, { i8*, i32, i32, i32, i32 }** %259, align 8
-  %262 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %257, i32 0, i32 3
-  store i32 1, i32* %262, align 4
-  %263 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %248, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %263, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @195, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @192, i32 0, i32 0), i32 1, i32 2, i32 %239, i32 %244)
+  %249 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %250 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %251 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %250, i32 0, i32 0
+  %252 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @193, i32 0, i32 0), i8** %252, align 8
+  %253 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 1
+  store i32 13, i32* %253, align 4
+  %254 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 2
+  store i32 9, i32* %254, align 4
+  %255 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 3
+  store i32 13, i32* %255, align 4
+  %256 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 4
+  store i32 18, i32* %256, align 4
+  %257 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @194, i32 0, i32 0))
+  %258 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %249, i32 0, i32 0
+  %259 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %250, i32 0, i32 0
+  %260 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 2
+  %261 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 0
+  store i1 true, i1* %261, align 1
+  %262 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 1
+  store i8* %257, i8** %262, align 8
+  store { i8*, i32, i32, i32, i32 }* %259, { i8*, i32, i32, i32, i32 }** %260, align 8
+  %263 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 3
+  store i32 1, i32* %263, align 4
+  %264 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %249, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %264, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @195, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @192, i32 0, i32 0), i32 1, i32 2, i32 %240, i32 %245)
   call void @exit(i32 1)
   unreachable
 
 ifcont22:                                         ; preds = %ifcont20
-  %264 = getelementptr %dimension_descriptor, %dimension_descriptor* %237, i32 0, i32 0
-  %265 = load i32, i32* %264, align 4
-  %266 = mul i32 %265, %242
-  %267 = add i32 %236, %266
-  %268 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %205, i32 2
-  %269 = getelementptr %dimension_descriptor, %dimension_descriptor* %268, i32 0, i32 1
-  %270 = load i32, i32* %269, align 4
-  %271 = getelementptr %dimension_descriptor, %dimension_descriptor* %268, i32 0, i32 2
-  %272 = load i32, i32* %271, align 4
-  %273 = sub i32 1, %270
-  %274 = add i32 %270, %272
-  %275 = sub i32 %274, 1
-  %276 = icmp slt i32 1, %270
-  %277 = icmp sgt i32 1, %275
-  %278 = or i1 %276, %277
-  br i1 %278, label %then23, label %ifcont24
+  %265 = getelementptr %dimension_descriptor, %dimension_descriptor* %238, i32 0, i32 0
+  %266 = load i32, i32* %265, align 4
+  %267 = mul i32 %266, %243
+  %268 = add i32 %237, %267
+  %269 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %206, i32 2
+  %270 = getelementptr %dimension_descriptor, %dimension_descriptor* %269, i32 0, i32 1
+  %271 = load i32, i32* %270, align 4
+  %272 = getelementptr %dimension_descriptor, %dimension_descriptor* %269, i32 0, i32 2
+  %273 = load i32, i32* %272, align 4
+  %274 = sub i32 1, %271
+  %275 = add i32 %271, %273
+  %276 = sub i32 %275, 1
+  %277 = icmp slt i32 1, %271
+  %278 = icmp sgt i32 1, %276
+  %279 = or i1 %277, %278
+  br i1 %279, label %then23, label %ifcont24
 
 then23:                                           ; preds = %ifcont22
-  %279 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %280 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %281 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %280, i32 0, i32 0
-  %282 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %281, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @197, i32 0, i32 0), i8** %282, align 8
-  %283 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %281, i32 0, i32 1
-  store i32 13, i32* %283, align 4
-  %284 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %281, i32 0, i32 2
-  store i32 9, i32* %284, align 4
-  %285 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %281, i32 0, i32 3
-  store i32 13, i32* %285, align 4
-  %286 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %281, i32 0, i32 4
-  store i32 18, i32* %286, align 4
-  %287 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @198, i32 0, i32 0))
-  %288 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %279, i32 0, i32 0
-  %289 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %280, i32 0, i32 0
-  %290 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %288, i32 0, i32 2
-  %291 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %288, i32 0, i32 0
-  store i1 true, i1* %291, align 1
-  %292 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %288, i32 0, i32 1
-  store i8* %287, i8** %292, align 8
-  store { i8*, i32, i32, i32, i32 }* %289, { i8*, i32, i32, i32, i32 }** %290, align 8
-  %293 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %288, i32 0, i32 3
-  store i32 1, i32* %293, align 4
-  %294 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %279, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %294, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @199, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @196, i32 0, i32 0), i32 1, i32 3, i32 %270, i32 %275)
+  %280 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %281 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %282 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %281, i32 0, i32 0
+  %283 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %282, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @197, i32 0, i32 0), i8** %283, align 8
+  %284 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %282, i32 0, i32 1
+  store i32 13, i32* %284, align 4
+  %285 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %282, i32 0, i32 2
+  store i32 9, i32* %285, align 4
+  %286 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %282, i32 0, i32 3
+  store i32 13, i32* %286, align 4
+  %287 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %282, i32 0, i32 4
+  store i32 18, i32* %287, align 4
+  %288 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @198, i32 0, i32 0))
+  %289 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %280, i32 0, i32 0
+  %290 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %281, i32 0, i32 0
+  %291 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %289, i32 0, i32 2
+  %292 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %289, i32 0, i32 0
+  store i1 true, i1* %292, align 1
+  %293 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %289, i32 0, i32 1
+  store i8* %288, i8** %293, align 8
+  store { i8*, i32, i32, i32, i32 }* %290, { i8*, i32, i32, i32, i32 }** %291, align 8
+  %294 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %289, i32 0, i32 3
+  store i32 1, i32* %294, align 4
+  %295 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %280, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %295, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @199, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @196, i32 0, i32 0), i32 1, i32 3, i32 %271, i32 %276)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %ifcont22
-  %295 = getelementptr %dimension_descriptor, %dimension_descriptor* %268, i32 0, i32 0
-  %296 = load i32, i32* %295, align 4
-  %297 = mul i32 %296, %273
-  %298 = add i32 %267, %297
-  %299 = getelementptr %array, %array* %180, i32 0, i32 1
-  %300 = load i32, i32* %299, align 4
-  %301 = add i32 %298, %300
-  %302 = getelementptr %array, %array* %180, i32 0, i32 0
-  %303 = load i32*, i32** %302, align 8
-  %304 = getelementptr inbounds i32, i32* %303, i32 %301
-  %305 = load i32, i32* %304, align 4
-  %306 = icmp ne i32 %305, 8
-  br i1 %306, label %then25, label %else26
+  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %269, i32 0, i32 0
+  %297 = load i32, i32* %296, align 4
+  %298 = mul i32 %297, %274
+  %299 = add i32 %268, %298
+  %300 = getelementptr %array, %array* %181, i32 0, i32 1
+  %301 = load i32, i32* %300, align 4
+  %302 = add i32 %299, %301
+  %303 = getelementptr %array, %array* %181, i32 0, i32 0
+  %304 = load i32*, i32** %303, align 8
+  %305 = getelementptr inbounds i32, i32* %304, i32 %302
+  %306 = load i32, i32* %305, align 4
+  %307 = icmp ne i32 %306, 8
+  br i1 %307, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @201, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @200, i32 0, i32 0))
@@ -764,7 +765,6 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %307 = alloca i64, align 8
   %308 = load %array*, %array** %c, align 8
   %309 = ptrtoint %array* %308 to i64
   %310 = icmp eq i64 %309, 0
@@ -968,8 +968,8 @@ ifcont38:                                         ; preds = %ifcont36
   %433 = load i32, i32* %432, align 4
   %434 = alloca i32, align 4
   store i32 %433, i32* %434, align 4
-  %435 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %307, i32 0, i32 0, i32* %434)
-  %436 = load i64, i64* %307, align 4
+  %435 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %434)
+  %436 = load i64, i64* %2, align 4
   %437 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %435, i8** %437, align 8
   %438 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -1371,435 +1371,436 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
 define i32 @g(%array** %x) {
 .entry:
   %stringFormat_desc31 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
-  %r = alloca i32, align 4
   %0 = alloca i64, align 8
-  %1 = load %array*, %array** %x, align 8
-  %2 = ptrtoint %array* %1 to i64
-  %3 = icmp eq i64 %2, 0
-  br i1 %3, label %merge_allocated, label %check_data
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %r = alloca i32, align 4
+  %2 = load %array*, %array** %x, align 8
+  %3 = ptrtoint %array* %2 to i64
+  %4 = icmp eq i64 %3, 0
+  br i1 %4, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %4 = getelementptr %array, %array* %1, i32 0, i32 0
-  %5 = load i32*, i32** %4, align 8
-  %6 = ptrtoint i32* %5 to i64
-  %7 = icmp ne i64 %6, 0
+  %5 = getelementptr %array, %array* %2, i32 0, i32 0
+  %6 = load i32*, i32** %5, align 8
+  %7 = ptrtoint i32* %6 to i64
+  %8 = icmp ne i64 %7, 0
   br label %merge_allocated
 
 merge_allocated:                                  ; preds = %check_data, %.entry
-  %is_allocated = phi i1 [ false, %.entry ], [ %7, %check_data ]
-  %8 = xor i1 %is_allocated, true
-  br i1 %8, label %then, label %ifcont
+  %is_allocated = phi i1 [ false, %.entry ], [ %8, %check_data ]
+  %9 = xor i1 %is_allocated, true
+  br i1 %9, label %then, label %ifcont
 
 then:                                             ; preds = %merge_allocated
-  %9 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %10 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %11 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %10, i32 0, i32 0
-  %12 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %11, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @22, i32 0, i32 0), i8** %12, align 8
-  %13 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %11, i32 0, i32 1
-  store i32 27, i32* %13, align 4
-  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %11, i32 0, i32 2
-  store i32 14, i32* %14, align 4
-  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %11, i32 0, i32 3
-  store i32 27, i32* %15, align 4
-  %16 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %11, i32 0, i32 4
-  store i32 23, i32* %16, align 4
-  %17 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @23, i32 0, i32 0))
-  %18 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %9, i32 0, i32 0
-  %19 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %10, i32 0, i32 0
-  %20 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %18, i32 0, i32 2
-  %21 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %18, i32 0, i32 0
-  store i1 true, i1* %21, align 1
-  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %18, i32 0, i32 1
-  store i8* %17, i8** %22, align 8
-  store { i8*, i32, i32, i32, i32 }* %19, { i8*, i32, i32, i32, i32 }** %20, align 8
-  %23 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %18, i32 0, i32 3
-  store i32 1, i32* %23, align 4
-  %24 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %9, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %24, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
+  %10 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %11 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %12 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %11, i32 0, i32 0
+  %13 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @22, i32 0, i32 0), i8** %13, align 8
+  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 1
+  store i32 27, i32* %14, align 4
+  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 2
+  store i32 14, i32* %15, align 4
+  %16 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 3
+  store i32 27, i32* %16, align 4
+  %17 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 4
+  store i32 23, i32* %17, align 4
+  %18 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @23, i32 0, i32 0))
+  %19 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %10, i32 0, i32 0
+  %20 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %11, i32 0, i32 0
+  %21 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 2
+  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 0
+  store i1 true, i1* %22, align 1
+  %23 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 1
+  store i8* %18, i8** %23, align 8
+  store { i8*, i32, i32, i32, i32 }* %20, { i8*, i32, i32, i32, i32 }** %21, align 8
+  %24 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 3
+  store i32 1, i32* %24, align 4
+  %25 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %10, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %merge_allocated
-  %25 = getelementptr %array, %array* %1, i32 0, i32 2
-  %26 = load %dimension_descriptor*, %dimension_descriptor** %25, align 8
-  %27 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %26, i32 0
-  %28 = getelementptr %dimension_descriptor, %dimension_descriptor* %27, i32 0, i32 1
-  %29 = load i32, i32* %28, align 4
-  %30 = getelementptr %dimension_descriptor, %dimension_descriptor* %27, i32 0, i32 2
-  %31 = load i32, i32* %30, align 4
-  %32 = sub i32 1, %29
-  %33 = add i32 %29, %31
-  %34 = sub i32 %33, 1
-  %35 = icmp slt i32 1, %29
-  %36 = icmp sgt i32 1, %34
-  %37 = or i1 %35, %36
-  br i1 %37, label %then1, label %ifcont2
+  %26 = getelementptr %array, %array* %2, i32 0, i32 2
+  %27 = load %dimension_descriptor*, %dimension_descriptor** %26, align 8
+  %28 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 0
+  %29 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 1
+  %30 = load i32, i32* %29, align 4
+  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 2
+  %32 = load i32, i32* %31, align 4
+  %33 = sub i32 1, %30
+  %34 = add i32 %30, %32
+  %35 = sub i32 %34, 1
+  %36 = icmp slt i32 1, %30
+  %37 = icmp sgt i32 1, %35
+  %38 = or i1 %36, %37
+  br i1 %38, label %then1, label %ifcont2
 
 then1:                                            ; preds = %ifcont
-  %38 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %39 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %40 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %39, i32 0, i32 0
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @26, i32 0, i32 0), i8** %41, align 8
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 1
-  store i32 27, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 2
-  store i32 14, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 3
-  store i32 27, i32* %44, align 4
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 4
-  store i32 23, i32* %45, align 4
-  %46 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @27, i32 0, i32 0))
-  %47 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %38, i32 0, i32 0
-  %48 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %39, i32 0, i32 0
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 2
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 0
-  store i1 true, i1* %50, align 1
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 1
-  store i8* %46, i8** %51, align 8
-  store { i8*, i32, i32, i32, i32 }* %48, { i8*, i32, i32, i32, i32 }** %49, align 8
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 3
-  store i32 1, i32* %52, align 4
-  %53 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %38, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0), i32 1, i32 1, i32 %29, i32 %34)
+  %39 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %40 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %41 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
+  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @26, i32 0, i32 0), i8** %42, align 8
+  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 1
+  store i32 27, i32* %43, align 4
+  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 2
+  store i32 14, i32* %44, align 4
+  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 3
+  store i32 27, i32* %45, align 4
+  %46 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 4
+  store i32 23, i32* %46, align 4
+  %47 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @27, i32 0, i32 0))
+  %48 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
+  %49 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
+  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 2
+  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 0
+  store i1 true, i1* %51, align 1
+  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 1
+  store i8* %47, i8** %52, align 8
+  store { i8*, i32, i32, i32, i32 }* %49, { i8*, i32, i32, i32, i32 }** %50, align 8
+  %53 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 3
+  store i32 1, i32* %53, align 4
+  %54 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0), i32 1, i32 1, i32 %30, i32 %35)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %54 = getelementptr %dimension_descriptor, %dimension_descriptor* %27, i32 0, i32 0
-  %55 = load i32, i32* %54, align 4
-  %56 = mul i32 %55, %32
-  %57 = add i32 0, %56
-  %58 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %26, i32 1
-  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 1
-  %60 = load i32, i32* %59, align 4
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 2
-  %62 = load i32, i32* %61, align 4
-  %63 = sub i32 1, %60
-  %64 = add i32 %60, %62
-  %65 = sub i32 %64, 1
-  %66 = icmp slt i32 1, %60
-  %67 = icmp sgt i32 1, %65
-  %68 = or i1 %66, %67
-  br i1 %68, label %then3, label %ifcont4
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 0
+  %56 = load i32, i32* %55, align 4
+  %57 = mul i32 %56, %33
+  %58 = add i32 0, %57
+  %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 1
+  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
+  %61 = load i32, i32* %60, align 4
+  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 2
+  %63 = load i32, i32* %62, align 4
+  %64 = sub i32 1, %61
+  %65 = add i32 %61, %63
+  %66 = sub i32 %65, 1
+  %67 = icmp slt i32 1, %61
+  %68 = icmp sgt i32 1, %66
+  %69 = or i1 %67, %68
+  br i1 %69, label %then3, label %ifcont4
 
 then3:                                            ; preds = %ifcont2
-  %69 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %70 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %71 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %70, i32 0, i32 0
-  %72 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @30, i32 0, i32 0), i8** %72, align 8
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 1
-  store i32 27, i32* %73, align 4
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 2
-  store i32 14, i32* %74, align 4
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 3
-  store i32 27, i32* %75, align 4
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 4
-  store i32 23, i32* %76, align 4
-  %77 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @31, i32 0, i32 0))
-  %78 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %69, i32 0, i32 0
-  %79 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %70, i32 0, i32 0
-  %80 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 2
-  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 0
-  store i1 true, i1* %81, align 1
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 1
-  store i8* %77, i8** %82, align 8
-  store { i8*, i32, i32, i32, i32 }* %79, { i8*, i32, i32, i32, i32 }** %80, align 8
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 3
-  store i32 1, i32* %83, align 4
-  %84 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %69, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %84, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0), i32 1, i32 2, i32 %60, i32 %65)
+  %70 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %71 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %72 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
+  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @30, i32 0, i32 0), i8** %73, align 8
+  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 1
+  store i32 27, i32* %74, align 4
+  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 2
+  store i32 14, i32* %75, align 4
+  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 3
+  store i32 27, i32* %76, align 4
+  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 4
+  store i32 23, i32* %77, align 4
+  %78 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @31, i32 0, i32 0))
+  %79 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
+  %80 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
+  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 2
+  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 0
+  store i1 true, i1* %82, align 1
+  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 1
+  store i8* %78, i8** %83, align 8
+  store { i8*, i32, i32, i32, i32 }* %80, { i8*, i32, i32, i32, i32 }** %81, align 8
+  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 3
+  store i32 1, i32* %84, align 4
+  %85 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %85, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0), i32 1, i32 2, i32 %61, i32 %66)
   call void @exit(i32 1)
   unreachable
 
 ifcont4:                                          ; preds = %ifcont2
-  %85 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 0
-  %86 = load i32, i32* %85, align 4
-  %87 = mul i32 %86, %63
-  %88 = add i32 %57, %87
-  %89 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %26, i32 2
-  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 1
-  %91 = load i32, i32* %90, align 4
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 2
-  %93 = load i32, i32* %92, align 4
-  %94 = sub i32 1, %91
-  %95 = add i32 %91, %93
-  %96 = sub i32 %95, 1
-  %97 = icmp slt i32 1, %91
-  %98 = icmp sgt i32 1, %96
-  %99 = or i1 %97, %98
-  br i1 %99, label %then5, label %ifcont6
+  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
+  %87 = load i32, i32* %86, align 4
+  %88 = mul i32 %87, %64
+  %89 = add i32 %58, %88
+  %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 2
+  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
+  %92 = load i32, i32* %91, align 4
+  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
+  %94 = load i32, i32* %93, align 4
+  %95 = sub i32 1, %92
+  %96 = add i32 %92, %94
+  %97 = sub i32 %96, 1
+  %98 = icmp slt i32 1, %92
+  %99 = icmp sgt i32 1, %97
+  %100 = or i1 %98, %99
+  br i1 %100, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %100 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %101 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %102 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %101, i32 0, i32 0
-  %103 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %102, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @34, i32 0, i32 0), i8** %103, align 8
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %102, i32 0, i32 1
-  store i32 27, i32* %104, align 4
-  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %102, i32 0, i32 2
-  store i32 14, i32* %105, align 4
-  %106 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %102, i32 0, i32 3
-  store i32 27, i32* %106, align 4
-  %107 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %102, i32 0, i32 4
-  store i32 23, i32* %107, align 4
-  %108 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @35, i32 0, i32 0))
-  %109 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %100, i32 0, i32 0
-  %110 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %101, i32 0, i32 0
-  %111 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %109, i32 0, i32 2
-  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %109, i32 0, i32 0
-  store i1 true, i1* %112, align 1
-  %113 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %109, i32 0, i32 1
-  store i8* %108, i8** %113, align 8
-  store { i8*, i32, i32, i32, i32 }* %110, { i8*, i32, i32, i32, i32 }** %111, align 8
-  %114 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %109, i32 0, i32 3
-  store i32 1, i32* %114, align 4
-  %115 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %100, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 3, i32 %91, i32 %96)
+  %101 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %102 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %103 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
+  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @34, i32 0, i32 0), i8** %104, align 8
+  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 1
+  store i32 27, i32* %105, align 4
+  %106 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 2
+  store i32 14, i32* %106, align 4
+  %107 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 3
+  store i32 27, i32* %107, align 4
+  %108 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 4
+  store i32 23, i32* %108, align 4
+  %109 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @35, i32 0, i32 0))
+  %110 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
+  %111 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
+  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 2
+  %113 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 0
+  store i1 true, i1* %113, align 1
+  %114 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 1
+  store i8* %109, i8** %114, align 8
+  store { i8*, i32, i32, i32, i32 }* %111, { i8*, i32, i32, i32, i32 }** %112, align 8
+  %115 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 3
+  store i32 1, i32* %115, align 4
+  %116 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i32 1, i32 3, i32 %92, i32 %97)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %116 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 0
-  %117 = load i32, i32* %116, align 4
-  %118 = mul i32 %117, %94
-  %119 = add i32 %88, %118
-  %120 = getelementptr %array, %array* %1, i32 0, i32 1
-  %121 = load i32, i32* %120, align 4
-  %122 = add i32 %119, %121
-  %123 = getelementptr %array, %array* %1, i32 0, i32 0
-  %124 = load i32*, i32** %123, align 8
-  %125 = getelementptr inbounds i32, i32* %124, i32 %122
-  %126 = load i32, i32* %125, align 4
-  %127 = alloca i32, align 4
-  store i32 %126, i32* %127, align 4
-  %128 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %127)
-  %129 = load i64, i64* %0, align 4
-  %130 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %128, i8** %130, align 8
-  %131 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %129, i64* %131, align 4
-  %132 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %133 = load i8*, i8** %132, align 8
-  %134 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %135 = load i64, i64* %134, align 4
-  %136 = trunc i64 %135 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %133, i32 %136, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
-  %137 = icmp eq i8* %128, null
-  br i1 %137, label %free_done, label %free_nonnull
+  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
+  %118 = load i32, i32* %117, align 4
+  %119 = mul i32 %118, %95
+  %120 = add i32 %89, %119
+  %121 = getelementptr %array, %array* %2, i32 0, i32 1
+  %122 = load i32, i32* %121, align 4
+  %123 = add i32 %120, %122
+  %124 = getelementptr %array, %array* %2, i32 0, i32 0
+  %125 = load i32*, i32** %124, align 8
+  %126 = getelementptr inbounds i32, i32* %125, i32 %123
+  %127 = load i32, i32* %126, align 4
+  %128 = alloca i32, align 4
+  store i32 %127, i32* %128, align 4
+  %129 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* %128)
+  %130 = load i64, i64* %1, align 4
+  %131 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %129, i8** %131, align 8
+  %132 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %130, i64* %132, align 4
+  %133 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %134 = load i8*, i8** %133, align 8
+  %135 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %136 = load i64, i64* %135, align 4
+  %137 = trunc i64 %136 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %134, i32 %137, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  %138 = icmp eq i8* %129, null
+  br i1 %138, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont6
-  call void @_lfortran_free(i8* %128)
+  call void @_lfortran_free(i8* %129)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
-  %138 = load %array*, %array** %x, align 8
-  %139 = ptrtoint %array* %138 to i64
-  %140 = icmp eq i64 %139, 0
-  br i1 %140, label %merge_allocated8, label %check_data7
+  %139 = load %array*, %array** %x, align 8
+  %140 = ptrtoint %array* %139 to i64
+  %141 = icmp eq i64 %140, 0
+  br i1 %141, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %free_done
-  %141 = getelementptr %array, %array* %138, i32 0, i32 0
-  %142 = load i32*, i32** %141, align 8
-  %143 = ptrtoint i32* %142 to i64
-  %144 = icmp ne i64 %143, 0
+  %142 = getelementptr %array, %array* %139, i32 0, i32 0
+  %143 = load i32*, i32** %142, align 8
+  %144 = ptrtoint i32* %143 to i64
+  %145 = icmp ne i64 %144, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %free_done
-  %is_allocated9 = phi i1 [ false, %free_done ], [ %144, %check_data7 ]
-  %145 = xor i1 %is_allocated9, true
-  br i1 %145, label %then10, label %ifcont11
+  %is_allocated9 = phi i1 [ false, %free_done ], [ %145, %check_data7 ]
+  %146 = xor i1 %is_allocated9, true
+  br i1 %146, label %then10, label %ifcont11
 
 then10:                                           ; preds = %merge_allocated8
-  %146 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %147 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %148 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %147, i32 0, i32 0
-  %149 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %148, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @39, i32 0, i32 0), i8** %149, align 8
-  %150 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %148, i32 0, i32 1
-  store i32 28, i32* %150, align 4
-  %151 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %148, i32 0, i32 2
-  store i32 9, i32* %151, align 4
-  %152 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %148, i32 0, i32 3
-  store i32 28, i32* %152, align 4
-  %153 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %148, i32 0, i32 4
-  store i32 18, i32* %153, align 4
-  %154 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %155 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %146, i32 0, i32 0
-  %156 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %147, i32 0, i32 0
-  %157 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 0, i32 2
-  %158 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 0, i32 0
-  store i1 true, i1* %158, align 1
-  %159 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 0, i32 1
-  store i8* %154, i8** %159, align 8
-  store { i8*, i32, i32, i32, i32 }* %156, { i8*, i32, i32, i32, i32 }** %157, align 8
-  %160 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 0, i32 3
-  store i32 1, i32* %160, align 4
-  %161 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %146, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %161, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
+  %147 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %148 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %149 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %148, i32 0, i32 0
+  %150 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @39, i32 0, i32 0), i8** %150, align 8
+  %151 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 1
+  store i32 28, i32* %151, align 4
+  %152 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 2
+  store i32 9, i32* %152, align 4
+  %153 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 3
+  store i32 28, i32* %153, align 4
+  %154 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 4
+  store i32 18, i32* %154, align 4
+  %155 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
+  %156 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %147, i32 0, i32 0
+  %157 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %148, i32 0, i32 0
+  %158 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 2
+  %159 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 0
+  store i1 true, i1* %159, align 1
+  %160 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 1
+  store i8* %155, i8** %160, align 8
+  store { i8*, i32, i32, i32, i32 }* %157, { i8*, i32, i32, i32, i32 }** %158, align 8
+  %161 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 3
+  store i32 1, i32* %161, align 4
+  %162 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %147, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %merge_allocated8
-  %162 = getelementptr %array, %array* %138, i32 0, i32 2
-  %163 = load %dimension_descriptor*, %dimension_descriptor** %162, align 8
-  %164 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 0
-  %165 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 1
-  %166 = load i32, i32* %165, align 4
-  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 2
-  %168 = load i32, i32* %167, align 4
-  %169 = sub i32 1, %166
-  %170 = add i32 %166, %168
-  %171 = sub i32 %170, 1
-  %172 = icmp slt i32 1, %166
-  %173 = icmp sgt i32 1, %171
-  %174 = or i1 %172, %173
-  br i1 %174, label %then12, label %ifcont13
+  %163 = getelementptr %array, %array* %139, i32 0, i32 2
+  %164 = load %dimension_descriptor*, %dimension_descriptor** %163, align 8
+  %165 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 0
+  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 1
+  %167 = load i32, i32* %166, align 4
+  %168 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 2
+  %169 = load i32, i32* %168, align 4
+  %170 = sub i32 1, %167
+  %171 = add i32 %167, %169
+  %172 = sub i32 %171, 1
+  %173 = icmp slt i32 1, %167
+  %174 = icmp sgt i32 1, %172
+  %175 = or i1 %173, %174
+  br i1 %175, label %then12, label %ifcont13
 
 then12:                                           ; preds = %ifcont11
-  %175 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %176 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %177 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %176, i32 0, i32 0
-  %178 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %177, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @43, i32 0, i32 0), i8** %178, align 8
-  %179 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %177, i32 0, i32 1
-  store i32 28, i32* %179, align 4
-  %180 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %177, i32 0, i32 2
-  store i32 9, i32* %180, align 4
-  %181 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %177, i32 0, i32 3
-  store i32 28, i32* %181, align 4
-  %182 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %177, i32 0, i32 4
-  store i32 18, i32* %182, align 4
-  %183 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @44, i32 0, i32 0))
-  %184 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %175, i32 0, i32 0
-  %185 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %176, i32 0, i32 0
-  %186 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %184, i32 0, i32 2
-  %187 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %184, i32 0, i32 0
-  store i1 true, i1* %187, align 1
-  %188 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %184, i32 0, i32 1
-  store i8* %183, i8** %188, align 8
-  store { i8*, i32, i32, i32, i32 }* %185, { i8*, i32, i32, i32, i32 }** %186, align 8
-  %189 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %184, i32 0, i32 3
-  store i32 1, i32* %189, align 4
-  %190 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %175, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %166, i32 %171)
+  %176 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %177 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %178 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
+  %179 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @43, i32 0, i32 0), i8** %179, align 8
+  %180 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 1
+  store i32 28, i32* %180, align 4
+  %181 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 2
+  store i32 9, i32* %181, align 4
+  %182 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 3
+  store i32 28, i32* %182, align 4
+  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 4
+  store i32 18, i32* %183, align 4
+  %184 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @44, i32 0, i32 0))
+  %185 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
+  %186 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
+  %187 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 2
+  %188 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 0
+  store i1 true, i1* %188, align 1
+  %189 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 1
+  store i8* %184, i8** %189, align 8
+  store { i8*, i32, i32, i32, i32 }* %186, { i8*, i32, i32, i32, i32 }** %187, align 8
+  %190 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 3
+  store i32 1, i32* %190, align 4
+  %191 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %191, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1, i32 1, i32 %167, i32 %172)
   call void @exit(i32 1)
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %191 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 0
-  %192 = load i32, i32* %191, align 4
-  %193 = mul i32 %192, %169
-  %194 = add i32 0, %193
-  %195 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 1
-  %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %195, i32 0, i32 1
-  %197 = load i32, i32* %196, align 4
-  %198 = getelementptr %dimension_descriptor, %dimension_descriptor* %195, i32 0, i32 2
-  %199 = load i32, i32* %198, align 4
-  %200 = sub i32 1, %197
-  %201 = add i32 %197, %199
-  %202 = sub i32 %201, 1
-  %203 = icmp slt i32 1, %197
-  %204 = icmp sgt i32 1, %202
-  %205 = or i1 %203, %204
-  br i1 %205, label %then14, label %ifcont15
+  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 0
+  %193 = load i32, i32* %192, align 4
+  %194 = mul i32 %193, %170
+  %195 = add i32 0, %194
+  %196 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 1
+  %197 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 1
+  %198 = load i32, i32* %197, align 4
+  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 2
+  %200 = load i32, i32* %199, align 4
+  %201 = sub i32 1, %198
+  %202 = add i32 %198, %200
+  %203 = sub i32 %202, 1
+  %204 = icmp slt i32 1, %198
+  %205 = icmp sgt i32 1, %203
+  %206 = or i1 %204, %205
+  br i1 %206, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  %206 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %207 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %208 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %207, i32 0, i32 0
-  %209 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @47, i32 0, i32 0), i8** %209, align 8
-  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 1
-  store i32 28, i32* %210, align 4
-  %211 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 2
-  store i32 9, i32* %211, align 4
-  %212 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 3
-  store i32 28, i32* %212, align 4
-  %213 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 4
-  store i32 18, i32* %213, align 4
-  %214 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @48, i32 0, i32 0))
-  %215 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %206, i32 0, i32 0
-  %216 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %207, i32 0, i32 0
-  %217 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 2
-  %218 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 0
-  store i1 true, i1* %218, align 1
-  %219 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 1
-  store i8* %214, i8** %219, align 8
-  store { i8*, i32, i32, i32, i32 }* %216, { i8*, i32, i32, i32, i32 }** %217, align 8
-  %220 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 3
-  store i32 1, i32* %220, align 4
-  %221 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %206, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %221, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 2, i32 %197, i32 %202)
+  %207 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %208 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %209 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %208, i32 0, i32 0
+  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @47, i32 0, i32 0), i8** %210, align 8
+  %211 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 1
+  store i32 28, i32* %211, align 4
+  %212 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 2
+  store i32 9, i32* %212, align 4
+  %213 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 3
+  store i32 28, i32* %213, align 4
+  %214 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 4
+  store i32 18, i32* %214, align 4
+  %215 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @48, i32 0, i32 0))
+  %216 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %207, i32 0, i32 0
+  %217 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %208, i32 0, i32 0
+  %218 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 2
+  %219 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 0
+  store i1 true, i1* %219, align 1
+  %220 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 1
+  store i8* %215, i8** %220, align 8
+  store { i8*, i32, i32, i32, i32 }* %217, { i8*, i32, i32, i32, i32 }** %218, align 8
+  %221 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 3
+  store i32 1, i32* %221, align 4
+  %222 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %207, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1, i32 2, i32 %198, i32 %203)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %222 = getelementptr %dimension_descriptor, %dimension_descriptor* %195, i32 0, i32 0
-  %223 = load i32, i32* %222, align 4
-  %224 = mul i32 %223, %200
-  %225 = add i32 %194, %224
-  %226 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 2
-  %227 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 1
-  %228 = load i32, i32* %227, align 4
-  %229 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 2
-  %230 = load i32, i32* %229, align 4
-  %231 = sub i32 1, %228
-  %232 = add i32 %228, %230
-  %233 = sub i32 %232, 1
-  %234 = icmp slt i32 1, %228
-  %235 = icmp sgt i32 1, %233
-  %236 = or i1 %234, %235
-  br i1 %236, label %then16, label %ifcont17
+  %223 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 0
+  %224 = load i32, i32* %223, align 4
+  %225 = mul i32 %224, %201
+  %226 = add i32 %195, %225
+  %227 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 2
+  %228 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 1
+  %229 = load i32, i32* %228, align 4
+  %230 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 2
+  %231 = load i32, i32* %230, align 4
+  %232 = sub i32 1, %229
+  %233 = add i32 %229, %231
+  %234 = sub i32 %233, 1
+  %235 = icmp slt i32 1, %229
+  %236 = icmp sgt i32 1, %234
+  %237 = or i1 %235, %236
+  br i1 %237, label %then16, label %ifcont17
 
 then16:                                           ; preds = %ifcont15
-  %237 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %238 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %239 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %238, i32 0, i32 0
-  %240 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @51, i32 0, i32 0), i8** %240, align 8
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 1
-  store i32 28, i32* %241, align 4
-  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 2
-  store i32 9, i32* %242, align 4
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 3
-  store i32 28, i32* %243, align 4
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 4
-  store i32 18, i32* %244, align 4
-  %245 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
-  %246 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %237, i32 0, i32 0
-  %247 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %238, i32 0, i32 0
-  %248 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 2
-  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 0
-  store i1 true, i1* %249, align 1
-  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 1
-  store i8* %245, i8** %250, align 8
-  store { i8*, i32, i32, i32, i32 }* %247, { i8*, i32, i32, i32, i32 }** %248, align 8
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 3
-  store i32 1, i32* %251, align 4
-  %252 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %237, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %252, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i32 1, i32 3, i32 %228, i32 %233)
+  %238 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %239 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %240 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
+  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @51, i32 0, i32 0), i8** %241, align 8
+  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 1
+  store i32 28, i32* %242, align 4
+  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 2
+  store i32 9, i32* %243, align 4
+  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 3
+  store i32 28, i32* %244, align 4
+  %245 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 4
+  store i32 18, i32* %245, align 4
+  %246 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
+  %247 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
+  %248 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
+  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 2
+  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 0
+  store i1 true, i1* %250, align 1
+  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 1
+  store i8* %246, i8** %251, align 8
+  store { i8*, i32, i32, i32, i32 }* %248, { i8*, i32, i32, i32, i32 }** %249, align 8
+  %252 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 3
+  store i32 1, i32* %252, align 4
+  %253 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i32 1, i32 3, i32 %229, i32 %234)
   call void @exit(i32 1)
   unreachable
 
 ifcont17:                                         ; preds = %ifcont15
-  %253 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 0
-  %254 = load i32, i32* %253, align 4
-  %255 = mul i32 %254, %231
-  %256 = add i32 %225, %255
-  %257 = getelementptr %array, %array* %138, i32 0, i32 1
-  %258 = load i32, i32* %257, align 4
-  %259 = add i32 %256, %258
-  %260 = getelementptr %array, %array* %138, i32 0, i32 0
-  %261 = load i32*, i32** %260, align 8
-  %262 = getelementptr inbounds i32, i32* %261, i32 %259
-  %263 = load i32, i32* %262, align 4
-  %264 = icmp ne i32 %263, 8
-  br i1 %264, label %then18, label %else
+  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 0
+  %255 = load i32, i32* %254, align 4
+  %256 = mul i32 %255, %232
+  %257 = add i32 %226, %256
+  %258 = getelementptr %array, %array* %139, i32 0, i32 1
+  %259 = load i32, i32* %258, align 4
+  %260 = add i32 %257, %259
+  %261 = getelementptr %array, %array* %139, i32 0, i32 0
+  %262 = load i32*, i32** %261, align 8
+  %263 = getelementptr inbounds i32, i32* %262, i32 %260
+  %264 = load i32, i32* %263, align 4
+  %265 = icmp ne i32 %264, 8
+  br i1 %265, label %then18, label %else
 
 then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
@@ -1811,7 +1812,6 @@ else:                                             ; preds = %ifcont17
 
 ifcont19:                                         ; preds = %else, %then18
   call void @f(%array** %x)
-  %265 = alloca i64, align 8
   %266 = load %array*, %array** %x, align 8
   %267 = ptrtoint %array* %266 to i64
   %268 = icmp eq i64 %267, 0
@@ -2015,8 +2015,8 @@ ifcont30:                                         ; preds = %ifcont28
   %391 = load i32, i32* %390, align 4
   %392 = alloca i32, align 4
   store i32 %391, i32* %392, align 4
-  %393 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %265, i32 0, i32 0, i32* %392)
-  %394 = load i64, i64* %265, align 4
+  %393 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %392)
+  %394 = load i64, i64* %0, align 4
   %395 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
   store i8* %393, i8** %395, align 8
   %396 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
@@ -2463,47 +2463,48 @@ FINALIZE_SYMTABLE_g:                              ; preds = %return
 define void @h(%array** %c) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = load %array*, %array** %c, align 8
+  %0 = alloca i64, align 8
   %1 = load %array*, %array** %c, align 8
-  %2 = ptrtoint %array* %1 to i64
-  %3 = icmp eq i64 %2, 0
-  br i1 %3, label %merge_allocated, label %check_data
+  %2 = load %array*, %array** %c, align 8
+  %3 = ptrtoint %array* %2 to i64
+  %4 = icmp eq i64 %3, 0
+  br i1 %4, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %4 = getelementptr %array, %array* %1, i32 0, i32 0
-  %5 = load i32*, i32** %4, align 8
-  %6 = ptrtoint i32* %5 to i64
-  %7 = icmp ne i64 %6, 0
+  %5 = getelementptr %array, %array* %2, i32 0, i32 0
+  %6 = load i32*, i32** %5, align 8
+  %7 = ptrtoint i32* %6 to i64
+  %8 = icmp ne i64 %7, 0
   br label %merge_allocated
 
 merge_allocated:                                  ; preds = %check_data, %.entry
-  %is_allocated = phi i1 [ false, %.entry ], [ %7, %check_data ]
+  %is_allocated = phi i1 [ false, %.entry ], [ %8, %check_data ]
   br i1 %is_allocated, label %then, label %else5
 
 then:                                             ; preds = %merge_allocated
-  %8 = load %array*, %array** %c, align 8
-  %9 = ptrtoint %array* %8 to i64
-  %10 = icmp eq i64 %9, 0
-  br i1 %10, label %merge_allocated2, label %check_data1
+  %9 = load %array*, %array** %c, align 8
+  %10 = ptrtoint %array* %9 to i64
+  %11 = icmp eq i64 %10, 0
+  br i1 %11, label %merge_allocated2, label %check_data1
 
 check_data1:                                      ; preds = %then
-  %11 = getelementptr %array, %array* %8, i32 0, i32 0
-  %12 = load i32*, i32** %11, align 8
-  %13 = ptrtoint i32* %12 to i64
-  %14 = icmp ne i64 %13, 0
+  %12 = getelementptr %array, %array* %9, i32 0, i32 0
+  %13 = load i32*, i32** %12, align 8
+  %14 = ptrtoint i32* %13 to i64
+  %15 = icmp ne i64 %14, 0
   br label %merge_allocated2
 
 merge_allocated2:                                 ; preds = %check_data1, %then
-  %is_allocated3 = phi i1 [ false, %then ], [ %14, %check_data1 ]
+  %is_allocated3 = phi i1 [ false, %then ], [ %15, %check_data1 ]
   br i1 %is_allocated3, label %then4, label %else
 
 then4:                                            ; preds = %merge_allocated2
-  %15 = getelementptr %array, %array* %8, i32 0, i32 0
-  %16 = load i32*, i32** %15, align 8
-  %17 = bitcast i32* %16 to i8*
-  call void @_lfortran_free(i8* %17)
-  %18 = getelementptr %array, %array* %8, i32 0, i32 0
-  store i32* null, i32** %18, align 8
+  %16 = getelementptr %array, %array* %9, i32 0, i32 0
+  %17 = load i32*, i32** %16, align 8
+  %18 = bitcast i32* %17 to i8*
+  call void @_lfortran_free(i8* %18)
+  %19 = getelementptr %array, %array* %9, i32 0, i32 0
+  store i32* null, i32** %19, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated2
@@ -2516,21 +2517,21 @@ else5:                                            ; preds = %merge_allocated
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont
-  %19 = load %array*, %array** %c, align 8
   %20 = load %array*, %array** %c, align 8
-  %21 = ptrtoint %array* %20 to i64
-  %22 = icmp eq i64 %21, 0
-  br i1 %22, label %merge_allocated8, label %check_data7
+  %21 = load %array*, %array** %c, align 8
+  %22 = ptrtoint %array* %21 to i64
+  %23 = icmp eq i64 %22, 0
+  br i1 %23, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %ifcont6
-  %23 = getelementptr %array, %array* %20, i32 0, i32 0
-  %24 = load i32*, i32** %23, align 8
-  %25 = ptrtoint i32* %24 to i64
-  %26 = icmp ne i64 %25, 0
+  %24 = getelementptr %array, %array* %21, i32 0, i32 0
+  %25 = load i32*, i32** %24, align 8
+  %26 = ptrtoint i32* %25 to i64
+  %27 = icmp ne i64 %26, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %26, %check_data7 ]
+  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %27, %check_data7 ]
   br i1 %is_allocated9, label %then10, label %else11
 
 then10:                                           ; preds = %merge_allocated8
@@ -2543,7 +2544,6 @@ else11:                                           ; preds = %merge_allocated8
 
 ifcont12:                                         ; preds = %else11, %then10
   call void @f(%array** %c)
-  %27 = alloca i64, align 8
   %28 = load %array*, %array** %c, align 8
   %29 = ptrtoint %array* %28 to i64
   %30 = icmp eq i64 %29, 0
@@ -2747,8 +2747,8 @@ ifcont23:                                         ; preds = %ifcont21
   %153 = load i32, i32* %152, align 4
   %154 = alloca i32, align 4
   store i32 %153, i32* %154, align 4
-  %155 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %154)
-  %156 = load i64, i64* %27, align 4
+  %155 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %154)
+  %156 = load i64, i64* %0, align 4
   %157 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %155, i8** %157, align 8
   %158 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -1,9 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%string_descriptor = type <{ i8*, i64 }>
 %array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
-%string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"c\00", align 1
 @1 = private unnamed_addr constant [43 x i8] c"tests/../integration_tests/allocate_03.f90\00", align 1
@@ -233,6 +233,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca %array*, align 8
   store %array* null, %array** %c, align 8
@@ -969,7 +970,6 @@ ifcont38:                                         ; preds = %ifcont36
   store i32 %433, i32* %434, align 4
   %435 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %307, i32 0, i32 0, i32* %434)
   %436 = load i64, i64* %307, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %437 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %435, i8** %437, align 8
   %438 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -1370,6 +1370,8 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
 
 define i32 @g(%array** %x) {
 .entry:
+  %stringFormat_desc31 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %r = alloca i32, align 4
   %0 = alloca i64, align 8
   %1 = load %array*, %array** %x, align 8
@@ -1577,7 +1579,6 @@ ifcont6:                                          ; preds = %ifcont4
   store i32 %126, i32* %127, align 4
   %128 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %127)
   %129 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %130 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %128, i8** %130, align 8
   %131 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -2016,7 +2017,6 @@ ifcont30:                                         ; preds = %ifcont28
   store i32 %391, i32* %392, align 4
   %393 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %265, i32 0, i32 0, i32* %392)
   %394 = load i64, i64* %265, align 4
-  %stringFormat_desc31 = alloca %string_descriptor, align 8
   %395 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
   store i8* %393, i8** %395, align 8
   %396 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
@@ -2462,6 +2462,7 @@ FINALIZE_SYMTABLE_g:                              ; preds = %return
 
 define void @h(%array** %c) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = load %array*, %array** %c, align 8
   %1 = load %array*, %array** %c, align 8
   %2 = ptrtoint %array* %1 to i64
@@ -2748,7 +2749,6 @@ ifcont23:                                         ; preds = %ifcont21
   store i32 %153, i32* %154, align 4
   %155 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %154)
   %156 = load i64, i64* %27, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %157 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %155, i8** %157, align 8
   %158 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "8b6a089422798d5cbc6ed08a302681a8b179857be0d1d1c7fdfd85d1",
+    "stdout_hash": "f194e5f31c33210122e74a8fbd5f9d6382e34a0647c682b2946ac231",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "90a56309cd671f6476ca24d84fbdc1bf198043a410e3331c977308cb",
+    "stdout_hash": "8b6a089422798d5cbc6ed08a302681a8b179857be0d1d1c7fdfd85d1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -31,208 +31,208 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %9 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [196 x i32], align 4
   %b = alloca [96 x i32], align 4
   %c = alloca [35 x i32], align 4
   %d = alloca [4 x i32], align 4
-  %2 = alloca i64, align 8
-  %3 = alloca i32, align 4
-  store i32 2, i32* %3, align 4
-  %4 = alloca i32, align 4
-  store i32 3, i32* %4, align 4
-  %5 = alloca i32, align 4
-  store i32 1, i32* %5, align 4
-  %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3, i32* %4, i32* %5)
-  %7 = load i64, i64* %2, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 4
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 4
-  %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
-  br i1 %15, label %free_done, label %free_nonnull
+  %10 = alloca i32, align 4
+  store i32 2, i32* %10, align 4
+  %11 = alloca i32, align 4
+  store i32 3, i32* %11, align 4
+  %12 = alloca i32, align 4
+  store i32 1, i32* %12, align 4
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, i32* %10, i32* %11, i32* %12)
+  %14 = load i64, i64* %9, align 4
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %13, i8** %15, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %14, i64* %16, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %18 = load i8*, i8** %17, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %20 = load i64, i64* %19, align 4
+  %21 = trunc i64 %20 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %22 = icmp eq i8* %13, null
+  br i1 %22, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %6)
+  call void @_lfortran_free(i8* %13)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %16 = alloca i64, align 8
-  %17 = alloca i32, align 4
-  store i32 5, i32* %17, align 4
-  %18 = alloca i32, align 4
-  store i32 9, i32* %18, align 4
-  %19 = alloca i32, align 4
-  store i32 7, i32* %19, align 4
-  %20 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %17, i32* %18, i32* %19)
-  %21 = load i64, i64* %16, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %20, i8** %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %21, i64* %23, align 4
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %25 = load i8*, i8** %24, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %27 = load i64, i64* %26, align 4
-  %28 = trunc i64 %27 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %25, i32 %28, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %29 = icmp eq i8* %20, null
-  br i1 %29, label %free_done3, label %free_nonnull2
+  %23 = alloca i32, align 4
+  store i32 5, i32* %23, align 4
+  %24 = alloca i32, align 4
+  store i32 9, i32* %24, align 4
+  %25 = alloca i32, align 4
+  store i32 7, i32* %25, align 4
+  %26 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info.1, i32 0, i32 0), i64* %8, i32 0, i32 0, i32* %23, i32* %24, i32* %25)
+  %27 = load i64, i64* %8, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %26, i8** %28, align 8
+  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %27, i64* %29, align 4
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %31 = load i8*, i8** %30, align 8
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %33 = load i64, i64* %32, align 4
+  %34 = trunc i64 %33 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %35 = icmp eq i8* %26, null
+  br i1 %35, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %20)
+  call void @_lfortran_free(i8* %26)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %30 = alloca i64, align 8
-  %31 = alloca i32, align 4
-  store i32 1, i32* %31, align 4
-  %32 = alloca i32, align 4
-  store i32 2, i32* %32, align 4
-  %33 = alloca i32, align 4
-  store i32 3, i32* %33, align 4
-  %34 = alloca i32, align 4
-  store i32 4, i32* %34, align 4
-  %35 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %30, i32 0, i32 0, i32* %31, i32* %32, i32* %33, i32* %34)
-  %36 = load i64, i64* %30, align 4
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %35, i8** %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %36, i64* %38, align 4
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %42 = load i64, i64* %41, align 4
-  %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %44 = icmp eq i8* %35, null
-  br i1 %44, label %free_done6, label %free_nonnull5
+  %36 = alloca i32, align 4
+  store i32 1, i32* %36, align 4
+  %37 = alloca i32, align 4
+  store i32 2, i32* %37, align 4
+  %38 = alloca i32, align 4
+  store i32 3, i32* %38, align 4
+  %39 = alloca i32, align 4
+  store i32 4, i32* %39, align 4
+  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %7, i32 0, i32 0, i32* %36, i32* %37, i32* %38, i32* %39)
+  %41 = load i64, i64* %7, align 4
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %40, i8** %42, align 8
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %41, i64* %43, align 4
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %45 = load i8*, i8** %44, align 8
+  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %47 = load i64, i64* %46, align 4
+  %48 = trunc i64 %47 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %45, i32 %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %49 = icmp eq i8* %40, null
+  br i1 %49, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %35)
+  call void @_lfortran_free(i8* %40)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %45 = alloca i64, align 8
-  %46 = alloca i32, align 4
-  store i32 2, i32* %46, align 4
-  %47 = alloca i32, align 4
-  store i32 4, i32* %47, align 4
-  %48 = alloca i32, align 4
-  store i32 6, i32* %48, align 4
-  %49 = alloca i32, align 4
-  store i32 7, i32* %49, align 4
-  %50 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.3, i32 0, i32 0), i64* %45, i32 0, i32 0, i32* %46, i32* %47, i32* %48, i32* %49)
-  %51 = load i64, i64* %45, align 4
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %50, i8** %52, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %51, i64* %53, align 4
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %55 = load i8*, i8** %54, align 8
-  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %57 = load i64, i64* %56, align 4
-  %58 = trunc i64 %57 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %55, i32 %58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %59 = icmp eq i8* %50, null
-  br i1 %59, label %free_done9, label %free_nonnull8
+  %50 = alloca i32, align 4
+  store i32 2, i32* %50, align 4
+  %51 = alloca i32, align 4
+  store i32 4, i32* %51, align 4
+  %52 = alloca i32, align 4
+  store i32 6, i32* %52, align 4
+  %53 = alloca i32, align 4
+  store i32 7, i32* %53, align 4
+  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.3, i32 0, i32 0), i64* %6, i32 0, i32 0, i32* %50, i32* %51, i32* %52, i32* %53)
+  %55 = load i64, i64* %6, align 4
+  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %54, i8** %56, align 8
+  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  store i64 %55, i64* %57, align 4
+  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %59 = load i8*, i8** %58, align 8
+  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %61 = load i64, i64* %60, align 4
+  %62 = trunc i64 %61 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %59, i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %63 = icmp eq i8* %54, null
+  br i1 %63, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free(i8* %50)
+  call void @_lfortran_free(i8* %54)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  %60 = alloca i64, align 8
-  %61 = alloca i32, align 4
-  store i32 6, i32* %61, align 4
-  %62 = alloca i32, align 4
-  store i32 1, i32* %62, align 4
-  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.4, i32 0, i32 0), i64* %60, i32 0, i32 0, i32* %61, i32* %62)
-  %64 = load i64, i64* %60, align 4
-  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %63, i8** %65, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %64, i64* %66, align 4
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %68 = load i8*, i8** %67, align 8
+  %64 = alloca i32, align 4
+  store i32 6, i32* %64, align 4
+  %65 = alloca i32, align 4
+  store i32 1, i32* %65, align 4
+  %66 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.4, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %64, i32* %65)
+  %67 = load i64, i64* %5, align 4
+  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  store i8* %66, i8** %68, align 8
   %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %70 = load i64, i64* %69, align 4
-  %71 = trunc i64 %70 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %68, i32 %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %72 = icmp eq i8* %63, null
-  br i1 %72, label %free_done12, label %free_nonnull11
+  store i64 %67, i64* %69, align 4
+  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %71 = load i8*, i8** %70, align 8
+  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %73 = load i64, i64* %72, align 4
+  %74 = trunc i64 %73 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %71, i32 %74, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %75 = icmp eq i8* %66, null
+  br i1 %75, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free(i8* %63)
+  call void @_lfortran_free(i8* %66)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
-  %73 = alloca i64, align 8
-  %74 = alloca i32, align 4
-  store i32 10, i32* %74, align 4
-  %75 = alloca i32, align 4
-  store i32 7, i32* %75, align 4
-  %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.5, i32 0, i32 0), i64* %73, i32 0, i32 0, i32* %74, i32* %75)
-  %77 = load i64, i64* %73, align 4
-  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %76, i8** %78, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %77, i64* %79, align 4
+  %76 = alloca i32, align 4
+  store i32 10, i32* %76, align 4
+  %77 = alloca i32, align 4
+  store i32 7, i32* %77, align 4
+  %78 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.5, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %76, i32* %77)
+  %79 = load i64, i64* %4, align 4
   %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %81 = load i8*, i8** %80, align 8
-  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %83 = load i64, i64* %82, align 4
-  %84 = trunc i64 %83 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %81, i32 %84, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %85 = icmp eq i8* %76, null
-  br i1 %85, label %free_done15, label %free_nonnull14
+  store i8* %78, i8** %80, align 8
+  %81 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  store i64 %79, i64* %81, align 4
+  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %83 = load i8*, i8** %82, align 8
+  %84 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %85 = load i64, i64* %84, align 4
+  %86 = trunc i64 %85 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %83, i32 %86, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %87 = icmp eq i8* %78, null
+  br i1 %87, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free(i8* %76)
+  call void @_lfortran_free(i8* %78)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  %86 = alloca i64, align 8
-  %87 = alloca i32, align 4
-  store i32 1, i32* %87, align 4
-  %88 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %86, i32 0, i32 0, i32* %87)
-  %89 = load i64, i64* %86, align 4
-  %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %88, i8** %90, align 8
-  %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %89, i64* %91, align 4
-  %92 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %93 = load i8*, i8** %92, align 8
-  %94 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %95 = load i64, i64* %94, align 4
-  %96 = trunc i64 %95 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %93, i32 %96, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %97 = icmp eq i8* %88, null
-  br i1 %97, label %free_done18, label %free_nonnull17
+  %88 = alloca i32, align 4
+  store i32 1, i32* %88, align 4
+  %89 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %88)
+  %90 = load i64, i64* %3, align 4
+  %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  store i8* %89, i8** %91, align 8
+  %92 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  store i64 %90, i64* %92, align 4
+  %93 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  %94 = load i8*, i8** %93, align 8
+  %95 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  %96 = load i64, i64* %95, align 4
+  %97 = trunc i64 %96 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %94, i32 %97, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %98 = icmp eq i8* %89, null
+  br i1 %98, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free(i8* %88)
+  call void @_lfortran_free(i8* %89)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
-  %98 = alloca i64, align 8
   %99 = alloca i32, align 4
   store i32 4, i32* %99, align 4
-  %100 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %98, i32 0, i32 0, i32* %99)
-  %101 = load i64, i64* %98, align 4
+  %100 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %99)
+  %101 = load i64, i64* %2, align 4
   %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %100, i8** %102, align 8
   %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -30,6 +30,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca [196 x i32], align 4
   %b = alloca [96 x i32], align 4
@@ -44,7 +52,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %5, align 4
   %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3, i32* %4, i32* %5)
   %7 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -72,7 +79,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 7, i32* %19, align 4
   %20 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %17, i32* %18, i32* %19)
   %21 = load i64, i64* %16, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %20, i8** %22, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -102,7 +108,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   store i32 4, i32* %34, align 4
   %35 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %30, i32 0, i32 0, i32* %31, i32* %32, i32* %33, i32* %34)
   %36 = load i64, i64* %30, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %35, i8** %37, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -132,7 +137,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   store i32 7, i32* %49, align 4
   %50 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.3, i32 0, i32 0), i64* %45, i32 0, i32 0, i32* %46, i32* %47, i32* %48, i32* %49)
   %51 = load i64, i64* %45, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %50, i8** %52, align 8
   %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -158,7 +162,6 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   store i32 1, i32* %62, align 4
   %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.4, i32 0, i32 0), i64* %60, i32 0, i32 0, i32* %61, i32* %62)
   %64 = load i64, i64* %60, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %63, i8** %65, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -184,7 +187,6 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   store i32 7, i32* %75, align 4
   %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.5, i32 0, i32 0), i64* %73, i32 0, i32 0, i32* %74, i32* %75)
   %77 = load i64, i64* %73, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %76, i8** %78, align 8
   %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
@@ -208,7 +210,6 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   store i32 1, i32* %87, align 4
   %88 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %86, i32 0, i32 0, i32* %87)
   %89 = load i64, i64* %86, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %88, i8** %90, align 8
   %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
@@ -232,7 +233,6 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   store i32 4, i32* %99, align 4
   %100 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %98, i32 0, i32 0, i32* %99)
   %101 = load i64, i64* %98, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
   %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %100, i8** %102, align 8
   %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "dc97287b9a5fac4b2b116f6fcdbff81491e6426dc05cbdb2e7adbd20",
+    "stdout_hash": "3f9518899d876fa1e64f4c3f8dd9032e306f8ca2eefaa3250e40585a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "31bd1c1429c4acf74b8a5612df4254288b5bbcc1bdc6bc91fe9109fc",
+    "stdout_hash": "dc97287b9a5fac4b2b116f6fcdbff81491e6426dc05cbdb2e7adbd20",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -34,6 +34,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
@@ -53,7 +61,6 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = load i32*, i32** %p1, align 8
   %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %5)
   %7 = load i64, i64* %4, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -75,7 +82,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* @associate_02.t1)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -106,7 +112,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %35 = load i32*, i32** %p1, align 8
   %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %34, i32 0, i32 0, i32* %35)
   %37 = load i64, i64* %34, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %36, i8** %38, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -128,7 +133,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %46 = alloca i64, align 8
   %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %46, i32 0, i32 0, i32* @associate_02.t1)
   %48 = load i64, i64* %46, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %47, i8** %49, align 8
   %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -152,7 +156,6 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %58 = load i32*, i32** %p1, align 8
   %59 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %57, i32 0, i32 0, i32* %58)
   %60 = load i64, i64* %57, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %59, i8** %61, align 8
   %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -174,7 +177,6 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %69 = alloca i64, align 8
   %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %69, i32 0, i32 0, i32* @associate_02.t1)
   %71 = load i64, i64* %69, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %70, i8** %72, align 8
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
@@ -211,7 +213,6 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %94 = load %complex_4*, %complex_4** %p3, align 8
   %95 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.6, i32 0, i32 0), i64* %93, i32 0, i32 0, %complex_4* %94)
   %96 = load i64, i64* %93, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %95, i8** %97, align 8
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
@@ -233,7 +234,6 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %105 = alloca i64, align 8
   %106 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.7, i32 0, i32 0), i64* %105, i32 0, i32 0, %complex_4* @associate_02.t3)
   %107 = load i64, i64* %105, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
   %108 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %106, i8** %108, align 8
   %109 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -35,13 +35,21 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %9 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
@@ -53,187 +61,179 @@ define i32 @main(i32 %0, i8** %1) {
   store i32* @associate_02.t1, i32** %p1, align 8
   store double* @associate_02.t2, double** %p2, align 8
   store %complex_4* @associate_02.t3, %complex_4** %p3, align 8
-  %2 = load i32*, i32** %p1, align 8
-  store i32 1, i32* %2, align 4
-  %3 = load double*, double** %p2, align 8
-  store double 4.000000e+00, double* %3, align 8
-  %4 = alloca i64, align 8
-  %5 = load i32*, i32** %p1, align 8
-  %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %5)
-  %7 = load i64, i64* %4, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 4
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 4
-  %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
-  br i1 %15, label %free_done, label %free_nonnull
+  %10 = load i32*, i32** %p1, align 8
+  store i32 1, i32* %10, align 4
+  %11 = load double*, double** %p2, align 8
+  store double 4.000000e+00, double* %11, align 8
+  %12 = load i32*, i32** %p1, align 8
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, i32* %12)
+  %14 = load i64, i64* %9, align 4
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %13, i8** %15, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %14, i64* %16, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %18 = load i8*, i8** %17, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %20 = load i64, i64* %19, align 4
+  %21 = trunc i64 %20 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %22 = icmp eq i8* %13, null
+  br i1 %22, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %6)
+  call void @_lfortran_free(i8* %13)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* @associate_02.t1)
-  %18 = load i64, i64* %16, align 4
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %18, i64* %20, align 4
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %24 = load i64, i64* %23, align 4
-  %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
-  br i1 %26, label %free_done3, label %free_nonnull2
+  %23 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %8, i32 0, i32 0, i32* @associate_02.t1)
+  %24 = load i64, i64* %8, align 4
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %23, i8** %25, align 8
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %24, i64* %26, align 4
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %28 = load i8*, i8** %27, align 8
+  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %30 = load i64, i64* %29, align 4
+  %31 = trunc i64 %30 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %32 = icmp eq i8* %23, null
+  br i1 %32, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %17)
+  call void @_lfortran_free(i8* %23)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %27 = load double*, double** %p2, align 8
-  %28 = load double, double* %27, align 8
-  %29 = load i32*, i32** %p1, align 8
-  %30 = load i32, i32* %29, align 4
-  %31 = sitofp i32 %30 to double
-  %32 = fadd double %28, %31
-  %33 = fptosi double %32 to i32
-  store i32 %33, i32* @associate_02.t1, align 4
-  %34 = alloca i64, align 8
+  %33 = load double*, double** %p2, align 8
+  %34 = load double, double* %33, align 8
   %35 = load i32*, i32** %p1, align 8
-  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %34, i32 0, i32 0, i32* %35)
-  %37 = load i64, i64* %34, align 4
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %37, i64* %39, align 4
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %43 = load i64, i64* %42, align 4
-  %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %45 = icmp eq i8* %36, null
-  br i1 %45, label %free_done6, label %free_nonnull5
+  %36 = load i32, i32* %35, align 4
+  %37 = sitofp i32 %36 to double
+  %38 = fadd double %34, %37
+  %39 = fptosi double %38 to i32
+  store i32 %39, i32* @associate_02.t1, align 4
+  %40 = load i32*, i32** %p1, align 8
+  %41 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %7, i32 0, i32 0, i32* %40)
+  %42 = load i64, i64* %7, align 4
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %41, i8** %43, align 8
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %42, i64* %44, align 4
+  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %46 = load i8*, i8** %45, align 8
+  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %48 = load i64, i64* %47, align 4
+  %49 = trunc i64 %48 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %50 = icmp eq i8* %41, null
+  br i1 %50, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %36)
+  call void @_lfortran_free(i8* %41)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %46 = alloca i64, align 8
-  %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %46, i32 0, i32 0, i32* @associate_02.t1)
-  %48 = load i64, i64* %46, align 4
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %47, i8** %49, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %48, i64* %50, align 4
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %52 = load i8*, i8** %51, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %54 = load i64, i64* %53, align 4
-  %55 = trunc i64 %54 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %56 = icmp eq i8* %47, null
-  br i1 %56, label %free_done9, label %free_nonnull8
+  %51 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %6, i32 0, i32 0, i32* @associate_02.t1)
+  %52 = load i64, i64* %6, align 4
+  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %51, i8** %53, align 8
+  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  store i64 %52, i64* %54, align 4
+  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %56 = load i8*, i8** %55, align 8
+  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %58 = load i64, i64* %57, align 4
+  %59 = trunc i64 %58 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %56, i32 %59, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %60 = icmp eq i8* %51, null
+  br i1 %60, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free(i8* %47)
+  call void @_lfortran_free(i8* %51)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
   store i32 8, i32* @associate_02.t1, align 4
-  %57 = alloca i64, align 8
-  %58 = load i32*, i32** %p1, align 8
-  %59 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %57, i32 0, i32 0, i32* %58)
-  %60 = load i64, i64* %57, align 4
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %59, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %60, i64* %62, align 4
-  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
+  %61 = load i32*, i32** %p1, align 8
+  %62 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %61)
+  %63 = load i64, i64* %5, align 4
+  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  store i8* %62, i8** %64, align 8
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %66 = load i64, i64* %65, align 4
-  %67 = trunc i64 %66 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %68 = icmp eq i8* %59, null
-  br i1 %68, label %free_done12, label %free_nonnull11
+  store i64 %63, i64* %65, align 4
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %67 = load i8*, i8** %66, align 8
+  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %69 = load i64, i64* %68, align 4
+  %70 = trunc i64 %69 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %67, i32 %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %71 = icmp eq i8* %62, null
+  br i1 %71, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free(i8* %59)
+  call void @_lfortran_free(i8* %62)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
-  %69 = alloca i64, align 8
-  %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %69, i32 0, i32 0, i32* @associate_02.t1)
-  %71 = load i64, i64* %69, align 4
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %70, i8** %72, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %71, i64* %73, align 4
+  %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* @associate_02.t1)
+  %73 = load i64, i64* %4, align 4
   %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %75 = load i8*, i8** %74, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %77 = load i64, i64* %76, align 4
-  %78 = trunc i64 %77 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %79 = icmp eq i8* %70, null
-  br i1 %79, label %free_done15, label %free_nonnull14
+  store i8* %72, i8** %74, align 8
+  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  store i64 %73, i64* %75, align 4
+  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %77 = load i8*, i8** %76, align 8
+  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %79 = load i64, i64* %78, align 4
+  %80 = trunc i64 %79 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %77, i32 %80, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %81 = icmp eq i8* %72, null
+  br i1 %81, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free(i8* %70)
+  call void @_lfortran_free(i8* %72)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  %80 = load %complex_4*, %complex_4** %p3, align 8
-  %81 = load %complex_4*, %complex_4** %p3, align 8
-  %82 = load %complex_4, %complex_4* %81, align 1
-  %83 = extractvalue %complex_4 %82, 0
-  %84 = extractvalue %complex_4 %82, 1
-  %85 = fmul float 2.000000e+00, %83
-  %86 = fmul float 0.000000e+00, %84
-  %87 = fmul float 2.000000e+00, %84
-  %88 = fmul float 0.000000e+00, %83
-  %89 = fsub float %85, %86
-  %90 = fadd float %87, %88
-  %91 = insertvalue %complex_4 undef, float %89, 0
-  %92 = insertvalue %complex_4 %91, float %90, 1
-  store %complex_4 %92, %complex_4* %80, align 1
-  %93 = alloca i64, align 8
-  %94 = load %complex_4*, %complex_4** %p3, align 8
-  %95 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.6, i32 0, i32 0), i64* %93, i32 0, i32 0, %complex_4* %94)
-  %96 = load i64, i64* %93, align 4
-  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %95, i8** %97, align 8
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %96, i64* %98, align 4
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %100 = load i8*, i8** %99, align 8
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %102 = load i64, i64* %101, align 4
-  %103 = trunc i64 %102 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %100, i32 %103, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %104 = icmp eq i8* %95, null
-  br i1 %104, label %free_done18, label %free_nonnull17
+  %82 = load %complex_4*, %complex_4** %p3, align 8
+  %83 = load %complex_4*, %complex_4** %p3, align 8
+  %84 = load %complex_4, %complex_4* %83, align 1
+  %85 = extractvalue %complex_4 %84, 0
+  %86 = extractvalue %complex_4 %84, 1
+  %87 = fmul float 2.000000e+00, %85
+  %88 = fmul float 0.000000e+00, %86
+  %89 = fmul float 2.000000e+00, %86
+  %90 = fmul float 0.000000e+00, %85
+  %91 = fsub float %87, %88
+  %92 = fadd float %89, %90
+  %93 = insertvalue %complex_4 undef, float %91, 0
+  %94 = insertvalue %complex_4 %93, float %92, 1
+  store %complex_4 %94, %complex_4* %82, align 1
+  %95 = load %complex_4*, %complex_4** %p3, align 8
+  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.6, i32 0, i32 0), i64* %3, i32 0, i32 0, %complex_4* %95)
+  %97 = load i64, i64* %3, align 4
+  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  store i8* %96, i8** %98, align 8
+  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  store i64 %97, i64* %99, align 4
+  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  %101 = load i8*, i8** %100, align 8
+  %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  %103 = load i64, i64* %102, align 4
+  %104 = trunc i64 %103 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %101, i32 %104, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %105 = icmp eq i8* %96, null
+  br i1 %105, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free(i8* %95)
+  call void @_lfortran_free(i8* %96)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
-  %105 = alloca i64, align 8
-  %106 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.7, i32 0, i32 0), i64* %105, i32 0, i32 0, %complex_4* @associate_02.t3)
-  %107 = load i64, i64* %105, align 4
+  %106 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.7, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* @associate_02.t3)
+  %107 = load i64, i64* %2, align 4
   %108 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %106, i8** %108, align 8
   %109 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "a32bc1b5c4b18a5bf66a88ac9b468d2ad2bd29e629f2881d797483cd",
+    "stdout_hash": "62a62e2ccf22bcf743b60736adffab6940418ad467a33a0f8e893bd5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "b22bf40c55ff78f93b966668201bf8ee24c3a0d3d50b0590634ec369",
+    "stdout_hash": "a32bc1b5c4b18a5bf66a88ac9b468d2ad2bd29e629f2881d797483cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -17,6 +17,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %p1 = alloca i32*, align 8
@@ -24,7 +26,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @associate_03.t1, i32* @associate_03.t2)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -61,7 +62,6 @@ ifcont:                                           ; preds = %else, %then
   %17 = load i32*, i32** %p1, align 8
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %17)
   %19 = load i64, i64* %16, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -18,36 +18,37 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %p1 = alloca i32*, align 8
   store i32* null, i32** %p1, align 8
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @associate_03.t1, i32* @associate_03.t2)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* @associate_03.t1, i32* @associate_03.t2)
+  %5 = load i64, i64* %3, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %4, i8** %6, align 8
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %5, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = trunc i64 %11 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %13 = icmp eq i8* %4, null
+  br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = load i32, i32* @associate_03.t1, align 4
-  %14 = load i32, i32* @associate_03.t2, align 4
-  %15 = icmp sgt i32 %13, %14
-  br i1 %15, label %then, label %else
+  %14 = load i32, i32* @associate_03.t1, align 4
+  %15 = load i32, i32* @associate_03.t2, align 4
+  %16 = icmp sgt i32 %14, %15
+  br i1 %16, label %then, label %else
 
 then:                                             ; preds = %free_done
   store i32* @associate_03.t1, i32** %p1, align 8
@@ -58,10 +59,9 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %16 = alloca i64, align 8
   %17 = load i32*, i32** %p1, align 8
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %17)
-  %19 = load i64, i64* %16, align 4
+  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %17)
+  %19 = load i64, i64* %2, align 4
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "cb90b1ad716420b0fd24477ef712899407ec426cde896ee981c95feb",
+    "stdout_hash": "315b7421b40155a9a179b4e2b3cd4a8ce293a21be5bd8e4563c2f07b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "315b7421b40155a9a179b4e2b3cd4a8ce293a21be5bd8e4563c2f07b",
+    "stdout_hash": "299fd3b68162a5af1c50c17ee271802316fd7c6b7e2829dd66de1495",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -33,6 +33,8 @@ declare float @_lfortran_scos(float)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca float, align 4
   %myreal = alloca float, align 4
@@ -75,7 +77,6 @@ associate_block_start:                            ; preds = %.entry
   %20 = load float*, float** %v, align 8
   %21 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %15, float* %19, float* %20)
   %22 = load i64, i64* %11, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %21, i8** %23, align 8
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -109,7 +110,6 @@ FINALIZE_SYMTABLE_associate_block:                ; preds = %associate_block_end
   %35 = alloca i64, align 8
   %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %35, i32 0, i32 0, float* %myreal)
   %37 = load i64, i64* %35, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %36, i8** %38, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -34,7 +34,9 @@ declare float @_lfortran_scos(float)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca float, align 4
   %myreal = alloca float, align 4
@@ -49,67 +51,65 @@ define i32 @main(i32 %0, i8** %1) {
   br label %associate_block_start
 
 associate_block_start:                            ; preds = %.entry
-  %2 = call i8* @llvm.stacksave()
+  %4 = call i8* @llvm.stacksave()
   %v = alloca float*, align 8
   store float* null, float** %v, align 8
   %z = alloca float, align 4
-  %3 = load float, float* %x, align 4
-  %4 = fmul float %3, 2.000000e+00
-  %5 = load float, float* %y, align 4
+  %5 = load float, float* %x, align 4
   %6 = fmul float %5, 2.000000e+00
-  %7 = fadd float %4, %6
-  %8 = fneg float %7
-  %9 = call float @_lcompilers_cos_f32(float* %theta)
-  %10 = fmul float %8, %9
-  store float %10, float* %z, align 4
+  %7 = load float, float* %y, align 4
+  %8 = fmul float %7, 2.000000e+00
+  %9 = fadd float %6, %8
+  %10 = fneg float %9
+  %11 = call float @_lcompilers_cos_f32(float* %theta)
+  %12 = fmul float %10, %11
+  store float %12, float* %z, align 4
   store float* %myreal, float** %v, align 8
-  %11 = alloca i64, align 8
-  %12 = load float, float* %a, align 4
-  %13 = load float, float* %z, align 4
-  %14 = fadd float %12, %13
-  %15 = alloca float, align 4
-  store float %14, float* %15, align 4
-  %16 = load float, float* %a, align 4
-  %17 = load float, float* %z, align 4
-  %18 = fsub float %16, %17
-  %19 = alloca float, align 4
-  store float %18, float* %19, align 4
-  %20 = load float*, float** %v, align 8
-  %21 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %15, float* %19, float* %20)
-  %22 = load i64, i64* %11, align 4
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %21, i8** %23, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %22, i64* %24, align 4
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %26 = load i8*, i8** %25, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %28 = load i64, i64* %27, align 4
-  %29 = trunc i64 %28 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %26, i32 %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %30 = icmp eq i8* %21, null
-  br i1 %30, label %free_done, label %free_nonnull
+  %13 = load float, float* %a, align 4
+  %14 = load float, float* %z, align 4
+  %15 = fadd float %13, %14
+  %16 = alloca float, align 4
+  store float %15, float* %16, align 4
+  %17 = load float, float* %a, align 4
+  %18 = load float, float* %z, align 4
+  %19 = fsub float %17, %18
+  %20 = alloca float, align 4
+  store float %19, float* %20, align 4
+  %21 = load float*, float** %v, align 8
+  %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, float* %16, float* %20, float* %21)
+  %23 = load i64, i64* %3, align 4
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %22, i8** %24, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %23, i64* %25, align 4
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %27 = load i8*, i8** %26, align 8
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %29 = load i64, i64* %28, align 4
+  %30 = trunc i64 %29 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %31 = icmp eq i8* %22, null
+  br i1 %31, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %associate_block_start
-  call void @_lfortran_free(i8* %21)
+  call void @_lfortran_free(i8* %22)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %associate_block_start
-  %31 = load float*, float** %v, align 8
   %32 = load float*, float** %v, align 8
-  %33 = load float, float* %32, align 4
-  %34 = fmul float %33, 0x4012666660000000
-  store float %34, float* %31, align 4
+  %33 = load float*, float** %v, align 8
+  %34 = load float, float* %33, align 4
+  %35 = fmul float %34, 0x4012666660000000
+  store float %35, float* %32, align 4
   br label %associate_block_end
 
 associate_block_end:                              ; preds = %free_done
   br label %FINALIZE_SYMTABLE_associate_block
 
 FINALIZE_SYMTABLE_associate_block:                ; preds = %associate_block_end
-  call void @llvm.stackrestore(i8* %2)
-  %35 = alloca i64, align 8
-  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %35, i32 0, i32 0, float* %myreal)
-  %37 = load i64, i64* %35, align 4
+  call void @llvm.stackrestore(i8* %4)
+  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %myreal)
+  %37 = load i64, i64* %2, align 4
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %36, i8** %38, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "550dde71a92ade615245bff27ed47a97ad64e9c4b6c434150f20328c",
+    "stdout_hash": "b8805bbfb9468b35fee6a5318d9f4f191c87e3b96ec14df909ecce1d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "b8805bbfb9468b35fee6a5318d9f4f191c87e3b96ec14df909ecce1d",
+    "stdout_hash": "aa86a22c0d310ba5ca04d7c412a9b1ae8a7af7a52869bd8c8e9fb35c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -12,6 +12,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca %complex_8, align 8
   %v = alloca %complex_8, align 8
@@ -21,7 +22,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, %complex_8* %u, align 1
   store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, %complex_8* %v, align 1
   store %complex_4 <{ float 0x3FC24924A0000000, float 0.000000e+00 }>, %complex_4* %x, align 1
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %zero, %complex_8* %v, %complex_4* %x, %complex_8* %u)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -1,9 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%string_descriptor = type <{ i8*, i64 }>
 %complex_8 = type <{ double, double }>
 %complex_4 = type <{ float, float }>
-%string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [32 x i8] c"{R4,R4},{R8,R8},{R4,R4},{R8,R8}\00", align 1
@@ -11,6 +11,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca %complex_8, align 8
   %v = alloca %complex_8, align 8
@@ -23,7 +24,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %zero, %complex_8* %v, %complex_4* %x, %complex_8* %u)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "c7e51dba22084afe7a0a0e2eaa9c9021cf2bdd16d6b2d633e246df32",
+    "stdout_hash": "43197cea2e7d6f9656990b401b3196a93a18613cb445911c94928b83",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "f27a9efe18798e002dbf5bc95b5eb4a89f5e384df911279236705617",
+    "stdout_hash": "c7e51dba22084afe7a0a0e2eaa9c9021cf2bdd16d6b2d633e246df32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
@@ -21,7 +22,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   store double 0x3FC2492492492492, double* %u, align 8
   store double 0x3FC2492492492492, double* %v, align 8
   store float 0x3FC24924A0000000, float* %x, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "48d850ccd2a9ac3651df9f9e4adb4dd1350f66edc8f09edabf828636",
+    "stdout_hash": "30c0cef2d66d1a1da7d555b5a0fc5a1f8e62d891eeed96825bed8a35",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "ee5b6635fe1154321948856ef813f50a15cbb16946d55ceb1799a47d",
+    "stdout_hash": "48d850ccd2a9ac3651df9f9e4adb4dd1350f66edc8f09edabf828636",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -13,6 +13,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
@@ -28,7 +30,6 @@ define i32 @main(i32 %0, i8** %1) {
   store void* %6, void** %7, align 8
   %8 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, void** %7, void** %queries)
   %9 = load i64, i64* %4, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %8, i8** %10, align 8
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -58,7 +59,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store void* %22, void** %23, align 8
   %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, void** %21, void** %23)
   %25 = load i64, i64* %18, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %24, i8** %26, align 8
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -14,42 +14,42 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
   store i16* null, i16** %x, align 8
   %y = alloca i16, align 2
-  %2 = load void*, void** %queries, align 8
-  %3 = bitcast void* %2 to i16*
-  store i16* %3, i16** %x, align 8
-  %4 = alloca i64, align 8
-  %5 = load i16*, i16** %x, align 8
-  %6 = bitcast i16* %5 to void*
-  %7 = alloca void*, align 8
-  store void* %6, void** %7, align 8
-  %8 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, void** %7, void** %queries)
-  %9 = load i64, i64* %4, align 4
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %8, i8** %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %9, i64* %11, align 4
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %13 = load i8*, i8** %12, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %15 = load i64, i64* %14, align 4
-  %16 = trunc i64 %15 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %13, i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %17 = icmp eq i8* %8, null
-  br i1 %17, label %free_done, label %free_nonnull
+  %4 = load void*, void** %queries, align 8
+  %5 = bitcast void* %4 to i16*
+  store i16* %5, i16** %x, align 8
+  %6 = load i16*, i16** %x, align 8
+  %7 = bitcast i16* %6 to void*
+  %8 = alloca void*, align 8
+  store void* %7, void** %8, align 8
+  %9 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, void** %8, void** %queries)
+  %10 = load i64, i64* %3, align 4
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %9, i8** %11, align 8
+  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %10, i64* %12, align 4
+  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %14 = load i8*, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %16 = load i64, i64* %15, align 4
+  %17 = trunc i64 %16 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %14, i32 %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %18 = icmp eq i8* %9, null
+  br i1 %18, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %8)
+  call void @_lfortran_free(i8* %9)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i16* %y, i16** %x, align 8
-  %18 = alloca i64, align 8
   %19 = load i16*, i16** %x, align 8
   %20 = bitcast i16* %19 to void*
   %21 = alloca void*, align 8
@@ -57,8 +57,8 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %22 = bitcast i16* %y to void*
   %23 = alloca void*, align 8
   store void* %22, void** %23, align 8
-  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, void** %21, void** %23)
-  %25 = load i64, i64* %18, align 4
+  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, void** %21, void** %23)
+  %25 = load i64, i64* %2, align 4
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %24, i8** %26, align 8
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "b52f1ccbcaea1fdbb56e32a61fa7d5343750be59969973226f8ba3f4",
+    "stdout_hash": "7682ff622d9b910a48501e6fcac0eb14fc5bfc3e49cfa834f3fad7b8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "fa00b91dde1dd3753ca446d0ba04d06ddae6b2020796161b9f9450b7",
+    "stdout_hash": "b52f1ccbcaea1fdbb56e32a61fa7d5343750be59969973226f8ba3f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -18,38 +18,39 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca i64, align 8
   %y = alloca double, align 8
   store i64 665663010, i64* %x, align 4
-  %2 = load i64, i64* %x, align 4
-  %simplified_pow_operation = mul i64 %2, %2
+  %4 = load i64, i64* %x, align 4
+  %simplified_pow_operation = mul i64 %4, %4
   store i64 %simplified_pow_operation, i64* %x, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %x)
-  %5 = load i64, i64* %3, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 4
-  %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
-  br i1 %13, label %free_done, label %free_nonnull
+  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %x)
+  %6 = load i64, i64* %3, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %5, i8** %7, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %6, i64* %8, align 4
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %10 = load i8*, i8** %9, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, i64* %11, align 4
+  %13 = trunc i64 %12 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %14 = icmp eq i8* %5, null
+  br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %4)
+  call void @_lfortran_free(i8* %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load i64, i64* %x, align 4
-  %15 = icmp ne i64 %14, 443107242882260100
-  br i1 %15, label %then, label %else
+  %15 = load i64, i64* %x, align 4
+  %16 = icmp ne i64 %15, 443107242882260100
+  br i1 %16, label %then, label %else
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -61,12 +62,11 @@ else:                                             ; preds = %free_done
 
 ifcont:                                           ; preds = %else, %then
   store double 0x41C3D69B11000000, double* %y, align 8
-  %16 = load double, double* %y, align 8
-  %simplified_pow_operation1 = fmul double %16, %16
+  %17 = load double, double* %y, align 8
+  %simplified_pow_operation1 = fmul double %17, %17
   store double %simplified_pow_operation1, double* %y, align 8
-  %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, double* %y)
-  %19 = load i64, i64* %17, align 4
+  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, double* %y)
+  %19 = load i64, i64* %2, align 4
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -17,6 +17,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc2 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca i64, align 8
   %y = alloca double, align 8
@@ -27,7 +29,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %x)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -66,7 +67,6 @@ ifcont:                                           ; preds = %else, %then
   %17 = alloca i64, align 8
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, double* %y)
   %19 = load i64, i64* %17, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "ccfe828bc9c2df79e3981bcb27a3b9a41de171fd42710231fa6d1194",
+    "stdout_hash": "f665927888fc5449042197cc1da85a94772942a9d99c18fa9cbe7bc9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "f665927888fc5449042197cc1da85a94772942a9d99c18fa9cbe7bc9",
+    "stdout_hash": "14d9553c5f5e6248a4f1d82dcf8ff1a79f68d31605ff40275dda73b0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -16,8 +16,11 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %all_ones = alloca i64, align 8
   store i64 -1, i64* %all_ones, align 4
@@ -25,57 +28,54 @@ define i32 @main(i32 %0, i8** %1) {
   store i64 0, i64* %all_zeros, align 4
   %block_size = alloca i32, align 4
   store i32 64, i32* %block_size, align 4
-  %2 = alloca i64, align 8
-  %3 = alloca i32, align 4
-  store i32 64, i32* %3, align 4
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3)
-  %5 = load i64, i64* %2, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 4
+  %5 = alloca i32, align 4
+  store i32 64, i32* %5, align 4
+  %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %5)
+  %7 = load i64, i64* %4, align 4
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 4
-  %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
-  br i1 %13, label %free_done, label %free_nonnull
+  store i8* %6, i8** %8, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %7, i64* %9, align 4
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %11 = load i8*, i8** %10, align 8
+  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %13 = load i64, i64* %12, align 4
+  %14 = trunc i64 %13 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %15 = icmp eq i8* %6, null
+  br i1 %15, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %4)
+  call void @_lfortran_free(i8* %6)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = alloca i64, align 8
-  %15 = alloca i64, align 8
-  store i64 0, i64* %15, align 4
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i64* %15)
-  %17 = load i64, i64* %14, align 4
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %16, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %17, i64* %19, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %23 = load i64, i64* %22, align 4
-  %24 = trunc i64 %23 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %25 = icmp eq i8* %16, null
-  br i1 %25, label %free_done3, label %free_nonnull2
+  %16 = alloca i64, align 8
+  store i64 0, i64* %16, align 4
+  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i64* %16)
+  %18 = load i64, i64* %3, align 4
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %17, i8** %19, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %18, i64* %20, align 4
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %22 = load i8*, i8** %21, align 8
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %24 = load i64, i64* %23, align 4
+  %25 = trunc i64 %24 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %26 = icmp eq i8* %17, null
+  br i1 %26, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %16)
+  call void @_lfortran_free(i8* %17)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %26 = alloca i64, align 8
   %27 = alloca i64, align 8
   store i64 -1, i64* %27, align 4
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %26, i32 0, i32 0, i64* %27)
-  %29 = load i64, i64* %26, align 4
+  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, i64* %27)
+  %29 = load i64, i64* %2, align 4
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -15,6 +15,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %all_ones = alloca i64, align 8
   store i64 -1, i64* %all_ones, align 4
@@ -27,7 +30,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 64, i32* %3, align 4
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3)
   %5 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -51,7 +53,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i64 0, i64* %15, align 4
   %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i64* %15)
   %17 = load i64, i64* %14, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -75,7 +76,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   store i64 -1, i64* %27, align 4
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %26, i32 0, i32 0, i64* %27)
   %29 = load i64, i64* %26, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "5dbead19c1bddb0b733081ee0242f87fd1bc39bbc289dd780ea33471",
+    "stdout_hash": "36daba3437e453473b335bb2101d76dcaad05e4059077b8bb5051177",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "36daba3437e453473b335bb2101d76dcaad05e4059077b8bb5051177",
+    "stdout_hash": "fba5708af2e864253a2699b99ec6649cacf39dd6af30759593e1ffb4",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -22,6 +22,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
@@ -117,7 +118,6 @@ ifcont15:                                         ; preds = %else14, %then13
   %15 = alloca i64, align 8
   %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %boz_1, i32* %boz_2, i32* %boz_3, i32* %boz_4, i32* %boz_5, float* %boz_6)
   %17 = load i64, i64* %15, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -23,6 +23,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
@@ -36,10 +37,10 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 180150001, i32* %boz_4, align 4
   store i32 180150001, i32* %boz_5, align 4
   store float 0x36DA000000000000, float* %boz_6, align 4
-  %2 = load i32, i32* %boz_4, align 4
-  %3 = load i32, i32* %boz_5, align 4
-  %4 = icmp ne i32 %2, %3
-  br i1 %4, label %then, label %else
+  %3 = load i32, i32* %boz_4, align 4
+  %4 = load i32, i32* %boz_5, align 4
+  %5 = icmp ne i32 %3, %4
+  br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -50,9 +51,9 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load i32, i32* %boz_1, align 4
-  %6 = icmp ne i32 %5, 93
-  br i1 %6, label %then1, label %else2
+  %6 = load i32, i32* %boz_1, align 4
+  %7 = icmp ne i32 %6, 93
+  br i1 %7, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -63,9 +64,9 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %7 = load i32, i32* %boz_2, align 4
-  %8 = icmp ne i32 %7, 1255
-  br i1 %8, label %then4, label %else5
+  %8 = load i32, i32* %boz_2, align 4
+  %9 = icmp ne i32 %8, 1255
+  br i1 %9, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -76,9 +77,9 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %9 = load i32, i32* %boz_3, align 4
-  %10 = icmp ne i32 %9, 2748
-  br i1 %10, label %then7, label %else8
+  %10 = load i32, i32* %boz_3, align 4
+  %11 = icmp ne i32 %10, 2748
+  br i1 %11, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
@@ -89,9 +90,9 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %11 = load i32, i32* %boz_4, align 4
-  %12 = icmp ne i32 %11, 180150001
-  br i1 %12, label %then10, label %else11
+  %12 = load i32, i32* %boz_4, align 4
+  %13 = icmp ne i32 %12, 180150001
+  br i1 %13, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -102,9 +103,9 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %13 = load i32, i32* %boz_5, align 4
-  %14 = icmp ne i32 %13, 180150001
-  br i1 %14, label %then13, label %else14
+  %14 = load i32, i32* %boz_5, align 4
+  %15 = icmp ne i32 %14, 180150001
+  br i1 %15, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
@@ -115,9 +116,8 @@ else14:                                           ; preds = %ifcont12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %boz_1, i32* %boz_2, i32* %boz_3, i32* %boz_4, i32* %boz_5, float* %boz_6)
-  %17 = load i64, i64* %15, align 4
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %boz_1, i32* %boz_2, i32* %boz_3, i32* %boz_4, i32* %boz_5, float* %boz_6)
+  %17 = load i64, i64* %2, align 4
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "fe5b828e3b260f1a2e479d2f14736acd659a8bcacdd44f8b86f1d84b",
+    "stdout_hash": "c68fcefae9fa3f8418b5163cc9b12503d977f3e574619f4ba36ae516",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -37,6 +37,7 @@ FINALIZE_SYMTABLE_get_i:                          ; preds = %return
 
 define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
   %2 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %1, i32 0, i32 1
@@ -47,7 +48,6 @@ define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
   store float %5, float* %6, align 4
   %7 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const, float* %6)
   %8 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %7, i8** %9, align 8
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "5f6f0541828cccb44a4909224a2121a690b7930595e6fdc14681e07a",
+    "stdout_hash": "44f3f8e9ca955330dfbeba10aea7c033c7c320e558dd40c1104d70c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -32,13 +32,13 @@ declare float @f(float*)
 
 define void @__module_callback_01_foo(float* %c, float* %d) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call float @__module_callback_01_cb(float (float*)* @foo.__module_callback_01_f, float* %c, float* %d)
   %2 = alloca float, align 4
   store float %1, float* %2, align 4
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %2)
   %4 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "747bd8d23147e75ae8e838f774de4162699312ab2d62c8e87bdaf967",
+    "stdout_hash": "8ceae46761cd906235b32368be2bbe65e773928cf1a9cd3a48183690",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "8ceae46761cd906235b32368be2bbe65e773928cf1a9cd3a48183690",
+    "stdout_hash": "ba6aeb3aea9b73994ebe3d0fcd4ee94037374c4acd7210acf99470b3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -17,61 +17,61 @@ source_filename = "LFortran"
 define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (float*, float*)* %f) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
-  call void %f(float* %a, float* %res)
   %0 = alloca i64, align 8
-  %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %res)
-  %2 = load i64, i64* %0, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %1, i8** %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %2, i64* %4, align 4
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
+  call void %f(float* %a, float* %res)
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %res)
+  %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %6 = load i8*, i8** %5, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %8 = load i64, i64* %7, align 4
-  %9 = trunc i64 %8 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %10 = icmp eq i8* %1, null
-  br i1 %10, label %free_done, label %free_nonnull
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %1)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   call void %f(float* %b, float* %res)
-  %11 = alloca i64, align 8
-  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %res)
-  %13 = load i64, i64* %11, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %13, i64* %15, align 4
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %19 = load i64, i64* %18, align 4
-  %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
-  br i1 %21, label %free_done3, label %free_nonnull2
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %1, i32 0, i32 0, float* %res)
+  %14 = load i64, i64* %1, align 4
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %13, i8** %15, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, i64* %16, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %18 = load i8*, i8** %17, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, i64* %19, align 4
+  %21 = trunc i64 %20 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %22 = icmp eq i8* %13, null
+  br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %12)
+  call void @_lfortran_free(i8* %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %22 = load float, float* %b, align 4
-  %23 = load float, float* %a, align 4
-  %24 = fsub float %22, %23
-  %25 = load float, float* %res, align 4
-  %26 = fmul float %24, %25
-  store float %26, float* %res, align 4
-  %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, float* %res)
-  %29 = load i64, i64* %27, align 4
+  %23 = load float, float* %b, align 4
+  %24 = load float, float* %a, align 4
+  %25 = fsub float %23, %24
+  %26 = load float, float* %res, align 4
+  %27 = fmul float %25, %26
+  store float %27, float* %res, align 4
+  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %res)
+  %29 = load i64, i64* %0, align 4
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -16,11 +16,13 @@ source_filename = "LFortran"
 
 define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (float*, float*)* %f) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void %f(float* %a, float* %res)
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %res)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -43,7 +45,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %11 = alloca i64, align 8
   %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %res)
   %13 = load i64, i64* %11, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %12, i8** %14, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -71,7 +72,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %27 = alloca i64, align 8
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, float* %res)
   %29 = load i64, i64* %27, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "071f49784261151fdd37c0b0cecce90b6071d0adc44919c45870627b",
+    "stdout_hash": "a13923a5dde6380a959c2f10083e03220e4718d6fdb0758c028801c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -35,13 +35,13 @@ declare float @f(float*)
 
 define void @__module_callback_03_foo1(float* %c, float* %d) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call float @__module_callback_03_cb(float (float*)* @foo1.__module_callback_03_f, float* %c, float* %d)
   %2 = alloca float, align 4
   store float %1, float* %2, align 4
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %2)
   %4 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -87,13 +87,13 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
 
 define void @__module_callback_03_foo2(float* %c, float* %d) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call float @__module_callback_03_cb(float (float*)* @foo2.__module_callback_03_f, float* %c, float* %d)
   %2 = alloca float, align 4
   store float %1, float* %2, align 4
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %2)
   %4 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "4bf5bd68b479133644c4e5faeee65e0c16783a78475a378cdda6bb3b",
+    "stdout_hash": "1438d19f1c8380490a13d2c2fbc7d43dfdf5e547ebd3146e5d02c965",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -22,10 +22,10 @@ FINALIZE_SYMTABLE_px_call1:                       ; preds = %return
 
 define void @px_call1.__module_callback_05_printx(i32* %x) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %x)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "5c2d625b697a6c95c237bb7e1ce15f0917bba1460db2f832e38967a5",
+    "stdout_hash": "dc96edc301dd955024c2002bddf26a0bf22e7b7b88a4cc76f2a12ee1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "dc96edc301dd955024c2002bddf26a0bf22e7b7b88a4cc76f2a12ee1",
+    "stdout_hash": "a101442a97ce092a1bae7c0505fd24ef6faed138e0a15ac1a2a6baef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -108,6 +108,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc58 = alloca %string_descriptor, align 8
+  %stringFormat_desc37 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %marks = alloca i32, align 4
   %out = alloca i32, align 4
@@ -222,7 +225,6 @@ ifcont15:                                         ; preds = %ifcont14, %then
   %41 = alloca i64, align 8
   %42 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
   %43 = load i64, i64* %41, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %42, i8** %44, align 8
   %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -357,7 +359,6 @@ ifcont36:                                         ; preds = %ifcont35, %then19
   %93 = alloca i64, align 8
   %94 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
   %95 = load i64, i64* %93, align 4
-  %stringFormat_desc37 = alloca %string_descriptor, align 8
   %96 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
   store i8* %94, i8** %96, align 8
   %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
@@ -479,7 +480,6 @@ ifcont57:                                         ; preds = %ifcont56, %then40
   %143 = alloca i64, align 8
   %144 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %143, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
   %145 = load i64, i64* %143, align 4
-  %stringFormat_desc58 = alloca %string_descriptor, align 8
   %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
   store i8* %144, i8** %146, align 8
   %147 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -109,101 +109,104 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc58 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc37 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %marks = alloca i32, align 4
   %out = alloca i32, align 4
   store i32 81, i32* %marks, align 4
-  %2 = load i32, i32* %marks, align 4
-  %3 = icmp sle i32 91, %2
-  %4 = load i32, i32* %marks, align 4
-  %5 = icmp sle i32 %4, 100
-  %6 = icmp eq i1 %3, false
-  %7 = select i1 %6, i1 %3, i1 %5
-  br i1 %7, label %then, label %else
+  %5 = load i32, i32* %marks, align 4
+  %6 = icmp sle i32 91, %5
+  %7 = load i32, i32* %marks, align 4
+  %8 = icmp sle i32 %7, 100
+  %9 = icmp eq i1 %6, false
+  %10 = select i1 %9, i1 %6, i1 %8
+  br i1 %10, label %then, label %else
 
 then:                                             ; preds = %.entry
   store i32 0, i32* %out, align 4
-  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %11 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont15
 
 else:                                             ; preds = %.entry
-  %9 = load i32, i32* %marks, align 4
-  %10 = icmp sle i32 81, %9
-  %11 = load i32, i32* %marks, align 4
-  %12 = icmp sle i32 %11, 90
-  %13 = icmp eq i1 %10, false
-  %14 = select i1 %13, i1 %10, i1 %12
-  br i1 %14, label %then1, label %else2
+  %12 = load i32, i32* %marks, align 4
+  %13 = icmp sle i32 81, %12
+  %14 = load i32, i32* %marks, align 4
+  %15 = icmp sle i32 %14, 90
+  %16 = icmp eq i1 %13, false
+  %17 = select i1 %16, i1 %13, i1 %15
+  br i1 %17, label %then1, label %else2
 
 then1:                                            ; preds = %else
   store i32 1, i32* %out, align 4
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %15, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont14
 
 else2:                                            ; preds = %else
-  %16 = load i32, i32* %marks, align 4
-  %17 = icmp sle i32 71, %16
-  %18 = load i32, i32* %marks, align 4
-  %19 = icmp sle i32 %18, 80
-  %20 = icmp eq i1 %17, false
-  %21 = select i1 %20, i1 %17, i1 %19
-  br i1 %21, label %then3, label %else4
+  %19 = load i32, i32* %marks, align 4
+  %20 = icmp sle i32 71, %19
+  %21 = load i32, i32* %marks, align 4
+  %22 = icmp sle i32 %21, 80
+  %23 = icmp eq i1 %20, false
+  %24 = select i1 %23, i1 %20, i1 %22
+  br i1 %24, label %then3, label %else4
 
 then3:                                            ; preds = %else2
   store i32 2, i32* %out, align 4
-  %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %22, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %25 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %25, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont13
 
 else4:                                            ; preds = %else2
-  %23 = load i32, i32* %marks, align 4
-  %24 = icmp sle i32 61, %23
-  %25 = load i32, i32* %marks, align 4
-  %26 = icmp sle i32 %25, 70
-  %27 = icmp eq i1 %24, false
-  %28 = select i1 %27, i1 %24, i1 %26
-  br i1 %28, label %then5, label %else6
+  %26 = load i32, i32* %marks, align 4
+  %27 = icmp sle i32 61, %26
+  %28 = load i32, i32* %marks, align 4
+  %29 = icmp sle i32 %28, 70
+  %30 = icmp eq i1 %27, false
+  %31 = select i1 %30, i1 %27, i1 %29
+  br i1 %31, label %then5, label %else6
 
 then5:                                            ; preds = %else4
   store i32 3, i32* %out, align 4
-  %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %29, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %32, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont12
 
 else6:                                            ; preds = %else4
-  %30 = load i32, i32* %marks, align 4
-  %31 = icmp sle i32 41, %30
-  %32 = load i32, i32* %marks, align 4
-  %33 = icmp sle i32 %32, 60
-  %34 = icmp eq i1 %31, false
-  %35 = select i1 %34, i1 %31, i1 %33
-  br i1 %35, label %then7, label %else8
+  %33 = load i32, i32* %marks, align 4
+  %34 = icmp sle i32 41, %33
+  %35 = load i32, i32* %marks, align 4
+  %36 = icmp sle i32 %35, 60
+  %37 = icmp eq i1 %34, false
+  %38 = select i1 %37, i1 %34, i1 %36
+  br i1 %38, label %then7, label %else8
 
 then7:                                            ; preds = %else6
   store i32 4, i32* %out, align 4
-  %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %36, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %39, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   br label %ifcont11
 
 else8:                                            ; preds = %else6
-  %37 = load i32, i32* %marks, align 4
-  %38 = icmp sle i32 %37, 40
-  br i1 %38, label %then9, label %else10
+  %40 = load i32, i32* %marks, align 4
+  %41 = icmp sle i32 %40, 40
+  br i1 %41, label %then9, label %else10
 
 then9:                                            ; preds = %else8
   store i32 5, i32* %out, align 4
-  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %39, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %42 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %42, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else10:                                           ; preds = %else8
   store i32 6, i32* %out, align 4
-  %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %40, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %43, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else10, %then9
@@ -222,30 +225,29 @@ ifcont14:                                         ; preds = %ifcont13, %then1
   br label %ifcont15
 
 ifcont15:                                         ; preds = %ifcont14, %then
-  %41 = alloca i64, align 8
-  %42 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
-  %43 = load i64, i64* %41, align 4
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %42, i8** %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %43, i64* %45, align 4
+  %44 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
+  %45 = load i64, i64* %4, align 4
   %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %47 = load i8*, i8** %46, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %49 = load i64, i64* %48, align 4
-  %50 = trunc i64 %49 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %47, i32 %50, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %51 = icmp eq i8* %42, null
-  br i1 %51, label %free_done, label %free_nonnull
+  store i8* %44, i8** %46, align 8
+  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %45, i64* %47, align 4
+  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %49 = load i8*, i8** %48, align 8
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %51 = load i64, i64* %50, align 4
+  %52 = trunc i64 %51 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %49, i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  %53 = icmp eq i8* %44, null
+  br i1 %53, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont15
-  call void @_lfortran_free(i8* %42)
+  call void @_lfortran_free(i8* %44)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont15
-  %52 = load i32, i32* %out, align 4
-  %53 = icmp ne i32 %52, 1
-  br i1 %53, label %then16, label %else17
+  %54 = load i32, i32* %out, align 4
+  %55 = icmp ne i32 %54, 1
+  br i1 %55, label %then16, label %else17
 
 then16:                                           ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
@@ -256,88 +258,88 @@ else17:                                           ; preds = %free_done
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %54 = load i32, i32* %marks, align 4
-  %55 = icmp sle i32 91, %54
   %56 = load i32, i32* %marks, align 4
-  %57 = icmp sle i32 %56, 100
-  %58 = icmp eq i1 %55, false
-  %59 = select i1 %58, i1 %55, i1 %57
-  br i1 %59, label %then19, label %else20
+  %57 = icmp sle i32 91, %56
+  %58 = load i32, i32* %marks, align 4
+  %59 = icmp sle i32 %58, 100
+  %60 = icmp eq i1 %57, false
+  %61 = select i1 %60, i1 %57, i1 %59
+  br i1 %61, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  %60 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %60, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  %62 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %62, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   br label %ifcont36
 
 else20:                                           ; preds = %ifcont18
-  %61 = load i32, i32* %marks, align 4
-  %62 = icmp sle i32 81, %61
   %63 = load i32, i32* %marks, align 4
-  %64 = icmp sle i32 %63, 90
-  %65 = icmp eq i1 %62, false
-  %66 = select i1 %65, i1 %62, i1 %64
-  br i1 %66, label %then21, label %else22
+  %64 = icmp sle i32 81, %63
+  %65 = load i32, i32* %marks, align 4
+  %66 = icmp sle i32 %65, 90
+  %67 = icmp eq i1 %64, false
+  %68 = select i1 %67, i1 %64, i1 %66
+  br i1 %68, label %then21, label %else22
 
 then21:                                           ; preds = %else20
-  %67 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %67, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  %69 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %69, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   br label %ifcont35
 
 else22:                                           ; preds = %else20
-  %68 = load i32, i32* %marks, align 4
-  %69 = icmp sle i32 71, %68
   %70 = load i32, i32* %marks, align 4
-  %71 = icmp sle i32 %70, 80
-  %72 = icmp eq i1 %69, false
-  %73 = select i1 %72, i1 %69, i1 %71
-  br i1 %73, label %then23, label %else24
+  %71 = icmp sle i32 71, %70
+  %72 = load i32, i32* %marks, align 4
+  %73 = icmp sle i32 %72, 80
+  %74 = icmp eq i1 %71, false
+  %75 = select i1 %74, i1 %71, i1 %73
+  br i1 %75, label %then23, label %else24
 
 then23:                                           ; preds = %else22
-  %74 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %74, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  %76 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %76, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   br label %ifcont34
 
 else24:                                           ; preds = %else22
-  %75 = load i32, i32* %marks, align 4
-  %76 = icmp sle i32 61, %75
   %77 = load i32, i32* %marks, align 4
-  %78 = icmp sle i32 %77, 70
-  %79 = icmp eq i1 %76, false
-  %80 = select i1 %79, i1 %76, i1 %78
-  br i1 %80, label %then25, label %else26
+  %78 = icmp sle i32 61, %77
+  %79 = load i32, i32* %marks, align 4
+  %80 = icmp sle i32 %79, 70
+  %81 = icmp eq i1 %78, false
+  %82 = select i1 %81, i1 %78, i1 %80
+  br i1 %82, label %then25, label %else26
 
 then25:                                           ; preds = %else24
-  %81 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %81, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  %83 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %83, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
   br label %ifcont33
 
 else26:                                           ; preds = %else24
-  %82 = load i32, i32* %marks, align 4
-  %83 = icmp sle i32 41, %82
   %84 = load i32, i32* %marks, align 4
-  %85 = icmp sle i32 %84, 60
-  %86 = icmp eq i1 %83, false
-  %87 = select i1 %86, i1 %83, i1 %85
-  br i1 %87, label %then27, label %else28
+  %85 = icmp sle i32 41, %84
+  %86 = load i32, i32* %marks, align 4
+  %87 = icmp sle i32 %86, 60
+  %88 = icmp eq i1 %85, false
+  %89 = select i1 %88, i1 %85, i1 %87
+  br i1 %89, label %then27, label %else28
 
 then27:                                           ; preds = %else26
-  %88 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %88, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  %90 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %90, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   br label %ifcont32
 
 else28:                                           ; preds = %else26
-  %89 = load i32, i32* %marks, align 4
-  %90 = icmp sle i32 %89, 40
-  br i1 %90, label %then29, label %else30
+  %91 = load i32, i32* %marks, align 4
+  %92 = icmp sle i32 %91, 40
+  br i1 %92, label %then29, label %else30
 
 then29:                                           ; preds = %else28
-  %91 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %91, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
+  %93 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %93, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
   br label %ifcont31
 
 else30:                                           ; preds = %else28
-  %92 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %92, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  %94 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %94, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   br label %ifcont31
 
 ifcont31:                                         ; preds = %else30, %then29
@@ -356,109 +358,108 @@ ifcont35:                                         ; preds = %ifcont34, %then21
   br label %ifcont36
 
 ifcont36:                                         ; preds = %ifcont35, %then19
-  %93 = alloca i64, align 8
-  %94 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
-  %95 = load i64, i64* %93, align 4
-  %96 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  store i8* %94, i8** %96, align 8
-  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  store i64 %95, i64* %97, align 4
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  %99 = load i8*, i8** %98, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  %101 = load i64, i64* %100, align 4
-  %102 = trunc i64 %101 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %99, i32 %102, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
-  %103 = icmp eq i8* %94, null
-  br i1 %103, label %free_done39, label %free_nonnull38
+  %95 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
+  %96 = load i64, i64* %3, align 4
+  %97 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
+  store i8* %95, i8** %97, align 8
+  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
+  store i64 %96, i64* %98, align 4
+  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
+  %100 = load i8*, i8** %99, align 8
+  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
+  %102 = load i64, i64* %101, align 4
+  %103 = trunc i64 %102 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %100, i32 %103, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
+  %104 = icmp eq i8* %95, null
+  br i1 %104, label %free_done39, label %free_nonnull38
 
 free_nonnull38:                                   ; preds = %ifcont36
-  call void @_lfortran_free(i8* %94)
+  call void @_lfortran_free(i8* %95)
   br label %free_done39
 
 free_done39:                                      ; preds = %free_nonnull38, %ifcont36
-  %104 = load i32, i32* %marks, align 4
-  %105 = icmp sle i32 91, %104
-  %106 = load i32, i32* %marks, align 4
-  %107 = icmp sle i32 %106, 100
-  %108 = icmp eq i1 %105, false
-  %109 = select i1 %108, i1 %105, i1 %107
-  br i1 %109, label %then40, label %else41
+  %105 = load i32, i32* %marks, align 4
+  %106 = icmp sle i32 91, %105
+  %107 = load i32, i32* %marks, align 4
+  %108 = icmp sle i32 %107, 100
+  %109 = icmp eq i1 %106, false
+  %110 = select i1 %109, i1 %106, i1 %108
+  br i1 %110, label %then40, label %else41
 
 then40:                                           ; preds = %free_done39
-  %110 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.33, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %110, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  %111 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.33, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %111, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   br label %ifcont57
 
 else41:                                           ; preds = %free_done39
-  %111 = load i32, i32* %marks, align 4
-  %112 = icmp sle i32 81, %111
-  %113 = load i32, i32* %marks, align 4
-  %114 = icmp sle i32 %113, 90
-  %115 = icmp eq i1 %112, false
-  %116 = select i1 %115, i1 %112, i1 %114
-  br i1 %116, label %then42, label %else43
+  %112 = load i32, i32* %marks, align 4
+  %113 = icmp sle i32 81, %112
+  %114 = load i32, i32* %marks, align 4
+  %115 = icmp sle i32 %114, 90
+  %116 = icmp eq i1 %113, false
+  %117 = select i1 %116, i1 %113, i1 %115
+  br i1 %117, label %then42, label %else43
 
 then42:                                           ; preds = %else41
-  %117 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.35, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %117, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
+  %118 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.35, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %118, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
   br label %ifcont56
 
 else43:                                           ; preds = %else41
-  %118 = load i32, i32* %marks, align 4
-  %119 = icmp sle i32 71, %118
-  %120 = load i32, i32* %marks, align 4
-  %121 = icmp sle i32 %120, 80
-  %122 = icmp eq i1 %119, false
-  %123 = select i1 %122, i1 %119, i1 %121
-  br i1 %123, label %then44, label %else45
+  %119 = load i32, i32* %marks, align 4
+  %120 = icmp sle i32 71, %119
+  %121 = load i32, i32* %marks, align 4
+  %122 = icmp sle i32 %121, 80
+  %123 = icmp eq i1 %120, false
+  %124 = select i1 %123, i1 %120, i1 %122
+  br i1 %124, label %then44, label %else45
 
 then44:                                           ; preds = %else43
-  %124 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.37, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %124, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  %125 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.37, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %125, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   br label %ifcont55
 
 else45:                                           ; preds = %else43
-  %125 = load i32, i32* %marks, align 4
-  %126 = icmp sle i32 61, %125
-  %127 = load i32, i32* %marks, align 4
-  %128 = icmp sle i32 %127, 70
-  %129 = icmp eq i1 %126, false
-  %130 = select i1 %129, i1 %126, i1 %128
-  br i1 %130, label %then46, label %else47
+  %126 = load i32, i32* %marks, align 4
+  %127 = icmp sle i32 61, %126
+  %128 = load i32, i32* %marks, align 4
+  %129 = icmp sle i32 %128, 70
+  %130 = icmp eq i1 %127, false
+  %131 = select i1 %130, i1 %127, i1 %129
+  br i1 %131, label %then46, label %else47
 
 then46:                                           ; preds = %else45
-  %131 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.39, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %131, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
+  %132 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.39, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %132, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
   br label %ifcont54
 
 else47:                                           ; preds = %else45
-  %132 = load i32, i32* %marks, align 4
-  %133 = icmp sle i32 41, %132
-  %134 = load i32, i32* %marks, align 4
-  %135 = icmp sle i32 %134, 60
-  %136 = icmp eq i1 %133, false
-  %137 = select i1 %136, i1 %133, i1 %135
-  br i1 %137, label %then48, label %else49
+  %133 = load i32, i32* %marks, align 4
+  %134 = icmp sle i32 41, %133
+  %135 = load i32, i32* %marks, align 4
+  %136 = icmp sle i32 %135, 60
+  %137 = icmp eq i1 %134, false
+  %138 = select i1 %137, i1 %134, i1 %136
+  br i1 %138, label %then48, label %else49
 
 then48:                                           ; preds = %else47
-  %138 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.41, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %138, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  %139 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.41, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %139, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
   br label %ifcont53
 
 else49:                                           ; preds = %else47
-  %139 = load i32, i32* %marks, align 4
-  %140 = icmp sle i32 %139, 40
-  br i1 %140, label %then50, label %else51
+  %140 = load i32, i32* %marks, align 4
+  %141 = icmp sle i32 %140, 40
+  br i1 %141, label %then50, label %else51
 
 then50:                                           ; preds = %else49
-  %141 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.43, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %141, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
+  %142 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.43, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %142, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
   br label %ifcont52
 
 else51:                                           ; preds = %else49
-  %142 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.45, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %142, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
+  %143 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.45, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %143, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
   br label %ifcont52
 
 ifcont52:                                         ; preds = %else51, %then50
@@ -477,9 +478,8 @@ ifcont56:                                         ; preds = %ifcont55, %then42
   br label %ifcont57
 
 ifcont57:                                         ; preds = %ifcont56, %then40
-  %143 = alloca i64, align 8
-  %144 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %143, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
-  %145 = load i64, i64* %143, align 4
+  %144 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
+  %145 = load i64, i64* %2, align 4
   %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
   store i8* %144, i8** %146, align 8
   %147 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "433cb208c3bc226f1385b9b8fae2e1d9dbe9b5ba2bbabc66c2de965a",
+    "stdout_hash": "1fac6aa64a7f0365e9717ca43bacfbe77a21cee719e42e10847123c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "1fac6aa64a7f0365e9717ca43bacfbe77a21cee719e42e10847123c2",
+    "stdout_hash": "13d266be471b52e92b86ef381e26459fe283c8ce8774d0c78872b3e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -41,7 +41,9 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   store i32 1, i32* %a, align 4
@@ -49,91 +51,89 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 2, i32* %b, align 4
   %marks = alloca i32, align 4
   store i32 94, i32* %marks, align 4
-  %2 = load i32, i32* %marks, align 4
-  %3 = icmp sle i32 42, %2
-  br i1 %3, label %then, label %else
+  %4 = load i32, i32* %marks, align 4
+  %5 = icmp sle i32 42, %4
+  br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %5 = load i32, i32* %marks, align 4
-  %6 = icmp sle i32 %5, 38
-  br i1 %6, label %then1, label %else2
+  %7 = load i32, i32* %marks, align 4
+  %8 = icmp sle i32 %7, 38
+  br i1 %8, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %9 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else2:                                            ; preds = %else
-  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %8, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
   br label %ifcont3
 
 ifcont3:                                          ; preds = %ifcont, %then
-  %9 = alloca i64, align 8
-  %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
-  %11 = load i64, i64* %9, align 4
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %10, i8** %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %11, i64* %13, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %15 = load i8*, i8** %14, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %17 = load i64, i64* %16, align 4
-  %18 = trunc i64 %17 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %15, i32 %18, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %19 = icmp eq i8* %10, null
-  br i1 %19, label %free_done, label %free_nonnull
+  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
+  %12 = load i64, i64* %3, align 4
+  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %11, i8** %13, align 8
+  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %12, i64* %14, align 4
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %16 = load i8*, i8** %15, align 8
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, i64* %17, align 4
+  %19 = trunc i64 %18 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %20 = icmp eq i8* %11, null
+  br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont3
-  call void @_lfortran_free(i8* %10)
+  call void @_lfortran_free(i8* %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont3
   store i32 -1, i32* %marks, align 4
-  %20 = load i32, i32* %marks, align 4
-  %21 = icmp sle i32 42, %20
-  br i1 %21, label %then4, label %else5
+  %21 = load i32, i32* %marks, align 4
+  %22 = icmp sle i32 42, %21
+  br i1 %22, label %then4, label %else5
 
 then4:                                            ; preds = %free_done
-  %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %22, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %23 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %23, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   br label %ifcont9
 
 else5:                                            ; preds = %free_done
-  %23 = load i32, i32* %marks, align 4
-  %24 = icmp sle i32 0, %23
-  %25 = load i32, i32* %marks, align 4
-  %26 = icmp sle i32 %25, 38
-  %27 = icmp eq i1 %24, false
-  %28 = select i1 %27, i1 %24, i1 %26
-  br i1 %28, label %then6, label %else7
+  %24 = load i32, i32* %marks, align 4
+  %25 = icmp sle i32 0, %24
+  %26 = load i32, i32* %marks, align 4
+  %27 = icmp sle i32 %26, 38
+  %28 = icmp eq i1 %25, false
+  %29 = select i1 %28, i1 %25, i1 %27
+  br i1 %29, label %then6, label %else7
 
 then6:                                            ; preds = %else5
-  %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %30, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont8
 
 else7:                                            ; preds = %else5
-  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %30, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %31, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %ifcont8, %then4
-  %31 = alloca i64, align 8
-  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
-  %33 = load i64, i64* %31, align 4
+  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
+  %33 = load i64, i64* %2, align 4
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %32, i8** %34, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -40,6 +40,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   store i32 1, i32* %a, align 4
@@ -78,7 +80,6 @@ ifcont3:                                          ; preds = %ifcont, %then
   %9 = alloca i64, align 8
   %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
   %11 = load i64, i64* %9, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %10, i8** %12, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -133,7 +134,6 @@ ifcont9:                                          ; preds = %ifcont8, %then4
   %31 = alloca i64, align 8
   %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
   %33 = load i64, i64* %31, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %32, i8** %34, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "288a82aa7efc4fe680f12e7aea3867008d50b2bf360f02f1de4da4eb",
+    "stdout_hash": "c4f10a254286cc294bfd57a27a232023cb6b17a3622bc47d5004ad25",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "c4f10a254286cc294bfd57a27a232023cb6b17a3622bc47d5004ad25",
+    "stdout_hash": "da4b41780ca0e9955f385925b727b129abdbfed0763e6e30b64ad785",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -40,6 +40,7 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
 
 define void @__module_class_circle1_circle_print(%class_circle1.circle_class* %this) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %area = alloca float, align 4
   %0 = bitcast %class_circle1.circle_class* %this to float (%class_circle1.circle_class*)***
   %1 = load float (%class_circle1.circle_class*)**, float (%class_circle1.circle_class*)*** %0, align 8
@@ -56,7 +57,6 @@ define void @__module_class_circle1_circle_print(%class_circle1.circle_class* %t
   store float %9, float* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
   %12 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -41,22 +41,22 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
 define void @__module_class_circle1_circle_print(%class_circle1.circle_class* %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %area = alloca float, align 4
-  %0 = bitcast %class_circle1.circle_class* %this to float (%class_circle1.circle_class*)***
-  %1 = load float (%class_circle1.circle_class*)**, float (%class_circle1.circle_class*)*** %0, align 8
-  %2 = getelementptr inbounds float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %1, i32 2
-  %3 = load float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %2, align 8
-  %4 = call float %3(%class_circle1.circle_class* %this)
-  store float %4, float* %area, align 4
-  %5 = alloca i64, align 8
+  %1 = bitcast %class_circle1.circle_class* %this to float (%class_circle1.circle_class*)***
+  %2 = load float (%class_circle1.circle_class*)**, float (%class_circle1.circle_class*)*** %1, align 8
+  %3 = getelementptr inbounds float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %2, i32 2
+  %4 = load float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %3, align 8
+  %5 = call float %4(%class_circle1.circle_class* %this)
+  store float %5, float* %area, align 4
   %6 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %this, i32 0, i32 1
   %7 = load %class_circle1.circle*, %class_circle1.circle** %6, align 8
   %8 = getelementptr %class_circle1.circle, %class_circle1.circle* %7, i32 0, i32 0
   %9 = load float, float* %8, align 4
   %10 = alloca float, align 4
   store float %9, float* %10, align 4
-  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
-  %12 = load i64, i64* %5, align 4
+  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
+  %12 = load i64, i64* %0, align 4
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "6d6d388ab6986211d969865c258786ea3aed916932e2bc5a6c84b04f",
+    "stdout_hash": "160f3d8b8043d506ac308091ff6bfc0bf03016e3e23b10b8ab7cc816",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "364f415064f235f4900a03a7da8405bed572e1d1d4450df2aa68c365",
+    "stdout_hash": "6d6d388ab6986211d969865c258786ea3aed916932e2bc5a6c84b04f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -40,6 +40,7 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
 
 define void @__module_class_circle2_circle_print(%class_circle2.circle_class* %this) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %area = alloca float, align 4
   %0 = bitcast %class_circle2.circle_class* %this to float (%class_circle2.circle_class*)***
   %1 = load float (%class_circle2.circle_class*)**, float (%class_circle2.circle_class*)*** %0, align 8
@@ -56,7 +57,6 @@ define void @__module_class_circle2_circle_print(%class_circle2.circle_class* %t
   store float %9, float* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
   %12 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -41,22 +41,22 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
 define void @__module_class_circle2_circle_print(%class_circle2.circle_class* %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %area = alloca float, align 4
-  %0 = bitcast %class_circle2.circle_class* %this to float (%class_circle2.circle_class*)***
-  %1 = load float (%class_circle2.circle_class*)**, float (%class_circle2.circle_class*)*** %0, align 8
-  %2 = getelementptr inbounds float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %1, i32 2
-  %3 = load float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %2, align 8
-  %4 = call float %3(%class_circle2.circle_class* %this)
-  store float %4, float* %area, align 4
-  %5 = alloca i64, align 8
+  %1 = bitcast %class_circle2.circle_class* %this to float (%class_circle2.circle_class*)***
+  %2 = load float (%class_circle2.circle_class*)**, float (%class_circle2.circle_class*)*** %1, align 8
+  %3 = getelementptr inbounds float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %2, i32 2
+  %4 = load float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %3, align 8
+  %5 = call float %4(%class_circle2.circle_class* %this)
+  store float %5, float* %area, align 4
   %6 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %this, i32 0, i32 1
   %7 = load %class_circle2.circle*, %class_circle2.circle** %6, align 8
   %8 = getelementptr %class_circle2.circle, %class_circle2.circle* %7, i32 0, i32 0
   %9 = load float, float* %8, align 4
   %10 = alloca float, align 4
   store float %9, float* %10, align 4
-  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
-  %12 = load i64, i64* %5, align 4
+  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const, float* %10, %string_descriptor* @string_const.2, float* %area)
+  %12 = load i64, i64* %0, align 4
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "c2883e9d347531f073abfa4edcdb0463823a80ee1d247c7b8d09b827",
+    "stdout_hash": "cd23cf750491de3b1c7be254b7e37fec090c0ea49a53c889b514ec0c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "cd23cf750491de3b1c7be254b7e37fec090c0ea49a53c889b514ec0c",
+    "stdout_hash": "9b38dcc8cbf6b7caaad837a1abc2e84b7f2a26f8d58eb6ecb86c4a51",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -1,13 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%string_descriptor = type <{ i8*, i64 }>
 %main.foo_c = type { %main.foo_b, %main.bar_c }
 %main.foo_b = type { %main.foo_a, %main.bar_b }
 %main.foo_a = type { %main.bar_a }
 %main.bar_a = type { i32 }
 %main.bar_b = type { %main.bar_a, i32 }
 %main.bar_c = type { %main.bar_b, i32 }
-%string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -24,6 +24,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %foo = alloca %main.foo_c, align 8
   %2 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
@@ -62,7 +65,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %30, i32* %31, align 4
   %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %25, i32 0, i32 0, i32* %31)
   %33 = load i64, i64* %25, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %32, i8** %34, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -90,7 +92,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 %46, i32* %47, align 4
   %48 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %42, i32 0, i32 0, i32* %47)
   %49 = load i64, i64* %42, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %48, i8** %50, align 8
   %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -117,7 +118,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   store i32 %61, i32* %62, align 4
   %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %58, i32 0, i32 0, i32* %62)
   %64 = load i64, i64* %58, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %63, i8** %65, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -25,99 +25,99 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %foo = alloca %main.foo_c, align 8
-  %2 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %3 = getelementptr %main.bar_c, %main.bar_c* %2, i32 0, i32 1
-  %4 = getelementptr %main.bar_c, %main.bar_c* %2, i32 0, i32 0
-  %5 = getelementptr %main.bar_b, %main.bar_b* %4, i32 0, i32 1
-  %6 = getelementptr %main.bar_b, %main.bar_b* %4, i32 0, i32 0
-  %7 = getelementptr %main.bar_a, %main.bar_a* %6, i32 0, i32 0
-  %8 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %9 = getelementptr %main.foo_b, %main.foo_b* %8, i32 0, i32 1
-  %10 = getelementptr %main.bar_b, %main.bar_b* %9, i32 0, i32 1
-  %11 = getelementptr %main.bar_b, %main.bar_b* %9, i32 0, i32 0
-  %12 = getelementptr %main.bar_a, %main.bar_a* %11, i32 0, i32 0
-  %13 = getelementptr %main.foo_b, %main.foo_b* %8, i32 0, i32 0
-  %14 = getelementptr %main.foo_a, %main.foo_a* %13, i32 0, i32 0
+  %5 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
+  %6 = getelementptr %main.bar_c, %main.bar_c* %5, i32 0, i32 1
+  %7 = getelementptr %main.bar_c, %main.bar_c* %5, i32 0, i32 0
+  %8 = getelementptr %main.bar_b, %main.bar_b* %7, i32 0, i32 1
+  %9 = getelementptr %main.bar_b, %main.bar_b* %7, i32 0, i32 0
+  %10 = getelementptr %main.bar_a, %main.bar_a* %9, i32 0, i32 0
+  %11 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
+  %12 = getelementptr %main.foo_b, %main.foo_b* %11, i32 0, i32 1
+  %13 = getelementptr %main.bar_b, %main.bar_b* %12, i32 0, i32 1
+  %14 = getelementptr %main.bar_b, %main.bar_b* %12, i32 0, i32 0
   %15 = getelementptr %main.bar_a, %main.bar_a* %14, i32 0, i32 0
-  %16 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %17 = getelementptr %main.foo_b, %main.foo_b* %16, i32 0, i32 0
-  %18 = getelementptr %main.foo_a, %main.foo_a* %17, i32 0, i32 0
-  %19 = getelementptr %main.bar_a, %main.bar_a* %18, i32 0, i32 0
-  store i32 -20, i32* %19, align 4
-  %20 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %21 = getelementptr %main.foo_b, %main.foo_b* %20, i32 0, i32 1
-  %22 = getelementptr %main.bar_b, %main.bar_b* %21, i32 0, i32 1
-  store i32 9, i32* %22, align 4
-  %23 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %24 = getelementptr %main.bar_c, %main.bar_c* %23, i32 0, i32 1
-  store i32 11, i32* %24, align 4
-  %25 = alloca i64, align 8
-  %26 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %27 = getelementptr %main.foo_b, %main.foo_b* %26, i32 0, i32 0
-  %28 = getelementptr %main.foo_a, %main.foo_a* %27, i32 0, i32 0
-  %29 = getelementptr %main.bar_a, %main.bar_a* %28, i32 0, i32 0
-  %30 = load i32, i32* %29, align 4
-  %31 = alloca i32, align 4
-  store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %25, i32 0, i32 0, i32* %31)
-  %33 = load i64, i64* %25, align 4
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %33, i64* %35, align 4
+  %16 = getelementptr %main.foo_b, %main.foo_b* %11, i32 0, i32 0
+  %17 = getelementptr %main.foo_a, %main.foo_a* %16, i32 0, i32 0
+  %18 = getelementptr %main.bar_a, %main.bar_a* %17, i32 0, i32 0
+  %19 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
+  %20 = getelementptr %main.foo_b, %main.foo_b* %19, i32 0, i32 0
+  %21 = getelementptr %main.foo_a, %main.foo_a* %20, i32 0, i32 0
+  %22 = getelementptr %main.bar_a, %main.bar_a* %21, i32 0, i32 0
+  store i32 -20, i32* %22, align 4
+  %23 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
+  %24 = getelementptr %main.foo_b, %main.foo_b* %23, i32 0, i32 1
+  %25 = getelementptr %main.bar_b, %main.bar_b* %24, i32 0, i32 1
+  store i32 9, i32* %25, align 4
+  %26 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
+  %27 = getelementptr %main.bar_c, %main.bar_c* %26, i32 0, i32 1
+  store i32 11, i32* %27, align 4
+  %28 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
+  %29 = getelementptr %main.foo_b, %main.foo_b* %28, i32 0, i32 0
+  %30 = getelementptr %main.foo_a, %main.foo_a* %29, i32 0, i32 0
+  %31 = getelementptr %main.bar_a, %main.bar_a* %30, i32 0, i32 0
+  %32 = load i32, i32* %31, align 4
+  %33 = alloca i32, align 4
+  store i32 %32, i32* %33, align 4
+  %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %33)
+  %35 = load i64, i64* %4, align 4
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %39 = load i64, i64* %38, align 4
-  %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
-  br i1 %41, label %free_done, label %free_nonnull
+  store i8* %34, i8** %36, align 8
+  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %35, i64* %37, align 4
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %39 = load i8*, i8** %38, align 8
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %41 = load i64, i64* %40, align 4
+  %42 = trunc i64 %41 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %39, i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %43 = icmp eq i8* %34, null
+  br i1 %43, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %32)
+  call void @_lfortran_free(i8* %34)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %42 = alloca i64, align 8
-  %43 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %44 = getelementptr %main.foo_b, %main.foo_b* %43, i32 0, i32 1
-  %45 = getelementptr %main.bar_b, %main.bar_b* %44, i32 0, i32 1
-  %46 = load i32, i32* %45, align 4
-  %47 = alloca i32, align 4
-  store i32 %46, i32* %47, align 4
-  %48 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %42, i32 0, i32 0, i32* %47)
-  %49 = load i64, i64* %42, align 4
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %48, i8** %50, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %49, i64* %51, align 4
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %55 = load i64, i64* %54, align 4
-  %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %57 = icmp eq i8* %48, null
-  br i1 %57, label %free_done3, label %free_nonnull2
+  %44 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
+  %45 = getelementptr %main.foo_b, %main.foo_b* %44, i32 0, i32 1
+  %46 = getelementptr %main.bar_b, %main.bar_b* %45, i32 0, i32 1
+  %47 = load i32, i32* %46, align 4
+  %48 = alloca i32, align 4
+  store i32 %47, i32* %48, align 4
+  %49 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %48)
+  %50 = load i64, i64* %3, align 4
+  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %49, i8** %51, align 8
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %50, i64* %52, align 4
+  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %54 = load i8*, i8** %53, align 8
+  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %56 = load i64, i64* %55, align 4
+  %57 = trunc i64 %56 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %54, i32 %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %58 = icmp eq i8* %49, null
+  br i1 %58, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %48)
+  call void @_lfortran_free(i8* %49)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %58 = alloca i64, align 8
   %59 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
   %60 = getelementptr %main.bar_c, %main.bar_c* %59, i32 0, i32 1
   %61 = load i32, i32* %60, align 4
   %62 = alloca i32, align 4
   store i32 %61, i32* %62, align 4
-  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %58, i32 0, i32 0, i32* %62)
-  %64 = load i64, i64* %58, align 4
+  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %62)
+  %64 = load i64, i64* %2, align 4
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %63, i8** %65, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "3e805a031d70ba3b9b71e9eb5a56f76f6115771ece97ba3f6ebc2d19",
+    "stdout_hash": "dcb396dd5fe8331e82225b35f9a6b34827b411d25d837a18e292bb06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "55a65fa510c01564afa6760b376659a68463a99a2f3876744f3bb9f8",
+    "stdout_hash": "3e805a031d70ba3b9b71e9eb5a56f76f6115771ece97ba3f6ebc2d19",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -32,6 +32,7 @@ FINALIZE_SYMTABLE_show_x:                         ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = alloca %xx.base_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %b = alloca %xx.base, align 8
@@ -50,7 +51,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %9, i32* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %7, i32 0, i32 0, i32* %10)
   %12 = load i64, i64* %7, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -33,24 +33,24 @@ FINALIZE_SYMTABLE_show_x:                         ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = alloca %xx.base_class, align 8
+  %2 = alloca i64, align 8
+  %3 = alloca %xx.base_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %b = alloca %xx.base, align 8
-  %3 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
   %4 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
-  store i32 10, i32* %4, align 4
-  %5 = getelementptr %xx.base_class, %xx.base_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %xx.base_class, %xx.base_class* %2, i32 0, i32 1
-  store %xx.base* %b, %xx.base** %6, align 8
-  call void @__module_xx_show_x(%xx.base_class* %2)
-  %7 = alloca i64, align 8
+  %5 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
+  store i32 10, i32* %5, align 4
+  %6 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 0
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
+  %7 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 1
+  store %xx.base* %b, %xx.base** %7, align 8
+  call void @__module_xx_show_x(%xx.base_class* %3)
   %8 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
   %9 = load i32, i32* %8, align 4
   %10 = alloca i32, align 4
   store i32 %9, i32* %10, align 4
-  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %7, i32 0, i32 0, i32* %10)
-  %12 = load i64, i64* %7, align 4
+  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %10)
+  %12 = load i64, i64* %2, align 4
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "442246932f86a92973ea9c70af0e55c595369c04c1dabfb59a6710ba",
+    "stdout_hash": "9d355b2dbebbda6192914d6888bbbbb30f1977c6346a81c51633e3fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "b12cb88080f783ad78b1b4a658e9a0176643a8207d448beb03cd1b79",
+    "stdout_hash": "442246932f86a92973ea9c70af0e55c595369c04c1dabfb59a6710ba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -17,86 +17,86 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %2 = load %complex_4, %complex_4* %x, align 1
-  %3 = extractvalue %complex_4 %2, 0
-  %4 = extractvalue %complex_4 %2, 1
-  %5 = fadd float %3, 4.000000e+00
-  %6 = fadd float %4, 0.000000e+00
-  %7 = insertvalue %complex_4 undef, float %5, 0
-  %8 = insertvalue %complex_4 %7, float %6, 1
-  store %complex_4 %8, %complex_4* %x, align 1
-  %9 = alloca i64, align 8
-  %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %complex_4* %x)
-  %11 = load i64, i64* %9, align 4
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %10, i8** %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %11, i64* %13, align 4
+  %5 = load %complex_4, %complex_4* %x, align 1
+  %6 = extractvalue %complex_4 %5, 0
+  %7 = extractvalue %complex_4 %5, 1
+  %8 = fadd float %6, 4.000000e+00
+  %9 = fadd float %7, 0.000000e+00
+  %10 = insertvalue %complex_4 undef, float %8, 0
+  %11 = insertvalue %complex_4 %10, float %9, 1
+  store %complex_4 %11, %complex_4* %x, align 1
+  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, %complex_4* %x)
+  %13 = load i64, i64* %4, align 4
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %15 = load i8*, i8** %14, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %17 = load i64, i64* %16, align 4
-  %18 = trunc i64 %17 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %15, i32 %18, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %19 = icmp eq i8* %10, null
-  br i1 %19, label %free_done, label %free_nonnull
+  store i8* %12, i8** %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %13, i64* %15, align 4
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %17 = load i8*, i8** %16, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, i64* %18, align 4
+  %20 = trunc i64 %19 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %21 = icmp eq i8* %12, null
+  br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %10)
+  call void @_lfortran_free(i8* %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %20 = load %complex_4, %complex_4* %x, align 1
-  %21 = extractvalue %complex_4 %20, 0
-  %22 = extractvalue %complex_4 %20, 1
-  %23 = fadd float 2.000000e+00, %21
-  %24 = fadd float 0.000000e+00, %22
-  %25 = insertvalue %complex_4 undef, float %23, 0
-  %26 = insertvalue %complex_4 %25, float %24, 1
-  store %complex_4 %26, %complex_4* %x, align 1
-  %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %27, i32 0, i32 0, %complex_4* %x)
-  %29 = load i64, i64* %27, align 4
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %29, i64* %31, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %35 = load i64, i64* %34, align 4
-  %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %37 = icmp eq i8* %28, null
-  br i1 %37, label %free_done3, label %free_nonnull2
+  %22 = load %complex_4, %complex_4* %x, align 1
+  %23 = extractvalue %complex_4 %22, 0
+  %24 = extractvalue %complex_4 %22, 1
+  %25 = fadd float 2.000000e+00, %23
+  %26 = fadd float 0.000000e+00, %24
+  %27 = insertvalue %complex_4 undef, float %25, 0
+  %28 = insertvalue %complex_4 %27, float %26, 1
+  store %complex_4 %28, %complex_4* %x, align 1
+  %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, %complex_4* %x)
+  %30 = load i64, i64* %3, align 4
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %29, i8** %31, align 8
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %30, i64* %32, align 4
+  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %34 = load i8*, i8** %33, align 8
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %36 = load i64, i64* %35, align 4
+  %37 = trunc i64 %36 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %38 = icmp eq i8* %29, null
+  br i1 %38, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %28)
+  call void @_lfortran_free(i8* %29)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %38 = load %complex_4, %complex_4* %x, align 1
-  %39 = extractvalue %complex_4 %38, 0
-  %40 = extractvalue %complex_4 %38, 1
-  %41 = fadd float 2.000000e+00, %39
-  %42 = fadd float 0.000000e+00, %40
-  %43 = insertvalue %complex_4 undef, float %41, 0
-  %44 = insertvalue %complex_4 %43, float %42, 1
-  %45 = extractvalue %complex_4 %44, 0
-  %46 = extractvalue %complex_4 %44, 1
-  %47 = fadd float %45, 0.000000e+00
-  %48 = fadd float %46, 3.000000e+00
-  %49 = insertvalue %complex_4 undef, float %47, 0
-  %50 = insertvalue %complex_4 %49, float %48, 1
-  store %complex_4 %50, %complex_4* %x, align 1
-  %51 = alloca i64, align 8
-  %52 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %51, i32 0, i32 0, %complex_4* %x)
-  %53 = load i64, i64* %51, align 4
+  %39 = load %complex_4, %complex_4* %x, align 1
+  %40 = extractvalue %complex_4 %39, 0
+  %41 = extractvalue %complex_4 %39, 1
+  %42 = fadd float 2.000000e+00, %40
+  %43 = fadd float 0.000000e+00, %41
+  %44 = insertvalue %complex_4 undef, float %42, 0
+  %45 = insertvalue %complex_4 %44, float %43, 1
+  %46 = extractvalue %complex_4 %45, 0
+  %47 = extractvalue %complex_4 %45, 1
+  %48 = fadd float %46, 0.000000e+00
+  %49 = fadd float %47, 3.000000e+00
+  %50 = insertvalue %complex_4 undef, float %48, 0
+  %51 = insertvalue %complex_4 %50, float %49, 1
+  store %complex_4 %51, %complex_4* %x, align 1
+  %52 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %x)
+  %53 = load i64, i64* %2, align 4
   %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %52, i8** %54, align 8
   %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%complex_4 = type <{ float, float }>
 %string_descriptor = type <{ i8*, i64 }>
+%complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
@@ -16,6 +16,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
@@ -30,7 +33,6 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = alloca i64, align 8
   %10 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %complex_4* %x)
   %11 = load i64, i64* %9, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %10, i8** %12, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -60,7 +62,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %27 = alloca i64, align 8
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %27, i32 0, i32 0, %complex_4* %x)
   %29 = load i64, i64* %27, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -96,7 +97,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %51 = alloca i64, align 8
   %52 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %51, i32 0, i32 0, %complex_4* %x)
   %53 = load i64, i64* %51, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %52, i8** %54, align 8
   %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "6114c877ccc5931047fa9ed566ba07a759312d260427c3f848d5aa8c",
+    "stdout_hash": "06bf67ed810eeb2ce79658ad277483ff0cec970c302f41b6a4b2df09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "06bf67ed810eeb2ce79658ad277483ff0cec970c302f41b6a4b2df09",
+    "stdout_hash": "267a1b32d7756e451ace91ae0b6737f63784e8f240c30b36d3ae5849",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%complex_4 = type <{ float, float }>
 %string_descriptor = type <{ i8*, i64 }>
+%complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
@@ -16,6 +16,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
@@ -54,7 +57,6 @@ complex_div_cont:                                 ; preds = %complex_div_r_lt_s,
   %24 = alloca i64, align 8
   %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %24, i32 0, i32 0, %complex_4* %x)
   %26 = load i64, i64* %24, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %25, i8** %27, align 8
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -114,7 +116,6 @@ complex_div_cont3:                                ; preds = %complex_div_r_lt_s2
   %63 = alloca i64, align 8
   %64 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %63, i32 0, i32 0, %complex_4* %x)
   %65 = load i64, i64* %63, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %64, i8** %66, align 8
   %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -180,7 +181,6 @@ complex_div_cont9:                                ; preds = %complex_div_r_lt_s8
   %108 = alloca i64, align 8
   %109 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %108, i32 0, i32 0, %complex_4* %x)
   %110 = load i64, i64* %108, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %111 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %109, i8** %111, align 8
   %112 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -17,170 +17,170 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %2 = load %complex_4, %complex_4* %x, align 1
-  %3 = extractvalue %complex_4 %2, 0
-  %4 = extractvalue %complex_4 %2, 1
-  %5 = call float @llvm.fabs.f32(float 4.000000e+00)
-  %6 = call float @llvm.fabs.f32(float 0.000000e+00)
-  %7 = fcmp oge float %5, %6
-  br i1 %7, label %complex_div_r_ge_s, label %complex_div_r_lt_s
+  %5 = load %complex_4, %complex_4* %x, align 1
+  %6 = extractvalue %complex_4 %5, 0
+  %7 = extractvalue %complex_4 %5, 1
+  %8 = call float @llvm.fabs.f32(float 4.000000e+00)
+  %9 = call float @llvm.fabs.f32(float 0.000000e+00)
+  %10 = fcmp oge float %8, %9
+  br i1 %10, label %complex_div_r_ge_s, label %complex_div_r_lt_s
 
 complex_div_r_ge_s:                               ; preds = %.entry
-  %8 = fmul float %4, 0.000000e+00
-  %9 = fadd float %3, %8
-  %10 = fmul float %3, 0.000000e+00
-  %11 = fsub float %4, %10
-  %12 = fdiv float %9, 4.000000e+00
-  %13 = fdiv float %11, 4.000000e+00
+  %11 = fmul float %7, 0.000000e+00
+  %12 = fadd float %6, %11
+  %13 = fmul float %6, 0.000000e+00
+  %14 = fsub float %7, %13
+  %15 = fdiv float %12, 4.000000e+00
+  %16 = fdiv float %14, 4.000000e+00
   br label %complex_div_cont
 
 complex_div_r_lt_s:                               ; preds = %.entry
-  %14 = fmul float %3, 0x7FF0000000000000
-  %15 = fadd float %14, %4
-  %16 = fmul float %4, 0x7FF0000000000000
-  %17 = fsub float %16, %3
-  %18 = fdiv float %15, 0x7FF0000000000000
-  %19 = fdiv float %17, 0x7FF0000000000000
+  %17 = fmul float %6, 0x7FF0000000000000
+  %18 = fadd float %17, %7
+  %19 = fmul float %7, 0x7FF0000000000000
+  %20 = fsub float %19, %6
+  %21 = fdiv float %18, 0x7FF0000000000000
+  %22 = fdiv float %20, 0x7FF0000000000000
   br label %complex_div_cont
 
 complex_div_cont:                                 ; preds = %complex_div_r_lt_s, %complex_div_r_ge_s
-  %20 = phi float [ %12, %complex_div_r_ge_s ], [ %18, %complex_div_r_lt_s ]
-  %21 = phi float [ %13, %complex_div_r_ge_s ], [ %19, %complex_div_r_lt_s ]
-  %22 = insertvalue %complex_4 undef, float %20, 0
-  %23 = insertvalue %complex_4 %22, float %21, 1
-  store %complex_4 %23, %complex_4* %x, align 1
-  %24 = alloca i64, align 8
-  %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %24, i32 0, i32 0, %complex_4* %x)
-  %26 = load i64, i64* %24, align 4
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %25, i8** %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %26, i64* %28, align 4
+  %23 = phi float [ %15, %complex_div_r_ge_s ], [ %21, %complex_div_r_lt_s ]
+  %24 = phi float [ %16, %complex_div_r_ge_s ], [ %22, %complex_div_r_lt_s ]
+  %25 = insertvalue %complex_4 undef, float %23, 0
+  %26 = insertvalue %complex_4 %25, float %24, 1
+  store %complex_4 %26, %complex_4* %x, align 1
+  %27 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, %complex_4* %x)
+  %28 = load i64, i64* %4, align 4
   %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %30 = load i8*, i8** %29, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %32 = load i64, i64* %31, align 4
-  %33 = trunc i64 %32 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %30, i32 %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %34 = icmp eq i8* %25, null
-  br i1 %34, label %free_done, label %free_nonnull
+  store i8* %27, i8** %29, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %28, i64* %30, align 4
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %32 = load i8*, i8** %31, align 8
+  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %34 = load i64, i64* %33, align 4
+  %35 = trunc i64 %34 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %32, i32 %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %36 = icmp eq i8* %27, null
+  br i1 %36, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %complex_div_cont
-  call void @_lfortran_free(i8* %25)
+  call void @_lfortran_free(i8* %27)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %complex_div_cont
-  %35 = load %complex_4, %complex_4* %x, align 1
-  %36 = extractvalue %complex_4 %35, 0
-  %37 = extractvalue %complex_4 %35, 1
-  %38 = call float @llvm.fabs.f32(float %36)
-  %39 = call float @llvm.fabs.f32(float %37)
-  %40 = fcmp oge float %38, %39
-  br i1 %40, label %complex_div_r_ge_s1, label %complex_div_r_lt_s2
+  %37 = load %complex_4, %complex_4* %x, align 1
+  %38 = extractvalue %complex_4 %37, 0
+  %39 = extractvalue %complex_4 %37, 1
+  %40 = call float @llvm.fabs.f32(float %38)
+  %41 = call float @llvm.fabs.f32(float %39)
+  %42 = fcmp oge float %40, %41
+  br i1 %42, label %complex_div_r_ge_s1, label %complex_div_r_lt_s2
 
 complex_div_r_ge_s1:                              ; preds = %free_done
-  %41 = fdiv float %37, %36
-  %42 = fmul float %37, %41
-  %43 = fadd float %36, %42
-  %44 = fmul float 0.000000e+00, %41
-  %45 = fadd float 2.000000e+00, %44
-  %46 = fmul float 2.000000e+00, %41
-  %47 = fsub float 0.000000e+00, %46
-  %48 = fdiv float %45, %43
-  %49 = fdiv float %47, %43
+  %43 = fdiv float %39, %38
+  %44 = fmul float %39, %43
+  %45 = fadd float %38, %44
+  %46 = fmul float 0.000000e+00, %43
+  %47 = fadd float 2.000000e+00, %46
+  %48 = fmul float 2.000000e+00, %43
+  %49 = fsub float 0.000000e+00, %48
+  %50 = fdiv float %47, %45
+  %51 = fdiv float %49, %45
   br label %complex_div_cont3
 
 complex_div_r_lt_s2:                              ; preds = %free_done
-  %50 = fdiv float %36, %37
-  %51 = fmul float %36, %50
-  %52 = fadd float %37, %51
-  %53 = fmul float 2.000000e+00, %50
-  %54 = fadd float %53, 0.000000e+00
-  %55 = fmul float 0.000000e+00, %50
-  %56 = fsub float %55, 2.000000e+00
-  %57 = fdiv float %54, %52
-  %58 = fdiv float %56, %52
+  %52 = fdiv float %38, %39
+  %53 = fmul float %38, %52
+  %54 = fadd float %39, %53
+  %55 = fmul float 2.000000e+00, %52
+  %56 = fadd float %55, 0.000000e+00
+  %57 = fmul float 0.000000e+00, %52
+  %58 = fsub float %57, 2.000000e+00
+  %59 = fdiv float %56, %54
+  %60 = fdiv float %58, %54
   br label %complex_div_cont3
 
 complex_div_cont3:                                ; preds = %complex_div_r_lt_s2, %complex_div_r_ge_s1
-  %59 = phi float [ %48, %complex_div_r_ge_s1 ], [ %57, %complex_div_r_lt_s2 ]
-  %60 = phi float [ %49, %complex_div_r_ge_s1 ], [ %58, %complex_div_r_lt_s2 ]
-  %61 = insertvalue %complex_4 undef, float %59, 0
-  %62 = insertvalue %complex_4 %61, float %60, 1
-  store %complex_4 %62, %complex_4* %x, align 1
-  %63 = alloca i64, align 8
-  %64 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %63, i32 0, i32 0, %complex_4* %x)
-  %65 = load i64, i64* %63, align 4
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %64, i8** %66, align 8
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %65, i64* %67, align 4
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %69 = load i8*, i8** %68, align 8
-  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %71 = load i64, i64* %70, align 4
-  %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %73 = icmp eq i8* %64, null
-  br i1 %73, label %free_done6, label %free_nonnull5
+  %61 = phi float [ %50, %complex_div_r_ge_s1 ], [ %59, %complex_div_r_lt_s2 ]
+  %62 = phi float [ %51, %complex_div_r_ge_s1 ], [ %60, %complex_div_r_lt_s2 ]
+  %63 = insertvalue %complex_4 undef, float %61, 0
+  %64 = insertvalue %complex_4 %63, float %62, 1
+  store %complex_4 %64, %complex_4* %x, align 1
+  %65 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, %complex_4* %x)
+  %66 = load i64, i64* %3, align 4
+  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %65, i8** %67, align 8
+  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %66, i64* %68, align 4
+  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %70 = load i8*, i8** %69, align 8
+  %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %72 = load i64, i64* %71, align 4
+  %73 = trunc i64 %72 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %70, i32 %73, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %74 = icmp eq i8* %65, null
+  br i1 %74, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %complex_div_cont3
-  call void @_lfortran_free(i8* %64)
+  call void @_lfortran_free(i8* %65)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %complex_div_cont3
-  %74 = load %complex_4, %complex_4* %x, align 1
-  %75 = extractvalue %complex_4 %74, 0
-  %76 = extractvalue %complex_4 %74, 1
-  %77 = fadd float %75, 0.000000e+00
-  %78 = fadd float %76, 3.000000e+00
-  %79 = insertvalue %complex_4 undef, float %77, 0
-  %80 = insertvalue %complex_4 %79, float %78, 1
-  %81 = extractvalue %complex_4 %80, 0
-  %82 = extractvalue %complex_4 %80, 1
-  %83 = call float @llvm.fabs.f32(float %81)
+  %75 = load %complex_4, %complex_4* %x, align 1
+  %76 = extractvalue %complex_4 %75, 0
+  %77 = extractvalue %complex_4 %75, 1
+  %78 = fadd float %76, 0.000000e+00
+  %79 = fadd float %77, 3.000000e+00
+  %80 = insertvalue %complex_4 undef, float %78, 0
+  %81 = insertvalue %complex_4 %80, float %79, 1
+  %82 = extractvalue %complex_4 %81, 0
+  %83 = extractvalue %complex_4 %81, 1
   %84 = call float @llvm.fabs.f32(float %82)
-  %85 = fcmp oge float %83, %84
-  br i1 %85, label %complex_div_r_ge_s7, label %complex_div_r_lt_s8
+  %85 = call float @llvm.fabs.f32(float %83)
+  %86 = fcmp oge float %84, %85
+  br i1 %86, label %complex_div_r_ge_s7, label %complex_div_r_lt_s8
 
 complex_div_r_ge_s7:                              ; preds = %free_done6
-  %86 = fdiv float %82, %81
-  %87 = fmul float %82, %86
-  %88 = fadd float %81, %87
-  %89 = fmul float 0.000000e+00, %86
-  %90 = fadd float 1.000000e+00, %89
-  %91 = fmul float 1.000000e+00, %86
-  %92 = fsub float 0.000000e+00, %91
-  %93 = fdiv float %90, %88
-  %94 = fdiv float %92, %88
+  %87 = fdiv float %83, %82
+  %88 = fmul float %83, %87
+  %89 = fadd float %82, %88
+  %90 = fmul float 0.000000e+00, %87
+  %91 = fadd float 1.000000e+00, %90
+  %92 = fmul float 1.000000e+00, %87
+  %93 = fsub float 0.000000e+00, %92
+  %94 = fdiv float %91, %89
+  %95 = fdiv float %93, %89
   br label %complex_div_cont9
 
 complex_div_r_lt_s8:                              ; preds = %free_done6
-  %95 = fdiv float %81, %82
-  %96 = fmul float %81, %95
-  %97 = fadd float %82, %96
-  %98 = fmul float 1.000000e+00, %95
-  %99 = fadd float %98, 0.000000e+00
-  %100 = fmul float 0.000000e+00, %95
-  %101 = fsub float %100, 1.000000e+00
-  %102 = fdiv float %99, %97
-  %103 = fdiv float %101, %97
+  %96 = fdiv float %82, %83
+  %97 = fmul float %82, %96
+  %98 = fadd float %83, %97
+  %99 = fmul float 1.000000e+00, %96
+  %100 = fadd float %99, 0.000000e+00
+  %101 = fmul float 0.000000e+00, %96
+  %102 = fsub float %101, 1.000000e+00
+  %103 = fdiv float %100, %98
+  %104 = fdiv float %102, %98
   br label %complex_div_cont9
 
 complex_div_cont9:                                ; preds = %complex_div_r_lt_s8, %complex_div_r_ge_s7
-  %104 = phi float [ %93, %complex_div_r_ge_s7 ], [ %102, %complex_div_r_lt_s8 ]
   %105 = phi float [ %94, %complex_div_r_ge_s7 ], [ %103, %complex_div_r_lt_s8 ]
-  %106 = insertvalue %complex_4 undef, float %104, 0
-  %107 = insertvalue %complex_4 %106, float %105, 1
-  store %complex_4 %107, %complex_4* %x, align 1
-  %108 = alloca i64, align 8
-  %109 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %108, i32 0, i32 0, %complex_4* %x)
-  %110 = load i64, i64* %108, align 4
+  %106 = phi float [ %95, %complex_div_r_ge_s7 ], [ %104, %complex_div_r_lt_s8 ]
+  %107 = insertvalue %complex_4 undef, float %105, 0
+  %108 = insertvalue %complex_4 %107, float %106, 1
+  store %complex_4 %108, %complex_4* %x, align 1
+  %109 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %x)
+  %110 = load i64, i64* %2, align 4
   %111 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %109, i8** %111, align 8
   %112 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "ee4d39b83eb66d7ffa2be9af0efd9deaf89ccb4802903db8606c76cb",
+    "stdout_hash": "dfb5f89a402d5dae19b8705630aef130ee44736ea787775945be5f01",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "8770a0bf114a2f62c962e1ed77eb54933fe931c38077f25fd989293f",
+    "stdout_hash": "ee4d39b83eb66d7ffa2be9af0efd9deaf89ccb4802903db8606c76cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -12,6 +12,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %v = alloca %complex_8, align 8
   %x = alloca %complex_4, align 8
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %complex_4 zeroinitializer, %complex_4* %zero, align 1
   store %complex_8 <{ double 0x3FF0CCCCC0000000, double 0x3FF0CCCCC0000000 }>, %complex_8* %v, align 1
   store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, %complex_4* %x, align 1
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_8* %v, %complex_4* %x, %complex_4* %zero)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -1,9 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%string_descriptor = type <{ i8*, i64 }>
 %complex_8 = type <{ double, double }>
 %complex_4 = type <{ float, float }>
-%string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [24 x i8] c"{R8,R8},{R4,R4},{R4,R4}\00", align 1
@@ -11,6 +11,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %v = alloca %complex_8, align 8
   %x = alloca %complex_4, align 8
@@ -21,7 +22,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_8* %v, %complex_4* %x, %complex_4* %zero)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "208f0903740833f342c5dc73f3b67ecca19de2469f8f4e8298e874f7",
+    "stdout_hash": "5ea53c8244a9869de4f87fa6e58465fd12510314f960137eb09e729a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "5ea53c8244a9869de4f87fa6e58465fd12510314f960137eb09e729a",
+    "stdout_hash": "f7ea6058cac2d12c96824b33596dacd08bc5fcb87f2ac466f1b91788",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -15,6 +15,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
@@ -23,7 +24,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, %complex_4* @complex_dp_param.u, align 1
   store %complex_8 <{ double 0x3FF0CCCCC0000000, double 1.050000e+00 }>, %complex_8* @complex_dp_param.v, align 1
   store %complex_8 zeroinitializer, %complex_8* @complex_dp_param.zero, align 1
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* @complex_dp_param.u, %complex_8* @complex_dp_param.v, %complex_8* @complex_dp_param.zero)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -14,6 +14,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
@@ -25,7 +26,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* @complex_dp_param.u, %complex_8* @complex_dp_param.v, %complex_8* @complex_dp_param.zero)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "c9d604b2d28347fae93b8e1a6a19139d3abf802808dd32b31156d011",
+    "stdout_hash": "d8406c91278caced1d24e5de8c8e45048ee5bdf5bfdf36ba4db99943",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "d8406c91278caced1d24e5de8c8e45048ee5bdf5bfdf36ba4db99943",
+    "stdout_hash": "adf7a4f45f64605e8ea3ff353441415c58625a83f01d20b5d4f6b960",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%complex_4 = type <{ float, float }>
 %string_descriptor = type <{ i8*, i64 }>
+%complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
@@ -16,6 +16,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
@@ -34,7 +37,6 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = alloca i64, align 8
   %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %13, i32 0, i32 0, %complex_4* %x)
   %15 = load i64, i64* %13, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %14, i8** %16, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -68,7 +70,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %35 = alloca i64, align 8
   %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %35, i32 0, i32 0, %complex_4* %x)
   %37 = load i64, i64* %35, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %36, i8** %38, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -102,7 +103,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %57 = alloca i64, align 8
   %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %57, i32 0, i32 0, %complex_4* %x)
   %59 = load i64, i64* %57, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %58, i8** %60, align 8
   %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -17,92 +17,92 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %2 = load %complex_4, %complex_4* %x, align 1
-  %3 = extractvalue %complex_4 %2, 0
-  %4 = extractvalue %complex_4 %2, 1
-  %5 = fmul float %3, 4.000000e+00
-  %6 = fmul float %4, 0.000000e+00
-  %7 = fmul float %3, 0.000000e+00
-  %8 = fmul float %4, 4.000000e+00
-  %9 = fsub float %5, %6
-  %10 = fadd float %7, %8
-  %11 = insertvalue %complex_4 undef, float %9, 0
-  %12 = insertvalue %complex_4 %11, float %10, 1
-  store %complex_4 %12, %complex_4* %x, align 1
-  %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %13, i32 0, i32 0, %complex_4* %x)
-  %15 = load i64, i64* %13, align 4
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %15, i64* %17, align 4
+  %5 = load %complex_4, %complex_4* %x, align 1
+  %6 = extractvalue %complex_4 %5, 0
+  %7 = extractvalue %complex_4 %5, 1
+  %8 = fmul float %6, 4.000000e+00
+  %9 = fmul float %7, 0.000000e+00
+  %10 = fmul float %6, 0.000000e+00
+  %11 = fmul float %7, 4.000000e+00
+  %12 = fsub float %8, %9
+  %13 = fadd float %10, %11
+  %14 = insertvalue %complex_4 undef, float %12, 0
+  %15 = insertvalue %complex_4 %14, float %13, 1
+  store %complex_4 %15, %complex_4* %x, align 1
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, %complex_4* %x)
+  %17 = load i64, i64* %4, align 4
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %21 = load i64, i64* %20, align 4
-  %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
-  br i1 %23, label %free_done, label %free_nonnull
+  store i8* %16, i8** %18, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %17, i64* %19, align 4
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %21 = load i8*, i8** %20, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %23 = load i64, i64* %22, align 4
+  %24 = trunc i64 %23 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %25 = icmp eq i8* %16, null
+  br i1 %25, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %14)
+  call void @_lfortran_free(i8* %16)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %24 = load %complex_4, %complex_4* %x, align 1
-  %25 = extractvalue %complex_4 %24, 0
-  %26 = extractvalue %complex_4 %24, 1
-  %27 = fmul float 2.000000e+00, %25
-  %28 = fmul float 0.000000e+00, %26
-  %29 = fmul float 2.000000e+00, %26
-  %30 = fmul float 0.000000e+00, %25
-  %31 = fsub float %27, %28
-  %32 = fadd float %29, %30
-  %33 = insertvalue %complex_4 undef, float %31, 0
-  %34 = insertvalue %complex_4 %33, float %32, 1
-  store %complex_4 %34, %complex_4* %x, align 1
-  %35 = alloca i64, align 8
-  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %35, i32 0, i32 0, %complex_4* %x)
-  %37 = load i64, i64* %35, align 4
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %37, i64* %39, align 4
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %43 = load i64, i64* %42, align 4
-  %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %45 = icmp eq i8* %36, null
-  br i1 %45, label %free_done3, label %free_nonnull2
+  %26 = load %complex_4, %complex_4* %x, align 1
+  %27 = extractvalue %complex_4 %26, 0
+  %28 = extractvalue %complex_4 %26, 1
+  %29 = fmul float 2.000000e+00, %27
+  %30 = fmul float 0.000000e+00, %28
+  %31 = fmul float 2.000000e+00, %28
+  %32 = fmul float 0.000000e+00, %27
+  %33 = fsub float %29, %30
+  %34 = fadd float %31, %32
+  %35 = insertvalue %complex_4 undef, float %33, 0
+  %36 = insertvalue %complex_4 %35, float %34, 1
+  store %complex_4 %36, %complex_4* %x, align 1
+  %37 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, %complex_4* %x)
+  %38 = load i64, i64* %3, align 4
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %37, i8** %39, align 8
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %38, i64* %40, align 4
+  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %42 = load i8*, i8** %41, align 8
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %44 = load i64, i64* %43, align 4
+  %45 = trunc i64 %44 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %46 = icmp eq i8* %37, null
+  br i1 %46, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %36)
+  call void @_lfortran_free(i8* %37)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %46 = load %complex_4, %complex_4* %x, align 1
-  %47 = extractvalue %complex_4 %46, 0
-  %48 = extractvalue %complex_4 %46, 1
-  %49 = fmul float %47, 0.000000e+00
-  %50 = fmul float %48, 3.000000e+00
-  %51 = fmul float %47, 3.000000e+00
-  %52 = fmul float %48, 0.000000e+00
-  %53 = fsub float %49, %50
-  %54 = fadd float %51, %52
-  %55 = insertvalue %complex_4 undef, float %53, 0
-  %56 = insertvalue %complex_4 %55, float %54, 1
-  store %complex_4 %56, %complex_4* %x, align 1
-  %57 = alloca i64, align 8
-  %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %57, i32 0, i32 0, %complex_4* %x)
-  %59 = load i64, i64* %57, align 4
+  %47 = load %complex_4, %complex_4* %x, align 1
+  %48 = extractvalue %complex_4 %47, 0
+  %49 = extractvalue %complex_4 %47, 1
+  %50 = fmul float %48, 0.000000e+00
+  %51 = fmul float %49, 3.000000e+00
+  %52 = fmul float %48, 3.000000e+00
+  %53 = fmul float %49, 0.000000e+00
+  %54 = fsub float %50, %51
+  %55 = fadd float %52, %53
+  %56 = insertvalue %complex_4 undef, float %54, 0
+  %57 = insertvalue %complex_4 %56, float %55, 1
+  store %complex_4 %57, %complex_4* %x, align 1
+  %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %x)
+  %59 = load i64, i64* %2, align 4
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %58, i8** %60, align 8
   %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "24a561389d0f54464c0bdf1c8f5490fb800ae87cc98991bb007c3385",
+    "stdout_hash": "2a107b8bf98ee4185933b8e768d6b6380a677c65e184e172de58b6c7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "2a107b8bf98ee4185933b8e768d6b6380a677c65e184e172de58b6c7",
+    "stdout_hash": "71c4de25b0102f7330cdd4b5e99a018235858e865627c82a448bd7f8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%complex_4 = type <{ float, float }>
 %string_descriptor = type <{ i8*, i64 }>
+%complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = alloca %complex_4, align 8
   %3 = alloca %complex_4, align 8
   %4 = alloca %complex_4, align 8
@@ -33,7 +34,6 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = alloca i64, align 8
   %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, %complex_4* %z)
   %14 = load i64, i64* %12, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -11,29 +11,29 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = alloca %complex_4, align 8
+  %2 = alloca i64, align 8
   %3 = alloca %complex_4, align 8
   %4 = alloca %complex_4, align 8
+  %5 = alloca %complex_4, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   %y = alloca %complex_4, align 8
   %z = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
   store %complex_4 <{ float 3.000000e+00, float 2.000000e+00 }>, %complex_4* %y, align 1
-  %5 = load %complex_4, %complex_4* %x, align 1
-  %6 = load %complex_4, %complex_4* %y, align 1
-  %7 = extractvalue %complex_4 %5, 0
-  %8 = extractvalue %complex_4 %5, 1
-  %9 = extractvalue %complex_4 %6, 0
-  %10 = extractvalue %complex_4 %6, 1
-  store %complex_4 %5, %complex_4* %4, align 1
-  store %complex_4 %6, %complex_4* %3, align 1
-  call void @_lfortran_complex_pow_32(%complex_4* %4, %complex_4* %3, %complex_4* %2)
-  %11 = load %complex_4, %complex_4* %2, align 1
-  store %complex_4 %11, %complex_4* %z, align 1
-  %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, %complex_4* %z)
-  %14 = load i64, i64* %12, align 4
+  %6 = load %complex_4, %complex_4* %x, align 1
+  %7 = load %complex_4, %complex_4* %y, align 1
+  %8 = extractvalue %complex_4 %6, 0
+  %9 = extractvalue %complex_4 %6, 1
+  %10 = extractvalue %complex_4 %7, 0
+  %11 = extractvalue %complex_4 %7, 1
+  store %complex_4 %6, %complex_4* %5, align 1
+  store %complex_4 %7, %complex_4* %4, align 1
+  call void @_lfortran_complex_pow_32(%complex_4* %5, %complex_4* %4, %complex_4* %3)
+  %12 = load %complex_4, %complex_4* %3, align 1
+  store %complex_4 %12, %complex_4* %z, align 1
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %z)
+  %14 = load i64, i64* %2, align 4
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "fed5a37d8cb62952ece2a9edfbb9b99e7710afdd494a956af988e348",
+    "stdout_hash": "4e66642e05d6601c6312d6f5289a3a1391773f677c1dcc6e7ab870b6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "4e66642e05d6601c6312d6f5289a3a1391773f677c1dcc6e7ab870b6",
+    "stdout_hash": "8665503530afa0a3bff28032bd490366d6f0d844fdbdcbf0680e8fe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -17,88 +17,88 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %2 = load %complex_4, %complex_4* %x, align 1
-  %3 = extractvalue %complex_4 %2, 0
-  %4 = extractvalue %complex_4 %2, 1
-  %5 = fsub float %3, 4.000000e+00
-  %6 = fsub float %4, 0.000000e+00
-  %7 = insertvalue %complex_4 undef, float %5, 0
-  %8 = insertvalue %complex_4 %7, float %6, 1
-  store %complex_4 %8, %complex_4* %x, align 1
-  %9 = load %complex_4, %complex_4* %x, align 1
-  %10 = extractvalue %complex_4 %9, 0
-  %11 = extractvalue %complex_4 %9, 1
-  %12 = fsub float 4.000000e+00, %10
-  %13 = fsub float 0.000000e+00, %11
-  %14 = insertvalue %complex_4 undef, float %12, 0
-  %15 = insertvalue %complex_4 %14, float %13, 1
-  store %complex_4 %15, %complex_4* %x, align 1
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, %complex_4* %x)
-  %18 = load i64, i64* %16, align 4
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %18, i64* %20, align 4
+  %5 = load %complex_4, %complex_4* %x, align 1
+  %6 = extractvalue %complex_4 %5, 0
+  %7 = extractvalue %complex_4 %5, 1
+  %8 = fsub float %6, 4.000000e+00
+  %9 = fsub float %7, 0.000000e+00
+  %10 = insertvalue %complex_4 undef, float %8, 0
+  %11 = insertvalue %complex_4 %10, float %9, 1
+  store %complex_4 %11, %complex_4* %x, align 1
+  %12 = load %complex_4, %complex_4* %x, align 1
+  %13 = extractvalue %complex_4 %12, 0
+  %14 = extractvalue %complex_4 %12, 1
+  %15 = fsub float 4.000000e+00, %13
+  %16 = fsub float 0.000000e+00, %14
+  %17 = insertvalue %complex_4 undef, float %15, 0
+  %18 = insertvalue %complex_4 %17, float %16, 1
+  store %complex_4 %18, %complex_4* %x, align 1
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, %complex_4* %x)
+  %20 = load i64, i64* %4, align 4
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %24 = load i64, i64* %23, align 4
-  %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
-  br i1 %26, label %free_done, label %free_nonnull
+  store i8* %19, i8** %21, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %20, i64* %22, align 4
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %24 = load i8*, i8** %23, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %26 = load i64, i64* %25, align 4
+  %27 = trunc i64 %26 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %28 = icmp eq i8* %19, null
+  br i1 %28, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %17)
+  call void @_lfortran_free(i8* %19)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %27 = load %complex_4, %complex_4* %x, align 1
-  %28 = extractvalue %complex_4 %27, 0
-  %29 = extractvalue %complex_4 %27, 1
-  %30 = fsub float 2.000000e+00, %28
-  %31 = fsub float 0.000000e+00, %29
-  %32 = insertvalue %complex_4 undef, float %30, 0
-  %33 = insertvalue %complex_4 %32, float %31, 1
-  store %complex_4 %33, %complex_4* %x, align 1
-  %34 = alloca i64, align 8
-  %35 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %34, i32 0, i32 0, %complex_4* %x)
-  %36 = load i64, i64* %34, align 4
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %35, i8** %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %36, i64* %38, align 4
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %42 = load i64, i64* %41, align 4
-  %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %44 = icmp eq i8* %35, null
-  br i1 %44, label %free_done3, label %free_nonnull2
+  %29 = load %complex_4, %complex_4* %x, align 1
+  %30 = extractvalue %complex_4 %29, 0
+  %31 = extractvalue %complex_4 %29, 1
+  %32 = fsub float 2.000000e+00, %30
+  %33 = fsub float 0.000000e+00, %31
+  %34 = insertvalue %complex_4 undef, float %32, 0
+  %35 = insertvalue %complex_4 %34, float %33, 1
+  store %complex_4 %35, %complex_4* %x, align 1
+  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, %complex_4* %x)
+  %37 = load i64, i64* %3, align 4
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %36, i8** %38, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %37, i64* %39, align 4
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %41 = load i8*, i8** %40, align 8
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %43 = load i64, i64* %42, align 4
+  %44 = trunc i64 %43 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %45 = icmp eq i8* %36, null
+  br i1 %45, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %35)
+  call void @_lfortran_free(i8* %36)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %45 = load %complex_4, %complex_4* %x, align 1
-  %46 = extractvalue %complex_4 %45, 0
-  %47 = extractvalue %complex_4 %45, 1
-  %48 = fsub float %46, 0.000000e+00
-  %49 = fsub float %47, 3.000000e+00
-  %50 = insertvalue %complex_4 undef, float %48, 0
-  %51 = insertvalue %complex_4 %50, float %49, 1
-  store %complex_4 %51, %complex_4* %x, align 1
-  %52 = alloca i64, align 8
-  %53 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %52, i32 0, i32 0, %complex_4* %x)
-  %54 = load i64, i64* %52, align 4
+  %46 = load %complex_4, %complex_4* %x, align 1
+  %47 = extractvalue %complex_4 %46, 0
+  %48 = extractvalue %complex_4 %46, 1
+  %49 = fsub float %47, 0.000000e+00
+  %50 = fsub float %48, 3.000000e+00
+  %51 = insertvalue %complex_4 undef, float %49, 0
+  %52 = insertvalue %complex_4 %51, float %50, 1
+  store %complex_4 %52, %complex_4* %x, align 1
+  %53 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, %complex_4* %x)
+  %54 = load i64, i64* %2, align 4
   %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %53, i8** %55, align 8
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%complex_4 = type <{ float, float }>
 %string_descriptor = type <{ i8*, i64 }>
+%complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
@@ -16,6 +16,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
@@ -38,7 +41,6 @@ define i32 @main(i32 %0, i8** %1) {
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, %complex_4* %x)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -68,7 +70,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %34 = alloca i64, align 8
   %35 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %34, i32 0, i32 0, %complex_4* %x)
   %36 = load i64, i64* %34, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %35, i8** %37, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -98,7 +99,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %52 = alloca i64, align 8
   %53 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %52, i32 0, i32 0, %complex_4* %x)
   %54 = load i64, i64* %52, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %53, i8** %55, align 8
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "079cf1090075269aedf99822cfe35b6c084262b638aefce43b5565d5",
+    "stdout_hash": "9a05a3a7da837234d76ae164736cae497ab4151e74876fffeb9b6b5b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "9a05a3a7da837234d76ae164736cae497ab4151e74876fffeb9b6b5b",
+    "stdout_hash": "be375a524a817edaa5f240a3ac65d1925a47d6cbe24a9fb31fbd787f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
@@ -21,7 +22,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   store double 0x3FF0CCCCC0000000, double* %u, align 8
   store double 1.050000e+00, double* %v, align 8
   store float 0x3FF0CCCCC0000000, float* %x, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "c7e81964775af67480fee251db2e0f46e56777ffe1db15d92533811b",
+    "stdout_hash": "dd6a2895f05b87efc22d0c1e30f9e51801d4d439adde0836d94ce9da",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "dd6a2895f05b87efc22d0c1e30f9e51801d4d439adde0836d94ce9da",
+    "stdout_hash": "ddc25765c220ad8b5ed80b7fd31c2c2333b97be6640ebc42c300ec63",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -130,52 +130,52 @@ FINALIZE_SYMTABLE__lcompilers_trim_str:           ; preds = %return
 define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %__libasr__created__var__2_return_slot = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__2_return_slot, align 1
   %buffer = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %buffer, align 1
-  %0 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
-  store i64 128, i64* %0, align 4
-  %1 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
-  %2 = call i8* @_lfortran_malloc(i64 128)
-  store i8* %2, i8** %1, align 8
+  %1 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
+  store i64 128, i64* %1, align 4
+  %2 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
+  %3 = call i8* @_lfortran_malloc(i64 128)
+  store i8* %3, i8** %2, align 8
   %buffer_len = alloca i32, align 4
   store i32 128, i32* %buffer_len, align 4
   %lfortran_iomsg = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
-  store i64 0, i64* %3, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %5 = call i8* @_lfortran_malloc(i64 1)
-  store i8* %5, i8** %4, align 8
-  %6 = load %string_descriptor, %string_descriptor* %string, align 1
-  %7 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = icmp ne i8* %8, null
-  br i1 %9, label %then, label %else
+  %4 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
+  store i64 0, i64* %4, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
+  %6 = call i8* @_lfortran_malloc(i64 1)
+  store i8* %6, i8** %5, align 8
+  %7 = load %string_descriptor, %string_descriptor* %string, align 1
+  %8 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = icmp ne i8* %9, null
+  br i1 %10, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %10 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %11 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %12 = load i8*, i8** %10, align 8
-  call void @_lfortran_free(i8* %12)
-  store i8* null, i8** %10, align 8
-  store i64 0, i64* %11, align 4
+  %11 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
+  %13 = load i8*, i8** %11, align 8
+  call void @_lfortran_free(i8* %13)
+  store i8* null, i8** %11, align 8
+  store i64 0, i64* %12, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %13 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
-  %14 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
-  %15 = alloca i32*, align 8
-  store i32* null, i32** %15, align 8
-  %16 = load i32*, i32** %15, align 8
-  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %18 = alloca i64, align 8
-  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %17, i64 4, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %18, i32 0, i32 0, double* %val)
-  %20 = load i64, i64* %18, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
+  %15 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
+  %16 = alloca i32*, align 8
+  store i32* null, i32** %16, align 8
+  %17 = load i32*, i32** %16, align 8
+  %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %18, i64 4, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, double* %val)
+  %20 = load i64, i64* %0, align 4
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %19, i8** %21, align 8
   %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -184,7 +184,7 @@ ifcont:                                           ; preds = %else, %then
   %24 = load i8*, i8** %23, align 8
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %26 = load i64, i64* %25, align 4
-  call void (i8**, i8, i8, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8** %13, i8 0, i8 0, i64* %14, i32* %16, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %24, i64 %26)
+  call void (i8**, i8, i8, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8** %14, i8 0, i8 0, i64* %15, i32* %17, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %24, i64 %26)
   %27 = icmp eq i8* %19, null
   br i1 %27, label %free_done, label %free_nonnull
 
@@ -275,6 +275,7 @@ declare void @_lfortran_strcpy(i8**, i64*, i8, i8, i8*, i64)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
@@ -282,14 +283,13 @@ define i32 @main(i32 %0, i8** %1) {
   store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__1_return_slot, align 1
   %value = alloca double, align 8
   store double 1.000000e+01, double* %value, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %4 = load i8*, i8** %2, align 8
-  call void @_lfortran_free(i8* %4)
-  store i8* null, i8** %2, align 8
-  store i64 0, i64* %3, align 4
+  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %5 = load i8*, i8** %3, align 8
+  call void @_lfortran_free(i8* %5)
+  store i8* null, i8** %3, align 8
+  store i64 0, i64* %4, align 4
   call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0_return_slot)
-  %5 = alloca i64, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
   %7 = load i8*, i8** %6, align 8
   %8 = ptrtoint i8* %7 to i64
@@ -332,8 +332,8 @@ ifcont:                                           ; preds = %.entry
   %28 = load %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
   %29 = alloca %string_descriptor, align 8
   store %string_descriptor %28, %string_descriptor* %29, align 1
-  %30 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %5, i32 0, i32 1, i64 %27, %string_descriptor* %29)
-  %31 = load i64, i64* %5, align 4
+  %30 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 1, i64 %27, %string_descriptor* %29)
+  %31 = load i64, i64* %2, align 4
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %30, i8** %32, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -129,6 +129,7 @@ FINALIZE_SYMTABLE__lcompilers_trim_str:           ; preds = %return
 
 define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %__libasr__created__var__2_return_slot = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__2_return_slot, align 1
   %buffer = alloca %string_descriptor, align 8
@@ -175,7 +176,6 @@ ifcont:                                           ; preds = %else, %then
   %18 = alloca i64, align 8
   %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %17, i64 4, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %18, i32 0, i32 0, double* %val)
   %20 = load i64, i64* %18, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %19, i8** %21, align 8
   %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -274,6 +274,7 @@ declare void @_lfortran_strcpy(i8**, i64*, i8, i8, i8*, i64)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
@@ -333,7 +334,6 @@ ifcont:                                           ; preds = %.entry
   store %string_descriptor %28, %string_descriptor* %29, align 1
   %30 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %5, i32 0, i32 1, i64 %27, %string_descriptor* %29)
   %31 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %30, i8** %32, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "cd44e288de149c6e01bee4c98c2054b780399c78e8c0c5e065b62ccd",
+    "stdout_hash": "4de16eedb46ccbd1e9dd5fe2e84e3cbe8237383ceccafd3025632e3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "87118ca8bea5d05ddb350263fae058a09814e478137d31580b67d1a1",
+    "stdout_hash": "cd44e288de149c6e01bee4c98c2054b780399c78e8c0c5e065b62ccd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -63,16 +63,27 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc88 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc79 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc70 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc61 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc52 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc43 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc34 = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   %stringFormat_desc25 = alloca %string_descriptor, align 8
+  %9 = alloca i64, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %10 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %11 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %12 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -81,25 +92,25 @@ define i32 @main(i32 %0, i8** %1) {
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
+  %13 = load i32, i32* %i, align 4
+  %14 = add i32 %13, 1
+  %15 = icmp sle i32 %14, 10
+  br i1 %15, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %j, align 4
-  %8 = load i32, i32* %i, align 4
-  %9 = add i32 %7, %8
-  store i32 %9, i32* %j, align 4
+  %16 = load i32, i32* %i, align 4
+  %17 = add i32 %16, 1
+  store i32 %17, i32* %i, align 4
+  %18 = load i32, i32* %j, align 4
+  %19 = load i32, i32* %i, align 4
+  %20 = add i32 %18, %19
+  store i32 %20, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %10 = load i32, i32* %j, align 4
-  %11 = icmp ne i32 %10, 55
-  br i1 %11, label %then, label %else
+  %21 = load i32, i32* %j, align 4
+  %22 = icmp ne i32 %21, 55
+  br i1 %22, label %then, label %else
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -110,24 +121,23 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32* %j)
-  %14 = load i64, i64* %12, align 4
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %14, i64* %16, align 4
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %20 = load i64, i64* %19, align 4
-  %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
-  br i1 %22, label %free_done, label %free_nonnull
+  %23 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32* %j)
+  %24 = load i64, i64* %12, align 4
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %23, i8** %25, align 8
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %24, i64* %26, align 4
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %28 = load i8*, i8** %27, align 8
+  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %30 = load i64, i64* %29, align 4
+  %31 = trunc i64 %30 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %32 = icmp eq i8* %23, null
+  br i1 %32, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free(i8* %13)
+  call void @_lfortran_free(i8* %23)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
@@ -136,25 +146,25 @@ free_done:                                        ; preds = %free_nonnull, %ifco
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.body2, %free_done
-  %23 = load i32, i32* %i, align 4
-  %24 = add i32 %23, -1
-  %25 = icmp sge i32 %24, 1
-  br i1 %25, label %loop.body2, label %loop.end3
+  %33 = load i32, i32* %i, align 4
+  %34 = add i32 %33, -1
+  %35 = icmp sge i32 %34, 1
+  br i1 %35, label %loop.body2, label %loop.end3
 
 loop.body2:                                       ; preds = %loop.head1
-  %26 = load i32, i32* %i, align 4
-  %27 = add i32 %26, -1
-  store i32 %27, i32* %i, align 4
-  %28 = load i32, i32* %j, align 4
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %28, %29
-  store i32 %30, i32* %j, align 4
+  %36 = load i32, i32* %i, align 4
+  %37 = add i32 %36, -1
+  store i32 %37, i32* %i, align 4
+  %38 = load i32, i32* %j, align 4
+  %39 = load i32, i32* %i, align 4
+  %40 = add i32 %38, %39
+  store i32 %40, i32* %j, align 4
   br label %loop.head1
 
 loop.end3:                                        ; preds = %loop.head1
-  %31 = load i32, i32* %j, align 4
-  %32 = icmp ne i32 %31, 55
-  br i1 %32, label %then4, label %else5
+  %41 = load i32, i32* %j, align 4
+  %42 = icmp ne i32 %41, 55
+  br i1 %42, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -165,24 +175,23 @@ else5:                                            ; preds = %loop.end3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %33 = alloca i64, align 8
-  %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %33, i32 0, i32 0, i32* %j)
-  %35 = load i64, i64* %33, align 4
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %34, i8** %36, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %35, i64* %37, align 4
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %39 = load i8*, i8** %38, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %41 = load i64, i64* %40, align 4
-  %42 = trunc i64 %41 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %39, i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %43 = icmp eq i8* %34, null
-  br i1 %43, label %free_done9, label %free_nonnull8
+  %43 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, i32* %j)
+  %44 = load i64, i64* %11, align 4
+  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %43, i8** %45, align 8
+  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  store i64 %44, i64* %46, align 4
+  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %48 = load i8*, i8** %47, align 8
+  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %50 = load i64, i64* %49, align 4
+  %51 = trunc i64 %50 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %48, i32 %51, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %52 = icmp eq i8* %43, null
+  br i1 %52, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %ifcont6
-  call void @_lfortran_free(i8* %34)
+  call void @_lfortran_free(i8* %43)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %ifcont6
@@ -191,25 +200,25 @@ free_done9:                                       ; preds = %free_nonnull8, %ifc
   br label %loop.head10
 
 loop.head10:                                      ; preds = %loop.body11, %free_done9
-  %44 = load i32, i32* %i, align 4
-  %45 = add i32 %44, 2
-  %46 = icmp sle i32 %45, 9
-  br i1 %46, label %loop.body11, label %loop.end12
+  %53 = load i32, i32* %i, align 4
+  %54 = add i32 %53, 2
+  %55 = icmp sle i32 %54, 9
+  br i1 %55, label %loop.body11, label %loop.end12
 
 loop.body11:                                      ; preds = %loop.head10
-  %47 = load i32, i32* %i, align 4
-  %48 = add i32 %47, 2
-  store i32 %48, i32* %i, align 4
-  %49 = load i32, i32* %j, align 4
-  %50 = load i32, i32* %i, align 4
-  %51 = add i32 %49, %50
-  store i32 %51, i32* %j, align 4
+  %56 = load i32, i32* %i, align 4
+  %57 = add i32 %56, 2
+  store i32 %57, i32* %i, align 4
+  %58 = load i32, i32* %j, align 4
+  %59 = load i32, i32* %i, align 4
+  %60 = add i32 %58, %59
+  store i32 %60, i32* %j, align 4
   br label %loop.head10
 
 loop.end12:                                       ; preds = %loop.head10
-  %52 = load i32, i32* %j, align 4
-  %53 = icmp ne i32 %52, 25
-  br i1 %53, label %then13, label %else14
+  %61 = load i32, i32* %j, align 4
+  %62 = icmp ne i32 %61, 25
+  br i1 %62, label %then13, label %else14
 
 then13:                                           ; preds = %loop.end12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -220,24 +229,23 @@ else14:                                           ; preds = %loop.end12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  %54 = alloca i64, align 8
-  %55 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %54, i32 0, i32 0, i32* %j)
-  %56 = load i64, i64* %54, align 4
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %55, i8** %57, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %56, i64* %58, align 4
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %60 = load i8*, i8** %59, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %62 = load i64, i64* %61, align 4
-  %63 = trunc i64 %62 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %60, i32 %63, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %64 = icmp eq i8* %55, null
-  br i1 %64, label %free_done18, label %free_nonnull17
+  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %10, i32 0, i32 0, i32* %j)
+  %64 = load i64, i64* %10, align 4
+  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  store i8* %63, i8** %65, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  store i64 %64, i64* %66, align 4
+  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  %68 = load i8*, i8** %67, align 8
+  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  %70 = load i64, i64* %69, align 4
+  %71 = trunc i64 %70 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %68, i32 %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %72 = icmp eq i8* %63, null
+  br i1 %72, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %ifcont15
-  call void @_lfortran_free(i8* %55)
+  call void @_lfortran_free(i8* %63)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %ifcont15
@@ -246,25 +254,25 @@ free_done18:                                      ; preds = %free_nonnull17, %if
   br label %loop.head19
 
 loop.head19:                                      ; preds = %loop.body20, %free_done18
-  %65 = load i32, i32* %i, align 4
-  %66 = add i32 %65, -2
-  %67 = icmp sge i32 %66, 1
-  br i1 %67, label %loop.body20, label %loop.end21
+  %73 = load i32, i32* %i, align 4
+  %74 = add i32 %73, -2
+  %75 = icmp sge i32 %74, 1
+  br i1 %75, label %loop.body20, label %loop.end21
 
 loop.body20:                                      ; preds = %loop.head19
-  %68 = load i32, i32* %i, align 4
-  %69 = add i32 %68, -2
-  store i32 %69, i32* %i, align 4
-  %70 = load i32, i32* %j, align 4
-  %71 = load i32, i32* %i, align 4
-  %72 = add i32 %70, %71
-  store i32 %72, i32* %j, align 4
+  %76 = load i32, i32* %i, align 4
+  %77 = add i32 %76, -2
+  store i32 %77, i32* %i, align 4
+  %78 = load i32, i32* %j, align 4
+  %79 = load i32, i32* %i, align 4
+  %80 = add i32 %78, %79
+  store i32 %80, i32* %j, align 4
   br label %loop.head19
 
 loop.end21:                                       ; preds = %loop.head19
-  %73 = load i32, i32* %j, align 4
-  %74 = icmp ne i32 %73, 25
-  br i1 %74, label %then22, label %else23
+  %81 = load i32, i32* %j, align 4
+  %82 = icmp ne i32 %81, 25
+  br i1 %82, label %then22, label %else23
 
 then22:                                           ; preds = %loop.end21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
@@ -275,24 +283,23 @@ else23:                                           ; preds = %loop.end21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  %75 = alloca i64, align 8
-  %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %75, i32 0, i32 0, i32* %j)
-  %77 = load i64, i64* %75, align 4
-  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
-  store i8* %76, i8** %78, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
-  store i64 %77, i64* %79, align 4
-  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
-  %81 = load i8*, i8** %80, align 8
-  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
-  %83 = load i64, i64* %82, align 4
-  %84 = trunc i64 %83 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %81, i32 %84, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %85 = icmp eq i8* %76, null
-  br i1 %85, label %free_done27, label %free_nonnull26
+  %83 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %9, i32 0, i32 0, i32* %j)
+  %84 = load i64, i64* %9, align 4
+  %85 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
+  store i8* %83, i8** %85, align 8
+  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
+  store i64 %84, i64* %86, align 4
+  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
+  %88 = load i8*, i8** %87, align 8
+  %89 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
+  %90 = load i64, i64* %89, align 4
+  %91 = trunc i64 %90 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %88, i32 %91, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  %92 = icmp eq i8* %83, null
+  br i1 %92, label %free_done27, label %free_nonnull26
 
 free_nonnull26:                                   ; preds = %ifcont24
-  call void @_lfortran_free(i8* %76)
+  call void @_lfortran_free(i8* %83)
   br label %free_done27
 
 free_done27:                                      ; preds = %free_nonnull26, %ifcont24
@@ -301,25 +308,25 @@ free_done27:                                      ; preds = %free_nonnull26, %if
   br label %loop.head28
 
 loop.head28:                                      ; preds = %loop.body29, %free_done27
-  %86 = load i32, i32* %i, align 4
-  %87 = add i32 %86, 2
-  %88 = icmp sle i32 %87, 10
-  br i1 %88, label %loop.body29, label %loop.end30
+  %93 = load i32, i32* %i, align 4
+  %94 = add i32 %93, 2
+  %95 = icmp sle i32 %94, 10
+  br i1 %95, label %loop.body29, label %loop.end30
 
 loop.body29:                                      ; preds = %loop.head28
-  %89 = load i32, i32* %i, align 4
-  %90 = add i32 %89, 2
-  store i32 %90, i32* %i, align 4
-  %91 = load i32, i32* %j, align 4
-  %92 = load i32, i32* %i, align 4
-  %93 = add i32 %91, %92
-  store i32 %93, i32* %j, align 4
+  %96 = load i32, i32* %i, align 4
+  %97 = add i32 %96, 2
+  store i32 %97, i32* %i, align 4
+  %98 = load i32, i32* %j, align 4
+  %99 = load i32, i32* %i, align 4
+  %100 = add i32 %98, %99
+  store i32 %100, i32* %j, align 4
   br label %loop.head28
 
 loop.end30:                                       ; preds = %loop.head28
-  %94 = load i32, i32* %j, align 4
-  %95 = icmp ne i32 %94, 25
-  br i1 %95, label %then31, label %else32
+  %101 = load i32, i32* %j, align 4
+  %102 = icmp ne i32 %101, 25
+  br i1 %102, label %then31, label %else32
 
 then31:                                           ; preds = %loop.end30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
@@ -330,24 +337,23 @@ else32:                                           ; preds = %loop.end30
   br label %ifcont33
 
 ifcont33:                                         ; preds = %else32, %then31
-  %96 = alloca i64, align 8
-  %97 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %96, i32 0, i32 0, i32* %j)
-  %98 = load i64, i64* %96, align 4
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
-  store i8* %97, i8** %99, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
-  store i64 %98, i64* %100, align 4
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
-  %102 = load i8*, i8** %101, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
-  %104 = load i64, i64* %103, align 4
-  %105 = trunc i64 %104 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
-  %106 = icmp eq i8* %97, null
-  br i1 %106, label %free_done36, label %free_nonnull35
+  %103 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %8, i32 0, i32 0, i32* %j)
+  %104 = load i64, i64* %8, align 4
+  %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
+  store i8* %103, i8** %105, align 8
+  %106 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
+  store i64 %104, i64* %106, align 4
+  %107 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
+  %108 = load i8*, i8** %107, align 8
+  %109 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
+  %110 = load i64, i64* %109, align 4
+  %111 = trunc i64 %110 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %108, i32 %111, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  %112 = icmp eq i8* %103, null
+  br i1 %112, label %free_done36, label %free_nonnull35
 
 free_nonnull35:                                   ; preds = %ifcont33
-  call void @_lfortran_free(i8* %97)
+  call void @_lfortran_free(i8* %103)
   br label %free_done36
 
 free_done36:                                      ; preds = %free_nonnull35, %ifcont33
@@ -356,25 +362,25 @@ free_done36:                                      ; preds = %free_nonnull35, %if
   br label %loop.head37
 
 loop.head37:                                      ; preds = %loop.body38, %free_done36
-  %107 = load i32, i32* %i, align 4
-  %108 = add i32 %107, 3
-  %109 = icmp sle i32 %108, 10
-  br i1 %109, label %loop.body38, label %loop.end39
+  %113 = load i32, i32* %i, align 4
+  %114 = add i32 %113, 3
+  %115 = icmp sle i32 %114, 10
+  br i1 %115, label %loop.body38, label %loop.end39
 
 loop.body38:                                      ; preds = %loop.head37
-  %110 = load i32, i32* %i, align 4
-  %111 = add i32 %110, 3
-  store i32 %111, i32* %i, align 4
-  %112 = load i32, i32* %j, align 4
-  %113 = load i32, i32* %i, align 4
-  %114 = add i32 %112, %113
-  store i32 %114, i32* %j, align 4
+  %116 = load i32, i32* %i, align 4
+  %117 = add i32 %116, 3
+  store i32 %117, i32* %i, align 4
+  %118 = load i32, i32* %j, align 4
+  %119 = load i32, i32* %i, align 4
+  %120 = add i32 %118, %119
+  store i32 %120, i32* %j, align 4
   br label %loop.head37
 
 loop.end39:                                       ; preds = %loop.head37
-  %115 = load i32, i32* %j, align 4
-  %116 = icmp ne i32 %115, 22
-  br i1 %116, label %then40, label %else41
+  %121 = load i32, i32* %j, align 4
+  %122 = icmp ne i32 %121, 22
+  br i1 %122, label %then40, label %else41
 
 then40:                                           ; preds = %loop.end39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
@@ -385,24 +391,23 @@ else41:                                           ; preds = %loop.end39
   br label %ifcont42
 
 ifcont42:                                         ; preds = %else41, %then40
-  %117 = alloca i64, align 8
-  %118 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %117, i32 0, i32 0, i32* %j)
-  %119 = load i64, i64* %117, align 4
-  %120 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
-  store i8* %118, i8** %120, align 8
-  %121 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
-  store i64 %119, i64* %121, align 4
-  %122 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
-  %123 = load i8*, i8** %122, align 8
-  %124 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
-  %125 = load i64, i64* %124, align 4
-  %126 = trunc i64 %125 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %123, i32 %126, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
-  %127 = icmp eq i8* %118, null
-  br i1 %127, label %free_done45, label %free_nonnull44
+  %123 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %7, i32 0, i32 0, i32* %j)
+  %124 = load i64, i64* %7, align 4
+  %125 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
+  store i8* %123, i8** %125, align 8
+  %126 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
+  store i64 %124, i64* %126, align 4
+  %127 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
+  %128 = load i8*, i8** %127, align 8
+  %129 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
+  %130 = load i64, i64* %129, align 4
+  %131 = trunc i64 %130 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %128, i32 %131, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  %132 = icmp eq i8* %123, null
+  br i1 %132, label %free_done45, label %free_nonnull44
 
 free_nonnull44:                                   ; preds = %ifcont42
-  call void @_lfortran_free(i8* %118)
+  call void @_lfortran_free(i8* %123)
   br label %free_done45
 
 free_done45:                                      ; preds = %free_nonnull44, %ifcont42
@@ -411,25 +416,25 @@ free_done45:                                      ; preds = %free_nonnull44, %if
   br label %loop.head46
 
 loop.head46:                                      ; preds = %loop.body47, %free_done45
-  %128 = load i32, i32* %i, align 4
-  %129 = add i32 %128, -3
-  %130 = icmp sge i32 %129, 1
-  br i1 %130, label %loop.body47, label %loop.end48
+  %133 = load i32, i32* %i, align 4
+  %134 = add i32 %133, -3
+  %135 = icmp sge i32 %134, 1
+  br i1 %135, label %loop.body47, label %loop.end48
 
 loop.body47:                                      ; preds = %loop.head46
-  %131 = load i32, i32* %i, align 4
-  %132 = add i32 %131, -3
-  store i32 %132, i32* %i, align 4
-  %133 = load i32, i32* %j, align 4
-  %134 = load i32, i32* %i, align 4
-  %135 = add i32 %133, %134
-  store i32 %135, i32* %j, align 4
+  %136 = load i32, i32* %i, align 4
+  %137 = add i32 %136, -3
+  store i32 %137, i32* %i, align 4
+  %138 = load i32, i32* %j, align 4
+  %139 = load i32, i32* %i, align 4
+  %140 = add i32 %138, %139
+  store i32 %140, i32* %j, align 4
   br label %loop.head46
 
 loop.end48:                                       ; preds = %loop.head46
-  %136 = load i32, i32* %j, align 4
-  %137 = icmp ne i32 %136, 22
-  br i1 %137, label %then49, label %else50
+  %141 = load i32, i32* %j, align 4
+  %142 = icmp ne i32 %141, 22
+  br i1 %142, label %then49, label %else50
 
 then49:                                           ; preds = %loop.end48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
@@ -440,24 +445,23 @@ else50:                                           ; preds = %loop.end48
   br label %ifcont51
 
 ifcont51:                                         ; preds = %else50, %then49
-  %138 = alloca i64, align 8
-  %139 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %138, i32 0, i32 0, i32* %j)
-  %140 = load i64, i64* %138, align 4
-  %141 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
-  store i8* %139, i8** %141, align 8
-  %142 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
-  store i64 %140, i64* %142, align 4
-  %143 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
-  %144 = load i8*, i8** %143, align 8
-  %145 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
-  %146 = load i64, i64* %145, align 4
-  %147 = trunc i64 %146 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %144, i32 %147, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
-  %148 = icmp eq i8* %139, null
-  br i1 %148, label %free_done54, label %free_nonnull53
+  %143 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %6, i32 0, i32 0, i32* %j)
+  %144 = load i64, i64* %6, align 4
+  %145 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
+  store i8* %143, i8** %145, align 8
+  %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
+  store i64 %144, i64* %146, align 4
+  %147 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
+  %148 = load i8*, i8** %147, align 8
+  %149 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
+  %150 = load i64, i64* %149, align 4
+  %151 = trunc i64 %150 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %148, i32 %151, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  %152 = icmp eq i8* %143, null
+  br i1 %152, label %free_done54, label %free_nonnull53
 
 free_nonnull53:                                   ; preds = %ifcont51
-  call void @_lfortran_free(i8* %139)
+  call void @_lfortran_free(i8* %143)
   br label %free_done54
 
 free_done54:                                      ; preds = %free_nonnull53, %ifcont51
@@ -466,25 +470,25 @@ free_done54:                                      ; preds = %free_nonnull53, %if
   br label %loop.head55
 
 loop.head55:                                      ; preds = %loop.body56, %free_done54
-  %149 = load i32, i32* %i, align 4
-  %150 = add i32 %149, 1
-  %151 = icmp sle i32 %150, 1
-  br i1 %151, label %loop.body56, label %loop.end57
+  %153 = load i32, i32* %i, align 4
+  %154 = add i32 %153, 1
+  %155 = icmp sle i32 %154, 1
+  br i1 %155, label %loop.body56, label %loop.end57
 
 loop.body56:                                      ; preds = %loop.head55
-  %152 = load i32, i32* %i, align 4
-  %153 = add i32 %152, 1
-  store i32 %153, i32* %i, align 4
-  %154 = load i32, i32* %j, align 4
-  %155 = load i32, i32* %i, align 4
-  %156 = add i32 %154, %155
-  store i32 %156, i32* %j, align 4
+  %156 = load i32, i32* %i, align 4
+  %157 = add i32 %156, 1
+  store i32 %157, i32* %i, align 4
+  %158 = load i32, i32* %j, align 4
+  %159 = load i32, i32* %i, align 4
+  %160 = add i32 %158, %159
+  store i32 %160, i32* %j, align 4
   br label %loop.head55
 
 loop.end57:                                       ; preds = %loop.head55
-  %157 = load i32, i32* %j, align 4
-  %158 = icmp ne i32 %157, 1
-  br i1 %158, label %then58, label %else59
+  %161 = load i32, i32* %j, align 4
+  %162 = icmp ne i32 %161, 1
+  br i1 %162, label %then58, label %else59
 
 then58:                                           ; preds = %loop.end57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
@@ -495,24 +499,23 @@ else59:                                           ; preds = %loop.end57
   br label %ifcont60
 
 ifcont60:                                         ; preds = %else59, %then58
-  %159 = alloca i64, align 8
-  %160 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %159, i32 0, i32 0, i32* %j)
-  %161 = load i64, i64* %159, align 4
-  %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
-  store i8* %160, i8** %162, align 8
-  %163 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
-  store i64 %161, i64* %163, align 4
-  %164 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
-  %165 = load i8*, i8** %164, align 8
+  %163 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %j)
+  %164 = load i64, i64* %5, align 4
+  %165 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
+  store i8* %163, i8** %165, align 8
   %166 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
-  %167 = load i64, i64* %166, align 4
-  %168 = trunc i64 %167 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %165, i32 %168, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  %169 = icmp eq i8* %160, null
-  br i1 %169, label %free_done63, label %free_nonnull62
+  store i64 %164, i64* %166, align 4
+  %167 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
+  %168 = load i8*, i8** %167, align 8
+  %169 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
+  %170 = load i64, i64* %169, align 4
+  %171 = trunc i64 %170 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %168, i32 %171, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  %172 = icmp eq i8* %163, null
+  br i1 %172, label %free_done63, label %free_nonnull62
 
 free_nonnull62:                                   ; preds = %ifcont60
-  call void @_lfortran_free(i8* %160)
+  call void @_lfortran_free(i8* %163)
   br label %free_done63
 
 free_done63:                                      ; preds = %free_nonnull62, %ifcont60
@@ -521,25 +524,25 @@ free_done63:                                      ; preds = %free_nonnull62, %if
   br label %loop.head64
 
 loop.head64:                                      ; preds = %loop.body65, %free_done63
-  %170 = load i32, i32* %i, align 4
-  %171 = add i32 %170, -1
-  %172 = icmp sge i32 %171, 1
-  br i1 %172, label %loop.body65, label %loop.end66
-
-loop.body65:                                      ; preds = %loop.head64
   %173 = load i32, i32* %i, align 4
   %174 = add i32 %173, -1
-  store i32 %174, i32* %i, align 4
-  %175 = load i32, i32* %j, align 4
+  %175 = icmp sge i32 %174, 1
+  br i1 %175, label %loop.body65, label %loop.end66
+
+loop.body65:                                      ; preds = %loop.head64
   %176 = load i32, i32* %i, align 4
-  %177 = add i32 %175, %176
-  store i32 %177, i32* %j, align 4
+  %177 = add i32 %176, -1
+  store i32 %177, i32* %i, align 4
+  %178 = load i32, i32* %j, align 4
+  %179 = load i32, i32* %i, align 4
+  %180 = add i32 %178, %179
+  store i32 %180, i32* %j, align 4
   br label %loop.head64
 
 loop.end66:                                       ; preds = %loop.head64
-  %178 = load i32, i32* %j, align 4
-  %179 = icmp ne i32 %178, 1
-  br i1 %179, label %then67, label %else68
+  %181 = load i32, i32* %j, align 4
+  %182 = icmp ne i32 %181, 1
+  br i1 %182, label %then67, label %else68
 
 then67:                                           ; preds = %loop.end66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
@@ -550,24 +553,23 @@ else68:                                           ; preds = %loop.end66
   br label %ifcont69
 
 ifcont69:                                         ; preds = %else68, %then67
-  %180 = alloca i64, align 8
-  %181 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %180, i32 0, i32 0, i32* %j)
-  %182 = load i64, i64* %180, align 4
-  %183 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
-  store i8* %181, i8** %183, align 8
-  %184 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
-  store i64 %182, i64* %184, align 4
+  %183 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %j)
+  %184 = load i64, i64* %4, align 4
   %185 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
-  %186 = load i8*, i8** %185, align 8
-  %187 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
-  %188 = load i64, i64* %187, align 4
-  %189 = trunc i64 %188 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %186, i32 %189, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
-  %190 = icmp eq i8* %181, null
-  br i1 %190, label %free_done72, label %free_nonnull71
+  store i8* %183, i8** %185, align 8
+  %186 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
+  store i64 %184, i64* %186, align 4
+  %187 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
+  %188 = load i8*, i8** %187, align 8
+  %189 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
+  %190 = load i64, i64* %189, align 4
+  %191 = trunc i64 %190 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %188, i32 %191, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  %192 = icmp eq i8* %183, null
+  br i1 %192, label %free_done72, label %free_nonnull71
 
 free_nonnull71:                                   ; preds = %ifcont69
-  call void @_lfortran_free(i8* %181)
+  call void @_lfortran_free(i8* %183)
   br label %free_done72
 
 free_done72:                                      ; preds = %free_nonnull71, %ifcont69
@@ -576,25 +578,25 @@ free_done72:                                      ; preds = %free_nonnull71, %if
   br label %loop.head73
 
 loop.head73:                                      ; preds = %loop.body74, %free_done72
-  %191 = load i32, i32* %i, align 4
-  %192 = add i32 %191, 1
-  %193 = icmp sle i32 %192, 0
-  br i1 %193, label %loop.body74, label %loop.end75
+  %193 = load i32, i32* %i, align 4
+  %194 = add i32 %193, 1
+  %195 = icmp sle i32 %194, 0
+  br i1 %195, label %loop.body74, label %loop.end75
 
 loop.body74:                                      ; preds = %loop.head73
-  %194 = load i32, i32* %i, align 4
-  %195 = add i32 %194, 1
-  store i32 %195, i32* %i, align 4
-  %196 = load i32, i32* %j, align 4
-  %197 = load i32, i32* %i, align 4
-  %198 = add i32 %196, %197
-  store i32 %198, i32* %j, align 4
+  %196 = load i32, i32* %i, align 4
+  %197 = add i32 %196, 1
+  store i32 %197, i32* %i, align 4
+  %198 = load i32, i32* %j, align 4
+  %199 = load i32, i32* %i, align 4
+  %200 = add i32 %198, %199
+  store i32 %200, i32* %j, align 4
   br label %loop.head73
 
 loop.end75:                                       ; preds = %loop.head73
-  %199 = load i32, i32* %j, align 4
-  %200 = icmp ne i32 %199, 0
-  br i1 %200, label %then76, label %else77
+  %201 = load i32, i32* %j, align 4
+  %202 = icmp ne i32 %201, 0
+  br i1 %202, label %then76, label %else77
 
 then76:                                           ; preds = %loop.end75
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
@@ -605,24 +607,23 @@ else77:                                           ; preds = %loop.end75
   br label %ifcont78
 
 ifcont78:                                         ; preds = %else77, %then76
-  %201 = alloca i64, align 8
-  %202 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %201, i32 0, i32 0, i32* %j)
-  %203 = load i64, i64* %201, align 4
-  %204 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
-  store i8* %202, i8** %204, align 8
-  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
-  store i64 %203, i64* %205, align 4
-  %206 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
-  %207 = load i8*, i8** %206, align 8
-  %208 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
-  %209 = load i64, i64* %208, align 4
-  %210 = trunc i64 %209 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %207, i32 %210, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
-  %211 = icmp eq i8* %202, null
-  br i1 %211, label %free_done81, label %free_nonnull80
+  %203 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %j)
+  %204 = load i64, i64* %3, align 4
+  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
+  store i8* %203, i8** %205, align 8
+  %206 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
+  store i64 %204, i64* %206, align 4
+  %207 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
+  %208 = load i8*, i8** %207, align 8
+  %209 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
+  %210 = load i64, i64* %209, align 4
+  %211 = trunc i64 %210 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %208, i32 %211, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  %212 = icmp eq i8* %203, null
+  br i1 %212, label %free_done81, label %free_nonnull80
 
 free_nonnull80:                                   ; preds = %ifcont78
-  call void @_lfortran_free(i8* %202)
+  call void @_lfortran_free(i8* %203)
   br label %free_done81
 
 free_done81:                                      ; preds = %free_nonnull80, %ifcont78
@@ -631,25 +632,25 @@ free_done81:                                      ; preds = %free_nonnull80, %if
   br label %loop.head82
 
 loop.head82:                                      ; preds = %loop.body83, %free_done81
-  %212 = load i32, i32* %i, align 4
-  %213 = add i32 %212, -1
-  %214 = icmp sge i32 %213, 1
-  br i1 %214, label %loop.body83, label %loop.end84
+  %213 = load i32, i32* %i, align 4
+  %214 = add i32 %213, -1
+  %215 = icmp sge i32 %214, 1
+  br i1 %215, label %loop.body83, label %loop.end84
 
 loop.body83:                                      ; preds = %loop.head82
-  %215 = load i32, i32* %i, align 4
-  %216 = add i32 %215, -1
-  store i32 %216, i32* %i, align 4
-  %217 = load i32, i32* %j, align 4
-  %218 = load i32, i32* %i, align 4
-  %219 = add i32 %217, %218
-  store i32 %219, i32* %j, align 4
+  %216 = load i32, i32* %i, align 4
+  %217 = add i32 %216, -1
+  store i32 %217, i32* %i, align 4
+  %218 = load i32, i32* %j, align 4
+  %219 = load i32, i32* %i, align 4
+  %220 = add i32 %218, %219
+  store i32 %220, i32* %j, align 4
   br label %loop.head82
 
 loop.end84:                                       ; preds = %loop.head82
-  %220 = load i32, i32* %j, align 4
-  %221 = icmp ne i32 %220, 0
-  br i1 %221, label %then85, label %else86
+  %221 = load i32, i32* %j, align 4
+  %222 = icmp ne i32 %221, 0
+  br i1 %222, label %then85, label %else86
 
 then85:                                           ; preds = %loop.end84
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
@@ -660,9 +661,8 @@ else86:                                           ; preds = %loop.end84
   br label %ifcont87
 
 ifcont87:                                         ; preds = %else86, %then85
-  %222 = alloca i64, align 8
-  %223 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %222, i32 0, i32 0, i32* %j)
-  %224 = load i64, i64* %222, align 4
+  %223 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %j)
+  %224 = load i64, i64* %2, align 4
   %225 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
   store i8* %223, i8** %225, align 8
   %226 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -62,6 +62,17 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc88 = alloca %string_descriptor, align 8
+  %stringFormat_desc79 = alloca %string_descriptor, align 8
+  %stringFormat_desc70 = alloca %string_descriptor, align 8
+  %stringFormat_desc61 = alloca %string_descriptor, align 8
+  %stringFormat_desc52 = alloca %string_descriptor, align 8
+  %stringFormat_desc43 = alloca %string_descriptor, align 8
+  %stringFormat_desc34 = alloca %string_descriptor, align 8
+  %stringFormat_desc25 = alloca %string_descriptor, align 8
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -102,7 +113,6 @@ ifcont:                                           ; preds = %else, %then
   %12 = alloca i64, align 8
   %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32* %j)
   %14 = load i64, i64* %12, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -158,7 +168,6 @@ ifcont6:                                          ; preds = %else5, %then4
   %33 = alloca i64, align 8
   %34 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %33, i32 0, i32 0, i32* %j)
   %35 = load i64, i64* %33, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %34, i8** %36, align 8
   %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -214,7 +223,6 @@ ifcont15:                                         ; preds = %else14, %then13
   %54 = alloca i64, align 8
   %55 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %54, i32 0, i32 0, i32* %j)
   %56 = load i64, i64* %54, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %55, i8** %57, align 8
   %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
@@ -270,7 +278,6 @@ ifcont24:                                         ; preds = %else23, %then22
   %75 = alloca i64, align 8
   %76 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %75, i32 0, i32 0, i32* %j)
   %77 = load i64, i64* %75, align 4
-  %stringFormat_desc25 = alloca %string_descriptor, align 8
   %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
   store i8* %76, i8** %78, align 8
   %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
@@ -326,7 +333,6 @@ ifcont33:                                         ; preds = %else32, %then31
   %96 = alloca i64, align 8
   %97 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %96, i32 0, i32 0, i32* %j)
   %98 = load i64, i64* %96, align 4
-  %stringFormat_desc34 = alloca %string_descriptor, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
   store i8* %97, i8** %99, align 8
   %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
@@ -382,7 +388,6 @@ ifcont42:                                         ; preds = %else41, %then40
   %117 = alloca i64, align 8
   %118 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %117, i32 0, i32 0, i32* %j)
   %119 = load i64, i64* %117, align 4
-  %stringFormat_desc43 = alloca %string_descriptor, align 8
   %120 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
   store i8* %118, i8** %120, align 8
   %121 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
@@ -438,7 +443,6 @@ ifcont51:                                         ; preds = %else50, %then49
   %138 = alloca i64, align 8
   %139 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %138, i32 0, i32 0, i32* %j)
   %140 = load i64, i64* %138, align 4
-  %stringFormat_desc52 = alloca %string_descriptor, align 8
   %141 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
   store i8* %139, i8** %141, align 8
   %142 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
@@ -494,7 +498,6 @@ ifcont60:                                         ; preds = %else59, %then58
   %159 = alloca i64, align 8
   %160 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %159, i32 0, i32 0, i32* %j)
   %161 = load i64, i64* %159, align 4
-  %stringFormat_desc61 = alloca %string_descriptor, align 8
   %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
   store i8* %160, i8** %162, align 8
   %163 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
@@ -550,7 +553,6 @@ ifcont69:                                         ; preds = %else68, %then67
   %180 = alloca i64, align 8
   %181 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %180, i32 0, i32 0, i32* %j)
   %182 = load i64, i64* %180, align 4
-  %stringFormat_desc70 = alloca %string_descriptor, align 8
   %183 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
   store i8* %181, i8** %183, align 8
   %184 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
@@ -606,7 +608,6 @@ ifcont78:                                         ; preds = %else77, %then76
   %201 = alloca i64, align 8
   %202 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %201, i32 0, i32 0, i32* %j)
   %203 = load i64, i64* %201, align 4
-  %stringFormat_desc79 = alloca %string_descriptor, align 8
   %204 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
   store i8* %202, i8** %204, align 8
   %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
@@ -662,7 +663,6 @@ ifcont87:                                         ; preds = %else86, %then85
   %222 = alloca i64, align 8
   %223 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %222, i32 0, i32 0, i32* %j)
   %224 = load i64, i64* %222, align 4
-  %stringFormat_desc88 = alloca %string_descriptor, align 8
   %225 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
   store i8* %223, i8** %225, align 8
   %226 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "ea49d5137821c5242a7b6fd0688f2ae5809252633ac82789e417b142",
+    "stdout_hash": "dd4c8933edad516a8e69d9cab570bd8bd48305d3c122f7ea0293a63c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "39656d0d845d8ef6f415ef43fb4915fb44768e3df20d815ca7dce3ef",
+    "stdout_hash": "ea49d5137821c5242a7b6fd0688f2ae5809252633ac82789e417b142",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -23,8 +23,11 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc22 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
@@ -35,34 +38,34 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 0, i32* %j, align 4
   store i32 1, i32* %a, align 4
   store i32 10, i32* %b, align 4
-  %2 = load i32, i32* %b, align 4
-  store i32 %2, i32* %__do_loop_end, align 4
-  %3 = load i32, i32* %a, align 4
-  %4 = sub i32 %3, 1
-  store i32 %4, i32* %i, align 4
+  %5 = load i32, i32* %b, align 4
+  store i32 %5, i32* %__do_loop_end, align 4
+  %6 = load i32, i32* %a, align 4
+  %7 = sub i32 %6, 1
+  store i32 %7, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %5 = load i32, i32* %i, align 4
-  %6 = add i32 %5, 1
-  %7 = load i32, i32* %__do_loop_end, align 4
-  %8 = icmp sle i32 %6, %7
-  br i1 %8, label %loop.body, label %loop.end
+  %8 = load i32, i32* %i, align 4
+  %9 = add i32 %8, 1
+  %10 = load i32, i32* %__do_loop_end, align 4
+  %11 = icmp sle i32 %9, %10
+  br i1 %11, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %9 = load i32, i32* %i, align 4
-  %10 = add i32 %9, 1
-  store i32 %10, i32* %i, align 4
-  %11 = load i32, i32* %j, align 4
   %12 = load i32, i32* %i, align 4
-  %13 = add i32 %11, %12
-  store i32 %13, i32* %j, align 4
+  %13 = add i32 %12, 1
+  store i32 %13, i32* %i, align 4
+  %14 = load i32, i32* %j, align 4
+  %15 = load i32, i32* %i, align 4
+  %16 = add i32 %14, %15
+  store i32 %16, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %14 = load i32, i32* %j, align 4
-  %15 = icmp ne i32 %14, 55
-  br i1 %15, label %then, label %else
+  %17 = load i32, i32* %j, align 4
+  %18 = icmp ne i32 %17, 55
+  br i1 %18, label %then, label %else
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -73,24 +76,23 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j)
-  %18 = load i64, i64* %16, align 4
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %18, i64* %20, align 4
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %j)
+  %20 = load i64, i64* %4, align 4
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %24 = load i64, i64* %23, align 4
-  %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
-  br i1 %26, label %free_done, label %free_nonnull
+  store i8* %19, i8** %21, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %20, i64* %22, align 4
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %24 = load i8*, i8** %23, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %26 = load i64, i64* %25, align 4
+  %27 = trunc i64 %26 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %28 = icmp eq i8* %19, null
+  br i1 %28, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free(i8* %17)
+  call void @_lfortran_free(i8* %19)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
@@ -99,45 +101,45 @@ free_done:                                        ; preds = %free_nonnull, %ifco
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.end5, %free_done
-  %27 = load i32, i32* %i, align 4
-  %28 = add i32 %27, 1
-  %29 = icmp sle i32 %28, 10
-  br i1 %29, label %loop.body2, label %loop.end6
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %29, 1
+  %31 = icmp sle i32 %30, 10
+  br i1 %31, label %loop.body2, label %loop.end6
 
 loop.body2:                                       ; preds = %loop.head1
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
+  %32 = load i32, i32* %i, align 4
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %i, align 4
   store i32 0, i32* %j, align 4
   br label %loop.head3
 
 loop.head3:                                       ; preds = %loop.body4, %loop.body2
-  %32 = load i32, i32* %j, align 4
-  %33 = add i32 %32, 1
-  %34 = icmp sle i32 %33, 10
-  br i1 %34, label %loop.body4, label %loop.end5
+  %34 = load i32, i32* %j, align 4
+  %35 = add i32 %34, 1
+  %36 = icmp sle i32 %35, 10
+  br i1 %36, label %loop.body4, label %loop.end5
 
 loop.body4:                                       ; preds = %loop.head3
-  %35 = load i32, i32* %j, align 4
-  %36 = add i32 %35, 1
-  store i32 %36, i32* %j, align 4
-  %37 = load i32, i32* %a, align 4
-  %38 = load i32, i32* %i, align 4
-  %39 = sub i32 %38, 1
-  %40 = mul i32 %39, 10
-  %41 = add i32 %37, %40
-  %42 = load i32, i32* %j, align 4
-  %43 = add i32 %41, %42
-  store i32 %43, i32* %a, align 4
+  %37 = load i32, i32* %j, align 4
+  %38 = add i32 %37, 1
+  store i32 %38, i32* %j, align 4
+  %39 = load i32, i32* %a, align 4
+  %40 = load i32, i32* %i, align 4
+  %41 = sub i32 %40, 1
+  %42 = mul i32 %41, 10
+  %43 = add i32 %39, %42
+  %44 = load i32, i32* %j, align 4
+  %45 = add i32 %43, %44
+  store i32 %45, i32* %a, align 4
   br label %loop.head3
 
 loop.end5:                                        ; preds = %loop.head3
   br label %loop.head1
 
 loop.end6:                                        ; preds = %loop.head1
-  %44 = load i32, i32* %a, align 4
-  %45 = icmp ne i32 %44, 5050
-  br i1 %45, label %then7, label %else8
+  %46 = load i32, i32* %a, align 4
+  %47 = icmp ne i32 %46, 5050
+  br i1 %47, label %then7, label %else8
 
 then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -148,24 +150,23 @@ else8:                                            ; preds = %loop.end6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %46 = alloca i64, align 8
-  %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %46, i32 0, i32 0, i32* %a)
-  %48 = load i64, i64* %46, align 4
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %47, i8** %49, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %48, i64* %50, align 4
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %52 = load i8*, i8** %51, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %54 = load i64, i64* %53, align 4
-  %55 = trunc i64 %54 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %56 = icmp eq i8* %47, null
-  br i1 %56, label %free_done12, label %free_nonnull11
+  %48 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %a)
+  %49 = load i64, i64* %3, align 4
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  store i8* %48, i8** %50, align 8
+  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  store i64 %49, i64* %51, align 4
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %53 = load i8*, i8** %52, align 8
+  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %55 = load i64, i64* %54, align 4
+  %56 = trunc i64 %55 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %57 = icmp eq i8* %48, null
+  br i1 %57, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %ifcont9
-  call void @_lfortran_free(i8* %47)
+  call void @_lfortran_free(i8* %48)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
@@ -174,44 +175,44 @@ free_done12:                                      ; preds = %free_nonnull11, %if
   br label %loop.head13
 
 loop.head13:                                      ; preds = %loop.end17, %free_done12
-  %57 = load i32, i32* %i, align 4
-  %58 = add i32 %57, 1
-  %59 = icmp sle i32 %58, 10
-  br i1 %59, label %loop.body14, label %loop.end18
+  %58 = load i32, i32* %i, align 4
+  %59 = add i32 %58, 1
+  %60 = icmp sle i32 %59, 10
+  br i1 %60, label %loop.body14, label %loop.end18
 
 loop.body14:                                      ; preds = %loop.head13
-  %60 = load i32, i32* %i, align 4
-  %61 = add i32 %60, 1
-  store i32 %61, i32* %i, align 4
-  %62 = load i32, i32* %i, align 4
-  store i32 %62, i32* %__do_loop_end1, align 4
+  %61 = load i32, i32* %i, align 4
+  %62 = add i32 %61, 1
+  store i32 %62, i32* %i, align 4
+  %63 = load i32, i32* %i, align 4
+  store i32 %63, i32* %__do_loop_end1, align 4
   store i32 0, i32* %j, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %loop.body16, %loop.body14
-  %63 = load i32, i32* %j, align 4
-  %64 = add i32 %63, 1
-  %65 = load i32, i32* %__do_loop_end1, align 4
-  %66 = icmp sle i32 %64, %65
-  br i1 %66, label %loop.body16, label %loop.end17
+  %64 = load i32, i32* %j, align 4
+  %65 = add i32 %64, 1
+  %66 = load i32, i32* %__do_loop_end1, align 4
+  %67 = icmp sle i32 %65, %66
+  br i1 %67, label %loop.body16, label %loop.end17
 
 loop.body16:                                      ; preds = %loop.head15
-  %67 = load i32, i32* %j, align 4
-  %68 = add i32 %67, 1
-  store i32 %68, i32* %j, align 4
-  %69 = load i32, i32* %a, align 4
-  %70 = load i32, i32* %j, align 4
-  %71 = add i32 %69, %70
-  store i32 %71, i32* %a, align 4
+  %68 = load i32, i32* %j, align 4
+  %69 = add i32 %68, 1
+  store i32 %69, i32* %j, align 4
+  %70 = load i32, i32* %a, align 4
+  %71 = load i32, i32* %j, align 4
+  %72 = add i32 %70, %71
+  store i32 %72, i32* %a, align 4
   br label %loop.head15
 
 loop.end17:                                       ; preds = %loop.head15
   br label %loop.head13
 
 loop.end18:                                       ; preds = %loop.head13
-  %72 = load i32, i32* %a, align 4
-  %73 = icmp ne i32 %72, 220
-  br i1 %73, label %then19, label %else20
+  %73 = load i32, i32* %a, align 4
+  %74 = icmp ne i32 %73, 220
+  br i1 %74, label %then19, label %else20
 
 then19:                                           ; preds = %loop.end18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -222,9 +223,8 @@ else20:                                           ; preds = %loop.end18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %74 = alloca i64, align 8
-  %75 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %74, i32 0, i32 0, i32* %a)
-  %76 = load i64, i64* %74, align 4
+  %75 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %a)
+  %76 = load i64, i64* %2, align 4
   %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
   store i8* %75, i8** %77, align 8
   %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -22,6 +22,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc22 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
@@ -73,7 +76,6 @@ ifcont:                                           ; preds = %else, %then
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -149,7 +151,6 @@ ifcont9:                                          ; preds = %else8, %then7
   %46 = alloca i64, align 8
   %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %46, i32 0, i32 0, i32* %a)
   %48 = load i64, i64* %46, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %47, i8** %49, align 8
   %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -224,7 +225,6 @@ ifcont21:                                         ; preds = %else20, %then19
   %74 = alloca i64, align 8
   %75 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %74, i32 0, i32 0, i32* %a)
   %76 = load i64, i64* %74, align 4
-  %stringFormat_desc22 = alloca %string_descriptor, align 8
   %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
   store i8* %75, i8** %77, align 8
   %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "2f570dd863f28a5e61198975d8d8a47414a053a16a4f8e0ebec119b4",
+    "stdout_hash": "467d6535b3043f127b2e50b66b6f4c7265fc2ffa05aa3cafd7de6313",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "226ee91892f31198923a7df99c5607752507c7c564025ed596e8bbe1",
+    "stdout_hash": "2f570dd863f28a5e61198975d8d8a47414a053a16a4f8e0ebec119b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -23,8 +23,11 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc29 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc17 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -33,22 +36,22 @@ define i32 @main(i32 %0, i8** %1) {
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont3, %.entry
-  %2 = load i32, i32* %i, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
-
-loop.body:                                        ; preds = %loop.head
   %5 = load i32, i32* %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  %7 = load i32, i32* %j, align 4
+  %7 = icmp sle i32 %6, 10
+  br i1 %7, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
   %8 = load i32, i32* %i, align 4
-  %9 = add i32 %7, %8
-  store i32 %9, i32* %j, align 4
-  %10 = load i32, i32* %i, align 4
-  %11 = icmp eq i32 %10, 3
-  br i1 %11, label %then, label %else
+  %9 = add i32 %8, 1
+  store i32 %9, i32* %i, align 4
+  %10 = load i32, i32* %j, align 4
+  %11 = load i32, i32* %i, align 4
+  %12 = add i32 %10, %11
+  store i32 %12, i32* %j, align 4
+  %13 = load i32, i32* %i, align 4
+  %14 = icmp eq i32 %13, 3
+  br i1 %14, label %then, label %else
 
 then:                                             ; preds = %loop.body
   br label %ifcont
@@ -57,9 +60,9 @@ else:                                             ; preds = %loop.body
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load i32, i32* %i, align 4
-  %13 = icmp eq i32 %12, 2
-  br i1 %13, label %then1, label %else2
+  %15 = load i32, i32* %i, align 4
+  %16 = icmp eq i32 %15, 2
+  br i1 %16, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   br label %loop.end
@@ -74,9 +77,9 @@ ifcont3:                                          ; preds = %else2, %unreachable
   br label %loop.head
 
 loop.end:                                         ; preds = %then1, %loop.head
-  %14 = load i32, i32* %j, align 4
-  %15 = icmp ne i32 %14, 3
-  br i1 %15, label %then4, label %else5
+  %17 = load i32, i32* %j, align 4
+  %18 = icmp ne i32 %17, 3
+  br i1 %18, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -87,24 +90,23 @@ else5:                                            ; preds = %loop.end
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j)
-  %18 = load i64, i64* %16, align 4
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %18, i64* %20, align 4
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %j)
+  %20 = load i64, i64* %4, align 4
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %24 = load i64, i64* %23, align 4
-  %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
-  br i1 %26, label %free_done, label %free_nonnull
+  store i8* %19, i8** %21, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %20, i64* %22, align 4
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %24 = load i8*, i8** %23, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %26 = load i64, i64* %25, align 4
+  %27 = trunc i64 %26 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %28 = icmp eq i8* %19, null
+  br i1 %28, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont6
-  call void @_lfortran_free(i8* %17)
+  call void @_lfortran_free(i8* %19)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
@@ -113,18 +115,18 @@ free_done:                                        ; preds = %free_nonnull, %ifco
   br label %loop.head7
 
 loop.head7:                                       ; preds = %ifcont12, %free_done
-  %27 = load i32, i32* %i, align 4
-  %28 = add i32 %27, 1
-  %29 = icmp sle i32 %28, 10
-  br i1 %29, label %loop.body8, label %loop.end13
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %29, 1
+  %31 = icmp sle i32 %30, 10
+  br i1 %31, label %loop.body8, label %loop.end13
 
 loop.body8:                                       ; preds = %loop.head7
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
   %32 = load i32, i32* %i, align 4
-  %33 = icmp eq i32 %32, 2
-  br i1 %33, label %then9, label %else11
+  %33 = add i32 %32, 1
+  store i32 %33, i32* %i, align 4
+  %34 = load i32, i32* %i, align 4
+  %35 = icmp eq i32 %34, 2
+  br i1 %35, label %then9, label %else11
 
 then9:                                            ; preds = %loop.body8
   br label %loop.end13
@@ -136,16 +138,16 @@ else11:                                           ; preds = %loop.body8
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %unreachable_after_exit10
-  %34 = load i32, i32* %j, align 4
-  %35 = load i32, i32* %i, align 4
-  %36 = add i32 %34, %35
-  store i32 %36, i32* %j, align 4
+  %36 = load i32, i32* %j, align 4
+  %37 = load i32, i32* %i, align 4
+  %38 = add i32 %36, %37
+  store i32 %38, i32* %j, align 4
   br label %loop.head7
 
 loop.end13:                                       ; preds = %then9, %loop.head7
-  %37 = load i32, i32* %j, align 4
-  %38 = icmp ne i32 %37, 1
-  br i1 %38, label %then14, label %else15
+  %39 = load i32, i32* %j, align 4
+  %40 = icmp ne i32 %39, 1
+  br i1 %40, label %then14, label %else15
 
 then14:                                           ; preds = %loop.end13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -156,24 +158,23 @@ else15:                                           ; preds = %loop.end13
   br label %ifcont16
 
 ifcont16:                                         ; preds = %else15, %then14
-  %39 = alloca i64, align 8
-  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %j)
-  %41 = load i64, i64* %39, align 4
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
-  store i8* %40, i8** %42, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
-  store i64 %41, i64* %43, align 4
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
-  %45 = load i8*, i8** %44, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
-  %47 = load i64, i64* %46, align 4
-  %48 = trunc i64 %47 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %45, i32 %48, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %49 = icmp eq i8* %40, null
-  br i1 %49, label %free_done19, label %free_nonnull18
+  %41 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %j)
+  %42 = load i64, i64* %3, align 4
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
+  store i8* %41, i8** %43, align 8
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
+  store i64 %42, i64* %44, align 4
+  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
+  %46 = load i8*, i8** %45, align 8
+  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
+  %48 = load i64, i64* %47, align 4
+  %49 = trunc i64 %48 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %50 = icmp eq i8* %41, null
+  br i1 %50, label %free_done19, label %free_nonnull18
 
 free_nonnull18:                                   ; preds = %ifcont16
-  call void @_lfortran_free(i8* %40)
+  call void @_lfortran_free(i8* %41)
   br label %free_done19
 
 free_done19:                                      ; preds = %free_nonnull18, %ifcont16
@@ -182,18 +183,18 @@ free_done19:                                      ; preds = %free_nonnull18, %if
   br label %loop.head20
 
 loop.head20:                                      ; preds = %ifcont24, %then22, %free_done19
-  %50 = load i32, i32* %i, align 4
-  %51 = add i32 %50, 1
-  %52 = icmp sle i32 %51, 10
-  br i1 %52, label %loop.body21, label %loop.end25
+  %51 = load i32, i32* %i, align 4
+  %52 = add i32 %51, 1
+  %53 = icmp sle i32 %52, 10
+  br i1 %53, label %loop.body21, label %loop.end25
 
 loop.body21:                                      ; preds = %loop.head20
-  %53 = load i32, i32* %i, align 4
-  %54 = add i32 %53, 1
-  store i32 %54, i32* %i, align 4
-  %55 = load i32, i32* %i, align 4
-  %56 = icmp eq i32 %55, 2
-  br i1 %56, label %then22, label %else23
+  %54 = load i32, i32* %i, align 4
+  %55 = add i32 %54, 1
+  store i32 %55, i32* %i, align 4
+  %56 = load i32, i32* %i, align 4
+  %57 = icmp eq i32 %56, 2
+  br i1 %57, label %then22, label %else23
 
 then22:                                           ; preds = %loop.body21
   br label %loop.head20
@@ -205,16 +206,16 @@ else23:                                           ; preds = %loop.body21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %unreachable_after_cycle
-  %57 = load i32, i32* %j, align 4
-  %58 = load i32, i32* %i, align 4
-  %59 = add i32 %57, %58
-  store i32 %59, i32* %j, align 4
+  %58 = load i32, i32* %j, align 4
+  %59 = load i32, i32* %i, align 4
+  %60 = add i32 %58, %59
+  store i32 %60, i32* %j, align 4
   br label %loop.head20
 
 loop.end25:                                       ; preds = %loop.head20
-  %60 = load i32, i32* %j, align 4
-  %61 = icmp ne i32 %60, 53
-  br i1 %61, label %then26, label %else27
+  %61 = load i32, i32* %j, align 4
+  %62 = icmp ne i32 %61, 53
+  br i1 %62, label %then26, label %else27
 
 then26:                                           ; preds = %loop.end25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -225,9 +226,8 @@ else27:                                           ; preds = %loop.end25
   br label %ifcont28
 
 ifcont28:                                         ; preds = %else27, %then26
-  %62 = alloca i64, align 8
-  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %62, i32 0, i32 0, i32* %j)
-  %64 = load i64, i64* %62, align 4
+  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %j)
+  %64 = load i64, i64* %2, align 4
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
   store i8* %63, i8** %65, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -22,6 +22,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc29 = alloca %string_descriptor, align 8
+  %stringFormat_desc17 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -87,7 +90,6 @@ ifcont6:                                          ; preds = %else5, %then4
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32* %j)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -157,7 +159,6 @@ ifcont16:                                         ; preds = %else15, %then14
   %39 = alloca i64, align 8
   %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %j)
   %41 = load i64, i64* %39, align 4
-  %stringFormat_desc17 = alloca %string_descriptor, align 8
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
   store i8* %40, i8** %42, align 8
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
@@ -227,7 +228,6 @@ ifcont28:                                         ; preds = %else27, %then26
   %62 = alloca i64, align 8
   %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %62, i32 0, i32 0, i32* %j)
   %64 = load i64, i64* %62, align 4
-  %stringFormat_desc29 = alloca %string_descriptor, align 8
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
   store i8* %63, i8** %65, align 8
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "653bcf96aaba5fe98520b4349f5f71045b8b15285b18d548c6c0eb64",
+    "stdout_hash": "3a3ac060576fc2d8cbe4e544fc4ab8e646fcbc786b1373ec5b66fbf8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "3a3ac060576fc2d8cbe4e544fc4ab8e646fcbc786b1373ec5b66fbf8",
+    "stdout_hash": "9a5279075cda3e1a629040fd3b559b28253d10c48727c11c0c4485c3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -23,6 +23,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__do_loop_inc = alloca i32, align 4
   %__do_loop_inc1 = alloca i32, align 4
@@ -88,7 +90,6 @@ ifcont:                                           ; preds = %else, %then
   %31 = alloca i64, align 8
   %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %31, i32 0, i32 0, i32* %j)
   %33 = load i64, i64* %31, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %32, i8** %34, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -165,7 +166,6 @@ ifcont6:                                          ; preds = %else5, %then4
   %71 = alloca i64, align 8
   %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %71, i32 0, i32 0, i32* %j)
   %73 = load i64, i64* %71, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %72, i8** %74, align 8
   %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -24,7 +24,9 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %__do_loop_inc = alloca i32, align 4
   %__do_loop_inc1 = alloca i32, align 4
@@ -34,49 +36,49 @@ define i32 @main(i32 %0, i8** %1) {
   %k = alloca i32, align 4
   store i32 0, i32* %j, align 4
   store i32 2, i32* %k, align 4
-  %2 = load i32, i32* %k, align 4
-  store i32 %2, i32* %__do_loop_inc, align 4
-  %3 = load i32, i32* %__do_loop_inc, align 4
-  %4 = sub i32 1, %3
-  store i32 %4, i32* %i, align 4
+  %4 = load i32, i32* %k, align 4
+  store i32 %4, i32* %__do_loop_inc, align 4
+  %5 = load i32, i32* %__do_loop_inc, align 4
+  %6 = sub i32 1, %5
+  store i32 %6, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %5 = load i32, i32* %__do_loop_inc, align 4
-  %6 = icmp sgt i32 %5, 0
-  %7 = load i32, i32* %i, align 4
-  %8 = load i32, i32* %__do_loop_inc, align 4
-  %9 = add i32 %7, %8
-  %10 = icmp sle i32 %9, 10
-  %11 = icmp eq i1 %6, false
-  %12 = select i1 %11, i1 %6, i1 %10
-  %13 = load i32, i32* %__do_loop_inc, align 4
-  %14 = icmp sle i32 %13, 0
-  %15 = load i32, i32* %i, align 4
-  %16 = load i32, i32* %__do_loop_inc, align 4
-  %17 = add i32 %15, %16
-  %18 = icmp sge i32 %17, 10
-  %19 = icmp eq i1 %14, false
-  %20 = select i1 %19, i1 %14, i1 %18
-  %21 = icmp eq i1 %12, false
-  %22 = select i1 %21, i1 %20, i1 %12
-  br i1 %22, label %loop.body, label %loop.end
+  %7 = load i32, i32* %__do_loop_inc, align 4
+  %8 = icmp sgt i32 %7, 0
+  %9 = load i32, i32* %i, align 4
+  %10 = load i32, i32* %__do_loop_inc, align 4
+  %11 = add i32 %9, %10
+  %12 = icmp sle i32 %11, 10
+  %13 = icmp eq i1 %8, false
+  %14 = select i1 %13, i1 %8, i1 %12
+  %15 = load i32, i32* %__do_loop_inc, align 4
+  %16 = icmp sle i32 %15, 0
+  %17 = load i32, i32* %i, align 4
+  %18 = load i32, i32* %__do_loop_inc, align 4
+  %19 = add i32 %17, %18
+  %20 = icmp sge i32 %19, 10
+  %21 = icmp eq i1 %16, false
+  %22 = select i1 %21, i1 %16, i1 %20
+  %23 = icmp eq i1 %14, false
+  %24 = select i1 %23, i1 %22, i1 %14
+  br i1 %24, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %23 = load i32, i32* %i, align 4
-  %24 = load i32, i32* %__do_loop_inc, align 4
-  %25 = add i32 %23, %24
-  store i32 %25, i32* %i, align 4
-  %26 = load i32, i32* %j, align 4
-  %27 = load i32, i32* %i, align 4
-  %28 = add i32 %26, %27
-  store i32 %28, i32* %j, align 4
+  %25 = load i32, i32* %i, align 4
+  %26 = load i32, i32* %__do_loop_inc, align 4
+  %27 = add i32 %25, %26
+  store i32 %27, i32* %i, align 4
+  %28 = load i32, i32* %j, align 4
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %28, %29
+  store i32 %30, i32* %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %29 = load i32, i32* %j, align 4
-  %30 = icmp ne i32 %29, 25
-  br i1 %30, label %then, label %else
+  %31 = load i32, i32* %j, align 4
+  %32 = icmp ne i32 %31, 25
+  br i1 %32, label %then, label %else
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -87,72 +89,71 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %31 = alloca i64, align 8
-  %32 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %31, i32 0, i32 0, i32* %j)
-  %33 = load i64, i64* %31, align 4
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %33, i64* %35, align 4
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %39 = load i64, i64* %38, align 4
-  %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
-  br i1 %41, label %free_done, label %free_nonnull
+  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %j)
+  %34 = load i64, i64* %3, align 4
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %33, i8** %35, align 8
+  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %34, i64* %36, align 4
+  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %38 = load i8*, i8** %37, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %40 = load i64, i64* %39, align 4
+  %41 = trunc i64 %40 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %38, i32 %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %42 = icmp eq i8* %33, null
+  br i1 %42, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free(i8* %32)
+  call void @_lfortran_free(i8* %33)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
   store i32 0, i32* %j, align 4
   store i32 -2, i32* %k, align 4
-  %42 = load i32, i32* %k, align 4
-  store i32 %42, i32* %__do_loop_inc1, align 4
-  %43 = load i32, i32* %__do_loop_inc1, align 4
-  %44 = sub i32 10, %43
-  store i32 %44, i32* %i, align 4
+  %43 = load i32, i32* %k, align 4
+  store i32 %43, i32* %__do_loop_inc1, align 4
+  %44 = load i32, i32* %__do_loop_inc1, align 4
+  %45 = sub i32 10, %44
+  store i32 %45, i32* %i, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.body2, %free_done
-  %45 = load i32, i32* %__do_loop_inc1, align 4
-  %46 = icmp sgt i32 %45, 0
-  %47 = load i32, i32* %i, align 4
-  %48 = load i32, i32* %__do_loop_inc1, align 4
-  %49 = add i32 %47, %48
-  %50 = icmp sle i32 %49, 1
-  %51 = icmp eq i1 %46, false
-  %52 = select i1 %51, i1 %46, i1 %50
-  %53 = load i32, i32* %__do_loop_inc1, align 4
-  %54 = icmp sle i32 %53, 0
-  %55 = load i32, i32* %i, align 4
-  %56 = load i32, i32* %__do_loop_inc1, align 4
-  %57 = add i32 %55, %56
-  %58 = icmp sge i32 %57, 1
-  %59 = icmp eq i1 %54, false
-  %60 = select i1 %59, i1 %54, i1 %58
-  %61 = icmp eq i1 %52, false
-  %62 = select i1 %61, i1 %60, i1 %52
-  br i1 %62, label %loop.body2, label %loop.end3
+  %46 = load i32, i32* %__do_loop_inc1, align 4
+  %47 = icmp sgt i32 %46, 0
+  %48 = load i32, i32* %i, align 4
+  %49 = load i32, i32* %__do_loop_inc1, align 4
+  %50 = add i32 %48, %49
+  %51 = icmp sle i32 %50, 1
+  %52 = icmp eq i1 %47, false
+  %53 = select i1 %52, i1 %47, i1 %51
+  %54 = load i32, i32* %__do_loop_inc1, align 4
+  %55 = icmp sle i32 %54, 0
+  %56 = load i32, i32* %i, align 4
+  %57 = load i32, i32* %__do_loop_inc1, align 4
+  %58 = add i32 %56, %57
+  %59 = icmp sge i32 %58, 1
+  %60 = icmp eq i1 %55, false
+  %61 = select i1 %60, i1 %55, i1 %59
+  %62 = icmp eq i1 %53, false
+  %63 = select i1 %62, i1 %61, i1 %53
+  br i1 %63, label %loop.body2, label %loop.end3
 
 loop.body2:                                       ; preds = %loop.head1
-  %63 = load i32, i32* %i, align 4
-  %64 = load i32, i32* %__do_loop_inc1, align 4
-  %65 = add i32 %63, %64
-  store i32 %65, i32* %i, align 4
-  %66 = load i32, i32* %j, align 4
-  %67 = load i32, i32* %i, align 4
-  %68 = add i32 %66, %67
-  store i32 %68, i32* %j, align 4
+  %64 = load i32, i32* %i, align 4
+  %65 = load i32, i32* %__do_loop_inc1, align 4
+  %66 = add i32 %64, %65
+  store i32 %66, i32* %i, align 4
+  %67 = load i32, i32* %j, align 4
+  %68 = load i32, i32* %i, align 4
+  %69 = add i32 %67, %68
+  store i32 %69, i32* %j, align 4
   br label %loop.head1
 
 loop.end3:                                        ; preds = %loop.head1
-  %69 = load i32, i32* %j, align 4
-  %70 = icmp ne i32 %69, 30
-  br i1 %70, label %then4, label %else5
+  %70 = load i32, i32* %j, align 4
+  %71 = icmp ne i32 %70, 30
+  br i1 %71, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -163,9 +164,8 @@ else5:                                            ; preds = %loop.end3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %71 = alloca i64, align 8
-  %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %71, i32 0, i32 0, i32* %j)
-  %73 = load i64, i64* %71, align 4
+  %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %j)
+  %73 = load i64, i64* %2, align 4
   %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %72, i8** %74, align 8
   %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "73cac86e0aeaa685c0525e073447a3aac497331abdd87d9d4143b83f",
+    "stdout_hash": "ad11bb0a51cf2079ba970aba49bc2574c3a73d589c45171770272779",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "ad11bb0a51cf2079ba970aba49bc2574c3a73d589c45171770272779",
+    "stdout_hash": "bfba09146de5c9cc81d03ffb4c852efa79d552473eb62acdbe7d3ed4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define void @a(float (float*)* %f) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value = alloca float, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %call_arg_value, align 4
@@ -17,7 +18,6 @@ define void @a(float (float*)* %f) {
   %1 = alloca i64, align 8
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, float* %r)
   %3 = load i64, i64* %1, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -10,14 +10,14 @@ source_filename = "LFortran"
 define void @a(float (float*)* %f) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %call_arg_value = alloca float, align 4
   %r = alloca float, align 4
   store float 2.000000e+00, float* %call_arg_value, align 4
-  %0 = call float %f(float* %call_arg_value)
-  store float %0, float* %r, align 4
-  %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, float* %r)
-  %3 = load i64, i64* %1, align 4
+  %1 = call float %f(float* %call_arg_value)
+  store float %1, float* %r, align 4
+  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %r)
+  %3 = load i64, i64* %0, align 4
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "3d010649819f12e8559c5aa66c4d81844f85b2bebe8d67d9e7b0b70b",
+    "stdout_hash": "1de0dc3674b6fe679f5e8584bb75404a72212b794dcae796a881ef07",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -1,8 +1,8 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %dimension_descriptor = type { i32, i32, i32 }
+%array = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %string_descriptor = type <{ i8*, i64 }>
 %array.0 = type { float*, i32, %dimension_descriptor*, i1, i32 }
 
@@ -14,19 +14,19 @@ source_filename = "LFortran"
 
 define void @__module_finalize_01_mod_ss() {
 .entry:
+  %0 = alloca i32, align 4
+  store i32 1, i32* %0, align 4
+  %1 = load i32, i32* %0, align 4
+  %2 = alloca %dimension_descriptor, i32 %1, align 8
+  %arr_desc = alloca %array, align 8
   %arr = alloca %array*, align 8
   store %array* null, %array** %arr, align 8
-  %arr_desc = alloca %array, align 8
-  %0 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %1 = alloca i32, align 4
-  store i32 1, i32* %1, align 4
-  %2 = load i32, i32* %1, align 4
-  %3 = alloca %dimension_descriptor, i32 %2, align 8
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
+  %3 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 1
   store i32 1, i32* %4, align 4
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
+  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 2
   store i32 1, i32* %5, align 4
-  store %dimension_descriptor* %3, %dimension_descriptor** %0, align 8
+  store %dimension_descriptor* %2, %dimension_descriptor** %3, align 8
   %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
   store i32 1, i32* %6, align 4
   %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -185,20 +185,20 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %2 = alloca i32, align 4
+  store i32 1, i32* %2, align 4
+  %3 = load i32, i32* %2, align 4
+  %4 = alloca %dimension_descriptor, i32 %3, align 8
+  %arr_desc = alloca %array, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %arr = alloca %array*, align 8
   store %array* null, %array** %arr, align 8
-  %arr_desc = alloca %array, align 8
-  %2 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %3 = alloca i32, align 4
-  store i32 1, i32* %3, align 4
-  %4 = load i32, i32* %3, align 4
-  %5 = alloca %dimension_descriptor, i32 %4, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
+  %5 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 1
   store i32 1, i32* %6, align 4
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
+  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 2
   store i32 1, i32* %7, align 4
-  store %dimension_descriptor* %5, %dimension_descriptor** %2, align 8
+  store %dimension_descriptor* %4, %dimension_descriptor** %5, align 8
   %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
   store i32 1, i32* %8, align 4
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -253,43 +253,43 @@ Finalize_Variable_str:                            ; preds = %Finalize_Variable_a
 
 define void @internal_sub() {
 .entry:
+  %0 = alloca i32, align 4
+  store i32 1, i32* %0, align 4
+  %1 = load i32, i32* %0, align 4
+  %2 = alloca %dimension_descriptor, i32 %1, align 8
+  %arr_desc1 = alloca %array, align 8
+  %3 = alloca i32, align 4
+  store i32 2, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  %arr_desc = alloca %array.0, align 8
   %arr_real = alloca %array.0*, align 8
   store %array.0* null, %array.0** %arr_real, align 8
-  %arr_desc = alloca %array.0, align 8
-  %0 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 2
-  %1 = alloca i32, align 4
-  store i32 2, i32* %1, align 4
-  %2 = load i32, i32* %1, align 4
-  %3 = alloca %dimension_descriptor, i32 %2, align 8
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
-  store i32 1, i32* %4, align 4
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i32 1, i32* %5, align 4
-  store %dimension_descriptor* %3, %dimension_descriptor** %0, align 8
-  %6 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 4
-  store i32 2, i32* %6, align 4
-  %7 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 0
-  store float* null, float** %7, align 8
+  %6 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 2
+  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
+  store i32 1, i32* %7, align 4
+  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
+  store i32 1, i32* %8, align 4
+  store %dimension_descriptor* %5, %dimension_descriptor** %6, align 8
+  %9 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 4
+  store i32 2, i32* %9, align 4
+  %10 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 0
+  store float* null, float** %10, align 8
   store %array.0* %arr_desc, %array.0** %arr_real, align 8
   %str = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %str, align 1
   br label %bl.start
 
 bl.start:                                         ; preds = %.entry
-  %8 = call i8* @llvm.stacksave()
+  %11 = call i8* @llvm.stacksave()
   %arr_in_block = alloca %array*, align 8
   store %array* null, %array** %arr_in_block, align 8
-  %arr_desc1 = alloca %array, align 8
-  %9 = getelementptr %array, %array* %arr_desc1, i32 0, i32 2
-  %10 = alloca i32, align 4
-  store i32 1, i32* %10, align 4
-  %11 = load i32, i32* %10, align 4
-  %12 = alloca %dimension_descriptor, i32 %11, align 8
-  %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 1
+  %12 = getelementptr %array, %array* %arr_desc1, i32 0, i32 2
+  %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 1
   store i32 1, i32* %13, align 4
-  %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 2
+  %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 2
   store i32 1, i32* %14, align 4
-  store %dimension_descriptor* %12, %dimension_descriptor** %9, align 8
+  store %dimension_descriptor* %2, %dimension_descriptor** %12, align 8
   %15 = getelementptr %array, %array* %arr_desc1, i32 0, i32 4
   store i32 1, i32* %15, align 4
   %16 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0
@@ -312,7 +312,7 @@ FINALIZE_SYMTABLE_bl:                             ; preds = %bl.end
 Finalize_Variable_arr_in_block:                   ; preds = %FINALIZE_SYMTABLE_bl
   %17 = load %array*, %array** %arr_in_block, align 8
   call void @finalize_allocatable__Array_i32(%array* %17, i1 false)
-  call void @llvm.stackrestore(i8* %8)
+  call void @llvm.stackrestore(i8* %11)
   br label %loop.head
 
 loop.head:                                        ; preds = %unreachable_after_return2, %Finalize_Variable_arr_in_block

--- a/tests/reference/llvm-finalize_02-cfb24d5.json
+++ b/tests/reference/llvm-finalize_02-cfb24d5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_02-cfb24d5.stdout",
-    "stdout_hash": "ad79fb4f16d5766ea9b947999cd0f6fcdf37b06efaaa05d8bbbb5205",
+    "stdout_hash": "b64b46eecefad892005f4755e68f44f67aa29d7af944cf8ed8acde53",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.stdout
+++ b/tests/reference/llvm-finalize_02-cfb24d5.stdout
@@ -1,13 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
+%dimension_descriptor = type { i32, i32, i32 }
+%array.1 = type { %string_descriptor*, i32, %dimension_descriptor*, i1, i32 }
+%string_descriptor = type <{ i8*, i64 }>
+%array.0 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
 %array = type { %finalize_02.tt*, i32, %dimension_descriptor*, i1, i32 }
 %finalize_02.tt = type { float, %finalize_02.t }
 %finalize_02.t = type { i32 }
-%dimension_descriptor = type { i32, i32, i32 }
-%array.0 = type { i32*, i32, %dimension_descriptor*, i1, i32 }
-%array.1 = type { %string_descriptor*, i32, %dimension_descriptor*, i1, i32 }
-%string_descriptor = type <{ i8*, i64 }>
 
 @deep_0 = internal global i32 0
 
@@ -29,117 +29,117 @@ FINALIZE_SYMTABLE_finalize_02:                    ; preds = %return
 
 define void @ss(i32* %nang) {
 .entry:
-  %arr_01 = alloca %array*, align 8
-  store %array* null, %array** %arr_01, align 8
-  %arr_desc = alloca %array, align 8
-  %0 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
-  %1 = alloca i32, align 4
-  store i32 1, i32* %1, align 4
-  %2 = load i32, i32* %1, align 4
-  %3 = alloca %dimension_descriptor, i32 %2, align 8
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
-  store i32 1, i32* %4, align 4
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i32 1, i32* %5, align 4
-  store %dimension_descriptor* %3, %dimension_descriptor** %0, align 8
-  %6 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
+  %0 = alloca i32, align 4
+  store i32 1, i32* %0, align 4
+  %1 = load i32, i32* %0, align 4
+  %2 = alloca %dimension_descriptor, i32 %1, align 8
+  %arr_desc4 = alloca %array.1, align 8
+  %3 = alloca i32, align 4
+  store i32 1, i32* %3, align 4
+  %4 = load i32, i32* %3, align 4
+  %5 = alloca %dimension_descriptor, i32 %4, align 8
+  %arr_desc3 = alloca %array.0, align 8
+  %6 = alloca i32, align 4
   store i32 1, i32* %6, align 4
-  %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
-  store %finalize_02.tt* null, %finalize_02.tt** %7, align 8
-  store %array* %arr_desc, %array** %arr_01, align 8
-  %arr_02 = alloca %array.0*, align 8
-  store %array.0* null, %array.0** %arr_02, align 8
-  %arr_desc1 = alloca %array.0, align 8
-  %8 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 2
+  %7 = load i32, i32* %6, align 4
+  %8 = alloca %dimension_descriptor, i32 %7, align 8
+  %arr_desc2 = alloca %array.1, align 8
   %9 = alloca i32, align 4
   store i32 1, i32* %9, align 4
   %10 = load i32, i32* %9, align 4
   %11 = alloca %dimension_descriptor, i32 %10, align 8
-  %12 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 1
+  %arr_desc1 = alloca %array.0, align 8
+  %12 = alloca i32, align 4
   store i32 1, i32* %12, align 4
-  %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 2
-  store i32 1, i32* %13, align 4
-  store %dimension_descriptor* %11, %dimension_descriptor** %8, align 8
-  %14 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 4
-  store i32 1, i32* %14, align 4
-  %15 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 0
-  store i32* null, i32** %15, align 8
+  %13 = load i32, i32* %12, align 4
+  %14 = alloca %dimension_descriptor, i32 %13, align 8
+  %arr_desc = alloca %array, align 8
+  %arr_01 = alloca %array*, align 8
+  store %array* null, %array** %arr_01, align 8
+  %15 = getelementptr %array, %array* %arr_desc, i32 0, i32 2
+  %16 = getelementptr %dimension_descriptor, %dimension_descriptor* %14, i32 0, i32 1
+  store i32 1, i32* %16, align 4
+  %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %14, i32 0, i32 2
+  store i32 1, i32* %17, align 4
+  store %dimension_descriptor* %14, %dimension_descriptor** %15, align 8
+  %18 = getelementptr %array, %array* %arr_desc, i32 0, i32 4
+  store i32 1, i32* %18, align 4
+  %19 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
+  store %finalize_02.tt* null, %finalize_02.tt** %19, align 8
+  store %array* %arr_desc, %array** %arr_01, align 8
+  %arr_02 = alloca %array.0*, align 8
+  store %array.0* null, %array.0** %arr_02, align 8
+  %20 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 2
+  %21 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 1
+  store i32 1, i32* %21, align 4
+  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 2
+  store i32 1, i32* %22, align 4
+  store %dimension_descriptor* %11, %dimension_descriptor** %20, align 8
+  %23 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 4
+  store i32 1, i32* %23, align 4
+  %24 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 0
+  store i32* null, i32** %24, align 8
   store %array.0* %arr_desc1, %array.0** %arr_02, align 8
   %arr_03 = alloca i32*, align 8
   store i32* null, i32** %arr_03, align 8
   %arr_04 = alloca %array.1*, align 8
   store %array.1* null, %array.1** %arr_04, align 8
-  %arr_desc2 = alloca %array.1, align 8
   %arr_desc_str_desc = alloca %string_descriptor, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 0
-  store i8* null, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 1
-  store i64 0, i64* %17, align 4
-  %18 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 0
-  store %string_descriptor* %arr_desc_str_desc, %string_descriptor** %18, align 8
-  %19 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 2
-  %20 = alloca i32, align 4
-  store i32 1, i32* %20, align 4
-  %21 = load i32, i32* %20, align 4
-  %22 = alloca %dimension_descriptor, i32 %21, align 8
-  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %22, i32 0, i32 1
-  store i32 1, i32* %23, align 4
-  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %22, i32 0, i32 2
-  store i32 1, i32* %24, align 4
-  store %dimension_descriptor* %22, %dimension_descriptor** %19, align 8
-  %25 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 4
-  store i32 1, i32* %25, align 4
+  %25 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 0
+  store i8* null, i8** %25, align 8
+  %26 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 1
+  store i64 0, i64* %26, align 4
+  %27 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 0
+  store %string_descriptor* %arr_desc_str_desc, %string_descriptor** %27, align 8
+  %28 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 2
+  %29 = getelementptr %dimension_descriptor, %dimension_descriptor* %8, i32 0, i32 1
+  store i32 1, i32* %29, align 4
+  %30 = getelementptr %dimension_descriptor, %dimension_descriptor* %8, i32 0, i32 2
+  store i32 1, i32* %30, align 4
+  store %dimension_descriptor* %8, %dimension_descriptor** %28, align 8
+  %31 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 4
+  store i32 1, i32* %31, align 4
   store %array.1* %arr_desc2, %array.1** %arr_04, align 8
   %arr_05 = alloca %string_descriptor, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
-  store i8* null, i8** %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
-  store i64 0, i64* %27, align 4
-  %28 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
-  store i64 20, i64* %28, align 4
-  %29 = call i8* @_lfortran_malloc(i64 100)
-  %30 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
-  store i8* %29, i8** %30, align 8
+  %32 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
+  store i8* null, i8** %32, align 8
+  %33 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
+  store i64 0, i64* %33, align 4
+  %34 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
+  store i64 20, i64* %34, align 4
+  %35 = call i8* @_lfortran_malloc(i64 100)
+  %36 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
+  store i8* %35, i8** %36, align 8
   %arr_06 = alloca %array.0*, align 8
   store %array.0* null, %array.0** %arr_06, align 8
-  %arr_desc3 = alloca %array.0, align 8
-  %31 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 2
-  %32 = alloca i32, align 4
-  store i32 1, i32* %32, align 4
-  %33 = load i32, i32* %32, align 4
-  %34 = alloca %dimension_descriptor, i32 %33, align 8
-  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %34, i32 0, i32 1
-  store i32 1, i32* %35, align 4
-  %36 = getelementptr %dimension_descriptor, %dimension_descriptor* %34, i32 0, i32 2
-  store i32 1, i32* %36, align 4
-  store %dimension_descriptor* %34, %dimension_descriptor** %31, align 8
-  %37 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 4
-  store i32 1, i32* %37, align 4
-  %38 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 0
-  store i32* null, i32** %38, align 8
+  %37 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 2
+  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
+  store i32 1, i32* %38, align 4
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
+  store i32 1, i32* %39, align 4
+  store %dimension_descriptor* %5, %dimension_descriptor** %37, align 8
+  %40 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 4
+  store i32 1, i32* %40, align 4
+  %41 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 0
+  store i32* null, i32** %41, align 8
   store %array.0* %arr_desc3, %array.0** %arr_06, align 8
   %arr_07 = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %arr_07, align 1
   %arr_08 = alloca %array.1*, align 8
   store %array.1* null, %array.1** %arr_08, align 8
-  %arr_desc4 = alloca %array.1, align 8
   %arr_desc_str_desc5 = alloca %string_descriptor, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 0
-  store i8* null, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 1
-  store i64 0, i64* %40, align 4
-  %41 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 0
-  store %string_descriptor* %arr_desc_str_desc5, %string_descriptor** %41, align 8
-  %42 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 2
-  %43 = alloca i32, align 4
-  store i32 1, i32* %43, align 4
-  %44 = load i32, i32* %43, align 4
-  %45 = alloca %dimension_descriptor, i32 %44, align 8
-  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %45, i32 0, i32 1
+  %42 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 0
+  store i8* null, i8** %42, align 8
+  %43 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 1
+  store i64 0, i64* %43, align 4
+  %44 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 0
+  store %string_descriptor* %arr_desc_str_desc5, %string_descriptor** %44, align 8
+  %45 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 2
+  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 1
   store i32 1, i32* %46, align 4
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %45, i32 0, i32 2
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %2, i32 0, i32 2
   store i32 1, i32* %47, align 4
-  store %dimension_descriptor* %45, %dimension_descriptor** %42, align 8
+  store %dimension_descriptor* %2, %dimension_descriptor** %45, align 8
   %48 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 4
   store i32 1, i32* %48, align 4
   store %array.1* %arr_desc4, %array.1** %arr_08, align 8

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "0c74bee262eb3d90e54f7bf9ef5d47ec55bc94d84be38e70a746f455",
+    "stdout_hash": "55dc7e7c5082e837be506d7ebca473986ce670b53c3e60ead1de52fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "67e59d971a52727c0ba2818127d87ab749d468081df2389afcd8d723",
+    "stdout_hash": "0c74bee262eb3d90e54f7bf9ef5d47ec55bc94d84be38e70a746f455",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -12,12 +12,12 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %a)
-  %5 = load i64, i64* %3, align 4
+  %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %3, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %a)
+  %5 = load i64, i64* %2, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -11,13 +11,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i32, align 4
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %a)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "f1b5b78273cd788cc6cf5fc0cfd3315b1eabe6b12cca6e90c9a96e48",
+    "stdout_hash": "5a488085835a4213a1282393942ab7ae99380eb2dc5ee4faed31f0a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "5a488085835a4213a1282393942ab7ae99380eb2dc5ee4faed31f0a4",
+    "stdout_hash": "dd49936cad1d6c57a6e521274f74f1414f6f795bae12bc697361ee45",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -100,7 +100,9 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %2 = alloca %complex_module.complextype_class, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = alloca %complex_module.complextype_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca %complex_module.complextype, align 8
@@ -143,7 +145,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float %19, float* %20, align 4
   %21 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %14, i32 0, i32 0, float* %17, float* %20)
   %22 = load i64, i64* %14, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %21, i8** %23, align 8
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -206,7 +207,6 @@ ifcont3:                                          ; preds = %else2, %then1
   store float %44, float* %45, align 4
   %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, float* %42, float* %45)
   %47 = load i64, i64* %39, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %46, i8** %48, align 8
   %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -101,16 +101,18 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %2 = alloca %complex_module.complextype_class, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %3 = alloca %complex_module.complextype_class, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
+  %5 = alloca %complex_module.complextype_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca %complex_module.complextype, align 8
-  %4 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
-  %5 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %7 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
   %c = alloca %complex_module.complextype, align 8
-  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
-  %7 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
+  %8 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
+  %9 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
@@ -123,50 +125,49 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %ione, align 4
   store i32 0, i32* %izero, align 4
   store float -1.000000e+00, float* %negfpone, align 4
-  %8 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
-  %9 = load float, float* %fpone, align 4
-  store float %9, float* %8, align 4
-  %10 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
-  %11 = load float, float* %fptwo, align 4
+  %10 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
+  %11 = load float, float* %fpone, align 4
   store float %11, float* %10, align 4
-  %12 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %3, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
-  %13 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %3, i32 0, i32 1
-  store %complex_module.complextype* %c, %complex_module.complextype** %13, align 8
-  call void @__module_complex_module_integer_add_subrout(%complex_module.complextype_class* %3, i32* %ione, i32* %izero, %complex_module.complextype* %a)
-  %14 = alloca i64, align 8
-  %15 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
-  %16 = load float, float* %15, align 4
-  %17 = alloca float, align 4
-  store float %16, float* %17, align 4
-  %18 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
-  %19 = load float, float* %18, align 4
-  %20 = alloca float, align 4
-  store float %19, float* %20, align 4
-  %21 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %14, i32 0, i32 0, float* %17, float* %20)
-  %22 = load i64, i64* %14, align 4
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %21, i8** %23, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %22, i64* %24, align 4
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %26 = load i8*, i8** %25, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %28 = load i64, i64* %27, align 4
-  %29 = trunc i64 %28 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %26, i32 %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %30 = icmp eq i8* %21, null
-  br i1 %30, label %free_done, label %free_nonnull
+  %12 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
+  %13 = load float, float* %fptwo, align 4
+  store float %13, float* %12, align 4
+  %14 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %5, i32 0, i32 0
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
+  %15 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %5, i32 0, i32 1
+  store %complex_module.complextype* %c, %complex_module.complextype** %15, align 8
+  call void @__module_complex_module_integer_add_subrout(%complex_module.complextype_class* %5, i32* %ione, i32* %izero, %complex_module.complextype* %a)
+  %16 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %17 = load float, float* %16, align 4
+  %18 = alloca float, align 4
+  store float %17, float* %18, align 4
+  %19 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %20 = load float, float* %19, align 4
+  %21 = alloca float, align 4
+  store float %20, float* %21, align 4
+  %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, float* %18, float* %21)
+  %23 = load i64, i64* %4, align 4
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %22, i8** %24, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %23, i64* %25, align 4
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %27 = load i8*, i8** %26, align 8
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %29 = load i64, i64* %28, align 4
+  %30 = trunc i64 %29 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %31 = icmp eq i8* %22, null
+  br i1 %31, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %21)
+  call void @_lfortran_free(i8* %22)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %31 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
-  %32 = load float, float* %31, align 4
-  %33 = fcmp une float %32, 2.000000e+00
-  br i1 %33, label %then, label %else
+  %32 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %33 = load float, float* %32, align 4
+  %34 = fcmp une float %33, 2.000000e+00
+  br i1 %34, label %then, label %else
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
@@ -177,10 +178,10 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %34 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
-  %35 = load float, float* %34, align 4
-  %36 = fcmp une float %35, 2.000000e+00
-  br i1 %36, label %then1, label %else2
+  %35 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %36 = load float, float* %35, align 4
+  %37 = fcmp une float %36, 2.000000e+00
+  br i1 %37, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -191,12 +192,11 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %37 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %37, align 8
-  %38 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 1
-  store %complex_module.complextype* %c, %complex_module.complextype** %38, align 8
-  call void @__module_complex_module_real_add_subrout(%complex_module.complextype_class* %2, float* %fpzero, float* %negfpone, %complex_module.complextype* %a)
-  %39 = alloca i64, align 8
+  %38 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %3, i32 0, i32 0
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %38, align 8
+  %39 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %3, i32 0, i32 1
+  store %complex_module.complextype* %c, %complex_module.complextype** %39, align 8
+  call void @__module_complex_module_real_add_subrout(%complex_module.complextype_class* %3, float* %fpzero, float* %negfpone, %complex_module.complextype* %a)
   %40 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
   %41 = load float, float* %40, align 4
   %42 = alloca float, align 4
@@ -205,8 +205,8 @@ ifcont3:                                          ; preds = %else2, %then1
   %44 = load float, float* %43, align 4
   %45 = alloca float, align 4
   store float %44, float* %45, align 4
-  %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, float* %42, float* %45)
-  %47 = load i64, i64* %39, align 4
+  %46 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %42, float* %45)
+  %47 = load i64, i64* %2, align 4
   %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %46, i8** %48, align 8
   %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "5fe8027cd7084bcec536795f4d87ea15be6151154bcdcd426d8b8ed2",
+    "stdout_hash": "407b74d5671c05eb4618a1de10d3856868a38083217cec7abe40ba4e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -233,12 +233,12 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 
 define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = alloca float, align 4
   store float 1.000000e+00, float* %1, align 4
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %1)
   %3 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "fc1f86fc39e19ef16904a5f159a56cf4bb91b2274fce952fb3bde3cc",
+    "stdout_hash": "2244bba010a76b2d30393ba9eae1b0e052747a83d53d8d5c70cf9899",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "086315ed1dc32c8439263915c3fc2cc19dd7ea6fe75c2cb615c8b10e",
+    "stdout_hash": "fc1f86fc39e19ef16904a5f159a56cf4bb91b2274fce952fb3bde3cc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -19,6 +19,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   store i32 1, i32* %i, align 4
@@ -36,7 +37,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 4.000000e+00, float* %r, align 4
   %r_minus = alloca float, align 4
   store float -4.000000e+00, float* %r_minus, align 4
-  %2 = alloca i64, align 8
   %3 = alloca i32, align 4
   store i32 1, i32* %3, align 4
   %4 = alloca i32, align 4

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -18,6 +18,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   store i32 1, i32* %i, align 4
@@ -54,7 +55,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float -4.000000e+00, float* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([36 x i8], [36 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3, i32* %4, float* %5, %complex_4* %6, i32* %7, i1* %8, i1* %9, float* %10, %string_descriptor* @string_const)
   %12 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "b99a04e12012c7656a52111b1f72f8833e3a956afe11889bc22f32c3",
+    "stdout_hash": "db2f0eeacf31f4238c6a1dee517388a7b5eb1efbdd39146a44d85516",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "db2f0eeacf31f4238c6a1dee517388a7b5eb1efbdd39146a44d85516",
+    "stdout_hash": "565b68a5cafe3cb1ac48ecc6dd5eef31c5831973e5313346ef5b0505",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -11,11 +11,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @int_dp.u, i64* @int_dp.v)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -12,8 +12,8 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @int_dp.u, i64* @int_dp.v)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "7b7c8cb0b3b16c319223db99f45dda496187f348484b0eb57b4266bd",
+    "stdout_hash": "e07369f584104301794f48341c23d23cf061d03deedb35989dc3bea0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "e07369f584104301794f48341c23d23cf061d03deedb35989dc3bea0",
+    "stdout_hash": "4619f50e7f1062fd95a4986ebcac9abeff06c09e3fe3237f32604324",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -12,12 +12,12 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @int_dp_param.u, i64* @int_dp_param.v)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -11,6 +11,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @int_dp_param.u, i64* @int_dp_param.v)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "fe1958ebe17ce6fd01d0ebfdbb1ef956381d5223ca60e6569ac11ce0",
+    "stdout_hash": "c8783411e54feea6ee9598236095edba9d9819bd9862fd9611dc6c2a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "c8783411e54feea6ee9598236095edba9d9819bd9862fd9611dc6c2a",
+    "stdout_hash": "519bce4acbb06ee2ec767e8452d9d02ad57cae41df6f14cfc64991be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -26,6 +26,7 @@ FINALIZE_SYMTABLE_foo:                            ; preds = %return
 
 define float @foo.__module_dflt_intent_f(float* %x) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %f = alloca float, align 4
   %0 = load float, float* %x, align 4
   %1 = fmul float 2.000000e+00, %0
@@ -33,7 +34,6 @@ define float @foo.__module_dflt_intent_f(float* %x) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %f)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -27,13 +27,13 @@ FINALIZE_SYMTABLE_foo:                            ; preds = %return
 define float @foo.__module_dflt_intent_f(float* %x) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %f = alloca float, align 4
-  %0 = load float, float* %x, align 4
-  %1 = fmul float 2.000000e+00, %0
-  store float %1, float* %f, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %f)
-  %4 = load i64, i64* %2, align 4
+  %1 = load float, float* %x, align 4
+  %2 = fmul float 2.000000e+00, %1
+  store float %2, float* %f, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %f)
+  %4 = load i64, i64* %0, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "6111d1e40858a534ddac2cc01c1f14668ca553d8286e783dd082aa2d",
+    "stdout_hash": "225c97346486f98e7cb2de08a40f81f48a279ac5cf3580e100f893a9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "b2f68f4ce03883f3a8f0842fc04187c74fe273b6ffaf3b259c01c078",
+    "stdout_hash": "6111d1e40858a534ddac2cc01c1f14668ca553d8286e783dd082aa2d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -60,10 +60,10 @@ define i32 @main(i32 %0, i8** %1) {
   %call_arg_value10 = alloca double, align 8
   %call_arg_value = alloca float, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %y = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %y, align 8
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @intrinsics_02.x, double* %y)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -59,13 +59,13 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value10 = alloca double, align 8
   %call_arg_value = alloca float, align 4
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %y = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %y, align 8
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @intrinsics_02.x, double* %y)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "fde11e1dddb7a9465a7590b35d3743c12776beb17d7265727efb2eae",
+    "stdout_hash": "9b10335a5dc1150274f73dea318a8038962d5c4b8e97afff6b625871",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "9b10335a5dc1150274f73dea318a8038962d5c4b8e97afff6b625871",
+    "stdout_hash": "d26dc55ffc31ce6022c4dbdb5a943d865591a2620970fab18f181b80",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -40,6 +40,7 @@ declare double @_lfortran_dcos(double)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %call_arg_value4 = alloca double, align 8
   %call_arg_value = alloca double, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -49,11 +50,11 @@ define i32 @main(i32 %0, i8** %1) {
   %x = alloca float, align 4
   store double 4.200000e+00, double* %a, align 8
   store float 0xBFEFE8D5A0000000, float* %x, align 4
-  %2 = load float, float* %x, align 4
-  %3 = fadd float %2, 0x3FEFE8D5A0000000
-  %4 = call float @llvm.fabs.f32(float %3)
-  %5 = fcmp ogt float %4, 0x3E7AD7F2A0000000
-  br i1 %5, label %then, label %else
+  %3 = load float, float* %x, align 4
+  %4 = fadd float %3, 0x3FEFE8D5A0000000
+  %5 = call float @llvm.fabs.f32(float %4)
+  %6 = fcmp ogt float %5, 0x3E7AD7F2A0000000
+  br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -64,11 +65,11 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %6 = call double @_lcompilers_cos_f64(double* %a)
-  %7 = fadd double %6, 0x3FDF606EE0000000
-  %8 = call double @llvm.fabs.f64(double %7)
-  %9 = fcmp ogt double %8, 0x3E7AD7F2A0000000
-  br i1 %9, label %then1, label %else2
+  %7 = call double @_lcompilers_cos_f64(double* %a)
+  %8 = fadd double %7, 0x3FDF606EE0000000
+  %9 = call double @llvm.fabs.f64(double %8)
+  %10 = fcmp ogt double %9, 0x3E7AD7F2A0000000
+  br i1 %10, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -79,18 +80,18 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %10 = load double, double* %a, align 8
-  %11 = call double @_lcompilers_cos_f64(double* %a)
-  %12 = fadd double %10, %11
-  store double %12, double* %call_arg_value, align 8
-  %13 = call double @_lcompilers_cos_f64(double* %call_arg_value)
-  %14 = fadd double 0x3FB21BD54FC5F9A7, %13
-  store double %14, double* %call_arg_value4, align 8
-  %15 = call double @_lcompilers_cos_f64(double* %call_arg_value4)
-  %16 = fsub double %15, 0x3FE6ECC720000000
-  %17 = call double @llvm.fabs.f64(double %16)
-  %18 = fcmp ogt double %17, 0x3E7AD7F2A0000000
-  br i1 %18, label %then5, label %else6
+  %11 = load double, double* %a, align 8
+  %12 = call double @_lcompilers_cos_f64(double* %a)
+  %13 = fadd double %11, %12
+  store double %13, double* %call_arg_value, align 8
+  %14 = call double @_lcompilers_cos_f64(double* %call_arg_value)
+  %15 = fadd double 0x3FB21BD54FC5F9A7, %14
+  store double %15, double* %call_arg_value4, align 8
+  %16 = call double @_lcompilers_cos_f64(double* %call_arg_value4)
+  %17 = fsub double %16, 0x3FE6ECC720000000
+  %18 = call double @llvm.fabs.f64(double %17)
+  %19 = fcmp ogt double %18, 0x3E7AD7F2A0000000
+  br i1 %19, label %then5, label %else6
 
 then5:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -101,15 +102,15 @@ else6:                                            ; preds = %ifcont3
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %19 = call double @_lcompilers_cos_f64(double* %a)
-  store double %19, double* %r1, align 8
+  %20 = call double @_lcompilers_cos_f64(double* %a)
+  store double %20, double* %r1, align 8
   store double 0xBFDF606EEC8AC71E, double* %r2, align 8
-  %20 = load double, double* %r1, align 8
-  %21 = load double, double* %r2, align 8
-  %22 = fsub double %20, %21
-  %23 = call double @llvm.fabs.f64(double %22)
-  %24 = fcmp ogt double %23, 1.000000e-15
-  br i1 %24, label %then8, label %else9
+  %21 = load double, double* %r1, align 8
+  %22 = load double, double* %r2, align 8
+  %23 = fsub double %21, %22
+  %24 = call double @llvm.fabs.f64(double %23)
+  %25 = fcmp ogt double %24, 1.000000e-15
+  br i1 %25, label %then8, label %else9
 
 then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
@@ -120,15 +121,14 @@ else9:                                            ; preds = %ifcont7
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %25 = alloca i64, align 8
   %26 = load i32, i32* @intrinsics_03.i, align 4
   %27 = sub i32 0, %26
   %28 = icmp sge i32 %26, 0
   %29 = select i1 %28, i32 %26, i32 %27
   %30 = alloca i32, align 4
   store i32 %29, i32* %30, align 4
-  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %25, i32 0, i32 0, i32* %30)
-  %32 = load i64, i64* %25, align 4
+  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %30)
+  %32 = load i64, i64* %2, align 4
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %31, i8** %33, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -39,6 +39,7 @@ declare double @_lfortran_dcos(double)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value4 = alloca double, align 8
   %call_arg_value = alloca double, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -128,7 +129,6 @@ ifcont10:                                         ; preds = %else9, %then8
   store i32 %29, i32* %30, align 4
   %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %25, i32 0, i32 0, i32* %30)
   %32 = load i64, i64* %25, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %31, i8** %33, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "49cc218e7c6a052862f607e40750e0764d10073aefe142d9c944bf89",
+    "stdout_hash": "40cf1d60b02f62e2d540e603b7f8c4aa68026f5a865dc2f1eb290d3d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "e23d4ab3636ed25f486d8919b314f73808c632a7f8cde0a15e62efc9",
+    "stdout_hash": "49cc218e7c6a052862f607e40750e0764d10073aefe142d9c944bf89",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -15,13 +15,15 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca float, align 4
   store float 0x3FF2CD9FC0000000, float* %x, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -44,7 +46,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %13 = alloca i64, align 8
   %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, float* %x)
   %15 = load i64, i64* %13, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -67,7 +68,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %24 = alloca i64, align 8
   %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %24, i32 0, i32 0, float* %x)
   %26 = load i64, i64* %24, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %25, i8** %27, align 8
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -16,58 +16,58 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca float, align 4
   store float 0x3FF2CD9FC0000000, float* %x, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
+  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, float* %x)
+  %6 = load i64, i64* %4, align 4
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  store i8* %5, i8** %7, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %6, i64* %8, align 4
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %10 = load i8*, i8** %9, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, i64* %11, align 4
+  %13 = trunc i64 %12 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %14 = icmp eq i8* %5, null
+  br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store float 0x3FF8B07560000000, float* %x, align 4
-  %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, float* %x)
-  %15 = load i64, i64* %13, align 4
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %15, i64* %17, align 4
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %21 = load i64, i64* %20, align 4
-  %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
-  br i1 %23, label %free_done3, label %free_nonnull2
+  %15 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, float* %x)
+  %16 = load i64, i64* %3, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %15, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %16, i64* %18, align 4
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %20 = load i8*, i8** %19, align 8
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %22 = load i64, i64* %21, align 4
+  %23 = trunc i64 %22 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %24 = icmp eq i8* %15, null
+  br i1 %24, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %14)
+  call void @_lfortran_free(i8* %15)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   store float 0x3FE85EFAC0000000, float* %x, align 4
-  %24 = alloca i64, align 8
-  %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %24, i32 0, i32 0, float* %x)
-  %26 = load i64, i64* %24, align 4
+  %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
+  %26 = load i64, i64* %2, align 4
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %25, i8** %27, align 8
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "fae4d62e98fcb3cdb8eba702a9172934cd8d7b72b8e03512c29caa21",
+    "stdout_hash": "2605e733310a1da78ed0d2faa1f2feed07e62b8085312c6d8850e05e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "b4b93905f6ee4168c20c7db3cab0e054539eb9cfee7d21f78347f796",
+    "stdout_hash": "fae4d62e98fcb3cdb8eba702a9172934cd8d7b72b8e03512c29caa21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -27,6 +27,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %dp = alloca i32, align 4
   store i32 8, i32* %dp, align 4
@@ -35,7 +42,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -58,7 +64,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %13 = alloca i64, align 8
   %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, float* %x)
   %15 = load i64, i64* %13, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -81,7 +86,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %24 = alloca i64, align 8
   %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %24, i32 0, i32 0, float* %x)
   %26 = load i64, i64* %24, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %25, i8** %27, align 8
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -104,7 +108,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %35 = alloca i64, align 8
   %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %35, i32 0, i32 0, float* %x)
   %37 = load i64, i64* %35, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %36, i8** %38, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -127,7 +130,6 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %46 = alloca i64, align 8
   %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %46, i32 0, i32 0, float* %x)
   %48 = load i64, i64* %46, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %47, i8** %49, align 8
   %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -150,7 +152,6 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %57 = alloca i64, align 8
   %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %57, i32 0, i32 0, float* %x)
   %59 = load i64, i64* %57, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %58, i8** %60, align 8
   %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
@@ -173,7 +174,6 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %68 = alloca i64, align 8
   %69 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %68, i32 0, i32 0, float* %x)
   %70 = load i64, i64* %68, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %69, i8** %71, align 8
   %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -28,152 +28,152 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %dp = alloca i32, align 4
   store i32 8, i32* %dp, align 4
   %x = alloca float, align 4
   store float 0x3FEFFFFFE0000000, float* %x, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  %9 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %8, i32 0, i32 0, float* %x)
+  %10 = load i64, i64* %8, align 4
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %9, i8** %11, align 8
+  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %10, i64* %12, align 4
+  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %14 = load i8*, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %16 = load i64, i64* %15, align 4
+  %17 = trunc i64 %16 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %14, i32 %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %18 = icmp eq i8* %9, null
+  br i1 %18, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %9)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store float 0x3FEFFFFFE0000000, float* %x, align 4
-  %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, float* %x)
-  %15 = load i64, i64* %13, align 4
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %15, i64* %17, align 4
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %21 = load i64, i64* %20, align 4
-  %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
-  br i1 %23, label %free_done3, label %free_nonnull2
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %7, i32 0, i32 0, float* %x)
+  %20 = load i64, i64* %7, align 4
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %19, i8** %21, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %20, i64* %22, align 4
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %24 = load i8*, i8** %23, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %26 = load i64, i64* %25, align 4
+  %27 = trunc i64 %26 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %28 = icmp eq i8* %19, null
+  br i1 %28, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %14)
+  call void @_lfortran_free(i8* %19)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   store float 1.000000e+00, float* %x, align 4
-  %24 = alloca i64, align 8
-  %25 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %24, i32 0, i32 0, float* %x)
-  %26 = load i64, i64* %24, align 4
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %25, i8** %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %26, i64* %28, align 4
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %30 = load i8*, i8** %29, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %32 = load i64, i64* %31, align 4
-  %33 = trunc i64 %32 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %30, i32 %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %34 = icmp eq i8* %25, null
-  br i1 %34, label %free_done6, label %free_nonnull5
+  %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %6, i32 0, i32 0, float* %x)
+  %30 = load i64, i64* %6, align 4
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %29, i8** %31, align 8
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %30, i64* %32, align 4
+  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %34 = load i8*, i8** %33, align 8
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %36 = load i64, i64* %35, align 4
+  %37 = trunc i64 %36 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %38 = icmp eq i8* %29, null
+  br i1 %38, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %25)
+  call void @_lfortran_free(i8* %29)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   store float 1.000000e+00, float* %x, align 4
-  %35 = alloca i64, align 8
-  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %35, i32 0, i32 0, float* %x)
-  %37 = load i64, i64* %35, align 4
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %37, i64* %39, align 4
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
+  %39 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %5, i32 0, i32 0, float* %x)
+  %40 = load i64, i64* %5, align 4
+  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %39, i8** %41, align 8
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %43 = load i64, i64* %42, align 4
-  %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %45 = icmp eq i8* %36, null
-  br i1 %45, label %free_done9, label %free_nonnull8
+  store i64 %40, i64* %42, align 4
+  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %44 = load i8*, i8** %43, align 8
+  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %46 = load i64, i64* %45, align 4
+  %47 = trunc i64 %46 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %44, i32 %47, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %48 = icmp eq i8* %39, null
+  br i1 %48, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free(i8* %36)
+  call void @_lfortran_free(i8* %39)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
   store float 1.000000e+00, float* %x, align 4
-  %46 = alloca i64, align 8
-  %47 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %46, i32 0, i32 0, float* %x)
-  %48 = load i64, i64* %46, align 4
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %47, i8** %49, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %48, i64* %50, align 4
+  %49 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %4, i32 0, i32 0, float* %x)
+  %50 = load i64, i64* %4, align 4
   %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %52 = load i8*, i8** %51, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %54 = load i64, i64* %53, align 4
-  %55 = trunc i64 %54 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %56 = icmp eq i8* %47, null
-  br i1 %56, label %free_done12, label %free_nonnull11
+  store i8* %49, i8** %51, align 8
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  store i64 %50, i64* %52, align 4
+  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %54 = load i8*, i8** %53, align 8
+  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %56 = load i64, i64* %55, align 4
+  %57 = trunc i64 %56 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %54, i32 %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %58 = icmp eq i8* %49, null
+  br i1 %58, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free(i8* %47)
+  call void @_lfortran_free(i8* %49)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
   store float 0x3FEFFFFFE0000000, float* %x, align 4
-  %57 = alloca i64, align 8
-  %58 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %57, i32 0, i32 0, float* %x)
-  %59 = load i64, i64* %57, align 4
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %58, i8** %60, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %59, i64* %61, align 4
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %63 = load i8*, i8** %62, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %65 = load i64, i64* %64, align 4
-  %66 = trunc i64 %65 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %67 = icmp eq i8* %58, null
-  br i1 %67, label %free_done15, label %free_nonnull14
+  %59 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %3, i32 0, i32 0, float* %x)
+  %60 = load i64, i64* %3, align 4
+  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  store i8* %59, i8** %61, align 8
+  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  store i64 %60, i64* %62, align 4
+  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %64 = load i8*, i8** %63, align 8
+  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %66 = load i64, i64* %65, align 4
+  %67 = trunc i64 %66 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %68 = icmp eq i8* %59, null
+  br i1 %68, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free(i8* %58)
+  call void @_lfortran_free(i8* %59)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
   store float 1.000000e+00, float* %x, align 4
-  %68 = alloca i64, align 8
-  %69 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %68, i32 0, i32 0, float* %x)
-  %70 = load i64, i64* %68, align 4
+  %69 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x)
+  %70 = load i64, i64* %2, align 4
   %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %69, i8** %71, align 8
   %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "d2c53b7ae6d0ccfcd170709253c9095f444e7bda1e07e9e4ed949c19",
+    "stdout_hash": "c9d07b4160b4d9204af35fbcf2b88f2d2c3f6b03f3884d8b4880d71c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "c9d07b4160b4d9204af35fbcf2b88f2d2c3f6b03f3884d8b4880d71c",
+    "stdout_hash": "8ec94e846add9a4023f299369ef7aaed1a0ca6c2a7793f203f3ef0eb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -116,6 +116,7 @@ declare void @exit(i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -244,7 +245,6 @@ ifcont8:                                          ; preds = %loop.end
   %53 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
   %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @serialization_info, i32 0, i32 0), i64* %52, i32 1, i32 0, i64 5, double* %53)
   %55 = load i64, i64* %52, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %54, i8** %56, align 8
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -117,6 +117,7 @@ declare void @exit(i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -133,8 +134,8 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %2 = load i32, i32* %array_bound, align 4
-  store i32 %2, i32* %__do_loop_end, align 4
+  %3 = load i32, i32* %array_bound, align 4
+  store i32 %3, i32* %__do_loop_end, align 4
   br i1 true, label %then2, label %else3
 
 then2:                                            ; preds = %ifcont
@@ -145,106 +146,105 @@ else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %then2
-  %3 = load i32, i32* %array_bound1, align 4
-  %4 = sub i32 %3, 1
-  store i32 %4, i32* %__libasr_index_0_, align 4
+  %4 = load i32, i32* %array_bound1, align 4
+  %5 = sub i32 %4, 1
+  store i32 %5, i32* %__libasr_index_0_, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont6, %ifcont4
-  %5 = load i32, i32* %__libasr_index_0_, align 4
-  %6 = add i32 %5, 1
-  %7 = load i32, i32* %__do_loop_end, align 4
-  %8 = icmp sle i32 %6, %7
-  br i1 %8, label %loop.body, label %loop.end
+  %6 = load i32, i32* %__libasr_index_0_, align 4
+  %7 = add i32 %6, 1
+  %8 = load i32, i32* %__do_loop_end, align 4
+  %9 = icmp sle i32 %7, %8
+  br i1 %9, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %9 = load i32, i32* %__libasr_index_0_, align 4
-  %10 = add i32 %9, 1
-  store i32 %10, i32* %__libasr_index_0_, align 4
-  %11 = load i32, i32* %__libasr_index_0_, align 4
-  %12 = sub i32 %11, 1
-  %13 = mul i32 1, %12
-  %14 = add i32 0, %13
-  %15 = icmp slt i32 %11, 1
-  %16 = icmp sgt i32 %11, 5
-  %17 = or i1 %15, %16
-  br i1 %17, label %then5, label %ifcont6
+  %10 = load i32, i32* %__libasr_index_0_, align 4
+  %11 = add i32 %10, 1
+  store i32 %11, i32* %__libasr_index_0_, align 4
+  %12 = load i32, i32* %__libasr_index_0_, align 4
+  %13 = sub i32 %12, 1
+  %14 = mul i32 1, %13
+  %15 = add i32 0, %14
+  %16 = icmp slt i32 %12, 1
+  %17 = icmp sgt i32 %12, 5
+  %18 = or i1 %16, %17
+  br i1 %18, label %then5, label %ifcont6
 
 then5:                                            ; preds = %loop.body
-  %18 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %19 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %20 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @5, i32 0, i32 0), i8** %21, align 8
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 1
-  store i32 18, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 2
-  store i32 1, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 3
-  store i32 18, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 4
-  store i32 1, i32* %25, align 4
-  %26 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %27 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
-  %28 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 2
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 0
-  store i1 true, i1* %30, align 1
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 1
-  store i8* %26, i8** %31, align 8
-  store { i8*, i32, i32, i32, i32 }* %28, { i8*, i32, i32, i32, i32 }** %29, align 8
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 3
-  store i32 1, i32* %32, align 4
-  %33 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %33, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 %11, i32 1, i32 1, i32 5)
+  %19 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %20 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %21 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
+  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @5, i32 0, i32 0), i8** %22, align 8
+  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 1
+  store i32 18, i32* %23, align 4
+  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 2
+  store i32 1, i32* %24, align 4
+  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 3
+  store i32 18, i32* %25, align 4
+  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 4
+  store i32 1, i32* %26, align 4
+  %27 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
+  %28 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
+  %29 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
+  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 2
+  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 0
+  store i1 true, i1* %31, align 1
+  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 1
+  store i8* %27, i8** %32, align 8
+  store { i8*, i32, i32, i32, i32 }* %29, { i8*, i32, i32, i32, i32 }** %30, align 8
+  %33 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 3
+  store i32 1, i32* %33, align 4
+  %34 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %34, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 %12, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %loop.body
-  %34 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 %14
-  store double 1.390000e+00, double* %34, align 8
+  %35 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 %15
+  store double 1.390000e+00, double* %35, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then7, label %ifcont8
 
 then7:                                            ; preds = %loop.end
-  %35 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %36 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %37 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %36, i32 0, i32 0
-  %38 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @9, i32 0, i32 0), i8** %38, align 8
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 1
-  store i32 19, i32* %39, align 4
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 2
-  store i32 8, i32* %40, align 4
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 3
-  store i32 19, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 4
-  store i32 8, i32* %42, align 4
-  %43 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %44 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %35, i32 0, i32 0
-  %45 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %36, i32 0, i32 0
-  %46 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 2
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 0
-  store i1 true, i1* %47, align 1
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 1
-  store i8* %43, i8** %48, align 8
-  store { i8*, i32, i32, i32, i32 }* %45, { i8*, i32, i32, i32, i32 }** %46, align 8
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 3
-  store i32 1, i32* %49, align 4
-  %50 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %35, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 1, i8* getelementptr inbounds ([143 x i8], [143 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 5, i32 1, i32 1, i32 5)
+  %36 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %37 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %38 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
+  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @9, i32 0, i32 0), i8** %39, align 8
+  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 1
+  store i32 19, i32* %40, align 4
+  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 2
+  store i32 8, i32* %41, align 4
+  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 3
+  store i32 19, i32* %42, align 4
+  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 4
+  store i32 8, i32* %43, align 4
+  %44 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
+  %45 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
+  %46 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
+  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 2
+  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 0
+  store i1 true, i1* %48, align 1
+  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 1
+  store i8* %44, i8** %49, align 8
+  store { i8*, i32, i32, i32, i32 }* %46, { i8*, i32, i32, i32, i32 }** %47, align 8
+  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 3
+  store i32 1, i32* %50, align 4
+  %51 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %51, i32 1, i8* getelementptr inbounds ([143 x i8], [143 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 5, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont8:                                          ; preds = %loop.end
-  %51 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
-  call void @a(double* %51)
-  %52 = alloca i64, align 8
+  %52 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
+  call void @a(double* %52)
   %53 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
-  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @serialization_info, i32 0, i32 0), i64* %52, i32 1, i32 0, i64 5, double* %53)
-  %55 = load i64, i64* %52, align 4
+  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 1, i32 0, i64 5, double* %53)
+  %55 = load i64, i64* %2, align 4
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %54, i8** %56, align 8
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "40aeda8443f06ece45f88da4e74c9aca9ac65cfe19c4fed636de4d3d",
+    "stdout_hash": "3f239b7759cc775a891f024dc2cd993743ce61e6a67f8474fafe85cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "3f239b7759cc775a891f024dc2cd993743ce61e6a67f8474fafe85cd",
+    "stdout_hash": "4cfe15606864bb3f07115f03e94e94b970804bb6e3efef1f53e62c44",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i1, align 1
   %b = alloca i1, align 1
@@ -17,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i1* %a, i1* %b)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -10,12 +10,12 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i1, align 1
   %b = alloca i1, align 1
   store i1 true, i1* %a, align 1
   store i1 false, i1* %b, align 1
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i1* %a, i1* %b)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "c156c8c5d50b0a4ea1f6b46e7b91129b6dca8f1e08ac32fc9e2e5ca5",
+    "stdout_hash": "46ab5c81dc590d45572c1d8e29b1c6c25badb2f0a9e35bff93def242",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "46ab5c81dc590d45572c1d8e29b1c6c25badb2f0a9e35bff93def242",
+    "stdout_hash": "349104532b191c866f7774e1c4493a75189825ab2e8357c9f5e5fa19",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i1, align 1
   %b = alloca i1, align 1
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i1* %a, i1* %b, i1* %c)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %a = alloca i1, align 1
   %b = alloca i1, align 1
@@ -17,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i1 true, i1* %a, align 1
   store i1 true, i1* %b, align 1
   store i1 false, i1* %c, align 1
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i1* %a, i1* %b, i1* %c)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "592c097b2c9ec68d4e2d1a6d70fa8dcd5f93e5b4a6a68d14d92272df",
+    "stdout_hash": "3ff2759f7d0ef7a07709c06912e1ba009a03a1300c381e85bdec7a1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "3ff2759f7d0ef7a07709c06912e1ba009a03a1300c381e85bdec7a1e",
+    "stdout_hash": "3f2dc98dd7bcb5bef2ea6c13e9ed1a228bad6a819ed8b974f5d2f3c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -32,13 +32,13 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
-  %2 = call i32 @__module_modules_06_a_b()
-  store i32 %2, i32* %i, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i)
-  %5 = load i64, i64* %3, align 4
+  %3 = call i32 @__module_modules_06_a_b()
+  store i32 %3, i32* %i, align 4
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i)
+  %5 = load i64, i64* %2, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -31,6 +31,7 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %2 = call i32 @__module_modules_06_a_b()
@@ -38,7 +39,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "4043e15eaf8f261ffa24af0ca374e9c7130c25a64683144e77c9dc7b",
+    "stdout_hash": "a7d5111a3180cf95f640b11240b42b8f2d6a677ddfc9c04b1601b0e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "a7d5111a3180cf95f640b11240b42b8f2d6a677ddfc9c04b1601b0e3",
+    "stdout_hash": "9a0947b96b77bc10ccf689280bbee22d3bfe2342385f76d60f1313d5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -18,10 +18,10 @@ source_filename = "LFortran"
 
 define void @__module_modules_11_module11_access_internally() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const, i32* @__module_modules_11_module11_i)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -57,11 +57,11 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.3, i32* @__module_modules_11_module11_j)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -58,8 +58,8 @@ declare void @_lfortran_free(i8*)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.3, i32* @__module_modules_11_module11_j)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "5e22f33bd12c49d43b4949d50cfca3c9e6d1a6bb4677572b8a3b5a74",
+    "stdout_hash": "632789c8e8e3c9d21d8476d637541034b634f83a52e0d89f454a6853",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "2927f300656c5b072e23db5b9bc74ae40e5618573c28e1ad1ef9880d",
+    "stdout_hash": "5e22f33bd12c49d43b4949d50cfca3c9e6d1a6bb4677572b8a3b5a74",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -38,6 +38,7 @@ FINALIZE_SYMTABLE_f2:                             ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i32, align 4
   %2 = call i32 @__module_module_13_f1()
@@ -45,7 +46,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %f)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -39,13 +39,13 @@ FINALIZE_SYMTABLE_f2:                             ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i32, align 4
-  %2 = call i32 @__module_module_13_f1()
-  store i32 %2, i32* %f, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %f)
-  %5 = load i64, i64* %3, align 4
+  %3 = call i32 @__module_module_13_f1()
+  store i32 %3, i32* %f, align 4
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %f)
+  %5 = load i64, i64* %2, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "8faf8250b4d74d54111f4663fcd9edd50b278f61021b3130e503cdde",
+    "stdout_hash": "c6d5a79383990ae69c67828142c5e8d6c0604148a440699b5180adfc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -27,12 +27,12 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 
 define void @b.__module_nested_02_a_c() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = alloca i32, align 4
   store i32 5, i32* %1, align 4
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %1)
   %3 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "44b6fea1aaa7968aed73420daa446a48058fb8c90b007d155dd5d94e",
+    "stdout_hash": "c6177879717bbb7794a0cf9d0b444680bc5500a8b2f9cc03d63a8220",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "a0b8bea3f34d8bc8e7c7284133c963361700beab1aad58d1c96f3841",
+    "stdout_hash": "44b6fea1aaa7968aed73420daa446a48058fb8c90b007d155dd5d94e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -37,12 +37,13 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 
 define void @b.__module_nested_03_a_c() {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = alloca i32, align 4
   store i32 5, i32* %1, align 4
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %1)
   %3 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -64,7 +65,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %12 = alloca i64, align 8
   %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
   %14 = load i64, i64* %12, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -38,33 +38,33 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 define void @b.__module_nested_03_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
-  %1 = alloca i32, align 4
-  store i32 5, i32* %1, align 4
-  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %1)
-  %3 = load i64, i64* %0, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 4
-  %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
-  br i1 %11, label %free_done, label %free_nonnull
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %2 = alloca i32, align 4
+  store i32 5, i32* %2, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* %2)
+  %4 = load i64, i64* %1, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %2)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
-  %14 = load i64, i64* %12, align 4
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
+  %14 = load i64, i64* %0, align 4
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "486d5525e5607fecc859b3bdbc0ff152311e628d778fd7c74e27b23c",
+    "stdout_hash": "21d17a6c0827c26d6e6d76c5a3c5453a4f1aea4e92a2531961ddfe37",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "21d17a6c0827c26d6e6d76c5a3c5453a4f1aea4e92a2531961ddfe37",
+    "stdout_hash": "e75b908bed1eec1d22945f57ae26c2ad7e4e850974a81e3d1d8a9b88",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -54,54 +54,54 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 define i32 @b.__module_nested_04_a_c(i32* %z) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
-  %c = alloca i32, align 4
   %0 = alloca i64, align 8
-  %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %z)
-  %2 = load i64, i64* %0, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %1, i8** %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %2, i64* %4, align 4
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
+  %c = alloca i32, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %z)
+  %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %6 = load i8*, i8** %5, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %8 = load i64, i64* %7, align 4
-  %9 = trunc i64 %8 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %10 = icmp eq i8* %1, null
-  br i1 %10, label %free_done, label %free_nonnull
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %1)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %11 = alloca i64, align 8
-  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__y)
-  %13 = load i64, i64* %11, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %13, i64* %15, align 4
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %19 = load i64, i64* %18, align 4
-  %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
-  br i1 %21, label %free_done3, label %free_nonnull2
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__y)
+  %14 = load i64, i64* %1, align 4
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %13, i8** %15, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, i64* %16, align 4
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %18 = load i8*, i8** %17, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, i64* %19, align 4
+  %21 = trunc i64 %20 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %22 = icmp eq i8* %13, null
+  br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %12)
+  call void @_lfortran_free(i8* %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %22 = alloca i64, align 8
-  %23 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %22, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__yy)
-  %24 = load i64, i64* %22, align 4
+  %23 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__yy)
+  %24 = load i64, i64* %0, align 4
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %23, i8** %25, align 8
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -53,11 +53,13 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 
 define i32 @b.__module_nested_04_a_c(i32* %z) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %c = alloca i32, align 4
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %z)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -79,7 +81,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %11 = alloca i64, align 8
   %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__y)
   %13 = load i64, i64* %11, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %12, i8** %14, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -101,7 +102,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %22 = alloca i64, align 8
   %23 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %22, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__yy)
   %24 = load i64, i64* %22, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %23, i8** %25, align 8
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "1e42fac1d7b176e430d5802bb94911b062818662997ed191a36931c7",
+    "stdout_hash": "af4e977b4136455aa2b73ab00666a95bbc3356d05e57155ab9968a37",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "af4e977b4136455aa2b73ab00666a95bbc3356d05e57155ab9968a37",
+    "stdout_hash": "60eeb21de5d6f68219b7cb841c6441661fb5101c563f539304f11921",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -26,6 +26,10 @@ source_filename = "LFortran"
 
 define void @__module_nested_05_a_b() {
 .entry:
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %x = alloca i32, align 4
   %y = alloca float, align 4
   store i32 6, i32* %x, align 4
@@ -33,7 +37,6 @@ define void @__module_nested_05_a_b() {
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %x)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -55,7 +58,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %11 = alloca i64, align 8
   %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %y)
   %13 = load i64, i64* %11, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %12, i8** %14, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -86,7 +88,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %26 = alloca i64, align 8
   %27 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %26, i32 0, i32 0, i32* %x)
   %28 = load i64, i64* %26, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %27, i8** %29, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -108,7 +109,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %37 = alloca i64, align 8
   %38 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %37, i32 0, i32 0, float* %y)
   %39 = load i64, i64* %37, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %38, i8** %40, align 8
   %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -138,10 +138,11 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 
 define void @b.__module_nested_05_a_c() {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__x)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -163,7 +164,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %11 = alloca i64, align 8
   %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__y)
   %13 = load i64, i64* %11, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %12, i8** %14, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -27,88 +27,88 @@ source_filename = "LFortran"
 define void @__module_nested_05_a_b() {
 .entry:
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %x = alloca i32, align 4
   %y = alloca float, align 4
   store i32 6, i32* %x, align 4
   store float 5.500000e+00, float* %y, align 4
-  %0 = alloca i64, align 8
-  %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %x)
-  %2 = load i64, i64* %0, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %1, i8** %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %2, i64* %4, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %6 = load i8*, i8** %5, align 8
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %x)
+  %5 = load i64, i64* %3, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %8 = load i64, i64* %7, align 4
-  %9 = trunc i64 %8 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %6, i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %10 = icmp eq i8* %1, null
-  br i1 %10, label %free_done, label %free_nonnull
+  store i64 %5, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = trunc i64 %11 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %13 = icmp eq i8* %4, null
+  br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %1)
+  call void @_lfortran_free(i8* %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %11 = alloca i64, align 8
-  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %11, i32 0, i32 0, float* %y)
-  %13 = load i64, i64* %11, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %13, i64* %15, align 4
+  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %y)
+  %15 = load i64, i64* %2, align 4
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %19 = load i64, i64* %18, align 4
-  %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
-  br i1 %21, label %free_done3, label %free_nonnull2
+  store i8* %14, i8** %16, align 8
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %15, i64* %17, align 4
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %19 = load i8*, i8** %18, align 8
+  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %21 = load i64, i64* %20, align 4
+  %22 = trunc i64 %21 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %23 = icmp eq i8* %14, null
+  br i1 %23, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %12)
+  call void @_lfortran_free(i8* %14)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %22 = load i32, i32* %x, align 4
-  store i32 %22, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  %23 = load float, float* %y, align 4
-  store float %23, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  %24 = load i32, i32* %x, align 4
+  store i32 %24, i32* @__module___lcompilers_created__nested_context__b__x, align 4
+  %25 = load float, float* %y, align 4
+  store float %25, float* @__module___lcompilers_created__nested_context__b__y, align 4
   call void @b.__module_nested_05_a_c()
-  %24 = load i32, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  store i32 %24, i32* %x, align 4
-  %25 = load float, float* @__module___lcompilers_created__nested_context__b__y, align 4
-  store float %25, float* %y, align 4
-  %26 = alloca i64, align 8
-  %27 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %26, i32 0, i32 0, i32* %x)
-  %28 = load i64, i64* %26, align 4
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %27, i8** %29, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %28, i64* %30, align 4
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %32 = load i8*, i8** %31, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %34 = load i64, i64* %33, align 4
-  %35 = trunc i64 %34 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %32, i32 %35, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %36 = icmp eq i8* %27, null
-  br i1 %36, label %free_done6, label %free_nonnull5
+  %26 = load i32, i32* @__module___lcompilers_created__nested_context__b__x, align 4
+  store i32 %26, i32* %x, align 4
+  %27 = load float, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  store float %27, float* %y, align 4
+  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* %x)
+  %29 = load i64, i64* %1, align 4
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %28, i8** %30, align 8
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %29, i64* %31, align 4
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %33 = load i8*, i8** %32, align 8
+  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %35 = load i64, i64* %34, align 4
+  %36 = trunc i64 %35 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %37 = icmp eq i8* %28, null
+  br i1 %37, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %27)
+  call void @_lfortran_free(i8* %28)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %37 = alloca i64, align 8
-  %38 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %37, i32 0, i32 0, float* %y)
-  %39 = load i64, i64* %37, align 4
+  %38 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %0, i32 0, i32 0, float* %y)
+  %39 = load i64, i64* %0, align 4
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %38, i8** %40, align 8
   %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -139,31 +139,31 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 define void @b.__module_nested_05_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
-  %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__x)
-  %2 = load i64, i64* %0, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %1, i8** %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %2, i64* %4, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %6 = load i8*, i8** %5, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %8 = load i64, i64* %7, align 4
-  %9 = trunc i64 %8 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 %9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %10 = icmp eq i8* %1, null
-  br i1 %10, label %free_done, label %free_nonnull
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__x)
+  %3 = load i64, i64* %1, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %2, i8** %4, align 8
+  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %3, i64* %5, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %7 = load i8*, i8** %6, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, i64* %8, align 4
+  %10 = trunc i64 %9 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %11 = icmp eq i8* %2, null
+  br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %1)
+  call void @_lfortran_free(i8* %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %11 = alloca i64, align 8
-  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %11, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__y)
-  %13 = load i64, i64* %11, align 4
+  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__y)
+  %13 = load i64, i64* %0, align 4
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %12, i8** %14, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "81649d758df30bbb8053cb6bf40b8f363cd38ba718560b8b446d47e4",
+    "stdout_hash": "c145fdb3b9f2fa02108a3ec1ca51527ed6d063ce943cdac38e47ad43",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "5e0c443c9d06ee6fc248f759cf5196ab1768a28100e764ef16061cc1",
+    "stdout_hash": "81649d758df30bbb8053cb6bf40b8f363cd38ba718560b8b446d47e4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -35,12 +35,13 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 
 define void @b.__module_nested_06_a_c() {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
   %1 = alloca i32, align 4
   store i32 5, i32* %1, align 4
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %1)
   %3 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -62,7 +63,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %12 = alloca i64, align 8
   %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
   %14 = load i64, i64* %12, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -36,33 +36,33 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 define void @b.__module_nested_06_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = alloca i64, align 8
-  %1 = alloca i32, align 4
-  store i32 5, i32* %1, align 4
-  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %1)
-  %3 = load i64, i64* %0, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 4
-  %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
-  br i1 %11, label %free_done, label %free_nonnull
+  %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
+  %2 = alloca i32, align 4
+  store i32 5, i32* %2, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32* %2)
+  %4 = load i64, i64* %1, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %2)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
-  %14 = load i64, i64* %12, align 4
+  %13 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
+  %14 = load i64, i64* %0, align 4
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "754716c6e3bb76edac340539b4883be6abecd1b5c6d6786f0553813b",
+    "stdout_hash": "d7814dd712993a50c8410c937c0dad880e0e38efd16011fdf8936f6a",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "d7814dd712993a50c8410c937c0dad880e0e38efd16011fdf8936f6a",
+    "stdout_hash": "7c7c3032f27df90e670cbdd2250db3eed9148eda01732ce07f071b4c",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -108,6 +108,14 @@ FINALIZE_SYMTABLE_logical_and:                    ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i1, align 1
   store i1 false, i1* %f, align 1
@@ -119,7 +127,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i1 %3, i1* %4, align 1
   %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %4)
   %6 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -144,7 +151,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i1 %16, i1* %17, align 1
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %17)
   %19 = load i64, i64* %15, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -169,7 +175,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   store i1 %29, i1* %30, align 1
   %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %28, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %30)
   %32 = load i64, i64* %28, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %31, i8** %33, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -194,7 +199,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   store i1 %42, i1* %43, align 1
   %44 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %43)
   %45 = load i64, i64* %41, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %44, i8** %46, align 8
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -219,7 +223,6 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   store i32 %55, i32* %56, align 4
   %57 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %54, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %56)
   %58 = load i64, i64* %54, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %57, i8** %59, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -244,7 +247,6 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   store i32 %68, i32* %69, align 4
   %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.13, i32 0, i32 0), i64* %67, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %69)
   %71 = load i64, i64* %67, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %70, i8** %72, align 8
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
@@ -269,7 +271,6 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   store i32 %81, i32* %82, align 4
   %83 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.16, i32 0, i32 0), i64* %80, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %82)
   %84 = load i64, i64* %80, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %85 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %83, i8** %85, align 8
   %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
@@ -294,7 +295,6 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   store i32 %94, i32* %95, align 4
   %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.19, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %95)
   %97 = load i64, i64* %93, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -109,192 +109,192 @@ FINALIZE_SYMTABLE_logical_and:                    ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %9 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i1, align 1
   store i1 false, i1* %f, align 1
   %t = alloca i1, align 1
   store i1 true, i1* %t, align 1
-  %2 = alloca i64, align 8
-  %3 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %t)
-  %4 = alloca i1, align 1
-  store i1 %3, i1* %4, align 1
-  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %4)
-  %6 = load i64, i64* %2, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 4
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 4
-  %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
-  br i1 %14, label %free_done, label %free_nonnull
+  %10 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %t)
+  %11 = alloca i1, align 1
+  store i1 %10, i1* %11, align 1
+  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const, i1* %11)
+  %13 = load i64, i64* %9, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %12, i8** %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %13, i64* %15, align 4
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %17 = load i8*, i8** %16, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, i64* %18, align 4
+  %20 = trunc i64 %19 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %21 = icmp eq i8* %12, null
+  br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %5)
+  call void @_lfortran_free(i8* %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %15 = alloca i64, align 8
-  %16 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %f)
-  %17 = alloca i1, align 1
-  store i1 %16, i1* %17, align 1
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %17)
-  %19 = load i64, i64* %15, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %25 = load i64, i64* %24, align 4
-  %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done3, label %free_nonnull2
+  %22 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %t, i1* %f)
+  %23 = alloca i1, align 1
+  store i1 %22, i1* %23, align 1
+  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %8, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %23)
+  %25 = load i64, i64* %8, align 4
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %24, i8** %26, align 8
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %25, i64* %27, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %29 = load i8*, i8** %28, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %31 = load i64, i64* %30, align 4
+  %32 = trunc i64 %31 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %33 = icmp eq i8* %24, null
+  br i1 %33, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %18)
+  call void @_lfortran_free(i8* %24)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %28 = alloca i64, align 8
-  %29 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %t)
-  %30 = alloca i1, align 1
-  store i1 %29, i1* %30, align 1
-  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %28, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %30)
-  %32 = load i64, i64* %28, align 4
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %31, i8** %33, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %32, i64* %34, align 4
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %36 = load i8*, i8** %35, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %38 = load i64, i64* %37, align 4
-  %39 = trunc i64 %38 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %36, i32 %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %40 = icmp eq i8* %31, null
-  br i1 %40, label %free_done6, label %free_nonnull5
+  %34 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %t)
+  %35 = alloca i1, align 1
+  store i1 %34, i1* %35, align 1
+  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %7, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %35)
+  %37 = load i64, i64* %7, align 4
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %36, i8** %38, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %37, i64* %39, align 4
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %41 = load i8*, i8** %40, align 8
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %43 = load i64, i64* %42, align 4
+  %44 = trunc i64 %43 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %45 = icmp eq i8* %36, null
+  br i1 %45, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %31)
+  call void @_lfortran_free(i8* %36)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %41 = alloca i64, align 8
-  %42 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %f)
-  %43 = alloca i1, align 1
-  store i1 %42, i1* %43, align 1
-  %44 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %43)
-  %45 = load i64, i64* %41, align 4
-  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %44, i8** %46, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %45, i64* %47, align 4
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %51 = load i64, i64* %50, align 4
-  %52 = trunc i64 %51 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %49, i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %53 = icmp eq i8* %44, null
-  br i1 %53, label %free_done9, label %free_nonnull8
+  %46 = call i1 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i1* %f, i1* %f)
+  %47 = alloca i1, align 1
+  store i1 %46, i1* %47, align 1
+  %48 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %6, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %47)
+  %49 = load i64, i64* %6, align 4
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %48, i8** %50, align 8
+  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  store i64 %49, i64* %51, align 4
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %53 = load i8*, i8** %52, align 8
+  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %55 = load i64, i64* %54, align 4
+  %56 = trunc i64 %55 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %57 = icmp eq i8* %48, null
+  br i1 %57, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free(i8* %44)
+  call void @_lfortran_free(i8* %48)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  %54 = alloca i64, align 8
-  %55 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %t)
-  %56 = alloca i32, align 4
-  store i32 %55, i32* %56, align 4
-  %57 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %54, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %56)
-  %58 = load i64, i64* %54, align 4
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %57, i8** %59, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %58, i64* %60, align 4
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %62 = load i8*, i8** %61, align 8
+  %58 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %t)
+  %59 = alloca i32, align 4
+  store i32 %58, i32* %59, align 4
+  %60 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %59)
+  %61 = load i64, i64* %5, align 4
+  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  store i8* %60, i8** %62, align 8
   %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %64 = load i64, i64* %63, align 4
-  %65 = trunc i64 %64 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %62, i32 %65, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %66 = icmp eq i8* %57, null
-  br i1 %66, label %free_done12, label %free_nonnull11
+  store i64 %61, i64* %63, align 4
+  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %65 = load i8*, i8** %64, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %67 = load i64, i64* %66, align 4
+  %68 = trunc i64 %67 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %69 = icmp eq i8* %60, null
+  br i1 %69, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free(i8* %57)
+  call void @_lfortran_free(i8* %60)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
-  %67 = alloca i64, align 8
-  %68 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %f)
-  %69 = alloca i32, align 4
-  store i32 %68, i32* %69, align 4
-  %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.13, i32 0, i32 0), i64* %67, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %69)
-  %71 = load i64, i64* %67, align 4
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %70, i8** %72, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %71, i64* %73, align 4
+  %70 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %t, i1* %f)
+  %71 = alloca i32, align 4
+  store i32 %70, i32* %71, align 4
+  %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.13, i32 0, i32 0), i64* %4, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %71)
+  %73 = load i64, i64* %4, align 4
   %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %75 = load i8*, i8** %74, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %77 = load i64, i64* %76, align 4
-  %78 = trunc i64 %77 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %79 = icmp eq i8* %70, null
-  br i1 %79, label %free_done15, label %free_nonnull14
+  store i8* %72, i8** %74, align 8
+  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  store i64 %73, i64* %75, align 4
+  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %77 = load i8*, i8** %76, align 8
+  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %79 = load i64, i64* %78, align 4
+  %80 = trunc i64 %79 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %77, i32 %80, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %81 = icmp eq i8* %72, null
+  br i1 %81, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free(i8* %70)
+  call void @_lfortran_free(i8* %72)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  %80 = alloca i64, align 8
-  %81 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %t)
-  %82 = alloca i32, align 4
-  store i32 %81, i32* %82, align 4
-  %83 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.16, i32 0, i32 0), i64* %80, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %82)
-  %84 = load i64, i64* %80, align 4
-  %85 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %83, i8** %85, align 8
-  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %84, i64* %86, align 4
-  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %88 = load i8*, i8** %87, align 8
-  %89 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %90 = load i64, i64* %89, align 4
-  %91 = trunc i64 %90 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %88, i32 %91, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %92 = icmp eq i8* %83, null
-  br i1 %92, label %free_done18, label %free_nonnull17
+  %82 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %t)
+  %83 = alloca i32, align 4
+  store i32 %82, i32* %83, align 4
+  %84 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.16, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
+  %85 = load i64, i64* %3, align 4
+  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  store i8* %84, i8** %86, align 8
+  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  store i64 %85, i64* %87, align 4
+  %88 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  %89 = load i8*, i8** %88, align 8
+  %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  %91 = load i64, i64* %90, align 4
+  %92 = trunc i64 %91 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %93 = icmp eq i8* %84, null
+  br i1 %93, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free(i8* %83)
+  call void @_lfortran_free(i8* %84)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
-  %93 = alloca i64, align 8
   %94 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i1* %f, i1* %f)
   %95 = alloca i32, align 4
   store i32 %94, i32* %95, align 4
-  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.19, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %95)
-  %97 = load i64, i64* %93, align 4
+  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.19, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %95)
+  %97 = load i64, i64* %2, align 4
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "d5073c35f0e0b985a1f1dfd624a2bd3ff86f082537c4d5ac16faf80c",
+    "stdout_hash": "c20b77fed9c527fa5f40d3700b972144ab0e6f7479fdfe1d6c32e848",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "eaaf35b17286e4b9d6b072d2ec05a1c3c4ebdb5a3e7bcba60c1c2872",
+    "stdout_hash": "d5073c35f0e0b985a1f1dfd624a2bd3ff86f082537c4d5ac16faf80c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -31,38 +31,38 @@ FINALIZE_SYMTABLE_logical_gets_integer:           ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %tf = alloca i1, align 1
   store i32 0, i32* %call_arg_value, align 4
   call void @__module_overload_assignment_m_logical_gets_integer(i1* %tf, i32* %call_arg_value)
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %tf)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const, i1* %tf)
+  %5 = load i64, i64* %3, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %4, i8** %6, align 8
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %5, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = trunc i64 %11 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %13 = icmp eq i8* %4, null
+  br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i32 1, i32* %call_arg_value, align 4
   call void @__module_overload_assignment_m_logical_gets_integer(i1* %tf, i32* %call_arg_value)
-  %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %tf)
-  %15 = load i64, i64* %13, align 4
+  %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %tf)
+  %15 = load i64, i64* %2, align 4
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -30,6 +30,8 @@ FINALIZE_SYMTABLE_logical_gets_integer:           ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %tf = alloca i1, align 1
@@ -38,7 +40,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %tf)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -62,7 +63,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %13 = alloca i64, align 8
   %14 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %tf)
   %15 = load i64, i64* %13, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "fc812db044e4bb23e3a9758b48d05a36afc2c30b316ec8e54864f9af",
+    "stdout_hash": "f78a1af48f2b947645f1c05ed6117cba3720286de71e4234db7ca0c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "f78a1af48f2b947645f1c05ed6117cba3720286de71e4234db7ca0c2",
+    "stdout_hash": "a2267cb35550bbf6f686d6816e7d7f630cb05bb009aa1ce1fa907b6d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -113,192 +113,192 @@ FINALIZE_SYMTABLE_less_than_inverse:              ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %6 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %7 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %8 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %9 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i1, align 1
   store i1 false, i1* %f, align 1
   %t = alloca i1, align 1
   store i1 true, i1* %t, align 1
-  %2 = alloca i64, align 8
-  %3 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %t)
-  %4 = alloca i1, align 1
-  store i1 %3, i1* %4, align 1
-  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %4)
-  %6 = load i64, i64* %2, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 4
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 4
-  %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
-  br i1 %14, label %free_done, label %free_nonnull
+  %10 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %t)
+  %11 = alloca i1, align 1
+  store i1 %10, i1* %11, align 1
+  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, %string_descriptor* @string_const, i1* %11)
+  %13 = load i64, i64* %9, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %12, i8** %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %13, i64* %15, align 4
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %17 = load i8*, i8** %16, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, i64* %18, align 4
+  %20 = trunc i64 %19 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %21 = icmp eq i8* %12, null
+  br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %5)
+  call void @_lfortran_free(i8* %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %15 = alloca i64, align 8
-  %16 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %f)
-  %17 = alloca i1, align 1
-  store i1 %16, i1* %17, align 1
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %17)
-  %19 = load i64, i64* %15, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %25 = load i64, i64* %24, align 4
-  %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done3, label %free_nonnull2
+  %22 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %t, i1* %f)
+  %23 = alloca i1, align 1
+  store i1 %22, i1* %23, align 1
+  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %8, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %23)
+  %25 = load i64, i64* %8, align 4
+  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %24, i8** %26, align 8
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %25, i64* %27, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %29 = load i8*, i8** %28, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %31 = load i64, i64* %30, align 4
+  %32 = trunc i64 %31 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %33 = icmp eq i8* %24, null
+  br i1 %33, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %18)
+  call void @_lfortran_free(i8* %24)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %28 = alloca i64, align 8
-  %29 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %t)
-  %30 = alloca i1, align 1
-  store i1 %29, i1* %30, align 1
-  %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %28, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %30)
-  %32 = load i64, i64* %28, align 4
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %31, i8** %33, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %32, i64* %34, align 4
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %36 = load i8*, i8** %35, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %38 = load i64, i64* %37, align 4
-  %39 = trunc i64 %38 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %36, i32 %39, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %40 = icmp eq i8* %31, null
-  br i1 %40, label %free_done6, label %free_nonnull5
+  %34 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %t)
+  %35 = alloca i1, align 1
+  store i1 %34, i1* %35, align 1
+  %36 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %7, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %35)
+  %37 = load i64, i64* %7, align 4
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %36, i8** %38, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %37, i64* %39, align 4
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %41 = load i8*, i8** %40, align 8
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %43 = load i64, i64* %42, align 4
+  %44 = trunc i64 %43 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %45 = icmp eq i8* %36, null
+  br i1 %45, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %31)
+  call void @_lfortran_free(i8* %36)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %41 = alloca i64, align 8
-  %42 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %f)
-  %43 = alloca i1, align 1
-  store i1 %42, i1* %43, align 1
-  %44 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %43)
-  %45 = load i64, i64* %41, align 4
-  %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %44, i8** %46, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %45, i64* %47, align 4
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %51 = load i64, i64* %50, align 4
-  %52 = trunc i64 %51 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %49, i32 %52, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %53 = icmp eq i8* %44, null
-  br i1 %53, label %free_done9, label %free_nonnull8
+  %46 = call i1 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i1* %f, i1* %f)
+  %47 = alloca i1, align 1
+  store i1 %46, i1* %47, align 1
+  %48 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %6, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %47)
+  %49 = load i64, i64* %6, align 4
+  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  store i8* %48, i8** %50, align 8
+  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  store i64 %49, i64* %51, align 4
+  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
+  %53 = load i8*, i8** %52, align 8
+  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
+  %55 = load i64, i64* %54, align 4
+  %56 = trunc i64 %55 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %57 = icmp eq i8* %48, null
+  br i1 %57, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free(i8* %44)
+  call void @_lfortran_free(i8* %48)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  %54 = alloca i64, align 8
-  %55 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %t)
-  %56 = alloca i1, align 1
-  store i1 %55, i1* %56, align 1
-  %57 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.10, i32 0, i32 0), i64* %54, i32 0, i32 0, %string_descriptor* @string_const.12, i1* %56)
-  %58 = load i64, i64* %54, align 4
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %57, i8** %59, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %58, i64* %60, align 4
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %62 = load i8*, i8** %61, align 8
+  %58 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %t)
+  %59 = alloca i1, align 1
+  store i1 %58, i1* %59, align 1
+  %60 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.10, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const.12, i1* %59)
+  %61 = load i64, i64* %5, align 4
+  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  store i8* %60, i8** %62, align 8
   %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %64 = load i64, i64* %63, align 4
-  %65 = trunc i64 %64 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %62, i32 %65, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %66 = icmp eq i8* %57, null
-  br i1 %66, label %free_done12, label %free_nonnull11
+  store i64 %61, i64* %63, align 4
+  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %65 = load i8*, i8** %64, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %67 = load i64, i64* %66, align 4
+  %68 = trunc i64 %67 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %69 = icmp eq i8* %60, null
+  br i1 %69, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free(i8* %57)
+  call void @_lfortran_free(i8* %60)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
-  %67 = alloca i64, align 8
-  %68 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %f)
-  %69 = alloca i1, align 1
-  store i1 %68, i1* %69, align 1
-  %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.13, i32 0, i32 0), i64* %67, i32 0, i32 0, %string_descriptor* @string_const.15, i1* %69)
-  %71 = load i64, i64* %67, align 4
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %70, i8** %72, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %71, i64* %73, align 4
+  %70 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %t, i1* %f)
+  %71 = alloca i1, align 1
+  store i1 %70, i1* %71, align 1
+  %72 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.13, i32 0, i32 0), i64* %4, i32 0, i32 0, %string_descriptor* @string_const.15, i1* %71)
+  %73 = load i64, i64* %4, align 4
   %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %75 = load i8*, i8** %74, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %77 = load i64, i64* %76, align 4
-  %78 = trunc i64 %77 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %79 = icmp eq i8* %70, null
-  br i1 %79, label %free_done15, label %free_nonnull14
+  store i8* %72, i8** %74, align 8
+  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  store i64 %73, i64* %75, align 4
+  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
+  %77 = load i8*, i8** %76, align 8
+  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
+  %79 = load i64, i64* %78, align 4
+  %80 = trunc i64 %79 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %77, i32 %80, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %81 = icmp eq i8* %72, null
+  br i1 %81, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free(i8* %70)
+  call void @_lfortran_free(i8* %72)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  %80 = alloca i64, align 8
-  %81 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %t)
-  %82 = alloca i1, align 1
-  store i1 %81, i1* %82, align 1
-  %83 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.16, i32 0, i32 0), i64* %80, i32 0, i32 0, %string_descriptor* @string_const.18, i1* %82)
-  %84 = load i64, i64* %80, align 4
-  %85 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %83, i8** %85, align 8
-  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %84, i64* %86, align 4
-  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %88 = load i8*, i8** %87, align 8
-  %89 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %90 = load i64, i64* %89, align 4
-  %91 = trunc i64 %90 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %88, i32 %91, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %92 = icmp eq i8* %83, null
-  br i1 %92, label %free_done18, label %free_nonnull17
+  %82 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %t)
+  %83 = alloca i1, align 1
+  store i1 %82, i1* %83, align 1
+  %84 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.16, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.18, i1* %83)
+  %85 = load i64, i64* %3, align 4
+  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  store i8* %84, i8** %86, align 8
+  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  store i64 %85, i64* %87, align 4
+  %88 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
+  %89 = load i8*, i8** %88, align 8
+  %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
+  %91 = load i64, i64* %90, align 4
+  %92 = trunc i64 %91 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %93 = icmp eq i8* %84, null
+  br i1 %93, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free(i8* %83)
+  call void @_lfortran_free(i8* %84)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
-  %93 = alloca i64, align 8
   %94 = call i1 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i1* %f, i1* %f)
   %95 = alloca i1, align 1
   store i1 %94, i1* %95, align 1
-  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.19, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.21, i1* %95)
-  %97 = load i64, i64* %93, align 4
+  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.19, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.21, i1* %95)
+  %97 = load i64, i64* %2, align 4
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -112,6 +112,14 @@ FINALIZE_SYMTABLE_less_than_inverse:              ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %stringFormat_desc16 = alloca %string_descriptor, align 8
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %f = alloca i1, align 1
   store i1 false, i1* %f, align 1
@@ -123,7 +131,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i1 %3, i1* %4, align 1
   %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, i1* %4)
   %6 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -148,7 +155,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i1 %16, i1* %17, align 1
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, %string_descriptor* @string_const.3, i1* %17)
   %19 = load i64, i64* %15, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -173,7 +179,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   store i1 %29, i1* %30, align 1
   %31 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.4, i32 0, i32 0), i64* %28, i32 0, i32 0, %string_descriptor* @string_const.6, i1* %30)
   %32 = load i64, i64* %28, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %31, i8** %33, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -198,7 +203,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   store i1 %42, i1* %43, align 1
   %44 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.7, i32 0, i32 0), i64* %41, i32 0, i32 0, %string_descriptor* @string_const.9, i1* %43)
   %45 = load i64, i64* %41, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %46 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %44, i8** %46, align 8
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
@@ -223,7 +227,6 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   store i1 %55, i1* %56, align 1
   %57 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.10, i32 0, i32 0), i64* %54, i32 0, i32 0, %string_descriptor* @string_const.12, i1* %56)
   %58 = load i64, i64* %54, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %57, i8** %59, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -248,7 +251,6 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   store i1 %68, i1* %69, align 1
   %70 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.13, i32 0, i32 0), i64* %67, i32 0, i32 0, %string_descriptor* @string_const.15, i1* %69)
   %71 = load i64, i64* %67, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %70, i8** %72, align 8
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
@@ -273,7 +275,6 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   store i1 %81, i1* %82, align 1
   %83 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.16, i32 0, i32 0), i64* %80, i32 0, i32 0, %string_descriptor* @string_const.18, i1* %82)
   %84 = load i64, i64* %80, align 4
-  %stringFormat_desc16 = alloca %string_descriptor, align 8
   %85 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %83, i8** %85, align 8
   %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
@@ -298,7 +299,6 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   store i1 %94, i1* %95, align 1
   %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([11 x i8], [11 x i8]* @serialization_info.19, i32 0, i32 0), i64* %93, i32 0, i32 0, %string_descriptor* @string_const.21, i1* %95)
   %97 = load i64, i64* %93, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "43d622d9150bd1ccf4112abd5e652906c6d7731264ca7f5780517658",
+    "stdout_hash": "0c82f007e17d6b26649246c691ee2ed44d58805b3c6d3c19f487accd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "0c82f007e17d6b26649246c691ee2ed44d58805b3c6d3c19f487accd",
+    "stdout_hash": "75f50c5445e3656e1d10c3f4689db6bd375d6ea28c01c14ab62fcf9c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -14,50 +14,50 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %lfortran_iomsg = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
-  %2 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
-  store i64 0, i64* %2, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %4 = call i8* @_lfortran_malloc(i64 1)
-  store i8* %4, i8** %3, align 8
+  %4 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
+  store i64 0, i64* %4, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
+  %6 = call i8* @_lfortran_malloc(i64 1)
+  store i8* %6, i8** %5, align 8
   %x = alloca i32, align 4
   store i32 25, i32* %x, align 4
-  %5 = alloca i64, align 8
-  %6 = alloca i32, align 4
-  store i32 1, i32* %6, align 4
   %7 = alloca i32, align 4
-  store i32 3, i32* %7, align 4
-  %8 = load i32, i32* %x, align 4
-  %9 = add i32 25, %8
-  %10 = alloca i32, align 4
-  store i32 %9, i32* %10, align 4
-  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %x, i32* %6, i32* %7, i32* %x, i32* %10)
-  %12 = load i64, i64* %5, align 4
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %11, i8** %13, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %12, i64* %14, align 4
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %16 = load i8*, i8** %15, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %18 = load i64, i64* %17, align 4
-  %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %20 = icmp eq i8* %11, null
-  br i1 %20, label %free_done, label %free_nonnull
+  store i32 1, i32* %7, align 4
+  %8 = alloca i32, align 4
+  store i32 3, i32* %8, align 4
+  %9 = load i32, i32* %x, align 4
+  %10 = add i32 25, %9
+  %11 = alloca i32, align 4
+  store i32 %10, i32* %11, align 4
+  %12 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %x, i32* %7, i32* %8, i32* %x, i32* %11)
+  %13 = load i64, i64* %3, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %12, i8** %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %13, i64* %15, align 4
+  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %17 = load i8*, i8** %16, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, i64* %18, align 4
+  %20 = trunc i64 %19 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %21 = icmp eq i8* %12, null
+  br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %11)
+  call void @_lfortran_free(i8* %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %21 = alloca i32*, align 8
-  store i32* null, i32** %21, align 8
-  %22 = load i32*, i32** %21, align 8
-  %23 = alloca i64, align 8
+  %22 = alloca i32*, align 8
+  store i32* null, i32** %22, align 8
+  %23 = load i32*, i32** %22, align 8
   %24 = alloca i32, align 4
   store i32 1, i32* %24, align 4
   %25 = alloca i32, align 4
@@ -66,8 +66,8 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %27 = add i32 25, %26
   %28 = alloca i32, align 4
   store i32 %27, i32* %28, align 4
-  %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %23, i32 0, i32 0, i32* %x, i32* %24, i32* %25, i32* %x, i32* %28)
-  %30 = load i64, i64* %23, align 4
+  %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %x, i32* %24, i32* %25, i32* %x, i32* %28)
+  %30 = load i64, i64* %2, align 4
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %29, i8** %31, align 8
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -76,7 +76,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %34 = load i8*, i8** %33, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %36 = load i64, i64* %35, align 4
-  call void (i32, i32*, i8*, i64, ...) @_lfortran_file_write(i32 6, i32* %22, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i64 4, i8* %34, i64 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i64 1)
+  call void (i32, i32*, i8*, i64, ...) @_lfortran_file_write(i32 6, i32* %23, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i64 4, i8* %34, i64 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i64 1)
   %37 = icmp eq i8* %29, null
   br i1 %37, label %free_done3, label %free_nonnull2
 

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -13,6 +13,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %lfortran_iomsg = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
@@ -34,7 +36,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %9, i32* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %x, i32* %6, i32* %7, i32* %x, i32* %10)
   %12 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -67,7 +68,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 %27, i32* %28, align 4
   %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %23, i32 0, i32 0, i32* %x, i32* %24, i32* %25, i32* %x, i32* %28)
   %30 = load i64, i64* %23, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %29, i8** %31, align 8
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "56c27fcd3534f7f0ced8c192dabd3210c4a5b8423e9c0b7279591c3a",
+    "stdout_hash": "7d508f47466560c522ce218759e11ca1d465a19972baceb6e73860fd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "d2ba4a52b0d0e2a8951914a1e28e0b9f2d699c0389bbe58a1067aee3",
+    "stdout_hash": "56c27fcd3534f7f0ced8c192dabd3210c4a5b8423e9c0b7279591c3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -12,13 +12,14 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   store i32 5, i32* %i, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -44,7 +45,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 %15, i32* %16, align 4
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32* %16)
   %18 = load i64, i64* %13, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -13,38 +13,38 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   store i32 5, i32* %i, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i)
+  %5 = load i64, i64* %3, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %4, i8** %6, align 8
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %5, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = trunc i64 %11 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %13 = icmp eq i8* %4, null
+  br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = alloca i64, align 8
   %14 = load i32, i32* %i, align 4
   %15 = add i32 %14, 1
   %16 = alloca i32, align 4
   store i32 %15, i32* %16, align 4
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32* %16)
-  %18 = load i64, i64* %13, align 4
+  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %16)
+  %18 = load i64, i64* %2, align 4
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "3d3425c4d1ca476b26f373de43dd86de32439c9d9aaa64bbf233915c",
+    "stdout_hash": "9929b7203c99ec0d768a7f45501fe92f823a549b2ece01b9b02ea985",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "5560475e6c9d14282bc9d5be1fcc964b58811ec8306ff4638831ad51",
+    "stdout_hash": "3d3425c4d1ca476b26f373de43dd86de32439c9d9aaa64bbf233915c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -12,30 +12,30 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %z = alloca i32, align 4
   store i32 0, i32* %z, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %free_done, %.entry
-  %2 = load i32, i32* %z, align 4
-  %3 = add i32 %2, 1
-  %4 = icmp sle i32 %3, 10
-  br i1 %4, label %loop.body, label %loop.end
+  %3 = load i32, i32* %z, align 4
+  %4 = add i32 %3, 1
+  %5 = icmp sle i32 %4, 10
+  br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %z, align 4
-  %6 = add i32 %5, 1
-  store i32 %6, i32* %z, align 4
-  %7 = load i32, i32* %z, align 4
-  store i32 %7, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
-  %8 = alloca i64, align 8
+  %6 = load i32, i32* %z, align 4
+  %7 = add i32 %6, 1
+  store i32 %7, i32* %z, align 4
+  %8 = load i32, i32* %z, align 4
+  store i32 %8, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
   store i32 1, i32* %call_arg_value, align 4
   %9 = call i32 @apply(i32 (i32*)* @add_z, i32* %call_arg_value)
   %10 = alloca i32, align 4
   store i32 %9, i32* %10, align 4
-  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %8, i32 0, i32 0, i32* %10)
-  %12 = load i64, i64* %8, align 4
+  %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %10)
+  %12 = load i64, i64* %2, align 4
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %z = alloca i32, align 4
@@ -35,7 +36,6 @@ loop.body:                                        ; preds = %loop.head
   store i32 %9, i32* %10, align 4
   %11 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %8, i32 0, i32 0, i32* %10)
   %12 = load i64, i64* %8, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "13e8195535217d3908839aef55d041ce58cc5d945bd0e2c84e0368e7",
+    "stdout_hash": "389f4718d5e24066e7afe205854e335f84120e7705791004a6297895",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "389f4718d5e24066e7afe205854e335f84120e7705791004a6297895",
+    "stdout_hash": "eb032968f41dec03f0e1690a5668ae272d59f13d9db8c9284fbca944",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -9,6 +9,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %v = alloca double, align 8
   %x = alloca float, align 4
@@ -19,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x, double* %v, float* %zero)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -10,6 +10,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %v = alloca double, align 8
   %x = alloca float, align 4
@@ -17,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %zero, align 4
   store double 0x3FF0CCCCC0000000, double* %v, align 8
   store float 0x3FF0CCCCC0000000, float* %x, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %x, double* %v, float* %zero)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "07870ff682c0bdfcd68cbd14b29770e728ff8ccbe2acfd275adb8471",
+    "stdout_hash": "f33090fbca0c3f6b1b70c1d9a398339e803fdc49d166b982863f2431",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "f33090fbca0c3f6b1b70c1d9a398339e803fdc49d166b982863f2431",
+    "stdout_hash": "1c23ca963889c0a6fda32e597ce016e3435be1ea8295c76c4af43b14",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -13,12 +13,12 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
   %prec2 = alloca i32, align 4
   store i32 8, i32* %prec2, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @real_dp_param.u, double* @real_dp_param.v, double* @real_dp_param.zero)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -12,6 +12,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %prec1 = alloca i32, align 4
   store i32 4, i32* %prec1, align 4
@@ -20,7 +21,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @real_dp_param.u, double* @real_dp_param.v, double* @real_dp_param.zero)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "1d186c9e52927b716390cb8b2ba8aaeac2ed9637a51e1989c7542636",
+    "stdout_hash": "3a412627400f1d8f9e029738c64a3da399c3d1b2d30de45f53a1d5fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "04cae25b03c2fc6a16161b00b4628fbc822a57ae069af6f30fdea32e",
+    "stdout_hash": "1d186c9e52927b716390cb8b2ba8aaeac2ed9637a51e1989c7542636",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -18,18 +18,18 @@ source_filename = "LFortran"
 define void @__module_recursion_01_sub1(i32* %x) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = load i32, i32* %x, align 4
-  %1 = load i32, i32* @__module_recursion_01_n, align 4
-  %2 = icmp slt i32 %0, %1
-  br i1 %2, label %then, label %else
+  %0 = alloca i64, align 8
+  %1 = load i32, i32* %x, align 4
+  %2 = load i32, i32* @__module_recursion_01_n, align 4
+  %3 = icmp slt i32 %1, %2
+  br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %3 = load i32, i32* %x, align 4
-  %4 = add i32 %3, 1
-  store i32 %4, i32* %x, align 4
-  %5 = alloca i64, align 8
-  %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
-  %7 = load i64, i64* %5, align 4
+  %4 = load i32, i32* %x, align 4
+  %5 = add i32 %4, 1
+  store i32 %5, i32* %x, align 4
+  %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
+  %7 = load i64, i64* %0, align 4
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -72,12 +72,12 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 define void @sub1.__module_recursion_01_sub2() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  %1 = add i32 %0, 1
-  store i32 %1, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1__x)
-  %4 = load i64, i64* %2, align 4
+  %0 = alloca i64, align 8
+  %1 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %2 = add i32 %1, 1
+  store i32 %2, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1__x)
+  %4 = load i64, i64* %0, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -17,6 +17,7 @@ source_filename = "LFortran"
 
 define void @__module_recursion_01_sub1(i32* %x) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = load i32, i32* %x, align 4
   %1 = load i32, i32* @__module_recursion_01_n, align 4
   %2 = icmp slt i32 %0, %1
@@ -29,7 +30,6 @@ then:                                             ; preds = %.entry
   %5 = alloca i64, align 8
   %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %5, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
   %7 = load i64, i64* %5, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -71,13 +71,13 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 
 define void @sub1.__module_recursion_01_sub2() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
   %1 = add i32 %0, 1
   store i32 %1, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1__x)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "58d500c5d35bdde13b75de135e6db95ed0e707a9796e2c535db96980",
+    "stdout_hash": "ec367548fc739815735d02d5eec963ec3b10d25d77ea946ad4ba13a8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "510b963b4339df0ebeb5622d9de2da743245184d3b9682f530e52c81",
+    "stdout_hash": "58d500c5d35bdde13b75de135e6db95ed0e707a9796e2c535db96980",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -32,45 +32,45 @@ source_filename = "LFortran"
 define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
-  %0 = call i32 %f()
-  store i32 %0, i32* %f_val, align 4
-  %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
-  %3 = load i64, i64* %1, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 4
-  %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
-  br i1 %11, label %free_done, label %free_nonnull
+  %2 = call i32 %f()
+  store i32 %2, i32* %f_val, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
+  %4 = load i64, i64* %1, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %2)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i32 2, i32* %call_arg_value, align 4
-  %12 = load i32, i32* %iter, align 4
-  %13 = sub i32 %12, 1
-  store i32 %13, i32* %call_arg_value1, align 4
-  %14 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %14, i32* %solver, align 4
-  %15 = call i32 %f()
-  store i32 %15, i32* %f_val, align 4
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
-  %18 = load i64, i64* %16, align 4
+  %13 = load i32, i32* %iter, align 4
+  %14 = sub i32 %13, 1
+  store i32 %14, i32* %call_arg_value1, align 4
+  %15 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %15, i32* %solver, align 4
+  %16 = call i32 %f()
+  store i32 %16, i32* %f_val, align 4
+  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
+  %18 = load i64, i64* %0, align 4
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
@@ -150,8 +150,8 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 define i32 @sub1.__module_recursion_02_getx() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %getx = alloca i32, align 4
   %0 = alloca i64, align 8
+  %getx = alloca i32, align 4
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__sub1__x)
   %2 = load i64, i64* %0, align 4
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -193,17 +193,17 @@ declare void @_lfortran_free(i8*)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %r = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
   store i32 3, i32* %call_arg_value1, align 4
-  %2 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %2, i32* %r, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
-  %5 = load i64, i64* %3, align 4
+  %3 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %3, i32* %r, align 4
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
+  %5 = load i64, i64* %2, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -31,8 +31,10 @@ source_filename = "LFortran"
 
 define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
 .entry:
+  %stringFormat_desc2 = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
   %0 = call i32 %f()
@@ -40,7 +42,6 @@ define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
   %1 = alloca i64, align 8
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
   %3 = load i64, i64* %1, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -70,7 +71,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
@@ -149,11 +149,11 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 
 define i32 @sub1.__module_recursion_02_getx() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %getx = alloca i32, align 4
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__sub1__x)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -192,6 +192,7 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -203,7 +204,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "4aba2c2d1bf0768967b1680286695fa021b5c8c8dc506f53853fd44b",
+    "stdout_hash": "30a6d12806eeac0dc158be97793d8f187ca116a4d45b51ab1bd08fe8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "e8b5bf5efcecf3c1fde126fef0a8449c3f5eca8dfeeca5317b21f5d9",
+    "stdout_hash": "4aba2c2d1bf0768967b1680286695fa021b5c8c8dc506f53853fd44b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -31,8 +31,10 @@ source_filename = "LFortran"
 
 define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
 .entry:
+  %stringFormat_desc2 = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
   %0 = call i32 %f()
@@ -40,7 +42,6 @@ define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
   %1 = alloca i64, align 8
   %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
   %3 = load i64, i64* %1, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -70,7 +71,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %16 = alloca i64, align 8
   %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %16, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
   %18 = load i64, i64* %16, align 4
-  %stringFormat_desc2 = alloca %string_descriptor, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
@@ -166,11 +166,11 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 
 define i32 @sub1.__module_recursion_03_getx() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %getx = alloca i32, align 4
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__sub1__x)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -209,6 +209,7 @@ declare void @_lfortran_free(i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -220,7 +221,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -32,45 +32,45 @@ source_filename = "LFortran"
 define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %1 = alloca i64, align 8
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
-  %0 = call i32 %f()
-  store i32 %0, i32* %f_val, align 4
-  %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
-  %3 = load i64, i64* %1, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 4
-  %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
-  br i1 %11, label %free_done, label %free_nonnull
+  %2 = call i32 %f()
+  store i32 %2, i32* %f_val, align 4
+  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
+  %4 = load i64, i64* %1, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %3, i8** %5, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %4, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, i64* %9, align 4
+  %11 = trunc i64 %10 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %12 = icmp eq i8* %3, null
+  br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %2)
+  call void @_lfortran_free(i8* %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i32 2, i32* %call_arg_value, align 4
-  %12 = load i32, i32* %iter, align 4
-  %13 = sub i32 %12, 1
-  store i32 %13, i32* %call_arg_value1, align 4
-  %14 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %14, i32* %solver, align 4
-  %15 = call i32 %f()
-  store i32 %15, i32* %f_val, align 4
-  %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %16, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
-  %18 = load i64, i64* %16, align 4
+  %13 = load i32, i32* %iter, align 4
+  %14 = sub i32 %13, 1
+  store i32 %14, i32* %call_arg_value1, align 4
+  %15 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %15, i32* %solver, align 4
+  %16 = call i32 %f()
+  store i32 %16, i32* %f_val, align 4
+  %17 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
+  %18 = load i64, i64* %0, align 4
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %17, i8** %19, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
@@ -167,8 +167,8 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 define i32 @sub1.__module_recursion_03_getx() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %getx = alloca i32, align 4
   %0 = alloca i64, align 8
+  %getx = alloca i32, align 4
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__sub1__x)
   %2 = load i64, i64* %0, align 4
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
@@ -210,17 +210,17 @@ declare void @_lfortran_free(i8*)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %r = alloca i32, align 4
   store i32 3, i32* %call_arg_value, align 4
   store i32 3, i32* %call_arg_value1, align 4
-  %2 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %2, i32* %r, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %3, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
-  %5 = load i64, i64* %3, align 4
+  %3 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 %3, i32* %r, align 4
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
+  %5 = load i64, i64* %2, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "e62c5b6f9e2520c4f4c671648cf86f4500fab7e2ea307f3ae0182002",
+    "stdout_hash": "f8ece054e10a1eca7cf3892727387915ceb7da924d94e12fd40bee13",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "f8ece054e10a1eca7cf3892727387915ceb7da924d94e12fd40bee13",
+    "stdout_hash": "e3409e87d39db097458c4809bc98890426f7145ca1af50cfce1e5408",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -102,90 +102,90 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca i32, align 4
   store i32 1, i32* %call_arg_value, align 4
-  %2 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %2, i32* %c, align 4
-  %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %c)
-  %5 = load i64, i64* %3, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
+  %6 = call i32 @__module_many_returns_b(i32* %call_arg_value)
+  store i32 %6, i32* %c, align 4
+  %7 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %c)
+  %8 = load i64, i64* %5, align 4
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %7, i8** %9, align 8
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 4
-  %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
-  br i1 %13, label %free_done, label %free_nonnull
+  store i64 %8, i64* %10, align 4
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %12 = load i8*, i8** %11, align 8
+  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %14 = load i64, i64* %13, align 4
+  %15 = trunc i64 %14 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %16 = icmp eq i8* %7, null
+  br i1 %16, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %4)
+  call void @_lfortran_free(i8* %7)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i32 2, i32* %call_arg_value, align 4
-  %14 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %14, i32* %c, align 4
-  %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %c)
-  %17 = load i64, i64* %15, align 4
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %16, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %17, i64* %19, align 4
+  %17 = call i32 @__module_many_returns_b(i32* %call_arg_value)
+  store i32 %17, i32* %c, align 4
+  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %c)
+  %19 = load i64, i64* %4, align 4
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %23 = load i64, i64* %22, align 4
-  %24 = trunc i64 %23 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %21, i32 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %25 = icmp eq i8* %16, null
-  br i1 %25, label %free_done3, label %free_nonnull2
+  store i8* %18, i8** %20, align 8
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %19, i64* %21, align 4
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %23 = load i8*, i8** %22, align 8
+  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %25 = load i64, i64* %24, align 4
+  %26 = trunc i64 %25 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %27 = icmp eq i8* %18, null
+  br i1 %27, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %16)
+  call void @_lfortran_free(i8* %18)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   store i32 3, i32* %call_arg_value, align 4
-  %26 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %26, i32* %c, align 4
-  %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %c)
-  %29 = load i64, i64* %27, align 4
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %29, i64* %31, align 4
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %35 = load i64, i64* %34, align 4
-  %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %37 = icmp eq i8* %28, null
-  br i1 %37, label %free_done6, label %free_nonnull5
+  %28 = call i32 @__module_many_returns_b(i32* %call_arg_value)
+  store i32 %28, i32* %c, align 4
+  %29 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %c)
+  %30 = load i64, i64* %3, align 4
+  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %29, i8** %31, align 8
+  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %30, i64* %32, align 4
+  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %34 = load i8*, i8** %33, align 8
+  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %36 = load i64, i64* %35, align 4
+  %37 = trunc i64 %36 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %38 = icmp eq i8* %29, null
+  br i1 %38, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free(i8* %28)
+  call void @_lfortran_free(i8* %29)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   store i32 4, i32* %call_arg_value, align 4
-  %38 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %38, i32* %c, align 4
-  %39 = alloca i64, align 8
-  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %c)
-  %41 = load i64, i64* %39, align 4
+  %39 = call i32 @__module_many_returns_b(i32* %call_arg_value)
+  store i32 %39, i32* %c, align 4
+  %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %c)
+  %41 = load i64, i64* %2, align 4
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %40, i8** %42, align 8
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -101,6 +101,10 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc7 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %c = alloca i32, align 4
@@ -110,7 +114,6 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = alloca i64, align 8
   %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %c)
   %5 = load i64, i64* %3, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -135,7 +138,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %15 = alloca i64, align 8
   %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %c)
   %17 = load i64, i64* %15, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -160,7 +162,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %27 = alloca i64, align 8
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32* %c)
   %29 = load i64, i64* %27, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -185,7 +186,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %39 = alloca i64, align 8
   %40 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %39, i32 0, i32 0, i32* %c)
   %41 = load i64, i64* %39, align 4
-  %stringFormat_desc7 = alloca %string_descriptor, align 8
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %40, i8** %42, align 8
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "7d9af8de63f1fc528e1305ed874fc4aadd2a586cf824983ae42d8331",
+    "stdout_hash": "a3fb3b4cf61d9db457104f17ae3d4d1e8534e4b3933779bbe54d27c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "3a6f171066ea108136d2c37b99c87097e327a2d40182fa5f144e6943",
+    "stdout_hash": "7d9af8de63f1fc528e1305ed874fc4aadd2a586cf824983ae42d8331",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -142,261 +142,262 @@ FINALIZE_SYMTABLE_rectangle_area:                 ; preds = %return
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc35 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %s1 = alloca %select_type_13_module.shape_class*, align 8
   store %select_type_13_module.shape_class* null, %select_type_13_module.shape_class** %s1, align 8
   %s2 = alloca %select_type_13_module.shape_class*, align 8
   store %select_type_13_module.shape_class* null, %select_type_13_module.shape_class** %s2, align 8
-  %2 = call i8* @_lfortran_malloc(i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 4, i1 false)
-  %3 = call i8* @_lfortran_malloc(i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %3, i8 0, i32 16, i1 false)
-  %4 = bitcast i8* %3 to %select_type_13_module.shape_class*
-  store %select_type_13_module.shape_class* %4, %select_type_13_module.shape_class** %s1, align 8
-  %5 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %6 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %5, i32 0, i32 1
-  %7 = bitcast i8* %2 to %select_type_13_module.shape*
-  store %select_type_13_module.shape* %7, %select_type_13_module.shape** %6, align 8
-  %8 = load %select_type_13_module.shape*, %select_type_13_module.shape** %6, align 8
-  %9 = bitcast %select_type_13_module.shape* %8 to %select_type_13_module.circle*
-  %10 = bitcast %select_type_13_module.shape_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %10, align 8
-  %11 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 1
-  %12 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 0
-  %13 = alloca i1, align 1
-  %14 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %15 = ptrtoint %select_type_13_module.shape_class* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %then1, label %else
+  %4 = call i8* @_lfortran_malloc(i64 4)
+  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
+  %5 = call i8* @_lfortran_malloc(i64 16)
+  call void @llvm.memset.p0i8.i32(i8* %5, i8 0, i32 16, i1 false)
+  %6 = bitcast i8* %5 to %select_type_13_module.shape_class*
+  store %select_type_13_module.shape_class* %6, %select_type_13_module.shape_class** %s1, align 8
+  %7 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %8 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %7, i32 0, i32 1
+  %9 = bitcast i8* %4 to %select_type_13_module.shape*
+  store %select_type_13_module.shape* %9, %select_type_13_module.shape** %8, align 8
+  %10 = load %select_type_13_module.shape*, %select_type_13_module.shape** %8, align 8
+  %11 = bitcast %select_type_13_module.shape* %10 to %select_type_13_module.circle*
+  %12 = bitcast %select_type_13_module.shape_class* %6 to i32 (...)***
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
+  %13 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %11, i32 0, i32 1
+  %14 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %11, i32 0, i32 0
+  %15 = alloca i1, align 1
+  %16 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %17 = ptrtoint %select_type_13_module.shape_class* %16 to i64
+  %18 = icmp eq i64 %17, 0
+  br i1 %18, label %then1, label %else
 
 then:                                             ; preds = %ifcont
   br label %"~select_type_block_.start"
 
 then1:                                            ; preds = %.entry
-  %17 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %17, align 8
-  %18 = bitcast i32 (...)*** %17 to i8*
-  %19 = call i8* @__lfortran_dynamic_cast(i8* %18, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %20 = icmp ne i8* %19, null
-  store i1 %20, i1* %13, align 1
+  %19 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %19, align 8
+  %20 = bitcast i32 (...)*** %19 to i8*
+  %21 = call i8* @__lfortran_dynamic_cast(i8* %20, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %22 = icmp ne i8* %21, null
+  store i1 %22, i1* %15, align 1
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %21 = bitcast %select_type_13_module.shape_class* %14 to i8*
-  %22 = call i8* @__lfortran_dynamic_cast(i8* %21, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %23 = icmp ne i8* %22, null
-  store i1 %23, i1* %13, align 1
+  %23 = bitcast %select_type_13_module.shape_class* %16 to i8*
+  %24 = call i8* @__lfortran_dynamic_cast(i8* %23, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %25 = icmp ne i8* %24, null
+  store i1 %25, i1* %15, align 1
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then1
-  %24 = load i1, i1* %13, align 1
-  br i1 %24, label %then, label %else2
+  %26 = load i1, i1* %15, align 1
+  br i1 %26, label %then, label %else2
 
 "~select_type_block_.start":                      ; preds = %then
-  %25 = call i8* @llvm.stacksave()
-  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %26, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %27 = call i8* @llvm.stacksave()
+  %28 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %28, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %"~select_type_block_.end"
 
 "~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_"
 
 "FINALIZE_SYMTABLE_~select_type_block_":          ; preds = %"~select_type_block_.end"
-  call void @llvm.stackrestore(i8* %25)
+  call void @llvm.stackrestore(i8* %27)
   br label %ifcont17
 
 else2:                                            ; preds = %ifcont
-  %27 = alloca i1, align 1
-  %28 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %29 = ptrtoint %select_type_13_module.shape_class* %28 to i64
-  %30 = icmp eq i64 %29, 0
-  br i1 %30, label %then4, label %else5
+  %29 = alloca i1, align 1
+  %30 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %31 = ptrtoint %select_type_13_module.shape_class* %30 to i64
+  %32 = icmp eq i64 %31, 0
+  br i1 %32, label %then4, label %else5
 
 then3:                                            ; preds = %ifcont6
   br label %"~select_type_block_1.start"
 
 then4:                                            ; preds = %else2
-  %31 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %31, align 8
-  %32 = bitcast i32 (...)*** %31 to i8*
-  %33 = call i8* @__lfortran_dynamic_cast(i8* %32, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %34 = icmp ne i8* %33, null
-  store i1 %34, i1* %27, align 1
+  %33 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %33, align 8
+  %34 = bitcast i32 (...)*** %33 to i8*
+  %35 = call i8* @__lfortran_dynamic_cast(i8* %34, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %36 = icmp ne i8* %35, null
+  store i1 %36, i1* %29, align 1
   br label %ifcont6
 
 else5:                                            ; preds = %else2
-  %35 = bitcast %select_type_13_module.shape_class* %28 to i8*
-  %36 = call i8* @__lfortran_dynamic_cast(i8* %35, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %37 = icmp ne i8* %36, null
-  store i1 %37, i1* %27, align 1
+  %37 = bitcast %select_type_13_module.shape_class* %30 to i8*
+  %38 = call i8* @__lfortran_dynamic_cast(i8* %37, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %39 = icmp ne i8* %38, null
+  store i1 %39, i1* %29, align 1
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %38 = load i1, i1* %27, align 1
-  br i1 %38, label %then3, label %else16
+  %40 = load i1, i1* %29, align 1
+  br i1 %40, label %then3, label %else16
 
 "~select_type_block_1.start":                     ; preds = %then3
-  %39 = call i8* @llvm.stacksave()
-  %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %41 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %42 = ptrtoint %select_type_13_module.shape_class** %41 to i64
-  %43 = icmp eq i64 %42, 0
-  br i1 %43, label %then7, label %ifcont8
+  %41 = call i8* @llvm.stacksave()
+  %42 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %43 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
+  %44 = ptrtoint %select_type_13_module.shape_class** %43 to i64
+  %45 = icmp eq i64 %44, 0
+  br i1 %45, label %then7, label %ifcont8
 
 then7:                                            ; preds = %"~select_type_block_1.start"
-  %44 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %45 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %46 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %45, i32 0, i32 0
-  %47 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %46, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @5, i32 0, i32 0), i8** %47, align 8
-  %48 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %46, i32 0, i32 1
-  store i32 56, i32* %48, align 4
-  %49 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %46, i32 0, i32 2
-  store i32 7, i32* %49, align 4
-  %50 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %46, i32 0, i32 3
+  %46 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %47 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %48 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %47, i32 0, i32 0
+  %49 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %48, i32 0, i32 0
+  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @5, i32 0, i32 0), i8** %49, align 8
+  %50 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %48, i32 0, i32 1
   store i32 56, i32* %50, align 4
-  %51 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %46, i32 0, i32 4
-  store i32 10, i32* %51, align 4
-  %52 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
-  %53 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %44, i32 0, i32 0
-  %54 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %45, i32 0, i32 0
-  %55 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 0, i32 2
-  %56 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 0, i32 0
-  store i1 true, i1* %56, align 1
-  %57 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 0, i32 1
-  store i8* %52, i8** %57, align 8
-  store { i8*, i32, i32, i32, i32 }* %54, { i8*, i32, i32, i32, i32 }** %55, align 8
-  %58 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 0, i32 3
-  store i32 1, i32* %58, align 4
-  %59 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %44, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %59, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
+  %51 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %48, i32 0, i32 2
+  store i32 7, i32* %51, align 4
+  %52 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %48, i32 0, i32 3
+  store i32 56, i32* %52, align 4
+  %53 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %48, i32 0, i32 4
+  store i32 10, i32* %53, align 4
+  %54 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
+  %55 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %46, i32 0, i32 0
+  %56 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %47, i32 0, i32 0
+  %57 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %55, i32 0, i32 2
+  %58 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %55, i32 0, i32 0
+  store i1 true, i1* %58, align 1
+  %59 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %55, i32 0, i32 1
+  store i8* %54, i8** %59, align 8
+  store { i8*, i32, i32, i32, i32 }* %56, { i8*, i32, i32, i32, i32 }** %57, align 8
+  %60 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %55, i32 0, i32 3
+  store i32 1, i32* %60, align 4
+  %61 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %46, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %61, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont8:                                          ; preds = %"~select_type_block_1.start"
-  %60 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %61 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %60, align 1
   %62 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %63 = bitcast %select_type_13_module.shape_class* %62 to %select_type_13_module.circle_class*
-  %64 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %63, i32 0, i32 1
-  %65 = load %select_type_13_module.circle*, %select_type_13_module.circle** %64, align 8
-  %66 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %65, i32 0, i32 1
-  store float 1.000000e+01, float* %66, align 4
-  %67 = alloca i64, align 8
-  %68 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %69 = ptrtoint %select_type_13_module.shape_class** %68 to i64
-  %70 = icmp eq i64 %69, 0
-  br i1 %70, label %then9, label %ifcont10
+  %63 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %62, align 1
+  %64 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %65 = bitcast %select_type_13_module.shape_class* %64 to %select_type_13_module.circle_class*
+  %66 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %65, i32 0, i32 1
+  %67 = load %select_type_13_module.circle*, %select_type_13_module.circle** %66, align 8
+  %68 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %67, i32 0, i32 1
+  store float 1.000000e+01, float* %68, align 4
+  %69 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
+  %70 = ptrtoint %select_type_13_module.shape_class** %69 to i64
+  %71 = icmp eq i64 %70, 0
+  br i1 %71, label %then9, label %ifcont10
 
 then9:                                            ; preds = %ifcont8
-  %71 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %72 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %73 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %72, i32 0, i32 0
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %73, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @10, i32 0, i32 0), i8** %74, align 8
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %73, i32 0, i32 1
-  store i32 57, i32* %75, align 4
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %73, i32 0, i32 2
-  store i32 16, i32* %76, align 4
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %73, i32 0, i32 3
-  store i32 57, i32* %77, align 4
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %73, i32 0, i32 4
-  store i32 19, i32* %78, align 4
-  %79 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
-  %80 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %71, i32 0, i32 0
-  %81 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %72, i32 0, i32 0
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %80, i32 0, i32 2
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %80, i32 0, i32 0
-  store i1 true, i1* %83, align 1
-  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %80, i32 0, i32 1
-  store i8* %79, i8** %84, align 8
-  store { i8*, i32, i32, i32, i32 }* %81, { i8*, i32, i32, i32, i32 }** %82, align 8
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %80, i32 0, i32 3
-  store i32 1, i32* %85, align 4
-  %86 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %71, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %86, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
+  %72 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %73 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %74 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %73, i32 0, i32 0
+  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 0
+  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @10, i32 0, i32 0), i8** %75, align 8
+  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 1
+  store i32 57, i32* %76, align 4
+  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 2
+  store i32 16, i32* %77, align 4
+  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 3
+  store i32 57, i32* %78, align 4
+  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 4
+  store i32 19, i32* %79, align 4
+  %80 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
+  %81 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %72, i32 0, i32 0
+  %82 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %73, i32 0, i32 0
+  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 2
+  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 0
+  store i1 true, i1* %84, align 1
+  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 1
+  store i8* %80, i8** %85, align 8
+  store { i8*, i32, i32, i32, i32 }* %82, { i8*, i32, i32, i32, i32 }** %83, align 8
+  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 3
+  store i32 1, i32* %86, align 4
+  %87 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %72, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
-  %87 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %88 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %87, align 1
-  %89 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %90 = bitcast %select_type_13_module.shape_class* %89 to %select_type_13_module.circle_class*
-  %91 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %90, i32 0, i32 1
-  %92 = load %select_type_13_module.circle*, %select_type_13_module.circle** %91, align 8
-  %93 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %92, i32 0, i32 1
-  %94 = load float, float* %93, align 4
-  %95 = alloca float, align 4
-  store float %94, float* %95, align 4
-  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %67, i32 0, i32 0, float* %95)
-  %97 = load i64, i64* %67, align 4
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %96, i8** %98, align 8
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %97, i64* %99, align 4
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %101 = load i8*, i8** %100, align 8
-  %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %103 = load i64, i64* %102, align 4
-  %104 = trunc i64 %103 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %101, i32 %104, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %105 = icmp eq i8* %96, null
-  br i1 %105, label %free_done, label %free_nonnull
+  %88 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %89 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %88, align 1
+  %90 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %91 = bitcast %select_type_13_module.shape_class* %90 to %select_type_13_module.circle_class*
+  %92 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %91, i32 0, i32 1
+  %93 = load %select_type_13_module.circle*, %select_type_13_module.circle** %92, align 8
+  %94 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %93, i32 0, i32 1
+  %95 = load float, float* %94, align 4
+  %96 = alloca float, align 4
+  store float %95, float* %96, align 4
+  %97 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, float* %96)
+  %98 = load i64, i64* %3, align 4
+  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %97, i8** %99, align 8
+  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %98, i64* %100, align 4
+  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %102 = load i8*, i8** %101, align 8
+  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %104 = load i64, i64* %103, align 4
+  %105 = trunc i64 %104 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %106 = icmp eq i8* %97, null
+  br i1 %106, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont10
-  call void @_lfortran_free(i8* %96)
+  call void @_lfortran_free(i8* %97)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont10
-  %106 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %107 = ptrtoint %select_type_13_module.shape_class** %106 to i64
-  %108 = icmp eq i64 %107, 0
-  br i1 %108, label %then11, label %ifcont12
+  %107 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
+  %108 = ptrtoint %select_type_13_module.shape_class** %107 to i64
+  %109 = icmp eq i64 %108, 0
+  br i1 %109, label %then11, label %ifcont12
 
 then11:                                           ; preds = %free_done
-  %109 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %110 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %111 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @15, i32 0, i32 0), i8** %112, align 8
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 1
-  store i32 58, i32* %113, align 4
-  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 2
-  store i32 11, i32* %114, align 4
-  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 3
-  store i32 58, i32* %115, align 4
-  %116 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 4
-  store i32 14, i32* %116, align 4
-  %117 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
-  %118 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
-  %119 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 2
-  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 0
-  store i1 true, i1* %121, align 1
-  %122 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 1
-  store i8* %117, i8** %122, align 8
-  store { i8*, i32, i32, i32, i32 }* %119, { i8*, i32, i32, i32, i32 }** %120, align 8
-  %123 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 3
-  store i32 1, i32* %123, align 4
-  %124 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
+  %110 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %111 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %112 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %111, i32 0, i32 0
+  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %112, i32 0, i32 0
+  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @15, i32 0, i32 0), i8** %113, align 8
+  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %112, i32 0, i32 1
+  store i32 58, i32* %114, align 4
+  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %112, i32 0, i32 2
+  store i32 11, i32* %115, align 4
+  %116 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %112, i32 0, i32 3
+  store i32 58, i32* %116, align 4
+  %117 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %112, i32 0, i32 4
+  store i32 14, i32* %117, align 4
+  %118 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
+  %119 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %110, i32 0, i32 0
+  %120 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %111, i32 0, i32 0
+  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %119, i32 0, i32 2
+  %122 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %119, i32 0, i32 0
+  store i1 true, i1* %122, align 1
+  %123 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %119, i32 0, i32 1
+  store i8* %118, i8** %123, align 8
+  store { i8*, i32, i32, i32, i32 }* %120, { i8*, i32, i32, i32, i32 }** %121, align 8
+  %124 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %119, i32 0, i32 3
+  store i32 1, i32* %124, align 4
+  %125 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %110, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %125, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %free_done
-  %125 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %126 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %125, align 1
-  %127 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %128 = bitcast %select_type_13_module.shape_class* %127 to %select_type_13_module.circle_class*
-  %129 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %128, i32 0, i32 1
-  %130 = load %select_type_13_module.circle*, %select_type_13_module.circle** %129, align 8
-  %131 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %130, i32 0, i32 1
-  %132 = load float, float* %131, align 4
-  %133 = fcmp une float %132, 1.000000e+01
-  br i1 %133, label %then13, label %else14
+  %126 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %127 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %126, align 1
+  %128 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
+  %129 = bitcast %select_type_13_module.shape_class* %128 to %select_type_13_module.circle_class*
+  %130 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %129, i32 0, i32 1
+  %131 = load %select_type_13_module.circle*, %select_type_13_module.circle** %130, align 8
+  %132 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %131, i32 0, i32 1
+  %133 = load float, float* %132, align 4
+  %134 = fcmp une float %133, 1.000000e+01
+  br i1 %134, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
@@ -413,208 +414,207 @@ ifcont15:                                         ; preds = %else14, %then13
   br label %"FINALIZE_SYMTABLE_~select_type_block_1"
 
 "FINALIZE_SYMTABLE_~select_type_block_1":         ; preds = %"~select_type_block_1.end"
-  call void @llvm.stackrestore(i8* %39)
+  call void @llvm.stackrestore(i8* %41)
   br label %ifcont17
 
 else16:                                           ; preds = %ifcont6
   br label %"~select_type_block_2.start"
 
 "~select_type_block_2.start":                     ; preds = %else16
-  %134 = call i8* @llvm.stacksave()
-  %135 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %135, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  %135 = call i8* @llvm.stacksave()
+  %136 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %136, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   br label %"~select_type_block_2.end"
 
 "~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_2"
 
 "FINALIZE_SYMTABLE_~select_type_block_2":         ; preds = %"~select_type_block_2.end"
-  call void @llvm.stackrestore(i8* %134)
+  call void @llvm.stackrestore(i8* %135)
   br label %ifcont17
 
 ifcont17:                                         ; preds = %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
-  %136 = call i8* @_lfortran_malloc(i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %136, i8 0, i32 8, i1 false)
-  %137 = call i8* @_lfortran_malloc(i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %137, i8 0, i32 16, i1 false)
-  %138 = bitcast i8* %137 to %select_type_13_module.shape_class*
-  store %select_type_13_module.shape_class* %138, %select_type_13_module.shape_class** %s2, align 8
-  %139 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %140 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %139, i32 0, i32 1
-  %141 = bitcast i8* %136 to %select_type_13_module.shape*
-  store %select_type_13_module.shape* %141, %select_type_13_module.shape** %140, align 8
-  %142 = load %select_type_13_module.shape*, %select_type_13_module.shape** %140, align 8
-  %143 = bitcast %select_type_13_module.shape* %142 to %select_type_13_module.rectangle*
-  %144 = bitcast %select_type_13_module.shape_class* %138 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %144, align 8
-  %145 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %143, i32 0, i32 1
-  %146 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %143, i32 0, i32 2
-  %147 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %143, i32 0, i32 0
-  %148 = alloca i1, align 1
-  %149 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %150 = ptrtoint %select_type_13_module.shape_class* %149 to i64
-  %151 = icmp eq i64 %150, 0
-  br i1 %151, label %then19, label %else20
+  %137 = call i8* @_lfortran_malloc(i64 8)
+  call void @llvm.memset.p0i8.i32(i8* %137, i8 0, i32 8, i1 false)
+  %138 = call i8* @_lfortran_malloc(i64 16)
+  call void @llvm.memset.p0i8.i32(i8* %138, i8 0, i32 16, i1 false)
+  %139 = bitcast i8* %138 to %select_type_13_module.shape_class*
+  store %select_type_13_module.shape_class* %139, %select_type_13_module.shape_class** %s2, align 8
+  %140 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %141 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %140, i32 0, i32 1
+  %142 = bitcast i8* %137 to %select_type_13_module.shape*
+  store %select_type_13_module.shape* %142, %select_type_13_module.shape** %141, align 8
+  %143 = load %select_type_13_module.shape*, %select_type_13_module.shape** %141, align 8
+  %144 = bitcast %select_type_13_module.shape* %143 to %select_type_13_module.rectangle*
+  %145 = bitcast %select_type_13_module.shape_class* %139 to i32 (...)***
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %145, align 8
+  %146 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %144, i32 0, i32 1
+  %147 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %144, i32 0, i32 2
+  %148 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %144, i32 0, i32 0
+  %149 = alloca i1, align 1
+  %150 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %151 = ptrtoint %select_type_13_module.shape_class* %150 to i64
+  %152 = icmp eq i64 %151, 0
+  br i1 %152, label %then19, label %else20
 
 then18:                                           ; preds = %ifcont21
   br label %"~select_type_block_3.start"
 
 then19:                                           ; preds = %ifcont17
-  %152 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %152, align 8
-  %153 = bitcast i32 (...)*** %152 to i8*
-  %154 = call i8* @__lfortran_dynamic_cast(i8* %153, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %155 = icmp ne i8* %154, null
-  store i1 %155, i1* %148, align 1
+  %153 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %153, align 8
+  %154 = bitcast i32 (...)*** %153 to i8*
+  %155 = call i8* @__lfortran_dynamic_cast(i8* %154, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %156 = icmp ne i8* %155, null
+  store i1 %156, i1* %149, align 1
   br label %ifcont21
 
 else20:                                           ; preds = %ifcont17
-  %156 = bitcast %select_type_13_module.shape_class* %149 to i8*
-  %157 = call i8* @__lfortran_dynamic_cast(i8* %156, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %158 = icmp ne i8* %157, null
-  store i1 %158, i1* %148, align 1
+  %157 = bitcast %select_type_13_module.shape_class* %150 to i8*
+  %158 = call i8* @__lfortran_dynamic_cast(i8* %157, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
+  %159 = icmp ne i8* %158, null
+  store i1 %159, i1* %149, align 1
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %159 = load i1, i1* %148, align 1
-  br i1 %159, label %then18, label %else22
+  %160 = load i1, i1* %149, align 1
+  br i1 %160, label %then18, label %else22
 
 "~select_type_block_3.start":                     ; preds = %then18
-  %160 = call i8* @llvm.stacksave()
-  %161 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %161, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  %161 = call i8* @llvm.stacksave()
+  %162 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %162, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   br label %"~select_type_block_3.end"
 
 "~select_type_block_3.end":                       ; preds = %"~select_type_block_3.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_3"
 
 "FINALIZE_SYMTABLE_~select_type_block_3":         ; preds = %"~select_type_block_3.end"
-  call void @llvm.stackrestore(i8* %160)
+  call void @llvm.stackrestore(i8* %161)
   br label %ifcont49
 
 else22:                                           ; preds = %ifcont21
-  %162 = alloca i1, align 1
-  %163 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %164 = ptrtoint %select_type_13_module.shape_class* %163 to i64
-  %165 = icmp eq i64 %164, 0
-  br i1 %165, label %then24, label %else25
+  %163 = alloca i1, align 1
+  %164 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %165 = ptrtoint %select_type_13_module.shape_class* %164 to i64
+  %166 = icmp eq i64 %165, 0
+  br i1 %166, label %then24, label %else25
 
 then23:                                           ; preds = %ifcont26
   br label %"~select_type_block_4.start"
 
 then24:                                           ; preds = %else22
-  %166 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %166, align 8
-  %167 = bitcast i32 (...)*** %166 to i8*
-  %168 = call i8* @__lfortran_dynamic_cast(i8* %167, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %169 = icmp ne i8* %168, null
-  store i1 %169, i1* %162, align 1
+  %167 = alloca i32 (...)**, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %167, align 8
+  %168 = bitcast i32 (...)*** %167 to i8*
+  %169 = call i8* @__lfortran_dynamic_cast(i8* %168, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %170 = icmp ne i8* %169, null
+  store i1 %170, i1* %163, align 1
   br label %ifcont26
 
 else25:                                           ; preds = %else22
-  %170 = bitcast %select_type_13_module.shape_class* %163 to i8*
-  %171 = call i8* @__lfortran_dynamic_cast(i8* %170, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %172 = icmp ne i8* %171, null
-  store i1 %172, i1* %162, align 1
+  %171 = bitcast %select_type_13_module.shape_class* %164 to i8*
+  %172 = call i8* @__lfortran_dynamic_cast(i8* %171, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
+  %173 = icmp ne i8* %172, null
+  store i1 %173, i1* %163, align 1
   br label %ifcont26
 
 ifcont26:                                         ; preds = %else25, %then24
-  %173 = load i1, i1* %162, align 1
-  br i1 %173, label %then23, label %else48
+  %174 = load i1, i1* %163, align 1
+  br i1 %174, label %then23, label %else48
 
 "~select_type_block_4.start":                     ; preds = %then23
-  %174 = call i8* @llvm.stacksave()
-  %175 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %175, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
-  %176 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %177 = ptrtoint %select_type_13_module.shape_class** %176 to i64
-  %178 = icmp eq i64 %177, 0
-  br i1 %178, label %then27, label %ifcont28
+  %175 = call i8* @llvm.stacksave()
+  %176 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %176, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  %177 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
+  %178 = ptrtoint %select_type_13_module.shape_class** %177 to i64
+  %179 = icmp eq i64 %178, 0
+  br i1 %179, label %then27, label %ifcont28
 
 then27:                                           ; preds = %"~select_type_block_4.start"
-  %179 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %180 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %181 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %180, i32 0, i32 0
-  %182 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %181, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @27, i32 0, i32 0), i8** %182, align 8
-  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %181, i32 0, i32 1
-  store i32 72, i32* %183, align 4
-  %184 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %181, i32 0, i32 2
-  store i32 7, i32* %184, align 4
-  %185 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %181, i32 0, i32 3
-  store i32 72, i32* %185, align 4
-  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %181, i32 0, i32 4
-  store i32 10, i32* %186, align 4
-  %187 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
-  %188 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %179, i32 0, i32 0
-  %189 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %180, i32 0, i32 0
-  %190 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %188, i32 0, i32 2
-  %191 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %188, i32 0, i32 0
-  store i1 true, i1* %191, align 1
-  %192 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %188, i32 0, i32 1
-  store i8* %187, i8** %192, align 8
-  store { i8*, i32, i32, i32, i32 }* %189, { i8*, i32, i32, i32, i32 }** %190, align 8
-  %193 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %188, i32 0, i32 3
-  store i32 1, i32* %193, align 4
-  %194 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %179, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %194, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
+  %180 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %181 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %182 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %181, i32 0, i32 0
+  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 0
+  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @27, i32 0, i32 0), i8** %183, align 8
+  %184 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 1
+  store i32 72, i32* %184, align 4
+  %185 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 2
+  store i32 7, i32* %185, align 4
+  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 3
+  store i32 72, i32* %186, align 4
+  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 4
+  store i32 10, i32* %187, align 4
+  %188 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
+  %189 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %180, i32 0, i32 0
+  %190 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %181, i32 0, i32 0
+  %191 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 2
+  %192 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 0
+  store i1 true, i1* %192, align 1
+  %193 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 1
+  store i8* %188, i8** %193, align 8
+  store { i8*, i32, i32, i32, i32 }* %190, { i8*, i32, i32, i32, i32 }** %191, align 8
+  %194 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 3
+  store i32 1, i32* %194, align 4
+  %195 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %180, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %195, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %"~select_type_block_4.start"
-  %195 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %196 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %195, align 1
-  %197 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %198 = bitcast %select_type_13_module.shape_class* %197 to %select_type_13_module.rectangle_class*
-  %199 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %198, i32 0, i32 1
-  %200 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %199, align 8
-  %201 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %200, i32 0, i32 1
-  store float 5.000000e+00, float* %201, align 4
-  %202 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %203 = ptrtoint %select_type_13_module.shape_class** %202 to i64
-  %204 = icmp eq i64 %203, 0
-  br i1 %204, label %then29, label %ifcont30
+  %196 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %197 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %196, align 1
+  %198 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %199 = bitcast %select_type_13_module.shape_class* %198 to %select_type_13_module.rectangle_class*
+  %200 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %199, i32 0, i32 1
+  %201 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %200, align 8
+  %202 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %201, i32 0, i32 1
+  store float 5.000000e+00, float* %202, align 4
+  %203 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
+  %204 = ptrtoint %select_type_13_module.shape_class** %203 to i64
+  %205 = icmp eq i64 %204, 0
+  br i1 %205, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %205 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %206 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %207 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %206, i32 0, i32 0
-  %208 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %207, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @31, i32 0, i32 0), i8** %208, align 8
-  %209 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %207, i32 0, i32 1
-  store i32 73, i32* %209, align 4
-  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %207, i32 0, i32 2
-  store i32 7, i32* %210, align 4
-  %211 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %207, i32 0, i32 3
-  store i32 73, i32* %211, align 4
-  %212 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %207, i32 0, i32 4
-  store i32 10, i32* %212, align 4
-  %213 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
-  %214 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %205, i32 0, i32 0
-  %215 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %206, i32 0, i32 0
-  %216 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %214, i32 0, i32 2
-  %217 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %214, i32 0, i32 0
-  store i1 true, i1* %217, align 1
-  %218 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %214, i32 0, i32 1
-  store i8* %213, i8** %218, align 8
-  store { i8*, i32, i32, i32, i32 }* %215, { i8*, i32, i32, i32, i32 }** %216, align 8
-  %219 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %214, i32 0, i32 3
-  store i32 1, i32* %219, align 4
-  %220 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %205, i32 0, i32 0
-  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %220, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
+  %206 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %207 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %208 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %207, i32 0, i32 0
+  %209 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 0
+  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @31, i32 0, i32 0), i8** %209, align 8
+  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 1
+  store i32 73, i32* %210, align 4
+  %211 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 2
+  store i32 7, i32* %211, align 4
+  %212 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 3
+  store i32 73, i32* %212, align 4
+  %213 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %208, i32 0, i32 4
+  store i32 10, i32* %213, align 4
+  %214 = call i8* (i8*, ...) @_lcompilers_snprintf(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
+  %215 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %206, i32 0, i32 0
+  %216 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %207, i32 0, i32 0
+  %217 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 2
+  %218 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 0
+  store i1 true, i1* %218, align 1
+  %219 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 1
+  store i8* %214, i8** %219, align 8
+  store { i8*, i32, i32, i32, i32 }* %216, { i8*, i32, i32, i32, i32 }** %217, align 8
+  %220 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %215, i32 0, i32 3
+  store i32 1, i32* %220, align 4
+  %221 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %206, i32 0, i32 0
+  call void ({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error({ i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %221, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %221 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %222 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %221, align 1
-  %223 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %224 = bitcast %select_type_13_module.shape_class* %223 to %select_type_13_module.rectangle_class*
-  %225 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %224, i32 0, i32 1
-  %226 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %225, align 8
-  %227 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %226, i32 0, i32 2
-  store float 4.000000e+00, float* %227, align 4
-  %228 = alloca i64, align 8
+  %222 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %223 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %222, align 1
+  %224 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
+  %225 = bitcast %select_type_13_module.shape_class* %224 to %select_type_13_module.rectangle_class*
+  %226 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %225, i32 0, i32 1
+  %227 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %226, align 8
+  %228 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %227, i32 0, i32 2
+  store float 4.000000e+00, float* %228, align 4
   %229 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
   %230 = ptrtoint %select_type_13_module.shape_class** %229 to i64
   %231 = icmp eq i64 %230, 0
@@ -707,8 +707,8 @@ ifcont34:                                         ; preds = %ifcont32
   %283 = load float, float* %282, align 4
   %284 = alloca float, align 4
   store float %283, float* %284, align 4
-  %285 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.9, i32 0, i32 0), i64* %228, i32 0, i32 0, float* %256, float* %284)
-  %286 = load i64, i64* %228, align 4
+  %285 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.9, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %256, float* %284)
+  %286 = load i64, i64* %2, align 4
   %287 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 0
   store i8* %285, i8** %287, align 8
   %288 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 1
@@ -845,7 +845,7 @@ ifcont47:                                         ; preds = %else46, %then45
   br label %"FINALIZE_SYMTABLE_~select_type_block_4"
 
 "FINALIZE_SYMTABLE_~select_type_block_4":         ; preds = %"~select_type_block_4.end"
-  call void @llvm.stackrestore(i8* %174)
+  call void @llvm.stackrestore(i8* %175)
   br label %ifcont49
 
 else48:                                           ; preds = %ifcont26

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -141,6 +141,8 @@ FINALIZE_SYMTABLE_rectangle_area:                 ; preds = %return
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc35 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %s1 = alloca %select_type_13_module.shape_class*, align 8
   store %select_type_13_module.shape_class* null, %select_type_13_module.shape_class** %s1, align 8
@@ -331,7 +333,6 @@ ifcont10:                                         ; preds = %ifcont8
   store float %94, float* %95, align 4
   %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %67, i32 0, i32 0, float* %95)
   %97 = load i64, i64* %67, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -708,7 +709,6 @@ ifcont34:                                         ; preds = %ifcont32
   store float %283, float* %284, align 4
   %285 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.9, i32 0, i32 0), i64* %228, i32 0, i32 0, float* %256, float* %284)
   %286 = load i64, i64* %228, align 4
-  %stringFormat_desc35 = alloca %string_descriptor, align 8
   %287 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 0
   store i8* %285, i8** %287, align 8
   %288 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 1

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "4d6bde197c4b7d4f1d622f37ec039b03449edeb036f320bf79272e40",
+    "stdout_hash": "1fbb153b4b1629abceb9617a762fe76aeec85820aa7fe92cc0905e9b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "1fbb153b4b1629abceb9617a762fe76aeec85820aa7fe92cc0905e9b",
+    "stdout_hash": "e3f56655d189290cd34445cfd4a66cd76d293ee40e4ed3d9dda3caef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -10,10 +10,10 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %x, align 8
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, double* %x)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -9,13 +9,13 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca double, align 8
   store double 0x3FEFEB7A9B2C6D8B, double* %x, align 8
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, double* %x)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "be2b3673a11f854ecfadca602eb894f64b2eb6fc59676c7d4e3c345b",
+    "stdout_hash": "c942ba6e1628f3a05e8d4e6375e7aa809b1ffd66ac5afb49282d0e7c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "c942ba6e1628f3a05e8d4e6375e7aa809b1ffd66ac5afb49282d0e7c",
+    "stdout_hash": "7be4fc0915f7bb0c2fd98519449e9c4dca423c203b2646bb90b604c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -13,6 +13,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
   %3 = load %string_descriptor, %string_descriptor* @my_name, align 1
@@ -20,7 +21,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %string_descriptor %3, %string_descriptor* %4, align 1
   %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const, %string_descriptor* %4)
   %6 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -14,8 +14,8 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = alloca i64, align 8
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %3 = load %string_descriptor, %string_descriptor* @my_name, align 1
   %4 = alloca %string_descriptor, align 8
   store %string_descriptor %3, %string_descriptor* %4, align 1

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "8ab2613e7711e7e81a69e1ce9d9dbc8e7f92c401bf80adf3ed9a765f",
+    "stdout_hash": "d4024d7a58d2498f85a5f3e7a9ac8e36c1485321b99499d811b8ef55",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "8b35ac39513acc1a4887c0fbf1634d399243a06b761378713534f811",
+    "stdout_hash": "8ab2613e7711e7e81a69e1ce9d9dbc8e7f92c401bf80adf3ed9a765f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -21,6 +21,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %firstname = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %firstname, align 1
@@ -78,7 +79,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %string_descriptor %31, %string_descriptor* %32, align 1
   %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([38 x i8], [38 x i8]* @serialization_info, i32 0, i32 0), i64* %26, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %28, %string_descriptor* %30, %string_descriptor* %32)
   %34 = load i64, i64* %26, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %33, i8** %35, align 8
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -22,52 +22,52 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %firstname = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %firstname, align 1
-  %2 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
-  store i64 15, i64* %2, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
-  %4 = call i8* @_lfortran_malloc(i64 15)
-  store i8* %4, i8** %3, align 8
+  %3 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
+  store i64 15, i64* %3, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
+  %5 = call i8* @_lfortran_malloc(i64 15)
+  store i8* %5, i8** %4, align 8
   %greetings = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %greetings, align 1
-  %5 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
-  store i64 25, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %7 = call i8* @_lfortran_malloc(i64 25)
-  store i8* %7, i8** %6, align 8
+  %6 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
+  store i64 25, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
+  %8 = call i8* @_lfortran_malloc(i64 25)
+  store i8* %8, i8** %7, align 8
   %surname = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %surname, align 1
-  %8 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
-  store i64 15, i64* %8, align 4
-  %9 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
-  %10 = call i8* @_lfortran_malloc(i64 15)
-  store i8* %10, i8** %9, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
+  store i64 15, i64* %9, align 4
+  %10 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
+  %11 = call i8* @_lfortran_malloc(i64 15)
+  store i8* %11, i8** %10, align 8
   %title = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %title, align 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  store i64 6, i64* %11, align 4
-  %12 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %13 = call i8* @_lfortran_malloc(i64 6)
-  store i8* %13, i8** %12, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %15 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  %16 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %14, i64* %15, i8 0, i8 0, i8* %16, i64 4)
-  %17 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
-  %18 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
-  %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %17, i64* %18, i8 0, i8 0, i8* %19, i64 6)
-  %20 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
-  %21 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
-  %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %20, i64* %21, i8 0, i8 0, i8* %22, i64 8)
-  %23 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %24 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
-  %25 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %23, i64* %24, i8 0, i8 0, i8* %25, i64 25)
-  %26 = alloca i64, align 8
+  %12 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
+  store i64 6, i64* %12, align 4
+  %13 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
+  %14 = call i8* @_lfortran_malloc(i64 6)
+  store i8* %14, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
+  %16 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
+  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %15, i64* %16, i8 0, i8 0, i8* %17, i64 4)
+  %18 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
+  %19 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
+  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %18, i64* %19, i8 0, i8 0, i8* %20, i64 6)
+  %21 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
+  %22 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
+  %23 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %21, i64* %22, i8 0, i8 0, i8* %23, i64 8)
+  %24 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
+  %25 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
+  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %24, i64* %25, i8 0, i8 0, i8* %26, i64 25)
   %27 = load %string_descriptor, %string_descriptor* %title, align 1
   %28 = alloca %string_descriptor, align 8
   store %string_descriptor %27, %string_descriptor* %28, align 1
@@ -77,8 +77,8 @@ define i32 @main(i32 %0, i8** %1) {
   %31 = load %string_descriptor, %string_descriptor* %surname, align 1
   %32 = alloca %string_descriptor, align 8
   store %string_descriptor %31, %string_descriptor* %32, align 1
-  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([38 x i8], [38 x i8]* @serialization_info, i32 0, i32 0), i64* %26, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %28, %string_descriptor* %30, %string_descriptor* %32)
-  %34 = load i64, i64* %26, align 4
+  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([38 x i8], [38 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %28, %string_descriptor* %30, %string_descriptor* %32)
+  %34 = load i64, i64* %2, align 4
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %33, i8** %35, align 8
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "04933083bac416a806291f14e7748ba9aee4a5a5ea1633105d2c9461",
+    "stdout_hash": "0990045f2e8436d44a89a64b3338895cbb094c6af92f7ad81cf72015",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "d170cc6ac529b7fe9b6bc757a36a819c2488e55eb3ba8541db0f13fc",
+    "stdout_hash": "04933083bac416a806291f14e7748ba9aee4a5a5ea1633105d2c9461",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -52,6 +52,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %is_alpha = alloca i1, align 1
   %num = alloca %string_descriptor, align 8
@@ -87,7 +90,6 @@ define i32 @main(i32 %0, i8** %1) {
   %27 = alloca i64, align 8
   %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info, i32 0, i32 0), i64* %27, i32 0, i32 0, i1* %is_alpha)
   %29 = load i64, i64* %27, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %28, i8** %30, align 8
   %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -134,7 +136,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %61 = alloca i64, align 8
   %62 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.17, i32 0, i32 0), i64* %61, i32 0, i32 0, i1* %is_alpha)
   %63 = load i64, i64* %61, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %62, i8** %64, align 8
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
@@ -181,7 +182,6 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %95 = alloca i64, align 8
   %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.28, i32 0, i32 0), i64* %95, i32 0, i32 0, i1* %is_alpha)
   %97 = load i64, i64* %95, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -53,135 +53,135 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %is_alpha = alloca i1, align 1
   %num = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %num, align 1
-  %2 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 1
-  store i64 3, i64* %2, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
-  %4 = call i8* @_lfortran_malloc(i64 3)
-  store i8* %4, i8** %3, align 8
-  %5 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %7 = call i32 @str_compare(i8* %5, i64 2, i8* %6, i64 1)
-  %8 = icmp sge i32 %7, 0
-  %9 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  %11 = call i32 @str_compare(i8* %9, i64 2, i8* %10, i64 1)
-  %12 = icmp sle i32 %11, 0
-  %13 = icmp eq i1 %8, false
-  %14 = select i1 %13, i1 %8, i1 %12
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %16 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  %17 = call i32 @str_compare(i8* %15, i64 2, i8* %16, i64 1)
-  %18 = icmp sge i32 %17, 0
-  %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  %21 = call i32 @str_compare(i8* %19, i64 2, i8* %20, i64 1)
-  %22 = icmp sle i32 %21, 0
-  %23 = icmp eq i1 %18, false
-  %24 = select i1 %23, i1 %18, i1 %22
-  %25 = icmp eq i1 %14, false
-  %26 = select i1 %25, i1 %24, i1 %14
-  store i1 %26, i1* %is_alpha, align 1
-  %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info, i32 0, i32 0), i64* %27, i32 0, i32 0, i1* %is_alpha)
-  %29 = load i64, i64* %27, align 4
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %29, i64* %31, align 4
+  %5 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 1
+  store i64 3, i64* %5, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
+  %7 = call i8* @_lfortran_malloc(i64 3)
+  store i8* %7, i8** %6, align 8
+  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %9 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %10 = call i32 @str_compare(i8* %8, i64 2, i8* %9, i64 1)
+  %11 = icmp sge i32 %10, 0
+  %12 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  %14 = call i32 @str_compare(i8* %12, i64 2, i8* %13, i64 1)
+  %15 = icmp sle i32 %14, 0
+  %16 = icmp eq i1 %11, false
+  %17 = select i1 %16, i1 %11, i1 %15
+  %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  %20 = call i32 @str_compare(i8* %18, i64 2, i8* %19, i64 1)
+  %21 = icmp sge i32 %20, 0
+  %22 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %23 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  %24 = call i32 @str_compare(i8* %22, i64 2, i8* %23, i64 1)
+  %25 = icmp sle i32 %24, 0
+  %26 = icmp eq i1 %21, false
+  %27 = select i1 %26, i1 %21, i1 %25
+  %28 = icmp eq i1 %17, false
+  %29 = select i1 %28, i1 %27, i1 %17
+  store i1 %29, i1* %is_alpha, align 1
+  %30 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i1* %is_alpha)
+  %31 = load i64, i64* %4, align 4
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %35 = load i64, i64* %34, align 4
-  %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %37 = icmp eq i8* %28, null
-  br i1 %37, label %free_done, label %free_nonnull
+  store i8* %30, i8** %32, align 8
+  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %31, i64* %33, align 4
+  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %35 = load i8*, i8** %34, align 8
+  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %37 = load i64, i64* %36, align 4
+  %38 = trunc i64 %37 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %35, i32 %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %39 = icmp eq i8* %30, null
+  br i1 %39, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %28)
+  call void @_lfortran_free(i8* %30)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %38, i64 2)
-  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  %41 = call i32 @str_compare(i8* %39, i64 2, i8* %40, i64 1)
-  %42 = icmp sge i32 %41, 0
-  %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %44 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  %45 = call i32 @str_compare(i8* %43, i64 2, i8* %44, i64 1)
-  %46 = icmp sle i32 %45, 0
-  %47 = icmp eq i1 %42, false
-  %48 = select i1 %47, i1 %42, i1 %46
-  %49 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %50 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  %51 = call i32 @str_compare(i8* %49, i64 2, i8* %50, i64 1)
-  %52 = icmp sge i32 %51, 0
-  %53 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %54 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  %55 = call i32 @str_compare(i8* %53, i64 2, i8* %54, i64 1)
-  %56 = icmp sle i32 %55, 0
-  %57 = icmp eq i1 %52, false
-  %58 = select i1 %57, i1 %52, i1 %56
-  %59 = icmp eq i1 %48, false
-  %60 = select i1 %59, i1 %58, i1 %48
-  store i1 %60, i1* %is_alpha, align 1
-  %61 = alloca i64, align 8
-  %62 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.17, i32 0, i32 0), i64* %61, i32 0, i32 0, i1* %is_alpha)
-  %63 = load i64, i64* %61, align 4
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %62, i8** %64, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %63, i64* %65, align 4
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %67 = load i8*, i8** %66, align 8
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %69 = load i64, i64* %68, align 4
-  %70 = trunc i64 %69 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %67, i32 %70, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %71 = icmp eq i8* %62, null
-  br i1 %71, label %free_done3, label %free_nonnull2
+  %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %40, i64 2)
+  %41 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %42 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
+  %43 = call i32 @str_compare(i8* %41, i64 2, i8* %42, i64 1)
+  %44 = icmp sge i32 %43, 0
+  %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %46 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
+  %47 = call i32 @str_compare(i8* %45, i64 2, i8* %46, i64 1)
+  %48 = icmp sle i32 %47, 0
+  %49 = icmp eq i1 %44, false
+  %50 = select i1 %49, i1 %44, i1 %48
+  %51 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %52 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
+  %53 = call i32 @str_compare(i8* %51, i64 2, i8* %52, i64 1)
+  %54 = icmp sge i32 %53, 0
+  %55 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %56 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
+  %57 = call i32 @str_compare(i8* %55, i64 2, i8* %56, i64 1)
+  %58 = icmp sle i32 %57, 0
+  %59 = icmp eq i1 %54, false
+  %60 = select i1 %59, i1 %54, i1 %58
+  %61 = icmp eq i1 %50, false
+  %62 = select i1 %61, i1 %60, i1 %50
+  store i1 %62, i1* %is_alpha, align 1
+  %63 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.17, i32 0, i32 0), i64* %3, i32 0, i32 0, i1* %is_alpha)
+  %64 = load i64, i64* %3, align 4
+  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  store i8* %63, i8** %65, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  store i64 %64, i64* %66, align 4
+  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
+  %68 = load i8*, i8** %67, align 8
+  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
+  %70 = load i64, i64* %69, align 4
+  %71 = trunc i64 %70 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %68, i32 %71, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %72 = icmp eq i8* %63, null
+  br i1 %72, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free(i8* %62)
+  call void @_lfortran_free(i8* %63)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %72 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.19, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %72, i64 2)
-  %73 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %74 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.21, i32 0, i32 0), align 8
-  %75 = call i32 @str_compare(i8* %73, i64 2, i8* %74, i64 1)
-  %76 = icmp sge i32 %75, 0
-  %77 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %78 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.23, i32 0, i32 0), align 8
-  %79 = call i32 @str_compare(i8* %77, i64 2, i8* %78, i64 1)
-  %80 = icmp sle i32 %79, 0
-  %81 = icmp eq i1 %76, false
-  %82 = select i1 %81, i1 %76, i1 %80
-  %83 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %84 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.25, i32 0, i32 0), align 8
-  %85 = call i32 @str_compare(i8* %83, i64 2, i8* %84, i64 1)
-  %86 = icmp sge i32 %85, 0
-  %87 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %88 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.27, i32 0, i32 0), align 8
-  %89 = call i32 @str_compare(i8* %87, i64 2, i8* %88, i64 1)
-  %90 = icmp sle i32 %89, 0
-  %91 = icmp eq i1 %86, false
-  %92 = select i1 %91, i1 %86, i1 %90
-  %93 = icmp eq i1 %82, false
-  %94 = select i1 %93, i1 %92, i1 %82
-  store i1 %94, i1* %is_alpha, align 1
-  %95 = alloca i64, align 8
-  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.28, i32 0, i32 0), i64* %95, i32 0, i32 0, i1* %is_alpha)
-  %97 = load i64, i64* %95, align 4
+  %73 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.19, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %73, i64 2)
+  %74 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %75 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.21, i32 0, i32 0), align 8
+  %76 = call i32 @str_compare(i8* %74, i64 2, i8* %75, i64 1)
+  %77 = icmp sge i32 %76, 0
+  %78 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %79 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.23, i32 0, i32 0), align 8
+  %80 = call i32 @str_compare(i8* %78, i64 2, i8* %79, i64 1)
+  %81 = icmp sle i32 %80, 0
+  %82 = icmp eq i1 %77, false
+  %83 = select i1 %82, i1 %77, i1 %81
+  %84 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %85 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.25, i32 0, i32 0), align 8
+  %86 = call i32 @str_compare(i8* %84, i64 2, i8* %85, i64 1)
+  %87 = icmp sge i32 %86, 0
+  %88 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
+  %89 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.27, i32 0, i32 0), align 8
+  %90 = call i32 @str_compare(i8* %88, i64 2, i8* %89, i64 1)
+  %91 = icmp sle i32 %90, 0
+  %92 = icmp eq i1 %87, false
+  %93 = select i1 %92, i1 %87, i1 %91
+  %94 = icmp eq i1 %83, false
+  %95 = select i1 %94, i1 %93, i1 %83
+  store i1 %95, i1* %is_alpha, align 1
+  %96 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @serialization_info.28, i32 0, i32 0), i64* %2, i32 0, i32 0, i1* %is_alpha)
+  %97 = load i64, i64* %2, align 4
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %96, i8** %98, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "e9b18cda211e998750f523481f038fc1ff401915924aca78ebdeb303",
+    "stdout_hash": "0681a321fa1abbb1e0e47d38f40c626dd8ed3d6758f4583c125758af",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "0681a321fa1abbb1e0e47d38f40c626dd8ed3d6758f4583c125758af",
+    "stdout_hash": "0be9660cc41e6c3d091969248fb6886c02d9fd368e40a4a003627838",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -351,6 +351,7 @@ declare i32 @str_compare(i8*, i64, i8*, i64)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i1, align 1
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
@@ -396,7 +397,6 @@ else:                                             ; preds = %.entry
   store i32 %18, i32* %19, align 4
   %20 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %17, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %19)
   %21 = load i64, i64* %17, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %20, i8** %22, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -352,51 +352,51 @@ declare i32 @str_compare(i8*, i64, i8*, i64)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i1, align 1
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %mystring = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %mystring, align 1
-  %2 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
-  store i64 30, i64* %2, align 4
-  %3 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
-  %4 = call i8* @_lfortran_malloc(i64 30)
-  store i8* %4, i8** %3, align 8
+  %3 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
+  store i64 30, i64* %3, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
+  %5 = call i8* @_lfortran_malloc(i64 30)
+  store i8* %5, i8** %4, align 8
   %teststring = alloca %string_descriptor, align 8
   store %string_descriptor zeroinitializer, %string_descriptor* %teststring, align 1
-  %5 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
-  store i64 10, i64* %5, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
-  %7 = call i8* @_lfortran_malloc(i64 10)
-  store i8* %7, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
-  %9 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
-  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %8, i64* %9, i8 0, i8 0, i8* %10, i64 14)
-  %11 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
-  %12 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy(i8** %11, i64* %12, i8 0, i8 0, i8* %13, i64 4)
+  %6 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
+  store i64 10, i64* %6, align 4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
+  %8 = call i8* @_lfortran_malloc(i64 10)
+  store i8* %8, i8** %7, align 8
+  %9 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
+  %10 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
+  %11 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %9, i64* %10, i8 0, i8 0, i8* %11, i64 14)
+  %12 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
+  %13 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
+  %14 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  call void @_lfortran_strcpy(i8** %12, i64* %13, i8 0, i8 0, i8* %14, i64 4)
   store i1 false, i1* %call_arg_value, align 1
   store i32 4, i32* %call_arg_value1, align 4
-  %14 = call i32 @_lcompilers_index_str(%string_descriptor* %mystring, %string_descriptor* %teststring, i1* %call_arg_value, i32* %call_arg_value1)
-  %15 = icmp eq i32 %14, 0
-  br i1 %15, label %then, label %else
+  %15 = call i32 @_lcompilers_index_str(%string_descriptor* %mystring, %string_descriptor* %teststring, i1* %call_arg_value, i32* %call_arg_value1)
+  %16 = icmp eq i32 %15, 0
+  br i1 %16, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %16 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %16, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %17 = alloca i64, align 8
   store i1 false, i1* %call_arg_value, align 1
   store i32 4, i32* %call_arg_value1, align 4
   %18 = call i32 @_lcompilers_index_str1(%string_descriptor* %mystring, %string_descriptor* %teststring, i1* %call_arg_value, i32* %call_arg_value1)
   %19 = alloca i32, align 4
   store i32 %18, i32* %19, align 4
-  %20 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %17, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %19)
-  %21 = load i64, i64* %17, align 4
+  %20 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %19)
+  %21 = load i64, i64* %2, align 4
   %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %20, i8** %22, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "8f68f39ce484339bdc0e5ab52ca53d113d3d49f43c80ff3307a8fed3",
+    "stdout_hash": "be6f9901bec788e2af82e3df132ee5e037ae090b571677edfda3b26d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "be6f9901bec788e2af82e3df132ee5e037ae090b571677edfda3b26d",
+    "stdout_hash": "0062687c752c9f3ee25b95e1a852f1e2b4e597016728399955b1681e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -17,6 +17,7 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %ia0 = alloca i32, align 4
   store i32 48, i32* %ia0, align 4
@@ -57,7 +58,6 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %2 = alloca i64, align 8
   %3 = alloca i32, align 4
   store i32 48, i32* %3, align 4
   %4 = alloca i32, align 4

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -16,6 +16,7 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %ia0 = alloca i32, align 4
   store i32 48, i32* %ia0, align 4
@@ -65,7 +66,6 @@ ifcont6:                                          ; preds = %else5, %then4
   store i32 57, i32* %5, align 4
   %6 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %3, i32* %4, i32* %5)
   %7 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "2af3c886f18d2a108de5b6e22ff43685f69b3e1eab9992088c344abf",
+    "stdout_hash": "1c6129313e39fd2036bdd3ec6950ec2e5d9b7ea93946072373cfc633",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "1c6129313e39fd2036bdd3ec6950ec2e5d9b7ea93946072373cfc633",
+    "stdout_hash": "a4c33f34ec609890164cf95d34cb131cc96f04929e3da59f598892cf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -37,7 +37,11 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc28 = alloca %string_descriptor, align 8
+  %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -60,7 +64,6 @@ ifcont:                                           ; preds = %else, %then
   %4 = alloca i64, align 8
   %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %i, i32* %j)
   %6 = load i64, i64* %4, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -124,7 +127,6 @@ ifcont9:                                          ; preds = %else8, %then7
   %21 = alloca i64, align 8
   %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %21, i32 0, i32 0, i32* %j)
   %23 = load i64, i64* %21, align 4
-  %stringFormat_desc10 = alloca %string_descriptor, align 8
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %22, i8** %24, align 8
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
@@ -175,7 +177,6 @@ ifcont18:                                         ; preds = %else17, %then16
   %36 = alloca i64, align 8
   %37 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %36, i32 0, i32 0, i32* %j)
   %38 = load i64, i64* %36, align 4
-  %stringFormat_desc19 = alloca %string_descriptor, align 8
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %37, i8** %39, align 8
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
@@ -228,7 +229,6 @@ ifcont27:                                         ; preds = %else26, %then25
   %53 = alloca i64, align 8
   %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %53, i32 0, i32 0, i32* %j)
   %55 = load i64, i64* %53, align 4
-  %stringFormat_desc28 = alloca %string_descriptor, align 8
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
   store i8* %54, i8** %56, align 8
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -38,18 +38,22 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc28 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc19 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %5 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   store i32 1, i32* %i, align 4
   store i32 1, i32* %j, align 4
-  %2 = load i32, i32* %j, align 4
-  %3 = icmp ne i32 %2, 1
-  br i1 %3, label %then, label %else
+  %6 = load i32, i32* %j, align 4
+  %7 = icmp ne i32 %6, 1
+  br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
@@ -61,30 +65,29 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %then
   call void @f(i32* %i, i32* %j)
-  %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %i, i32* %j)
-  %6 = load i64, i64* %4, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 4
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
+  %8 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32* %i, i32* %j)
+  %9 = load i64, i64* %5, align 4
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %8, i8** %10, align 8
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 4
-  %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
-  br i1 %14, label %free_done, label %free_nonnull
+  store i64 %9, i64* %11, align 4
+  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %13 = load i8*, i8** %12, align 8
+  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %15 = load i64, i64* %14, align 4
+  %16 = trunc i64 %15 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %13, i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %17 = icmp eq i8* %8, null
+  br i1 %17, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free(i8* %5)
+  call void @_lfortran_free(i8* %8)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  %15 = load i32, i32* %i, align 4
-  %16 = icmp ne i32 %15, 1
-  br i1 %16, label %then1, label %else2
+  %18 = load i32, i32* %i, align 4
+  %19 = icmp ne i32 %18, 1
+  br i1 %19, label %then1, label %else2
 
 then1:                                            ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -95,9 +98,9 @@ else2:                                            ; preds = %free_done
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %17 = load i32, i32* %j, align 4
-  %18 = icmp ne i32 %17, 2
-  br i1 %18, label %then4, label %else5
+  %20 = load i32, i32* %j, align 4
+  %21 = icmp ne i32 %20, 2
+  br i1 %21, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
@@ -109,9 +112,9 @@ else5:                                            ; preds = %ifcont3
 
 ifcont6:                                          ; preds = %else5, %then4
   store i32 1, i32* %j, align 4
-  %19 = load i32, i32* %j, align 4
-  %20 = icmp ne i32 %19, 1
-  br i1 %20, label %then7, label %else8
+  %22 = load i32, i32* %j, align 4
+  %23 = icmp ne i32 %22, 1
+  br i1 %23, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -124,30 +127,29 @@ else8:                                            ; preds = %ifcont6
 ifcont9:                                          ; preds = %else8, %then7
   store i32 3, i32* %call_arg_value, align 4
   call void @f(i32* %call_arg_value, i32* %j)
-  %21 = alloca i64, align 8
-  %22 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %21, i32 0, i32 0, i32* %j)
-  %23 = load i64, i64* %21, align 4
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %22, i8** %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %23, i64* %25, align 4
+  %24 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %j)
+  %25 = load i64, i64* %4, align 4
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %27 = load i8*, i8** %26, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %29 = load i64, i64* %28, align 4
-  %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %31 = icmp eq i8* %22, null
-  br i1 %31, label %free_done12, label %free_nonnull11
+  store i8* %24, i8** %26, align 8
+  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  store i64 %25, i64* %27, align 4
+  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
+  %29 = load i8*, i8** %28, align 8
+  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
+  %31 = load i64, i64* %30, align 4
+  %32 = trunc i64 %31 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %33 = icmp eq i8* %24, null
+  br i1 %33, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %ifcont9
-  call void @_lfortran_free(i8* %22)
+  call void @_lfortran_free(i8* %24)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
-  %32 = load i32, i32* %j, align 4
-  %33 = icmp ne i32 %32, 4
-  br i1 %33, label %then13, label %else14
+  %34 = load i32, i32* %j, align 4
+  %35 = icmp ne i32 %34, 4
+  br i1 %35, label %then13, label %else14
 
 then13:                                           ; preds = %free_done12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
@@ -159,9 +161,9 @@ else14:                                           ; preds = %free_done12
 
 ifcont15:                                         ; preds = %else14, %then13
   store i32 1, i32* %j, align 4
-  %34 = load i32, i32* %j, align 4
-  %35 = icmp ne i32 %34, 1
-  br i1 %35, label %then16, label %else17
+  %36 = load i32, i32* %j, align 4
+  %37 = icmp ne i32 %36, 1
+  br i1 %37, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
@@ -174,30 +176,29 @@ else17:                                           ; preds = %ifcont15
 ifcont18:                                         ; preds = %else17, %then16
   store i32 3, i32* %call_arg_value, align 4
   call void @f(i32* %call_arg_value, i32* %j)
-  %36 = alloca i64, align 8
-  %37 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %36, i32 0, i32 0, i32* %j)
-  %38 = load i64, i64* %36, align 4
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %38, i64* %40, align 4
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %44 = load i64, i64* %43, align 4
-  %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
-  %46 = icmp eq i8* %37, null
-  br i1 %46, label %free_done21, label %free_nonnull20
+  %38 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %j)
+  %39 = load i64, i64* %3, align 4
+  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
+  store i8* %38, i8** %40, align 8
+  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
+  store i64 %39, i64* %41, align 4
+  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
+  %43 = load i8*, i8** %42, align 8
+  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
+  %45 = load i64, i64* %44, align 4
+  %46 = trunc i64 %45 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
+  %47 = icmp eq i8* %38, null
+  br i1 %47, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %ifcont18
-  call void @_lfortran_free(i8* %37)
+  call void @_lfortran_free(i8* %38)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %ifcont18
-  %47 = load i32, i32* %j, align 4
-  %48 = icmp ne i32 %47, 4
-  br i1 %48, label %then22, label %else23
+  %48 = load i32, i32* %j, align 4
+  %49 = icmp ne i32 %48, 4
+  br i1 %49, label %then22, label %else23
 
 then22:                                           ; preds = %free_done21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
@@ -209,9 +210,9 @@ else23:                                           ; preds = %free_done21
 
 ifcont24:                                         ; preds = %else23, %then22
   store i32 1, i32* %j, align 4
-  %49 = load i32, i32* %j, align 4
-  %50 = icmp ne i32 %49, 1
-  br i1 %50, label %then25, label %else26
+  %50 = load i32, i32* %j, align 4
+  %51 = icmp ne i32 %50, 1
+  br i1 %51, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
@@ -222,13 +223,12 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %51 = load i32, i32* %i, align 4
-  %52 = add i32 %51, 2
-  store i32 %52, i32* %call_arg_value, align 4
+  %52 = load i32, i32* %i, align 4
+  %53 = add i32 %52, 2
+  store i32 %53, i32* %call_arg_value, align 4
   call void @f(i32* %call_arg_value, i32* %j)
-  %53 = alloca i64, align 8
-  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %53, i32 0, i32 0, i32* %j)
-  %55 = load i64, i64* %53, align 4
+  %54 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %j)
+  %55 = load i64, i64* %2, align 4
   %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
   store i8* %54, i8** %56, align 8
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "42b7194849aba17b826fc54dc56b9a7a2467b9bfa7422bb7c0ea8332",
+    "stdout_hash": "359ac022a67d7a4db8be4ba93f39dcd1223fab0a393c1cd36863c712",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "75688d1068b991b52465d0338841d9b5037353e7bb2f2e767330595b",
+    "stdout_hash": "42b7194849aba17b826fc54dc56b9a7a2467b9bfa7422bb7c0ea8332",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -28,6 +28,9 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
@@ -37,7 +40,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i, i32* %j)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -86,7 +88,6 @@ ifcont3:                                          ; preds = %else2, %then1
   %17 = alloca i64, align 8
   %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32* %i, i32* %j)
   %19 = load i64, i64* %17, align 4
-  %stringFormat_desc4 = alloca %string_descriptor, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %18, i8** %20, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
@@ -135,7 +136,6 @@ ifcont12:                                         ; preds = %else11, %then10
   %32 = alloca i64, align 8
   %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %32, i32 0, i32 0, i32* %i, i32* %j)
   %34 = load i64, i64* %32, align 4
-  %stringFormat_desc13 = alloca %string_descriptor, align 8
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %33, i8** %35, align 8
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -29,38 +29,40 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc13 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %4 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   store i32 1, i32* %i, align 4
   store i32 1, i32* %j, align 4
   call void @f(i32* %i, i32* %j)
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i, i32* %j)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
+  %5 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32* %i, i32* %j)
+  %6 = load i64, i64* %4, align 4
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  store i8* %5, i8** %7, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %6, i64* %8, align 4
+  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %10 = load i8*, i8** %9, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, i64* %11, align 4
+  %13 = trunc i64 %12 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %14 = icmp eq i8* %5, null
+  br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = load i32, i32* %i, align 4
-  %14 = icmp ne i32 %13, 1
-  br i1 %14, label %then, label %else
+  %15 = load i32, i32* %i, align 4
+  %16 = icmp ne i32 %15, 1
+  br i1 %16, label %then, label %else
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
@@ -71,9 +73,9 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %15 = load i32, i32* %j, align 4
-  %16 = icmp ne i32 %15, 2
-  br i1 %16, label %then1, label %else2
+  %17 = load i32, i32* %j, align 4
+  %18 = icmp ne i32 %17, 2
+  br i1 %18, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
@@ -85,30 +87,29 @@ else2:                                            ; preds = %ifcont
 
 ifcont3:                                          ; preds = %else2, %then1
   call void @g(i32* %i, i32* %j)
-  %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32* %i, i32* %j)
-  %19 = load i64, i64* %17, align 4
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %19, i64* %21, align 4
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %25 = load i64, i64* %24, align 4
-  %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
-  br i1 %27, label %free_done6, label %free_nonnull5
+  %19 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32* %i, i32* %j)
+  %20 = load i64, i64* %3, align 4
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %19, i8** %21, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %20, i64* %22, align 4
+  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %24 = load i8*, i8** %23, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %26 = load i64, i64* %25, align 4
+  %27 = trunc i64 %26 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %28 = icmp eq i8* %19, null
+  br i1 %28, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %ifcont3
-  call void @_lfortran_free(i8* %18)
+  call void @_lfortran_free(i8* %19)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %ifcont3
-  %28 = load i32, i32* %i, align 4
-  %29 = icmp ne i32 %28, 1
-  br i1 %29, label %then7, label %else8
+  %29 = load i32, i32* %i, align 4
+  %30 = icmp ne i32 %29, 1
+  br i1 %30, label %then7, label %else8
 
 then7:                                            ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
@@ -119,9 +120,9 @@ else8:                                            ; preds = %free_done6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %30 = load i32, i32* %j, align 4
-  %31 = icmp ne i32 %30, 0
-  br i1 %31, label %then10, label %else11
+  %31 = load i32, i32* %j, align 4
+  %32 = icmp ne i32 %31, 0
+  br i1 %32, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
@@ -133,9 +134,8 @@ else11:                                           ; preds = %ifcont9
 
 ifcont12:                                         ; preds = %else11, %then10
   call void @h(i32* %i, i32* %j)
-  %32 = alloca i64, align 8
-  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %32, i32 0, i32 0, i32* %i, i32* %j)
-  %34 = load i64, i64* %32, align 4
+  %33 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i, i32* %j)
+  %34 = load i64, i64* %2, align 4
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %33, i8** %35, align 8
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "618118cc40d09741d85236f4b4dbf5d983ccf0d15fef5b82fbec8b25",
+    "stdout_hash": "e60c76f2807ed2f58913770a07e1b3a4f5341f0406bf870a5782f4fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "e60c76f2807ed2f58913770a07e1b3a4f5341f0406bf870a5782f4fb",
+    "stdout_hash": "e11b12121524c58e5a38302236bb60afa214c01be8360e49c8ef42d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -24,9 +24,9 @@ FINALIZE_SYMTABLE_print_it:                       ; preds = %return
 define void @print_int() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %0 = alloca i64, align 8
   %a = alloca i32, align 4
   store i32 5, i32* %a, align 4
-  %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %a)
   %2 = load i64, i64* %0, align 4
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -23,12 +23,12 @@ FINALIZE_SYMTABLE_print_it:                       ; preds = %return
 
 define void @print_int() {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   %a = alloca i32, align 4
   store i32 5, i32* %a, align 4
   %0 = alloca i64, align 8
   %1 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %0, i32 0, i32 0, i32* %a)
   %2 = load i64, i64* %0, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %1, i8** %3, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "44ac25df05eb388c4f3bbab8c0673b1600e7d756c500da87297c5b21",
+    "stdout_hash": "5dc560b0230a4df3b0bb565434d046480d79b9e50490aca48b3523b5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "e2f0d503e2431267a6732a2da406ab9e00fbcf8ac4933b98d4cf69e3",
+    "stdout_hash": "44ac25df05eb388c4f3bbab8c0673b1600e7d756c500da87297c5b21",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -12,6 +12,8 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
@@ -19,7 +21,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %r)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
@@ -44,7 +45,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %15 = alloca i64, align 8
   %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %i)
   %17 = load i64, i64* %15, align 4
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -13,38 +13,38 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %3 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
   store float 1.500000e+00, float* %r, align 4
-  %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* %r)
-  %4 = load i64, i64* %2, align 4
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 4
-  %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
-  br i1 %12, label %free_done, label %free_nonnull
+  %4 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, float* %r)
+  %5 = load i64, i64* %3, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %4, i8** %6, align 8
+  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %5, i64* %7, align 4
+  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %9 = load i8*, i8** %8, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, i64* %10, align 4
+  %12 = trunc i64 %11 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %13 = icmp eq i8* %4, null
+  br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free(i8* %3)
+  call void @_lfortran_free(i8* %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = load float, float* %r, align 4
-  %14 = fptosi float %13 to i32
-  store i32 %14, i32* %i, align 4
-  %15 = alloca i64, align 8
-  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32* %i)
-  %17 = load i64, i64* %15, align 4
+  %14 = load float, float* %r, align 4
+  %15 = fptosi float %14 to i32
+  store i32 %15, i32* %i, align 4
+  %16 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %2, i32 0, i32 0, i32* %i)
+  %17 = load i64, i64* %2, align 4
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %16, i8** %18, align 8
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1

--- a/tests/reference/llvm-volatile_02-2beae13.json
+++ b/tests/reference/llvm-volatile_02-2beae13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_02-2beae13.stdout",
-    "stdout_hash": "35246084da9b2744f7c6de954a4c66499b129abcab267c33955a6ba3",
+    "stdout_hash": "11d0f1a2dfd7485e2698b5e2c088504426609d28b7c49d39a2348eff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_02-2beae13.json
+++ b/tests/reference/llvm-volatile_02-2beae13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_02-2beae13.stdout",
-    "stdout_hash": "a0887b897cb738eaf462b6c61c1bd0d194de8ab7a5f69f746c4c3830",
+    "stdout_hash": "35246084da9b2744f7c6de954a4c66499b129abcab267c33955a6ba3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_02-2beae13.stdout
+++ b/tests/reference/llvm-volatile_02-2beae13.stdout
@@ -10,12 +10,12 @@ source_filename = "LFortran"
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
+  %stringFormat_desc = alloca %string_descriptor, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store volatile float 5.000000e-01, float* @volatile_02.iota_2, align 4
   %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @volatile_02.iota_2)
   %4 = load i64, i64* %2, align 4
-  %stringFormat_desc = alloca %string_descriptor, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1

--- a/tests/reference/llvm-volatile_02-2beae13.stdout
+++ b/tests/reference/llvm-volatile_02-2beae13.stdout
@@ -11,9 +11,9 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
+  %2 = alloca i64, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store volatile float 5.000000e-01, float* @volatile_02.iota_2, align 4
-  %2 = alloca i64, align 8
   %3 = call i8* (i8*, i64, i8*, i64*, i32, i32, ...) @_lcompilers_string_format_fortran(i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, float* @volatile_02.iota_2)
   %4 = load i64, i64* %2, align 4
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0


### PR DESCRIPTION
Towards #10359

Here, in this PR; Changes are made to llvm backend to initialize few allocations at function entry, rather than function body.

This reduces the stack allocations, particularly helpful inside do-loops... As the temporaries allocated are reused in each iteration.
In current main, these temporaries are allocated inside each loop.

Each commit represents a separate allocation optimization