### PR TITLE
Fix list-directed internal read with multiple values

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3015,13 +3015,11 @@ RUN(NAME read_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_50 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_51 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_52 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-
-
-
 RUN(NAME read_53 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME read_54 LABELS gfortran llvm)
 RUN(NAME read_55 LABELS gfortran llvm)
 RUN(NAME read_56 LABELS gfortran llvm)
+RUN(NAME read_57 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_57.f90
+++ b/integration_tests/read_57.f90
@@ -1,0 +1,47 @@
+program read_57
+  ! Test list-directed internal read with multiple values of mixed types
+  implicit none
+  character(len=20) :: line
+  integer :: x, y
+  character(1) :: c
+  real :: r
+  character(len=5) :: s
+
+  ! Integer then character
+  line = '1 A'
+  read(line, *) x, c
+  if (x /= 1) error stop
+  if (c /= 'A') error stop
+
+  ! Two integers
+  line = '10 20'
+  read(line, *) x, y
+  if (x /= 10) error stop
+  if (y /= 20) error stop
+
+  ! Integer then real
+  line = '3 2.5'
+  read(line, *) x, r
+  if (x /= 3) error stop
+  if (abs(r - 2.5) > 1.0e-6) error stop
+
+  ! Comma-separated values
+  line = '7,8'
+  read(line, *) x, y
+  if (x /= 7) error stop
+  if (y /= 8) error stop
+
+  ! Three values: integer, real, character
+  line = '42 3.14 Z'
+  read(line, *) x, r, c
+  if (x /= 42) error stop
+  if (abs(r - 3.14) > 0.01) error stop
+  if (c /= 'Z') error stop
+
+  ! Single value (regression: should still work)
+  line = '99'
+  read(line, *) x
+  if (x /= 99) error stop
+
+  print *, 'PASS'
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -14844,6 +14844,18 @@ public:
             emit_formatted_read(x, unit_val, iostat, read_size, advance, advance_length, is_string);
         } else {
             llvm::Value* var_to_read_into = nullptr; // Var expression that we'll read into.
+            // For multi-value list-directed internal reads, track position
+            llvm::Value *str_offset = nullptr;
+            llvm::Value *str_src_data = nullptr, *str_src_len = nullptr;
+            if (is_string) {
+                str_offset = llvm_utils->CreateAlloca(*builder,
+                    llvm::Type::getInt64Ty(context), nullptr, "str_read_offset");
+                builder->CreateStore(
+                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), 0),
+                    str_offset);
+                std::tie(str_src_data, str_src_len) = llvm_utils->get_string_length_data(
+                    ASRUtils::get_string_type(x.m_unit), unit_val);
+            }
             for (size_t i=0; i<x.n_values; i++) {
                 // Handle ImpliedDoLoop: read(10,*) (vals(j), j=1,n)
                 // Transform to reading n elements into vals starting at start index
@@ -15006,7 +15018,6 @@ public:
                     var_to_read_into = llvm_symtab[h];
                 }
                 if (is_string) {
-                    // TODO: Support multiple arguments and fmt
                     std::string runtime_func_name = "_lfortran_string_read_" +
                                             ASRUtils::type_to_str_python_expr(ASRUtils::extract_type(type), x.m_values[i]);
                     if (ASRUtils::is_array(type)) {
@@ -15022,7 +15033,8 @@ public:
                                     character_type /*src_data*/,
                                     llvm::Type::getInt64Ty(context) /*src_length*/,
                                     character_type /*dest_data*/,
-                                    llvm::Type::getInt64Ty(context) /*dest_length*/
+                                    llvm::Type::getInt64Ty(context) /*dest_length*/,
+                                    llvm::Type::getInt64Ty(context)->getPointerTo() /*offset*/
                                 },
                                 false);
                         } else if (ASRUtils::is_array(type)) {
@@ -15049,7 +15061,8 @@ public:
                                         ASRUtils::type_get_past_allocatable_pointer(type),
                                         module.get()
                                     )->getPointerTo(),
-                                    llvm::Type::getInt32Ty(context)->getPointerTo() /*iostat*/
+                                    llvm::Type::getInt32Ty(context)->getPointerTo() /*iostat*/,
+                                    llvm::Type::getInt64Ty(context)->getPointerTo() /*offset*/
                                 },
                                 false);
                         }
@@ -15082,15 +15095,12 @@ public:
                         fmt = complex_type->m_kind == 4 ? LCompilers::create_global_string_ptr(context, *module, *builder, " (%f,%f)")
                                                        : LCompilers::create_global_string_ptr(context, *module, *builder, " (%lf,%lf)");
                     }
