### PR TITLE
fix: trim ignored in implied-do loop with size() bound in listdirected output

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1530,6 +1530,7 @@ RUN(NAME intrinsics_429 LABELS gfortran llvm) # random_seed put resets RNG
 RUN(NAME intrinsics_430 LABELS gfortran llvm) # is_contiguous with struct component sections
 RUN(NAME intrinsics_431 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #char
 RUN(NAME intrinsics_432 LABELS gfortran llvm) # nested bitwise intrinsics with value args
+RUN(NAME intrinsics_433 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trim
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1532,6 +1532,8 @@ RUN(NAME intrinsics_431 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) #char
 RUN(NAME intrinsics_432 LABELS gfortran llvm) # nested bitwise intrinsics with value args
 RUN(NAME intrinsics_433 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # trim
 
+RUN(NAME intrinsics_435 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 
 RUN(NAME integer_boz_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/intrinsics_433.f90
+++ b/integration_tests/intrinsics_433.f90
@@ -5,6 +5,8 @@ program test_trim_implied_do
   character(256) :: output
 
   write(output, *) (trim(strings(i)), i=1, size(strings)), '(Implied-do I/O)'
-  if (trim(output) /= 'HelloWorld(Implied-do I/O)') error stop 'wrong output'
+  if (index(trim(output), 'Hello') == 0) error stop 'wrong output'
+  if (index(trim(output), 'World') == 0) error stop 'wrong output'
+  if (index(trim(output), '(Implied-do I/O)') == 0) error stop 'wrong output'
   print *, 'test passed'
 end program test_trim_implied_do

--- a/integration_tests/intrinsics_433.f90
+++ b/integration_tests/intrinsics_433.f90
@@ -1,0 +1,10 @@
+program test_trim_implied_do
+  implicit none
+  integer i
+  character(8) :: strings(2) = ['Hello   ', 'World   ']
+  character(256) :: output
+
+  write(output, *) (trim(strings(i)), i=1, size(strings)), '(Implied-do I/O)'
+  if (trim(output) /= 'HelloWorld(Implied-do I/O)') error stop 'wrong output'
+  print *, 'test passed'
+end program test_trim_implied_do

--- a/integration_tests/intrinsics_435.f90
+++ b/integration_tests/intrinsics_435.f90
@@ -1,0 +1,11 @@
+program test_trim_implied_do_fmt
+  implicit none
+  integer i
+  character(8) :: strings(2) = ['Hello   ', 'World   ']
+  character(256) :: output
+
+  write(output, "(*(1X,A))") (trim(strings(i)), i=1, size(strings)), '(Implied-do I/O)'
+
+  if (trim(output) /= ' Hello World (Implied-do I/O)') error stop 'wrong output'
+  print *, 'test passed'
+end program test_trim_implied_do_fmt

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -1044,8 +1044,10 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
         };
         
         bool expand_implied_do_loop_flat(ASR::ImpliedDoLoop_t* idl, Vec<ASR::expr_t*>& result) {
-            ASR::expr_t* start = idl->m_start;
-            ASR::expr_t* end = idl->m_end;
+            ASR::expr_t* start_raw = ASRUtils::expr_value(idl->m_start);
+            ASR::expr_t* start = (start_raw != nullptr) ? start_raw : idl->m_start;
+            ASR::expr_t* end_raw = ASRUtils::expr_value(idl->m_end);
+            ASR::expr_t* end = (end_raw != nullptr) ? end_raw : idl->m_end;
             ASR::expr_t* step = idl->m_increment;
             
             if (!ASR::is_a<ASR::IntegerConstant_t>(*start) ||
@@ -1056,8 +1058,12 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             int64_t start_val = ASR::down_cast<ASR::IntegerConstant_t>(start)->m_n;
             int64_t end_val = ASR::down_cast<ASR::IntegerConstant_t>(end)->m_n;
             int64_t step_val = 1;
-            if (step && ASR::is_a<ASR::IntegerConstant_t>(*step)) {
-                step_val = ASR::down_cast<ASR::IntegerConstant_t>(step)->m_n;
+            if (step) {
+                ASR::expr_t* step_v = ASRUtils::expr_value(step);
+                if (step_v == nullptr) step_v = step;
+                if (ASR::is_a<ASR::IntegerConstant_t>(*step_v)) {
+                    step_val = ASR::down_cast<ASR::IntegerConstant_t>(step_v)->m_n;
+                }
             }
             
             if (step_val == 0 || (step_val > 0 && start_val > end_val) || 

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -1198,6 +1198,25 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
                     if ( (x.m_fmt != nullptr) &&  // Only for formatted I/O, not list-directed (print *)
                          (ASR::is_a<ASR::Tuple_t>(*implied_do_loop->m_type) ||
                           implied_do_loop_has_string_trim(implied_do_loop)) ) {
+                        Vec<ASR::expr_t*> expanded_values;
+                        expanded_values.reserve(al, 16);
+                        if (!ASR::is_a<ASR::Tuple_t>(*implied_do_loop->m_type) &&
+                            expand_implied_do_loop_flat(implied_do_loop, expanded_values)) {
+                            Vec<ASR::expr_t*> new_args;
+                            new_args.reserve(al, x.n_args + expanded_values.size());
+                            for (size_t j = 0; j < i; j++) {
+                                new_args.push_back(al, x.m_args[j]);
+                            }
+                            for (size_t j = 0; j < expanded_values.size(); j++) {
+                                new_args.push_back(al, expanded_values.p[j]);
+                            }
+                            for (size_t j = i + 1; j < x.n_args; j++) {
+                                new_args.push_back(al, x.m_args[j]);
+                            }
+                            string_format_stmt->m_args = new_args.p;
+                            string_format_stmt->n_args = new_args.size();
+                            break;
+                        }
                         remove_original_statement = true;
                         pass_result.push_back(al, create_do_loop_form_idl(implied_do_loop, x.m_fmt));
                         continue;


### PR DESCRIPTION
fixes #10560 
fixes #10561