### PR TITLE
fix: preserve logical kind in ASR type construction

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1949,7 +1949,7 @@ RUN(NAME logical3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME logical4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME logical_casting_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
     EXTRA_ARGS --logical-casting NO_STD_F23)
-
+RUN(NAME logical5 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME tsunami LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME pdt_01 LABELS gfortran llvm)

--- a/integration_tests/logical5.f90
+++ b/integration_tests/logical5.f90
@@ -1,0 +1,15 @@
+program storage_size_logical_test
+  use, intrinsic :: iso_fortran_env
+  implicit none
+
+  logical(int8)  :: b8
+  logical(int16) :: b16
+  logical(int32) :: b32
+  logical(int64) :: b64
+
+  if (storage_size(b8) /= 8)  error stop "incorrect storage size of int8"
+  if (storage_size(b16) /= 16) error stop "incorrect storage size of int16"
+  if (storage_size(b32) /= 32) error stop "incorrect storage size of int32"
+  if (storage_size(b64) /= 64) error stop "incorrect storage size of int64"
+  print *, "test passed"
+end program storage_size_logical_test

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7932,9 +7932,12 @@ public:
             // currently we change the kind's of all logical's to
             // 'default_integer_kind'. GFortran support's logical's of
             // different kind's, we need to think about this
-            type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, compiler_options.po.default_integer_kind));
-            type = ASRUtils::make_Array_t_util(
-                al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
+            type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, a_kind));
+            if (is_assumed_rank) {
+                type = ASRUtils::TYPE(ASR::make_Array_t(al, loc, type, nullptr, 0, ASR::array_physical_typeType::AssumedRankArray));
+            } else {
+                type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size(), abi, is_argument, ASR::array_physical_typeType::DescriptorArray, false, is_dimension_star);
+            }
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc,
                     ASRUtils::type_get_past_allocatable(type)));

--- a/tests/reference/asr_openmp-openmp_37-2c7ae83.json
+++ b/tests/reference/asr_openmp-openmp_37-2c7ae83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_37-2c7ae83.stdout",
-    "stdout_hash": "0e6b9a17b85b02ba54cedc02601d355ea1b08e7cb82441253d8a000b",
+    "stdout_hash": "f30e731b64030667e790dfc23a4d164cdd812fb151bd281e458ee1f7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_37-2c7ae83.stdout
+++ b/tests/reference/asr_openmp-openmp_37-2c7ae83.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()

--- a/tests/reference/asr_openmp-openmp_38-2731560.json
+++ b/tests/reference/asr_openmp-openmp_38-2731560.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_38-2731560.stdout",
-    "stdout_hash": "588ecf512047bef1590f437384c472cb7d4656f741c6d6c649701abc",
+    "stdout_hash": "4d7f993873e0fdb459365988f6d538411a8437694349ab8fdfb33a8f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_38-2731560.stdout
+++ b/tests/reference/asr_openmp-openmp_38-2731560.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()

--- a/tests/reference/asr_openmp-openmp_39-aaf2ba8.json
+++ b/tests/reference/asr_openmp-openmp_39-aaf2ba8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_39-aaf2ba8.stdout",
-    "stdout_hash": "2ffba90e5c7168c18218162c1b41b5ff6d779748a83c54a07d88e945",
+    "stdout_hash": "97731059c2e8c44e5bc03ae515d4396e7212aacf02af6deedcbeea98",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_39-aaf2ba8.stdout
+++ b/tests/reference/asr_openmp-openmp_39-aaf2ba8.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()

--- a/tests/reference/asr_openmp-openmp_44-1c0f6fe.json
+++ b/tests/reference/asr_openmp-openmp_44-1c0f6fe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_44-1c0f6fe.stdout",
-    "stdout_hash": "9dd7378de5d1c728c9bb3cc72e06b7f44368afdf8d6c56786099adcc",
+    "stdout_hash": "960a7143e1740f081bcb82f6ec2841b9501cb0adb17e11d09a352f26",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_44-1c0f6fe.stdout
+++ b/tests/reference/asr_openmp-openmp_44-1c0f6fe.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()

--- a/tests/reference/asr_openmp-openmp_45-1c0e790.json
+++ b/tests/reference/asr_openmp-openmp_45-1c0e790.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_45-1c0e790.stdout",
-    "stdout_hash": "39d1dae7ce7059cdc1fe238ba8d41b92382f7618ab5a8d35a3320ed4",
+    "stdout_hash": "4185b365ae5f47964d4d6bbb0199a74615ce8bf94f839cc912cbb19d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_45-1c0e790.stdout
+++ b/tests/reference/asr_openmp-openmp_45-1c0e790.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()

--- a/tests/reference/asr_openmp-openmp_46-1b93fa8.json
+++ b/tests/reference/asr_openmp-openmp_46-1b93fa8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_openmp-openmp_46-1b93fa8.stdout",
-    "stdout_hash": "63ba53a2004e6989a747bfff755aa5a96ad8bb967d3e4a264fdd4411",
+    "stdout_hash": "ddc31deb17e6465f7229659d2b2ab446bd6d6b9735302b39594a3c4e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr_openmp-openmp_46-1b93fa8.stdout
+++ b/tests/reference/asr_openmp-openmp_46-1b93fa8.stdout
@@ -228,7 +228,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -287,7 +287,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_next"
@@ -344,7 +344,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -448,7 +448,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_auto_start"
@@ -487,7 +487,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -546,7 +546,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_next"
@@ -624,7 +624,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -729,7 +729,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_dynamic_start"
@@ -831,7 +831,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -890,7 +890,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_next"
@@ -968,7 +968,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1073,7 +1073,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_guided_start"
@@ -1113,7 +1113,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1172,7 +1172,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_next"
@@ -1229,7 +1229,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1333,7 +1333,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_runtime_start"
@@ -1372,7 +1372,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1431,7 +1431,7 @@
                                     (FunctionType
                                         [(Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_next"
@@ -1509,7 +1509,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     Source
                                                     Public
@@ -1614,7 +1614,7 @@
                                         (Integer 8)
                                         (Integer 8)
                                         (Integer 8)]
-                                        (Logical 4)
+                                        (Logical 1)
                                         BindC
                                         Interface
                                         "GOMP_loop_static_start"
@@ -2075,7 +2075,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Logical 4)
+                                                    (Logical 1)
                                                     ()
                                                     BindC
                                                     Public
@@ -2095,7 +2095,7 @@
                                         (CPtr)
                                         (Integer 8)
                                         (Integer 8)
-                                        (Logical 4)
+                                        (Logical 1)
                                         (Integer 4)
                                         (CPtr)]
                                         ()


### PR DESCRIPTION
fixes #10581 