-                    llvm::Value *src_data, *src_len;
-                    std::tie(src_data, src_len) = llvm_utils->get_string_length_data(
-                        ASRUtils::get_string_type(x.m_unit), unit_val);
 
                     if(ASRUtils::is_string_only(type)){
                         llvm::Value* dest_data, *dest_len;
                         std::tie(dest_data, dest_len) = llvm_utils->get_string_length_data(
                             ASRUtils::get_string_type(x.m_values[i]), var_to_read_into);
-                        builder->CreateCall(fn, { src_data, src_len, dest_data, dest_len });
+                        builder->CreateCall(fn, { str_src_data, str_src_len, dest_data, dest_len, str_offset });
                     } else if (ASRUtils::is_array(type)) {
                         llvm::Value* arr_data = var_to_read_into;
                         if (ASR::is_a<ASR::Allocatable_t>(*type) ||
@@ -15119,7 +15129,7 @@ public:
                                 arr_data = builder->CreateBitCast(arr_data, fn_param_type);
                             }
                         }
-                        builder->CreateCall(fn, { src_data, src_len, fmt, arr_data });
+                        builder->CreateCall(fn, { str_src_data, str_src_len, fmt, arr_data });
                     } else {
                         if (ASR::is_a<ASR::Allocatable_t>(*type) ||
                                 ASR::is_a<ASR::Pointer_t>(*type)) {
@@ -15129,8 +15139,7 @@ public:
                                 module.get())->getPointerTo();
                             var_to_read_into = llvm_utils->CreateLoad2(t, var_to_read_into);
                         }
-                        // iostat is already i32*
-                        builder->CreateCall(fn, { src_data, src_len, fmt, var_to_read_into, iostat });
+                        builder->CreateCall(fn, { str_src_data, str_src_len, fmt, var_to_read_into, iostat, str_offset });
                     }
                     // Copy temporary i32 iostat back to user's variable
                     if (iostat_user && iostat_kind != 4) {
@@ -15140,7 +15149,7 @@ public:
                         builder->CreateStore(extended, iostat_user);
                     }
                     emit_set_read_iomsg();
-                    return;
+                    continue;
                 } else {
                     fn = get_read_function(type);
                 }
@@ -15233,6 +15242,8 @@ public:
             // read, and anything after that will be skipped.
             // Here, we can use `_lfortran_empty_read` function to move to the
             // pointer to the next line.
+            // Skip for internal (string) reads — no file position to advance.
+            if (!is_string) {
             std::string runtime_func_name = "_lfortran_empty_read";
             llvm::Function *fn = module->getFunction(runtime_func_name);
             if (!fn) {
@@ -15258,6 +15269,7 @@ public:
                 }, [](){});
             } else {
                 builder->CreateCall(fn, {unit_val, iostat_for_empty_read});
+            }
             }
         }
         // Copy temporary i32 iostat back to user's variable if needed

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -8257,9 +8257,19 @@ LFORTRAN_API void _lfortran_string_write(char **str_holder, bool is_allocatable,
     if(iostat != NULL) *iostat = 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
-    int rc = sscanf(buf, format, i);
+LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, "%d%n", i, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, i);
+    }
     free(buf);
     if (rc != 1) {
         if (iostat) { *iostat = 5010; return; }
@@ -8270,9 +8280,19 @@ LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format
 }
 
 
-LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format, int64_t *i, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
-    int rc = sscanf(buf, format, i);
+LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format, int64_t *i, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, "%" PRId64 "%n", i, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, i);
+    }
     free(buf);
     if (rc != 1) {
         if (iostat) { *iostat = 5010; return; }
@@ -8282,10 +8302,20 @@ LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format
     if (iostat) *iostat = 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format, float *f, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
+LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format, float *f, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
     convert_fortran_d_exponent(buf);
-    int rc = sscanf(buf, format, f);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, "%f%n", f, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, f);
+    }
     free(buf);
     if (rc != 1) {
         if (iostat) { *iostat = 5010; return; }
@@ -8295,10 +8325,20 @@ LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format
     if (iostat) *iostat = 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_f64(char *str, int64_t len, char *format, double *f, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
+LFORTRAN_API void _lfortran_string_read_f64(char *str, int64_t len, char *format, double *f, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
     convert_fortran_d_exponent(buf);
-    int rc = sscanf(buf, format, f);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, "%lf%n", f, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, f);
+    }
     free(buf);
     if (rc != 1) {
         if (iostat) { *iostat = 5010; return; }
@@ -8331,9 +8371,10 @@ char* remove_whitespace(char* str, int64_t* len) {
     return str;
 }
 
-LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len) {
-    int64_t pos = 0;
-    while (pos < src_len && (src_data[pos] == ' ' || src_data[pos] == '\t')) {
+LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len, int64_t *offset) {
+    int64_t pos = offset ? *offset : 0;
+
+    while (pos < src_len && (src_data[pos] == ' ' || src_data[pos] == '\t' || (offset && src_data[pos] == ','))) {
         pos++;
     }
 
@@ -8360,20 +8401,41 @@ LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, cha
             }
         }
         pad_with_spaces(dest_data, dest_pos, dest_len);
+    } else if (offset) {
+        // Multi-value read: read one token (until separator)
+        int64_t start = pos;
+        while (pos < src_len && src_data[pos] != ' ' && src_data[pos] != '\t' &&
+               src_data[pos] != ',' && src_data[pos] != '\n') {
+            pos++;
+        }
+        int64_t token_len = pos - start;
+        _lfortran_copy_str_and_pad(dest_data, dest_len, src_data + start, token_len);
     } else {
         int64_t remaining = src_len - pos;
         _lfortran_copy_str_and_pad(
             dest_data, dest_len,
             src_data + pos, remaining);
     }
