### PR TITLE
fix: only trigger exhaustive CI when Tests::Run-Exhaustive label is added

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -35,7 +35,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -101,7 +101,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -210,7 +210,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     strategy:
       fail-fast: false
       matrix:
@@ -568,7 +568,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -605,7 +605,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -631,7 +631,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -685,7 +685,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -741,7 +741,7 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive') &&
-           (github.event.action != 'labeled' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
+           (github.event.action == 'synchronize' || github.event.label.name == 'Tests::Run-Exhaustive')) }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes #10378

Previously, any `labeled` event (e.g. adding "needs review") would 
trigger all exhaustive CI jobs if the PR already had the 
`Tests::Run-Exhaustive` label on it.

Added a guard condition to all 8 jobs so exhaustive checks only 
fire when the label being added is specifically `Tests::Run-Exhaustive