### PR TITLE
fix: add _GNU_SOURCE define for Linux - issue #10214

### DIFF
--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -145,6 +145,11 @@ if (WITH_LLVM)
     target_link_libraries(lfortran_utils p::llvm)
 endif()
 
+# _GNU_SOURCE is required for dl_phdr_info and feenableexcept on Linux
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(lfortran_utils PRIVATE _GNU_SOURCE)
+endif()
+
 # Install the dwarf_convert.py and dat_convert.py
 install(
     FILES dwarf_convert.py dat_convert.py

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1,6 +1,3 @@
-#if defined(__linux__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -106,16 +103,6 @@ static int _lfortran_use_runtime_colors = 0;  // disabled by default
 #ifdef HAVE_LFORTRAN_LINK
 // For dl_iterate_phdr() functionality
 #  include <link.h>
-#ifndef _GNU_SOURCE
-struct dl_phdr_info {
-    ElfW(Addr) dlpi_addr;
-    const char *dlpi_name;
-    const ElfW(Phdr) *dlpi_phdr;
-    ElfW(Half) dlpi_phnum;
-};
-extern int dl_iterate_phdr (int (*__callback) (struct dl_phdr_info *,
-    size_t, void *), void *__data);
-#endif
 #endif
 
 #ifdef HAVE_LFORTRAN_UNWIND


### PR DESCRIPTION
## Summary
- Add CMake target_compile_definitions for _GNU_SOURCE on Linux
- Remove hardcoded #define _GNU_SOURCE from lfortran_intrinsics.c  
- Remove hardcoded struct dl_phdr_info definition from lfortran_intrinsics.c

## Why
The _GNU_SOURCE macro is required for:
- dl_phdr_info structure (in <link.h>)
- feenableexcept() function (in <fenv.h>)

PR #10201 added these hardcodeds but didn't provide the CMake configuration as requested.

## Changes
- src/libasr/CMakeLists.txt: Add target_compile_definitions for _GNU_SOURCE on Linux
- src/libasr/runtime/lfortran_intrinsics.c: Remove hardcoded #define and struct dl_phdr_info

## Note
This PR was created by qwen 3.5 122B for testing.

Fixes #10214