### PR TITLE
Fix crash with optional class() arg in constructor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2725,6 +2725,7 @@ RUN(NAME class_allocate_03 LABELS gfortran llvm)
 RUN(NAME class_allocate_04 LABELS gfortran llvm)
 RUN(NAME class_allocate_05 LABELS gfortran llvm)
 RUN(NAME class_allocate_06 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME class_optional_01 LABELS gfortran llvm)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/class_optional_01.f90
+++ b/integration_tests/class_optional_01.f90
@@ -1,0 +1,35 @@
+module class_optional_01_mod
+   implicit none
+   type :: MyType
+      integer, allocatable :: s
+   end type MyType
+   interface MyType
+      procedure :: my_constructor
+   end interface MyType
+contains
+   function my_constructor(obj) result(self)
+      class(MyType), optional, intent(in) :: obj
+      type(MyType) :: self
+      if (present(obj)) then
+         self%s = 10
+      else
+         self%s = 5
+      end if
+   end function my_constructor
+end module class_optional_01_mod
+
+program class_optional_01
+   use class_optional_01_mod
+   implicit none
+   type(MyType) :: a
+
+   ! Call constructor with no arguments (optional class arg absent).
+   ! Previously caused "pointer being freed was not allocated" crash
+   ! because the class wrapper for the absent optional argument had
+   ! its inner struct pointer left uninitialized.
+   a = MyType()
+   if (.not. allocated(a%s)) error stop "a%s should be allocated"
+   if (a%s /= 5) error stop "a%s should be 5"
+
+   print *, "PASS"
+end program class_optional_01

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5598,6 +5598,16 @@ public:
                             ASRUtils::is_class_type(ASRUtils::extract_type(v->m_type))) {
                         struct_api->store_class_vptr(ASRUtils::symbol_get_past_external(v->m_type_declaration), 
                             ptr_member, module.get());
+                        ASR::symbol_t* sym_past = ASRUtils::symbol_get_past_external(v->m_type_declaration);
+                        ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(sym_past);
+                        if (!ASRUtils::is_unlimited_polymorphic_type(sym_past)) {
+                            llvm::Type* class_type = llvm_utils->getClassType(struct_t);
+                            llvm::Value* struct_ptr_field = llvm_utils->CreateGEP2(class_type, ptr_member, 1);
+                            llvm::Type* inner_ptr_type = llvm_utils->getStructType(struct_t, module.get(), true);
+                            builder->CreateStore(
+                                llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(inner_ptr_type)),
+                                struct_ptr_field);
+                        }
                     } else {
                         set_pointer_variable_to_null(v, llvm::Constant::getNullValue(
                             llvm_utils->get_type_from_ttype_t_util(ASRUtils::EXPR(ASR::make_Var_t(
@@ -6403,6 +6413,20 @@ public:
                     ASRUtils::is_class_type(ASRUtils::extract_type(v->m_type))) {
                 struct_api->store_class_vptr(ASRUtils::symbol_get_past_external(v->m_type_declaration),
                     ptr, module.get());
+                // Null-initialize the inner struct pointer (field 1) so that
+                // finalizers do not dereference uninitialized memory when the
+                // class wrapper is only default-initialized (e.g. for absent
+                // optional class() arguments).
+                ASR::symbol_t* sym_past = ASRUtils::symbol_get_past_external(v->m_type_declaration);
+                ASR::Struct_t* struct_t = ASR::down_cast<ASR::Struct_t>(sym_past);
+                if (!ASRUtils::is_unlimited_polymorphic_type(sym_past)) {
+                    llvm::Type* class_type = llvm_utils->getClassType(struct_t);
+                    llvm::Value* struct_ptr_field = llvm_utils->CreateGEP2(class_type, ptr, 1);
+                    llvm::Type* inner_ptr_type = llvm_utils->getStructType(struct_t, module.get(), true);
+                    builder->CreateStore(
+                        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(inner_ptr_type)),
+                        struct_ptr_field);
+                }
             } else {
                 set_pointer_variable_to_null(v, llvm::ConstantPointerNull::get(
                     static_cast<llvm::PointerType*>(type)), ptr);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -1285,6 +1285,25 @@ class ASRToLLVMVisitor;
                     llvm_utils_->create_gep2(derived_llvm_type, ptr, 1));
             }
 
+            if (ASRUtils::is_class_type(t)) {
+                // Guard: if the inner struct pointer is null (e.g. class wrapper
+                // was only default-initialized for an absent optional argument),
+                // skip member finalization to avoid dereferencing a null pointer.
+                llvm::BasicBlock* finalize_bb = llvm::BasicBlock::Create(
+                    builder_->getContext(), "class_ptr_valid",
+                    builder_->GetInsertBlock()->getParent());
+                llvm::BasicBlock* ret_bb = llvm::BasicBlock::Create(
+                    builder_->getContext(), "class_ptr_null",
+                    builder_->GetInsertBlock()->getParent());
+                llvm::Value* is_null = builder_->CreateICmpEQ(ptr,
+                    llvm::ConstantPointerNull::get(
+                        llvm::cast<llvm::PointerType>(ptr->getType())));
+                builder_->CreateCondBr(is_null, ret_bb, finalize_bb);
+                builder_->SetInsertPoint(ret_bb);
+                builder_->CreateRetVoid();
+                builder_->SetInsertPoint(finalize_bb);
+            }
+
             // Finalize members
             for (int i = 0; i < (int)struct_sym->n_members; i++){
                 auto const member_variable =  ASR::down_cast<ASR::Variable_t>(struct_sym->m_symtab->get_symbol(struct_sym->m_members[i]));


### PR DESCRIPTION
When calling a type constructor with an absent optional class() argument, the compiler-generated class wrapper temporary had its inner struct pointer (field 1) left uninitialized. At function exit, the finalizer followed this garbage pointer and tried to free memory at a random address, causing a 'pointer being freed was not allocated' abort.

Fix:
- Null-initialize the inner struct pointer of class wrappers at both local variable and struct member initialization sites.
- Add a null-pointer guard in the class type finalizer to skip member finalization when the inner pointer is null.

An integration test is added that exercises a type with an allocatable component and a custom constructor taking an optional class() argument, called with no arguments.

Fixes #10666.