### PR TITLE
Fix statement function in associate block

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2291,6 +2291,7 @@ RUN(NAME associate_37 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_38 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_39 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME associate_40 LABELS gfortran llvm)
+RUN(NAME associate_41 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_41.f90
+++ b/integration_tests/associate_41.f90
@@ -1,0 +1,18 @@
+module associate_41_mod
+implicit none
+contains
+subroutine sub()
+    real :: f, x, result
+    f(x) = x * 2.0
+    associate (fnew => f(1.0))
+        result = fnew
+    end associate
+    print *, result
+    if (abs(result - 2.0) > 1e-6) error stop
+end subroutine
+end module associate_41_mod
+
+program associate_41
+use associate_41_mod, only: sub
+call sub()
+end program associate_41

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -5136,11 +5136,14 @@ public:
         SetChar variable_dependencies_vec;
         variable_dependencies_vec.reserve(al, 1);
         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type, nullptr, nullptr, return_var_name);
+        // Statement functions return intrinsic scalar types, so
+        // m_type_declaration must be nullptr (not the variable being
+        // replaced by this function).
         ASR::asr_t *return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
             current_scope, s2c(al, return_var_name),
             variable_dependencies_vec.p, variable_dependencies_vec.size(),
             ASRUtils::intent_return_var, nullptr, nullptr,
-            ASR::storage_typeType::Default, type, sym,
+            ASR::storage_typeType::Default, type, nullptr,
             ASR::abiType::Source, ASR::Public, ASR::presenceType::Required,
             false);
         current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));

--- a/tests/reference/asr-entry_05-f368f0e.json
+++ b/tests/reference/asr-entry_05-f368f0e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-entry_05-f368f0e.stdout",
-    "stdout_hash": "5a9b2566e1f6194dfb136fc71d6d3961be1a75f6f2ed154e59fedf5b",
+    "stdout_hash": "3a9cca2aee6f39bb09a6afb800df1623370bc780e633a231f027c187",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-entry_05-f368f0e.stdout
+++ b/tests/reference/asr-entry_05-f368f0e.stdout
@@ -428,7 +428,7 @@
                                                     ()
                                                     Default
                                                     (Real 8)
-                                                    4 ftol
+                                                    ()
                                                     Source
                                                     Public
                                                     Required

--- a/tests/reference/asr-statement1-481e9b6.json
+++ b/tests/reference/asr-statement1-481e9b6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-statement1-481e9b6.stdout",
-    "stdout_hash": "7537678bb5a085e0c1540b3b63eff19342042282de5c7e616a59e9db",
+    "stdout_hash": "2c382d3777c1cd6837be51eb0dd9359b291f915c9a076d498648b175",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-statement1-481e9b6.stdout
+++ b/tests/reference/asr-statement1-481e9b6.stdout
@@ -22,7 +22,7 @@
                                                     ()
                                                     Default
                                                     (Real 8)
-                                                    2 dfloat
+                                                    ()
                                                     Source
                                                     Public
                                                     Required
@@ -207,7 +207,7 @@
                                                     ()
                                                     Default
                                                     (Integer 4)
-                                                    2 ifloat
+                                                    ()
                                                     Source
                                                     Public
                                                     Required
@@ -356,7 +356,7 @@
                                                     ()
                                                     Default
                                                     (Real 4)
-                                                    2 sfloat
+                                                    ()
                                                     Source
                                                     Public
                                                     Required

--- a/tests/reference/asr-statement1-60b7ed3.json
+++ b/tests/reference/asr-statement1-60b7ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-statement1-60b7ed3.stdout",
-    "stdout_hash": "970c13d4dac210507226bcfe8b60b78372349713814fb2fa323eecbe",
+    "stdout_hash": "484fca6508a867fe5033297c0ced1cd468544fd83d15a1eaa6099a0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-statement1-60b7ed3.stdout
+++ b/tests/reference/asr-statement1-60b7ed3.stdout
@@ -85,7 +85,7 @@
                                                     ()
                                                     Default
                                                     (Logical 4)
-                                                    2 q
+                                                    ()
                                                     Source
                                                     Public
                                                     Required

--- a/tests/reference/asr-statement_01-00eefc8.json
+++ b/tests/reference/asr-statement_01-00eefc8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-statement_01-00eefc8.stdout",
-    "stdout_hash": "baa7dd9c6982ca447b26a10851a278d63a93849179f78c544890a1d9",
+    "stdout_hash": "a989c329018eaad45e2cb2925da5d2616c5351067bd570778a006347",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-statement_01-00eefc8.stdout
+++ b/tests/reference/asr-statement_01-00eefc8.stdout
@@ -85,7 +85,7 @@
                                                     ()
                                                     Default
                                                     (Real 8)
-                                                    2 zexp
+                                                    ()
                                                     Source
                                                     Public
                                                     Required

--- a/tests/reference/asr-statement_02-daaef34.json
+++ b/tests/reference/asr-statement_02-daaef34.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-statement_02-daaef34.stdout",
-    "stdout_hash": "e277e57df0e0fc48b185ee884b81c5399aa5fa4bfa99fadb904a9d01",
+    "stdout_hash": "6ae2c483bd6a5670456117723c9889fcb656dd145a00884dabc81e97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-statement_02-daaef34.stdout
+++ b/tests/reference/asr-statement_02-daaef34.stdout
@@ -22,7 +22,7 @@
                                                     ()
                                                     Default
                                                     (Real 4)
-                                                    2 fpoint
+                                                    ()
                                                     Source
                                                     Public
                                                     Required


### PR DESCRIPTION
The return variable of a statement function had its m_type_declaration incorrectly set to the original variable symbol (which gets overwritten by add_or_overwrite_symbol). This caused get_struct_sym_from_struct_expr to return a stale pointer, leading import_struct_sym_as_external to create an ExternalSymbol pointing to the old variable instead of the new function, triggering an ASR verify error.

Set m_type_declaration to nullptr since statement functions return intrinsic scalar types and never need a type declaration symbol.

Fixes #10642.