### PR TITLE
Fix codegen for deferred type-bound assignment on polymorphic types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2111,6 +2111,7 @@ RUN(NAME derived_types_121 LABELS gfortran llvm
         EXTRAFILES derived_types_121_module.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME derived_types_122 LABELS gfortran llvm)
 RUN(NAME derived_types_123 LABELS gfortran llvm EXTRA_ARGS -g GFORTRAN_ARGS -g)
+RUN(NAME derived_types_124 LABELS gfortran llvm)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_124.f90
+++ b/integration_tests/derived_types_124.f90
@@ -1,0 +1,60 @@
+module derived_types_124_mod
+    implicit none
+
+    type, abstract :: BaseType
+    contains
+        procedure(assign_iface), deferred :: assign_impl
+        generic, public :: assignment(=) => assign_impl
+    end type BaseType
+
+    abstract interface
+        subroutine assign_iface(self, other)
+            import
+            class(BaseType), intent(out) :: self
+            class(BaseType), intent(in)  :: other
+        end subroutine assign_iface
+    end interface
+
+    type, extends(BaseType) :: ConcreteType
+        integer :: val = 0
+    contains
+        procedure :: assign_impl => concrete_assign
+    end type ConcreteType
+
+contains
+
+    subroutine concrete_assign(self, other)
+        class(ConcreteType), intent(out) :: self
+        class(BaseType), intent(in) :: other
+        select type(other)
+        type is (ConcreteType)
+            self%val = other%val + 10
+        end select
+    end subroutine concrete_assign
+
+    subroutine test_polymorphic_assignment()
+        class(BaseType), allocatable :: a, b
+        allocate(ConcreteType :: a)
+        allocate(ConcreteType :: b)
+        select type(b)
+        type is (ConcreteType)
+            b%val = 5
+        end select
+        a = b
+        select type(a)
+        type is (ConcreteType)
+            print *, a%val
+            if (a%val /= 15) error stop
+        class default
+            error stop
+        end select
+    end subroutine test_polymorphic_assignment
+
+end module derived_types_124_mod
+
+program derived_types_124
+    use derived_types_124_mod
+    implicit none
+    call test_polymorphic_assignment()
+    print *, "PASS"
+end program derived_types_124

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2021,11 +2021,41 @@ bool use_overloaded_assignment(ASR::expr_t* target, ASR::expr_t* value,
                 }
                 case ASR::symbolType::StructMethodDeclaration: {
                     ASR::StructMethodDeclaration_t* class_proc = ASR::down_cast<ASR::StructMethodDeclaration_t>(proc);
-                    ASR::symbol_t* proc_func = ASR::down_cast<ASR::StructMethodDeclaration_t>(proc)->m_proc;
+                    ASR::symbol_t* proc_func = class_proc->m_proc;
                     process_overloaded_assignment_function(proc_func, target, value, target_type,
                         value_type, found, al, target->base.loc, value->base.loc, curr_scope,
                         current_function_dependencies, current_module_dependencies, asr, proc_func, loc,
                         expr_dt, err, class_proc->m_self_argument);
+                    if (found && expr_dt && ASRUtils::is_class_type(
+                            ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(expr_dt)))) {
+                        // For polymorphic (class) types, create a type-bound call
+                        // referencing the StructMethodDeclaration with m_dt set,
+                        // so codegen can use vtable dispatch.
+                        std::string method_name = std::string(class_proc->m_name) + "@~assign";
+                        ASR::symbol_t* ext_sym = curr_scope->get_symbol(method_name);
+                        if (ext_sym == nullptr) {
+                            ext_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(
+                                al, loc, curr_scope, s2c(al, method_name), proc,
+                                ASRUtils::symbol_name(ASRUtils::get_asr_owner(proc)),
+                                nullptr, 0, class_proc->m_name, ASR::accessType::Public));
+                            curr_scope->add_symbol(method_name, ext_sym);
+                        }
+                        if (ASRUtils::symbol_parent_symtab(ext_sym)->get_counter() != curr_scope->get_counter()) {
+                            ADD_ASR_DEPENDENCIES_WITH_NAME(curr_scope, ext_sym, current_function_dependencies, s2c(al, method_name));
+                        }
+                        ASRUtils::insert_module_dependency(ext_sym, al, current_module_dependencies);
+
+                        ASR::expr_t* non_pass_arg = (expr_dt == target) ? value : target;
+                        Vec<ASR::call_arg_t> a_args;
+                        a_args.reserve(al, 1);
+                        ASR::call_arg_t arg;
+                        arg.loc = non_pass_arg->base.loc;
+                        arg.m_value = non_pass_arg;
+                        a_args.push_back(al, arg);
+
+                        asr = ASRUtils::make_SubroutineCall_t_util(al, loc, ext_sym, ext_sym,
+                            a_args.p, 1, expr_dt, nullptr, false);
+                    }
                     break;
                 }
                 default: {


### PR DESCRIPTION
When an overloaded assignment(=) was resolved through a deferred type-bound procedure on a class (polymorphic) variable, the semantics created a SubroutineCall referencing the abstract interface function directly with no m_dt. This caused the LLVM codegen to fail with 'Subroutine code not generated' since the abstract function has no body.

Fix: in use_overloaded_assignment, when the resolved procedure is a StructMethodDeclaration and the target is a class type, create a proper type-bound SubroutineCall that references the StructMethodDeclaration with m_dt set, enabling vtable-based dynamic dispatch in codegen.

An integration test (derived_types_124) is added.

Fixes #10620.