### PR TITLE
Fix polymorphic allocatable function in overloaded assignment

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3553,6 +3553,7 @@ RUN(NAME module_function_without_nopass LABELS gfortran llvm llvm_wasm llvm_wasm
 RUN(NAME polymorphic_arguments_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME polymorphic_arguments_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocatable_polymorphic_mold_01 LABELS gfortran llvm)
+RUN(NAME allocatable_polymorphic_assign_01 LABELS gfortran llvm)
 RUN(NAME allocatable_dummy_descriptor_01 LABELS gfortran llvm)
 
 RUN(NAME polymorphic_class_compare LABELS gfortran)

--- a/integration_tests/allocatable_polymorphic_assign_01.f90
+++ b/integration_tests/allocatable_polymorphic_assign_01.f90
@@ -1,0 +1,33 @@
+module allocatable_polymorphic_assign_01_mod
+
+    type, abstract :: base_t
+    contains
+        procedure(assign_op), deferred :: assign
+        generic :: assignment(=) => assign
+    end type base_t
+
+    abstract interface
+        subroutine assign_op(self, other)
+            import
+            class(base_t), intent(out) :: self
+            class(base_t), intent(in)  :: other
+        end subroutine assign_op
+    end interface
+
+contains
+
+    subroutine test_assign_from_function()
+        class(base_t), allocatable :: a
+        a = make_base()
+    end subroutine test_assign_from_function
+
+    function make_base() result(b)
+        class(base_t), allocatable :: b
+    end function make_base
+
+end module allocatable_polymorphic_assign_01_mod
+
+program allocatable_polymorphic_assign_01
+    implicit none
+    print *, "PASS"
+end program allocatable_polymorphic_assign_01

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -746,10 +746,13 @@ class ReplaceFunctionCallWithSubroutineCallVisitor:
             if(is_function_call_returning_aggregate_type(x.m_value)) {
                 if (x.m_overloaded) {
                     // User-defined assignment(=) where the RHS is a function
-                    // call returning an aggregate type. The array_struct_temporary
-                    // pass has already created a temp for the function result
-                    // and wired the m_overloaded SubroutineCall to use it.
-                    // Just emit the overloaded call and drop this Assignment.
+                    // call returning an aggregate type.  Visit the overloaded
+                    // SubroutineCall so that any FunctionCall nodes in its
+                    // arguments are replaced with SubroutineCall + temp var
+                    // (the function was already converted to a subroutine in
+                    // Phase 1).  Then emit the overloaded call and drop the
+                    // Assignment.
+                    this->visit_stmt(*x.m_overloaded);
                     pass_result.push_back(al, x.m_overloaded);
                     remove_original_statement = true;
                     return;


### PR DESCRIPTION
The subroutine_from_function pass was emitting the m_overloaded SubroutineCall without first visiting its argument expressions. When the RHS of an assignment with user-defined assignment(=) was a FunctionCall returning a polymorphic allocatable (class) type, Phase 1 converted the function to a subroutine (void return), but the FunctionCall inside the overloaded call's arguments was never replaced, leaving an invalid FunctionCall to a void-returning function.

Fix: visit the overloaded SubroutineCall before emitting it so the expression replacer converts any nested FunctionCalls to SubroutineCall + temp variable.

Integration test added.

Fixes #10644.