### PR TITLE
fix: rename function in developer_tutorial notebook to avoid duplicate

### DIFF
--- a/doc/build.py
+++ b/doc/build.py
@@ -148,6 +148,7 @@ def build_docs(language: str) -> None:
             f"-Dlanguage={language}",
         ],
         cwd=root,
+        check=True,
     )
 
 

--- a/doc/src/developer_tutorial.ipynb
+++ b/doc/src/developer_tutorial.ipynb
@@ -109,7 +109,7 @@
    "outputs": [],
    "source": [
     "%%showasr\n",
-    "integer function f(a, b) result(r)\n",
+    "integer function f2(a, b) result(r)\n",
     "integer, intent(in) :: a, b\n",
     "r = a + b\n",
     "end function"


### PR DESCRIPTION
The %%showasr cell in developer_tutorial.ipynb reused the function name
'f' already defined in an earlier cell.  After commit 545aa01b3e5adfb23a32187212b832d7862e25ad added
stricter duplicate-procedure checking, this triggered 'Procedure f is
already defined as an interface body'.  Rename the function to f2 in the
%%showasr cell.

Also add check=True to doc/build.py so Sphinx failures abort the build
instead of silently deploying broken documentation.

Fixes #10598.