+    if (offset) *offset = pos;
 }
 
-LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat) {
-    char *buf = (char*)malloc(len + 1);
+LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    int64_t eff_len = len - off;
+    char *buf = (char*)malloc(eff_len + 1);
     if (!buf) return;
-    memcpy(buf, str, len);
-    buf[len] = '\0';
-    int rc = sscanf(buf, format, i);
+    memcpy(buf, str + off, eff_len);
+    buf[eff_len] = '\0';
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, "%d%n", i, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, i);
+    }
     free(buf);
     if (rc != 1) {
         if (iostat) { *iostat = 5010; return; }
@@ -8393,10 +8455,20 @@ static void _lfortran_replace_d_exponent(char *buf) {
     }
 }
 
-LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format, struct _lfortran_complex_32 *c, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
+LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format, struct _lfortran_complex_32 *c, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
     _lfortran_replace_d_exponent(buf);
-    int rc = sscanf(buf, format, &c->re, &c->im);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, " (%f,%f)%n", &c->re, &c->im, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, &c->re, &c->im);
+    }
     free(buf);
     if (rc != 2) {
         if (iostat) { *iostat = 5010; return; }
@@ -8406,10 +8478,20 @@ LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format
     if (iostat) *iostat = 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_c64(char *str, int64_t len, char *format, struct _lfortran_complex_64 *c, int32_t *iostat) {
-    char *buf = to_c_string((const fchar*)str, len);
+LFORTRAN_API void _lfortran_string_read_c64(char *str, int64_t len, char *format, struct _lfortran_complex_64 *c, int32_t *iostat, int64_t *offset) {
+    int64_t off = offset ? *offset : 0;
+    char *buf = to_c_string((const fchar*)(str + off), len - off);
     _lfortran_replace_d_exponent(buf);
-    int rc = sscanf(buf, format, &c->re, &c->im);
+    int rc;
+    if (offset) {
+        int skip = 0;
+        while (buf[skip] && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) skip++;
+        int n = 0;
+        rc = sscanf(buf + skip, " (%lf,%lf)%n", &c->re, &c->im, &n);
+        *offset = off + skip + n;
+    } else {
+        rc = sscanf(buf, format, &c->re, &c->im);
+    }
     free(buf);
     if (rc != 2) {
         if (iostat) { *iostat = 5010; return; }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -294,19 +294,19 @@ LFORTRAN_API void _lfortran_string_write(char **str_holder, bool is_allocatable,
         int64_t* len, int32_t* iostat, const char* format,
         int64_t format_len, ...);
 LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const char* format_data, int64_t format_len, ...);
-LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat);
+LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *format, int32_t *arr);
-LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format, int64_t *i, int32_t *iostat);
+LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format, int64_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *format, int64_t *arr);
-LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format, float *f, int32_t *iostat);
+LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format, float *f, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *format, float *arr);
-LFORTRAN_API void _lfortran_string_read_f64(char *str, int64_t len, char *format, double *f, int32_t *iostat);
+LFORTRAN_API void _lfortran_string_read_f64(char *str, int64_t len, char *format, double *f, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *format, double *arr);
-LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len);
+LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_str_array(char *str, int64_t len, char *format, char **arr);
-LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat);
-LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format, struct _lfortran_complex_32 *c, int32_t *iostat);
-LFORTRAN_API void _lfortran_string_read_c64(char *str, int64_t len, char *format, struct _lfortran_complex_64 *c, int32_t *iostat);
+LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);
+LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format, struct _lfortran_complex_32 *c, int32_t *iostat, int64_t *offset);
+LFORTRAN_API void _lfortran_string_read_c64(char *str, int64_t len, char *format, struct _lfortran_complex_64 *c, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat);
 LFORTRAN_API void _lfortran_set_read_iomsg(int32_t iostat, char* iomsg, int64_t iomsg_len);
 LFORTRAN_API void _lfortran_file_seek(int32_t unit_num, int64_t pos, int32_t* iostat);


### PR DESCRIPTION
The list-directed internal `read (read(string, *) x, y, ...)` only read the first value and returned, ignoring subsequent values. This was caused by a premature 'return' in the is_string codegen path in visit_FileRead.

Additionally, each runtime `_lfortran_string_read_*` function always parsed from position 0 of the source string, so even without the early return, the second value would re-read from the start instead of continuing.

Fix:
- Add `int64_t *offset` parameter to all scalar `_lfortran_string_read_*` runtime functions to track the current read position across calls
- Change 'return' to 'continue' in the codegen loop so all values are read
- Allocate a shared offset variable in the codegen before the loop
- Skip `_lfortran_empty_read` for internal (string) reads since there is no file position to advance

Integration test read_56.f90 covers: int+char, int+int, int+real, comma-separated, three mixed values, and single-value regression.