### PR TITLE
Fix segfault in allocate for class arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2193,6 +2193,7 @@ RUN(NAME allocate_53 LABELS gfortran llvm)
 RUN(NAME allocate_54 LABELS gfortran llvm)
 RUN(NAME allocate_55 LABELS gfortran llvm)
 RUN(NAME allocate_56 LABELS gfortran llvm)
+RUN(NAME allocate_57 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_57.f90
+++ b/integration_tests/allocate_57.f90
@@ -1,0 +1,57 @@
+! Test: allocate with source= for a derived type containing
+! a polymorphic allocatable array component (class(T), allocatable :: a(:)).
+! Previously caused a segfault because the destination class array elements
+! had uninitialized vtable and data pointers during deep copy.
+program allocate_57
+    implicit none
+
+    type :: base_t
+        integer :: val = 0
+    end type base_t
+
+    type :: container_t
+        class(base_t), allocatable :: items(:)
+    end type container_t
+
+    type(container_t), allocatable :: x
+    type(container_t) :: y
+
+    ! Test 1: allocate with source= from a function result
+    allocate(x, source = make_container(3))
+    if (.not. allocated(x)) error stop
+    if (.not. allocated(x%items)) error stop
+    if (size(x%items) /= 3) error stop
+    if (x%items(1)%val /= 10) error stop
+    if (x%items(2)%val /= 20) error stop
+    if (x%items(3)%val /= 30) error stop
+    print *, "Test 1 passed: allocate with source= from function"
+
+    ! Test 2: allocate with source= from a variable
+    y = make_container(2)
+    deallocate(x)
+    allocate(x, source = y)
+    if (size(x%items) /= 2) error stop
+    if (x%items(1)%val /= 10) error stop
+    if (x%items(2)%val /= 20) error stop
+    print *, "Test 2 passed: allocate with source= from variable"
+
+    ! Test 3: verify deep copy (modifying source doesn't affect copy)
+    y%items(1)%val = 999
+    if (x%items(1)%val /= 10) error stop
+    print *, "Test 3 passed: deep copy independence"
+
+    print *, "All tests passed!"
+
+contains
+
+    function make_container(n) result(r)
+        integer, intent(in) :: n
+        type(container_t) :: r
+        integer :: i
+        allocate(r%items(n))
+        do i = 1, n
+            r%items(i)%val = i * 10
+        end do
+    end function make_container
+
+end program allocate_57

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -9682,9 +9682,11 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
 
             bool is_upoly = ASRUtils::is_unlimited_polymorphic_type(struct_sym);
 
-            if (ASRUtils::is_allocatable(src_expr) && !is_upoly) {
+            if (ASRUtils::is_allocatable(src_expr) && !is_upoly
+                    && !(is_src_class || is_dest_class)) {
                 // Check if src_data is not null before realloc operations
-                // (For upoly, reallocation is handled in the deepcopy block below)
+                // (For upoly and class arrays, reallocation is handled in
+                // their dedicated deepcopy blocks below)
                 llvm::Value* src_data_not_null = builder->CreateICmpNE(
                     src_data, llvm::Constant::getNullValue(src_data->getType()));
                 llvm_utils->create_if_else(src_data_not_null, [&]() {
@@ -9763,6 +9765,78 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                 return;
             }
 
+            // Non-upoly class arrays also use ONE-wrapper layout:
+            // a single wrapper {vptr, data_ptr} where data_ptr points to
+            // a contiguous buffer of N elements. Use compile-time elem_size.
+            if (is_src_class && is_dest_class) {
+                llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
+                    struct_sym->m_struct_signature, &struct_sym->base, module);
+                llvm::DataLayout dl(module->getDataLayout());
+                uint64_t elem_size = dl.getTypeAllocSize(actual_struct_type);
+                llvm::Type* i64_ty = llvm::Type::getInt64Ty(context);
+
+                // Extract source wrapper fields
+                llvm::Value* src_vptr = llvm_utils->CreateLoad2(llvm_utils->vptr_type,
+                    builder->CreateBitCast(src_data, llvm_utils->vptr_type->getPointerTo()));
+                llvm::Value* src_raw_data = llvm_utils->CreateLoad2(
+                    actual_struct_type->getPointerTo(),
+                    llvm_utils->create_gep2(llvm_data_type, src_data, 1));
+                src_raw_data = builder->CreateBitCast(src_raw_data,
+                    llvm::Type::getInt8Ty(context)->getPointerTo());
+
+                // Get copy function from vtable
+                llvm::Value* fn = llvm_utils->CreateLoad2(
+                    llvm::FunctionType::get(llvm_utils->getIntType(4), {}, true)->getPointerTo(),
+                    src_vptr);
+                fn = builder->CreateBitCast(fn, fnPtrTy);
+
+                // Allocate dest data buffer = num_elements * elem_size
+                llvm::Value* num_elems_64 = builder->CreateSExtOrTrunc(num_elements, i64_ty);
+                llvm::Value* total_bytes = builder->CreateMul(num_elems_64,
+                    llvm::ConstantInt::get(i64_ty, elem_size));
+                llvm::Value* dest_raw_data = llvm_utils->allocate_zeroed_bytes(total_bytes);
+
+                // Ensure dest has a wrapper allocated
+                llvm::Value* dest_wrapper = dest_data;
+                if (ASRUtils::is_allocatable(src_expr) ||
+                        ASRUtils::is_allocatable(dest_ty)) {
+                    dest_wrapper = llvm_utils->alloc_zeroed_type(llvm_data_type);
+                    builder->CreateStore(dest_wrapper,
+                        llvm_utils->arr_api->get_pointer_to_data(llvm_array_type, dest));
+                }
+
+                // Copy vptr and store data pointer in dest wrapper
+                builder->CreateStore(src_vptr, builder->CreateBitCast(
+                    dest_wrapper, llvm_utils->vptr_type->getPointerTo()));
+                builder->CreateStore(
+                    builder->CreateBitCast(dest_raw_data, actual_struct_type->getPointerTo()),
+                    llvm_utils->create_gep2(llvm_data_type, dest_wrapper, 1));
+
+                // Loop: copy each element using byte offsets
+                llvm::Value* ui = llvm_utils->CreateAlloca(*builder, i64_ty);
+                builder->CreateStore(llvm::ConstantInt::get(i64_ty, 0), ui);
+                llvm_utils->create_loop("class_deepcopy", [&]() {
+                    return builder->CreateICmpSLT(
+                        llvm_utils->CreateLoad2(i64_ty, ui), num_elems_64);
+                }, [&]() {
+                    llvm::Value* ui_val = llvm_utils->CreateLoad2(i64_ty, ui);
+                    llvm::Value* byte_offset = builder->CreateMul(ui_val,
+                        llvm::ConstantInt::get(i64_ty, elem_size));
+                    llvm::Value* src_elem = builder->CreateGEP(
+                        llvm::Type::getInt8Ty(context), src_raw_data, byte_offset);
+                    llvm::Value* dest_elem = builder->CreateGEP(
+                        llvm::Type::getInt8Ty(context), dest_raw_data, byte_offset);
+                    builder->CreateCall(fnTy, fn, {src_elem, dest_elem});
+                    builder->CreateStore(
+                        builder->CreateAdd(ui_val, llvm::ConstantInt::get(i64_ty, 1)), ui);
+                });
+
+                if (is_descriptor_array) {
+                    copy_dimension_descriptors(llvm_array_type, src, dest, module);
+                }
+                return;
+            }
+
             llvm::Value* fn = nullptr;
             {
                 llvm::Value* vtable_ptr = get_pointer_to_method(&struct_sym->base, module);
@@ -9794,7 +9868,7 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
             i_val = llvm_utils->CreateLoad2(index_type, i);
             llvm::Value* src_elem_ptr  = builder->CreateInBoundsGEP(llvm_data_type, src_data, i_val);
             llvm::Value* dest_elem_ptr = builder->CreateInBoundsGEP(llvm_data_type, dest_data, i_val);
-            if (!is_src_class && !is_dest_class) {
+            {
                     // Elements are plain structs (declared as type(), not
                     // class()), so they have no class wrapper.  Copy each
                     // element directly via deepcopy on the element type.
@@ -9805,44 +9879,6 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                     }
                     llvm_utils->deepcopy(src_expr, src_elem_ptr, dest_elem_ptr,
                         elem_type, ASRUtils::extract_type(dest_ty), module);
-                } else {
-                    // For class arrays, call allocate_struct_array_members
-                    // BEFORE unwrapping the class wrapper, because the function
-                    // expects a class pointer and will unwrap it internally.
-                    if (is_descriptor_array) {
-                        allocate_struct_array_members(
-                            struct_sym, dest_elem_ptr, ASRUtils::extract_type(src_ty), false);
-                    }
-
-                    // Get actual struct from class wrapper
-                    if (is_src_class) {
-                        llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
-                            struct_sym->m_struct_signature, &struct_sym->base, module);
-                        src_elem_ptr =  llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                            llvm_utils->create_gep2(llvm_data_type, src_elem_ptr, 1));
-                    }
-                    if (is_dest_class) {
-                        llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
-                            struct_sym->m_struct_signature, &struct_sym->base, module);
-                        if (ASRUtils::is_allocatable(dest_ty)) {
-                            llvm::DataLayout data_layout(module->getDataLayout());
-                            int64_t type_size = data_layout.getTypeAllocSize(actual_struct_type);
-                            llvm::Value* malloc_size = llvm::ConstantInt::get(
-                                llvm_utils->getIntType(4), llvm::APInt(32, type_size));
-                            llvm::Value* malloc_ptr = LLVMArrUtils::lfortran_malloc(
-                                context, *module, *builder, malloc_size);
-                            builder->CreateMemSet(malloc_ptr, llvm::ConstantInt::get(
-                                context, llvm::APInt(8, 0)), malloc_size, llvm::MaybeAlign());
-                            builder->CreateStore(builder->CreateBitCast(malloc_ptr, actual_struct_type->getPointerTo()),
-                                llvm_utils->create_gep2(llvm_data_type, dest_elem_ptr, 1));
-                        }
-                        dest_elem_ptr =  llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                            llvm_utils->create_gep2(llvm_data_type, dest_elem_ptr, 1));
-                    }
-
-                    src_elem_ptr = builder->CreateBitCast(src_elem_ptr, llvm_utils->i8_ptr);
-                    dest_elem_ptr = builder->CreateBitCast(dest_elem_ptr, llvm_utils->i8_ptr);
-                    builder->CreateCall(fnTy, fn, {src_elem_ptr, dest_elem_ptr});
                 }
 
             llvm::Value* i_next = builder->CreateAdd(i_val, llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)));


### PR DESCRIPTION
The deep copy of polymorphic (class) allocatable array components used the wrong memory layout model. Class arrays use a ONE-wrapper layout: a single {vptr, data_ptr} wrapper where data_ptr points to a contiguous buffer of N elements. The deep copy code incorrectly treated them as N separate wrappers, causing out-of-bounds access for arrays with 2+ elements.

Fix: add a dedicated class array deep copy path (similar to the existing unlimited polymorphic path) that correctly handles the ONE-wrapper layout with compile-time element size. Skip the N-wrapper realloc for class arrays since they only have one wrapper.

An integration test (allocate_56) is added covering allocate with source= from both function results and variables, with multi-element arrays and deep copy independence verification.

Fixes #10617.