### PR TITLE
doc: add --no-style-suggestions flag to man page

### DIFF
--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -58,6 +58,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--time-report`: Show compilation time report
 - `--static`: Create a static executable
 - `--no-warnings`: Turn off all warnings
+- `--no-style-suggestions`: Turn off style suggestions
 - `--no-error-banner`: Turn off error banner
 - `--continue-compilation`: Collect error messages and continue compilation after encountering semantic errors
 - `--error-format TEXT=human`: Control how errors are produced (human, short)


### PR DESCRIPTION
Fixes #10602

## Summary

- Added the `--no-style-suggestions` flag description to the man page (`doc/man/lfortran.md`), placed alongside the related `--no-warnings` flag.

## Test 
- Verified the flag description matches the help text defined in `src/bin/lfortran_command_line_parser.cpp`.
- No code changes; documentation only.
