### PR TITLE
Fix operator(**) overloading lookup

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3649,6 +3649,7 @@ RUN(NAME separate_compilation_41 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_42 LABELS llvm EXTRA_ARGS --separate-compilation)
 
 RUN(NAME separate_compilation_43 LABELS gfortran llvm EXTRAFILES separate_compilation_43a.f90 separate_compilation_43b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_44 LABELS gfortran llvm EXTRAFILES separate_compilation_44a.f90 separate_compilation_44b.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_44.f90
+++ b/integration_tests/separate_compilation_44.f90
@@ -1,0 +1,7 @@
+program separate_compilation_44
+    use separate_compilation_44b_module
+    implicit none
+
+    call client()
+    print *, "ok"
+end program separate_compilation_44

--- a/integration_tests/separate_compilation_44a.f90
+++ b/integration_tests/separate_compilation_44a.f90
@@ -1,0 +1,29 @@
+module separate_compilation_44a_module
+    implicit none
+
+    type :: MyType
+        real(8) :: val
+    end type MyType
+
+    interface operator(**)
+        module procedure dpow
+        module procedure ipow
+    end interface operator(**)
+
+contains
+
+    function dpow(a, y) result(res)
+        type(MyType), intent(in) :: a
+        real(8),      intent(in) :: y
+        type(MyType)             :: res
+        res%val = a%val ** y
+    end function dpow
+
+    function ipow(a, n) result(res)
+        type(MyType), intent(in) :: a
+        integer(4),   intent(in) :: n
+        type(MyType)             :: res
+        res%val = a%val ** n
+    end function ipow
+
+end module separate_compilation_44a_module

--- a/integration_tests/separate_compilation_44b.f90
+++ b/integration_tests/separate_compilation_44b.f90
@@ -1,0 +1,16 @@
+module separate_compilation_44b_module
+    use separate_compilation_44a_module
+    implicit none
+
+contains
+
+    subroutine client()
+        type(MyType) :: a, b
+        a%val = 3.0d0
+        b = a ** 2
+        if (abs(b%val - 9.0d0) > 1.0d-12) error stop
+        b = a ** 2.0d0
+        if (abs(b%val - 9.0d0) > 1.0d-12) error stop
+    end subroutine client
+
+end module separate_compilation_44b_module

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1568,6 +1568,7 @@ public:
         {AST::operatorType::Add, "~add"},
         {AST::operatorType::Sub, "~sub"},
         {AST::operatorType::Div, "~div"},
+        {AST::operatorType::Pow, "~pow"},
     };
 
     std::map<AST::boolopType, std::string> boolop2str = {


### PR DESCRIPTION
The binop2str map was missing the Pow entry, so operator(**) overloading was never resolved. This caused an ICE when using a derived type with an overloaded ** operator in separate compilation, because the code fell through to implicit cast rules which cannot handle StructType.

Fixes #10523.