### PR TITLE
Fix class(*) char array writes lost in select type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1731,6 +1731,7 @@ RUN(NAME select_type_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_38 LABELS gfortran llvm)
 RUN(NAME select_type_39 LABELS gfortran llvm)
 RUN(NAME select_type_40 LABELS gfortran llvm)
+RUN(NAME select_type_41 LABELS gfortran llvm)
 
 RUN(NAME select_type_42 LABELS gfortran llvm)
 

--- a/integration_tests/select_type_41.f90
+++ b/integration_tests/select_type_41.f90
@@ -1,0 +1,23 @@
+! Test that writes to a class(*) character array through
+! a select type selector persist after end select.
+program select_type_41
+    implicit none
+    class(*), allocatable :: arr(:)
+    allocate(character(3) :: arr(2))
+
+    ! Write through first select type block
+    select type (arr)
+    type is (character(*))
+        arr(1) = "foo"
+        arr(2) = "bar"
+    end select
+
+    ! Read back through second select type block
+    select type (arr)
+    type is (character(*))
+        if (arr(1) /= "foo") error stop
+        if (arr(2) /= "bar") error stop
+    end select
+
+    print *, "PASS"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -275,6 +275,12 @@ public:
     Vec<llvm::Value*> strings_to_be_deallocated;
     Vec<llvm::Value*> heap_fixed_size_arrays;  // Heap-allocated large fixed-size arrays for cleanup
     bool in_block_context = false;  // Flag to track if we're inside a BLOCK construct
+    struct CharConsolidationWriteback {
+        llvm::Value* original_descs_i8;
+        llvm::Value* consolidated_desc;
+        llvm::Value* n_elems_i64;
+    };
+    std::vector<CharConsolidationWriteback> pending_char_writebacks;
     struct to_be_allocated_array{ // struct to hold details for the initializing pointer_to_array_type later inside main function.
         ASR::expr_t* expr;
         llvm::Constant* pointer_to_array_type;
@@ -8563,8 +8569,11 @@ public:
                                                     value_array_desc_type, llvm_value, nullptr, 4);
                                                 llvm::Value* n_elems_i64 = builder->CreateSExt(
                                                     n_elems, llvm::Type::getInt64Ty(context));
+                                                llvm::Value* orig_descs = loaded_data_ptr;
                                                 loaded_data_ptr = llvm_utils->consolidate_char_descriptors(
                                                     loaded_data_ptr, n_elems_i64);
+                                                pending_char_writebacks.push_back(
+                                                    {orig_descs, loaded_data_ptr, n_elems_i64});
                                             } else {
                                                 loaded_data_ptr = builder->CreateBitCast(
                                                     loaded_data_ptr, target_el_type->getPointerTo());
@@ -10852,6 +10861,7 @@ public:
         // BLOCK arrays always use heap allocation (can be in loops)
         // Track allocations separately for cleanup at BLOCK exit
         size_t heap_arrays_before = heap_fixed_size_arrays.n;
+        size_t wb_before = pending_char_writebacks.size();
         in_block_context = true;
         declare_vars(*block);
         in_block_context = false;
@@ -10860,6 +10870,15 @@ public:
         for (size_t i = 0; i < block->n_body; i++) {
             this->visit_stmt(*(block->m_body[i]));
         }
+
+        // Write back consolidated character data to original polymorphic
+        // per-element string descriptors (select type char array fix).
+        for (size_t i = wb_before; i < pending_char_writebacks.size(); i++) {
+            auto& wb = pending_char_writebacks[i];
+            llvm_utils->writeback_char_to_polymorphic_descriptors(
+                wb.original_descs_i8, wb.consolidated_desc, wb.n_elems_i64);
+        }
+        pending_char_writebacks.resize(wb_before);
 
         start_new_block(blockend);
         // Finalize struct members before freeing the backing array memory

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3188,6 +3188,39 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
         return result;
     }
 
+    void LLVMUtils::writeback_char_to_polymorphic_descriptors(
+            llvm::Value* original_descs_i8, llvm::Value* consolidated_desc,
+            llvm::Value* n_elems_i64) {
+        llvm::Type* str_desc_ty = string_descriptor;
+        llvm::Type* i64_ty = llvm::Type::getInt64Ty(context);
+        llvm::Type* i8_ty = llvm::Type::getInt8Ty(context);
+
+        llvm::Value* descs = builder->CreateBitCast(
+            original_descs_i8, str_desc_ty->getPointerTo());
+        llvm::Value* flat_buf = CreateLoad2(character_type,
+            create_gep2(str_desc_ty, consolidated_desc, 0));
+        llvm::Value* char_len = CreateLoad2(i64_ty,
+            create_gep2(str_desc_ty, consolidated_desc, 1));
+
+        llvm::Value* idx = CreateAlloca(*builder, i64_ty);
+        builder->CreateStore(llvm::ConstantInt::get(i64_ty, 0), idx);
+        create_loop("char_writeback", [&]() {
+            return builder->CreateICmpSLT(
+                CreateLoad2(i64_ty, idx), n_elems_i64);
+        }, [&]() {
+            llvm::Value* i = CreateLoad2(i64_ty, idx);
+            llvm::Value* src_off = builder->CreateMul(i, char_len);
+            llvm::Value* src_chars = builder->CreateGEP(i8_ty, flat_buf, src_off);
+            llvm::Value* dst_desc = create_ptr_gep2(str_desc_ty, descs, i);
+            llvm::Value* dst_chars = CreateLoad2(character_type,
+                create_gep2(str_desc_ty, dst_desc, 0));
+            builder->CreateMemCpy(dst_chars, llvm::MaybeAlign(),
+                src_chars, llvm::MaybeAlign(), char_len);
+            builder->CreateStore(
+                builder->CreateAdd(i, llvm::ConstantInt::get(i64_ty, 1)), idx);
+        });
+    }
+
     llvm::Value* LLVMUtils::expand_flat_to_char_descriptors(
             llvm::Value* flat_data, llvm::Value* char_len,
             llvm::Value* n_elems_i64) {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -732,6 +732,12 @@ class ASRToLLVMVisitor;
             llvm::Value* consolidate_char_descriptors(
                 llvm::Value* descs_i8, llvm::Value* n_elems_i64);
 
+            // Write back consolidated flat char buffer to original
+            // per-element string_descriptors in a polymorphic array.
+            void writeback_char_to_polymorphic_descriptors(
+                llvm::Value* original_descs_i8, llvm::Value* consolidated_desc,
+                llvm::Value* n_elems_i64);
+
             // Expand a flat char buffer into per-element string_descriptors.
             llvm::Value* expand_flat_to_char_descriptors(
                 llvm::Value* flat_data, llvm::Value* char_len,


### PR DESCRIPTION
`consolidate_char_descriptors()` copies character data from per-element string descriptors into a flat buffer. Writes inside select type went to the copy, not the original.

Add `writeback_char_to_polymorphic_descriptors()` which copies modified data from the flat buffer back to the original per-element descriptors at the end of the select type block.

This conversion back and forth is needed until we refactor the array of wrappers (#10542).