### PR TITLE
Fix LLVM type confusion for local types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1732,6 +1732,7 @@ RUN(NAME select_type_34 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_36 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_38 LABELS gfortran llvm)
+RUN(NAME select_type_39 LABELS gfortran llvm)
 
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/select_type_39.f90
+++ b/integration_tests/select_type_39.f90
@@ -1,0 +1,67 @@
+! Test: two contained subroutines with same-named local derived types
+! combined with class(*) polymorphic allocation. Verifies that the
+! LLVM codegen correctly distinguishes types in different scopes.
+
+module select_type_39_mod
+  implicit none
+  type :: container
+    class(*), allocatable :: value(:)
+  end type
+  interface container
+    module procedure container_init
+  end interface
+contains
+  function container_init(value) result(obj)
+    class(*), intent(in) :: value(:)
+    type(container) :: obj
+    allocate(obj%value, source=value)
+  end function
+  subroutine get_value(this, value)
+    type(container), intent(in) :: this
+    class(*), allocatable, intent(out) :: value(:)
+    allocate(value, source=this%value)
+  end subroutine
+end module
+
+program select_type_39
+  use select_type_39_mod
+  implicit none
+  call test_sub1
+  call test_sub2
+contains
+  subroutine test_sub1
+    type(container) :: x
+    class(*), allocatable :: val(:)
+    type :: point
+      real :: x, y
+    end type
+    x = container([point(1.0, 2.0), point(3.0, 4.0)])
+    call get_value(x, val)
+    select type (val)
+    type is (point)
+      if (abs(val(1)%x - 1.0) > 1e-6) error stop
+      if (abs(val(1)%y - 2.0) > 1e-6) error stop
+      if (abs(val(2)%x - 3.0) > 1e-6) error stop
+      if (abs(val(2)%y - 4.0) > 1e-6) error stop
+    class default
+      error stop
+    end select
+  end subroutine
+
+  subroutine test_sub2
+    type(container) :: x
+    class(*), allocatable :: val(:)
+    type :: point
+      real :: x, y
+    end type
+    x = container([point(5.0, 6.0)])
+    call get_value(x, val)
+    select type (val)
+    type is (point)
+      if (abs(val(1)%x - 5.0) > 1e-6) error stop
+      if (abs(val(1)%y - 6.0) > 1e-6) error stop
+    class default
+      error stop
+    end select
+  end subroutine
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2149,17 +2149,21 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
             return "CPtr";
         }
         case ASR::ttypeType::StructType: {
-            // TODO: StructType
-            // ASR::StructType_t* d = ASR::down_cast<ASR::StructType_t>(t);
-            // if( ASRUtils::symbol_get_past_external(d->m_derived_type) ) {
-            //     res = symbol_name(ASRUtils::symbol_get_past_external(d->m_derived_type));
-            // } else {
-            //     res = symbol_name(d->m_derived_type);
-            // }
             ASR::StructType_t* struct_type = ASR::down_cast<ASR::StructType_t>(t);
             if ( expr != nullptr ) {
                 ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(expr));
                 res = symbol_name(sym);
+                if (sym != nullptr && !res.empty() && res[0] != '~' &&
+                        ASR::is_a<ASR::Struct_t>(*sym)) {
+                    ASR::Struct_t* struct_decl = ASR::down_cast<ASR::Struct_t>(sym);
+                    if (struct_decl->m_symtab && struct_decl->m_symtab->parent &&
+                            struct_decl->m_symtab->parent->asr_owner &&
+                            ASR::is_a<ASR::symbol_t>(*struct_decl->m_symtab->parent->asr_owner)) {
+                        ASR::symbol_t* parent_sym = ASR::down_cast<ASR::symbol_t>(
+                            struct_decl->m_symtab->parent->asr_owner);
+                        res = std::string(symbol_name(parent_sym)) + "." + res;
+                    }
+                }
             } else {
                 res = "StructType";
             }


### PR DESCRIPTION
When two contained subroutines defined the same-named local derived type and used class(*) polymorphic
allocation, the LLVM codegen confused their types
(e.g. %test_sub1.point vs %test_sub2.point).

The root cause was get_type_code() using bare
symbol_name() for StructType, producing the same
cache key for distinct locally-scoped types. This
caused the tkr2array cache to reuse the wrong LLVM array descriptor type.

Fix: qualify StructType names with parent scope in get_type_code(), matching the existing get_type_key() logic, while skipping internal sentinel types (~).