### PR TITLE
Use fixed static array for argv instead of malloc

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5416,16 +5416,6 @@ public:
             this->visit_stmt(*x.m_body[i]);
         }
         if (compiler_options.emit_debug_info) debug_emit_loc(x);
-        {
-            llvm::Function *fn = module->getFunction("_lpython_free_argv");
-            if(!fn) {
-                llvm::FunctionType *function_type = llvm::FunctionType::get(
-                    llvm::Type::getVoidTy(context), {}, false);
-                fn = llvm::Function::Create(function_type,
-                    llvm::Function::ExternalLinkage, "_lpython_free_argv", module.get());
-            }
-            builder->CreateCall(fn, {});
-        }
         start_new_block(proc_return);
         llvm_symtab_finalizer.finalize_symtab(x.m_symtab);
         free_heap_fixed_size_arrays();
@@ -17482,16 +17472,6 @@ public:
 
         /* EXIT WITH CODE */
         {
-            {
-                llvm::Function *fn_free_argv = module->getFunction("_lpython_free_argv");
-                if (!fn_free_argv) {
-                    llvm::FunctionType *ft = llvm::FunctionType::get(
-                        llvm::Type::getVoidTy(context), {}, false);
-                    fn_free_argv = llvm::Function::Create(ft,
-                        llvm::Function::ExternalLinkage, "_lpython_free_argv", module.get());
-                }
-                builder->CreateCall(fn_free_argv, {});
-            }
             llvm::Function *fn_finalize = module->getFunction(
                 "_lfortran_internal_alloc_finalize");
             if (!fn_finalize) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -286,7 +286,6 @@ static void _lfortran_close_all_units(void);
 
 LFORTRAN_API void _lfortran_internal_alloc_finalize(void)
 {
-    _lpython_free_argv();
     _lfortran_close_all_units();
 #ifdef LFORTRAN_INTERNAL_ALLOC_CHECK
     int has_leaks = (_internal_alloc_count > 0);
@@ -9040,28 +9039,28 @@ LFORTRAN_API int32_t _lfortran_iachar(char *c) {
     return (int32_t) (uint8_t)(c[0]);
 }
 
-// Command line arguments
+// Command line arguments (fixed static storage, no allocation needed)
+enum { ARGV_MAX_ARGS = 256, ARGV_MAX_LEN = 4096 };
+static char _argv_buf[ARGV_MAX_ARGS][ARGV_MAX_LEN];
+static char *_argv_ptrs[ARGV_MAX_ARGS];
 int32_t _argc;
 char **_argv;
 
 LFORTRAN_API void _lpython_set_argv(int32_t argc_1, char *argv_1[]) {
-    _argv = internal_malloc(argc_1 * sizeof(char *));
-    for (size_t i = 0; i < argc_1; i++) {
-        size_t len = strlen(argv_1[i]) + 1;
-        _argv[i] = internal_malloc(len);
-        memcpy(_argv[i], argv_1[i], len);
+    if (argc_1 > ARGV_MAX_ARGS) argc_1 = ARGV_MAX_ARGS;
+    for (int32_t i = 0; i < argc_1; i++) {
+        size_t len = strlen(argv_1[i]);
+        if (len >= ARGV_MAX_LEN) len = ARGV_MAX_LEN - 1;
+        memcpy(_argv_buf[i], argv_1[i], len);
+        _argv_buf[i][len] = '\0';
+        _argv_ptrs[i] = _argv_buf[i];
     }
     _argc = argc_1;
+    _argv = _argv_ptrs;
 }
 
 LFORTRAN_API void _lpython_free_argv() {
-    if (_argv != NULL) {
-        for (size_t i = 0; i < _argc; i++) {
-            internal_free(_argv[i]);
-        }
-        internal_free(_argv);
-        _argv = NULL;
-    }
+    // No-op: argv uses fixed static storage
 }
 
 LFORTRAN_API void _lfortran_set_use_runtime_colors(int use_colors) {

--- a/tests/reference/llvm-abort_01-7212a3d.json
+++ b/tests/reference/llvm-abort_01-7212a3d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-abort_01-7212a3d.stdout",
-    "stdout_hash": "321a37fc08bd7f2ef39a443e71539e66634b4c9bac8531b53850f9b1",
+    "stdout_hash": "0727fd30deb34d06864c0fa006150783f2752a050861f41c155be546",
     "stderr": "llvm-abort_01-7212a3d.stderr",
     "stderr_hash": "132e12d6d59905849ec72f4c5e5303920f043e68e199519ab136643f",
     "returncode": 0

--- a/tests/reference/llvm-abort_01-7212a3d.stdout
+++ b/tests/reference/llvm-abort_01-7212a3d.stdout
@@ -28,7 +28,6 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -40,7 +39,5 @@ FINALIZE_SYMTABLE_abort1:                         ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "d272d6a69bd39d3159e186c3a142270acdddf3a1a8b49d75da1a832a",
+    "stdout_hash": "7924dda46ecea397a7ce11855b23520036cb1f322adc1876a7b833f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -208,7 +208,6 @@ ifcont10:                                         ; preds = %merge_allocated7
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -237,8 +236,6 @@ declare void @exit(i32)
 declare i8* @_lfortran_malloc_alloc(i8*, i64)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 define internal void @finalize_allocatable__Array_i32(%array* %0, i1 %1) {
 entry:

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "572a9ccc652c4915708c1f5b6deaf04ea0296d1be3a48cf91b3abdfe",
+    "stdout_hash": "d3b4c63521e1008fa60c4117c6928ae5b2272fc468fa8255b62c1ae2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -354,7 +354,6 @@ ifcont:                                           ; preds = %merge_allocated
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @166, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont2
@@ -773,7 +772,6 @@ ifcont24:                                         ; preds = %ifcont22
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @201, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @200, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -1007,7 +1005,6 @@ free_nonnull:                                     ; preds = %ifcont38
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont38
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -1821,7 +1818,6 @@ ifcont17:                                         ; preds = %ifcont15
 
 then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont19
@@ -2262,7 +2258,6 @@ ifcont44:                                         ; preds = %ifcont42
 
 then45:                                           ; preds = %ifcont44
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -2558,7 +2553,6 @@ merge_allocated8:                                 ; preds = %check_data7, %ifcon
 
 then10:                                           ; preds = %merge_allocated8
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -2999,7 +2993,6 @@ ifcont34:                                         ; preds = %ifcont32
 
 then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @145, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @144, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -3238,8 +3231,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-array2-4254183.json
+++ b/tests/reference/llvm-array2-4254183.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2-4254183.stdout",
-    "stdout_hash": "06a0c1e34e34cf2f05fe99d4e8370377a11d693d7ecde13ecf661593",
+    "stdout_hash": "ec8dc2c9bc0d59655491a30fc7d243829ba7a0f0e914d4fa6678e6aa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2-4254183.stdout
+++ b/tests/reference/llvm-array2-4254183.stdout
@@ -14,7 +14,6 @@ define i32 @main(i32 %0, i8** %1) {
   %h = alloca [24 x float], align 4
   %i = alloca [36 x i32], align 4
   %j = alloca [20 x i32], align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,7 +25,5 @@ FINALIZE_SYMTABLE_array2:                         ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "c414c8448549870e3cd0f5fb9d3c4007fdec8feaaa885497e13c4ae5",
+    "stdout_hash": "4ba7e508678ac0b21900733b986fe26e05fc4ed73c139ec330ca9fd9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -252,7 +252,6 @@ free_nonnull20:                                   ; preds = %free_done18
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done21
@@ -272,7 +271,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "48f769cfcd2915de8b309f80de79b91b67a9638102ebe09670c7ed80",
+    "stdout_hash": "833e8cca4ad975e0b063d2b1dc1915d238c083fa9e44c8d3ef94e905",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -227,7 +227,6 @@ ifcont2:                                          ; preds = %loop.end
 
 then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -276,7 +275,6 @@ ifcont6:                                          ; preds = %ifcont4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -325,7 +323,6 @@ ifcont11:                                         ; preds = %ifcont9
 
 then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -435,7 +432,6 @@ ifcont21:                                         ; preds = %loop.end19
 
 then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -484,7 +480,6 @@ ifcont26:                                         ; preds = %ifcont24
 
 then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -533,7 +528,6 @@ ifcont31:                                         ; preds = %ifcont29
 
 then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -582,7 +576,6 @@ ifcont36:                                         ; preds = %ifcont34
 
 then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -734,7 +727,6 @@ ifcont48:                                         ; preds = %loop.end46
 
 then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -783,7 +775,6 @@ ifcont53:                                         ; preds = %ifcont51
 
 then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -832,7 +823,6 @@ ifcont58:                                         ; preds = %ifcont56
 
 then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -1059,7 +1049,6 @@ ifcont73:                                         ; preds = %ifcont71
 
 then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1178,7 +1167,6 @@ ifcont82:                                         ; preds = %ifcont80
 
 then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1187,7 +1175,6 @@ else84:                                           ; preds = %ifcont82
   br label %ifcont85
 
 ifcont85:                                         ; preds = %else84, %then83
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont85
@@ -1209,7 +1196,5 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "7db1eb9a6db85c4c3464379d4f5ee2f0d5b792f48217b14a2e8b0fff",
+    "stdout_hash": "d5a7307263df2e7ba426efce6eea71da39c930423e634bd10e33b43e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -286,7 +286,6 @@ ifcont2:                                          ; preds = %loop.end
 
 then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -339,7 +338,6 @@ ifcont6:                                          ; preds = %ifcont4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -392,7 +390,6 @@ ifcont11:                                         ; preds = %ifcont9
 
 then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -509,7 +506,6 @@ ifcont21:                                         ; preds = %loop.end19
 
 then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -562,7 +558,6 @@ ifcont26:                                         ; preds = %ifcont24
 
 then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -615,7 +610,6 @@ ifcont31:                                         ; preds = %ifcont29
 
 then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -668,7 +662,6 @@ ifcont36:                                         ; preds = %ifcont34
 
 then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -829,7 +822,6 @@ ifcont48:                                         ; preds = %loop.end46
 
 then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -882,7 +874,6 @@ ifcont53:                                         ; preds = %ifcont51
 
 then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -935,7 +926,6 @@ ifcont58:                                         ; preds = %ifcont56
 
 then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -1187,7 +1177,6 @@ ifcont73:                                         ; preds = %ifcont71
 
 then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1310,7 +1299,6 @@ ifcont82:                                         ; preds = %ifcont80
 
 then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1519,7 +1507,6 @@ ifcont99:                                         ; preds = %ifcont97
 
 then100:                                          ; preds = %ifcont99
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @133, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont102
@@ -1605,7 +1592,6 @@ ifcont106:                                        ; preds = %ifcont104
 
 then107:                                          ; preds = %ifcont106
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @142, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont109
@@ -1691,7 +1677,6 @@ ifcont113:                                        ; preds = %ifcont111
 
 then114:                                          ; preds = %ifcont113
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @153, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @152, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont116
@@ -1777,7 +1762,6 @@ ifcont120:                                        ; preds = %ifcont118
 
 then121:                                          ; preds = %ifcont120
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @163, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont123
@@ -1786,7 +1770,6 @@ else122:                                          ; preds = %ifcont120
   br label %ifcont123
 
 ifcont123:                                        ; preds = %else122, %then121
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont123
@@ -1808,7 +1791,5 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "675d1989facf6b9d5d9052108d7bfb56abe43741ac78bd6310c5b6aa",
+    "stdout_hash": "8f1997b1ae3bd12539b68738f4163be1e65992bddacab7f185635526",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -380,7 +380,6 @@ ifcont6:                                          ; preds = %loop.end
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -429,7 +428,6 @@ ifcont10:                                         ; preds = %ifcont8
 
 then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -479,7 +477,6 @@ ifcont15:                                         ; preds = %ifcont13
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -669,7 +666,6 @@ ifcont29:                                         ; preds = %loop.end27
 
 then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont32
@@ -719,7 +715,6 @@ ifcont34:                                         ; preds = %ifcont32
 
 then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -768,7 +763,6 @@ ifcont39:                                         ; preds = %ifcont37
 
 then40:                                           ; preds = %ifcont39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -818,7 +812,6 @@ ifcont44:                                         ; preds = %ifcont42
 
 then45:                                           ; preds = %ifcont44
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -970,7 +963,6 @@ ifcont56:                                         ; preds = %loop.end54
 
 then57:                                           ; preds = %ifcont56
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont59
@@ -1019,7 +1011,6 @@ ifcont61:                                         ; preds = %ifcont59
 
 then62:                                           ; preds = %ifcont61
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont64
@@ -1068,7 +1059,6 @@ ifcont66:                                         ; preds = %ifcont64
 
 then67:                                           ; preds = %ifcont66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -1296,7 +1286,6 @@ ifcont81:                                         ; preds = %ifcont79
 
 then82:                                           ; preds = %ifcont81
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @117, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @116, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont84
@@ -1416,7 +1405,6 @@ ifcont90:                                         ; preds = %ifcont88
 
 then91:                                           ; preds = %ifcont90
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @131, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @130, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont93
@@ -1717,7 +1705,6 @@ ifcont114:                                        ; preds = %ifcont112
 
 then115:                                          ; preds = %ifcont114
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @157, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @156, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont117
@@ -1800,7 +1787,6 @@ ifcont121:                                        ; preds = %ifcont119
 
 then122:                                          ; preds = %ifcont121
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @166, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont124
@@ -1883,7 +1869,6 @@ ifcont128:                                        ; preds = %ifcont126
 
 then129:                                          ; preds = %ifcont128
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @177, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont131
@@ -1965,7 +1950,6 @@ ifcont135:                                        ; preds = %ifcont133
 
 then136:                                          ; preds = %ifcont135
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @186, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont138
@@ -1974,7 +1958,6 @@ else137:                                          ; preds = %ifcont135
   br label %ifcont138
 
 ifcont138:                                        ; preds = %else137, %then136
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont138
@@ -1996,7 +1979,5 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "15787698ce2d7ba7bb7259360bb8d3a49bb525c1a7c447d67ddfe042",
+    "stdout_hash": "9ae8dd4cf9802a1c46c6bd2b2017b47d00ea917884e0f3dadc7a43a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -278,7 +278,6 @@ ifcont2:                                          ; preds = %loop.end
 
 then3:                                            ; preds = %ifcont2
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -327,7 +326,6 @@ ifcont6:                                          ; preds = %ifcont4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -376,7 +374,6 @@ ifcont11:                                         ; preds = %ifcont9
 
 then12:                                           ; preds = %ifcont11
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -487,7 +484,6 @@ ifcont21:                                         ; preds = %loop.end19
 
 then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -536,7 +532,6 @@ ifcont26:                                         ; preds = %ifcont24
 
 then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -585,7 +580,6 @@ ifcont31:                                         ; preds = %ifcont29
 
 then32:                                           ; preds = %ifcont31
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -634,7 +628,6 @@ ifcont36:                                         ; preds = %ifcont34
 
 then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -786,7 +779,6 @@ ifcont48:                                         ; preds = %loop.end46
 
 then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -835,7 +827,6 @@ ifcont53:                                         ; preds = %ifcont51
 
 then54:                                           ; preds = %ifcont53
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -884,7 +875,6 @@ ifcont58:                                         ; preds = %ifcont56
 
 then59:                                           ; preds = %ifcont58
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -1111,7 +1101,6 @@ ifcont73:                                         ; preds = %ifcont71
 
 then74:                                           ; preds = %ifcont73
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1230,7 +1219,6 @@ ifcont82:                                         ; preds = %ifcont80
 
 then83:                                           ; preds = %ifcont82
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1433,7 +1421,6 @@ ifcont99:                                         ; preds = %ifcont97
 
 then100:                                          ; preds = %ifcont99
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @133, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont102
@@ -1515,7 +1502,6 @@ ifcont106:                                        ; preds = %ifcont104
 
 then107:                                          ; preds = %ifcont106
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @142, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont109
@@ -1597,7 +1583,6 @@ ifcont113:                                        ; preds = %ifcont111
 
 then114:                                          ; preds = %ifcont113
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @153, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @152, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont116
@@ -1679,7 +1664,6 @@ ifcont120:                                        ; preds = %ifcont118
 
 then121:                                          ; preds = %ifcont120
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @163, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont123
@@ -1688,7 +1672,6 @@ else122:                                          ; preds = %ifcont120
   br label %ifcont123
 
 ifcont123:                                        ; preds = %else122, %then121
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont123
@@ -1710,7 +1693,5 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "c2b345085a94d78c83d5493d641e32a988b08305da8f5204d114aa96",
+    "stdout_hash": "18a96fcd1567512d51dbf5638861ed563eefd1d97d76ce89c526b41e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -143,7 +143,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -158,7 +157,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -271,7 +269,6 @@ ifcont7:                                          ; preds = %loop.end
 
 then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont10
@@ -320,7 +317,6 @@ ifcont12:                                         ; preds = %ifcont10
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -369,7 +365,6 @@ ifcont17:                                         ; preds = %ifcont15
 
 then18:                                           ; preds = %ifcont17
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont20
@@ -483,7 +478,6 @@ ifcont27:                                         ; preds = %loop.end25
 
 then28:                                           ; preds = %ifcont27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont30
@@ -532,7 +526,6 @@ ifcont32:                                         ; preds = %ifcont30
 
 then33:                                           ; preds = %ifcont32
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont35
@@ -581,7 +574,6 @@ ifcont37:                                         ; preds = %ifcont35
 
 then38:                                           ; preds = %ifcont37
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont40
@@ -630,7 +622,6 @@ ifcont42:                                         ; preds = %ifcont40
 
 then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont45
@@ -785,7 +776,6 @@ ifcont54:                                         ; preds = %loop.end52
 
 then55:                                           ; preds = %ifcont54
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont57
@@ -834,7 +824,6 @@ ifcont59:                                         ; preds = %ifcont57
 
 then60:                                           ; preds = %ifcont59
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont62
@@ -883,7 +872,6 @@ ifcont64:                                         ; preds = %ifcont62
 
 then65:                                           ; preds = %ifcont64
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont67
@@ -1110,7 +1098,6 @@ ifcont79:                                         ; preds = %ifcont77
 
 then80:                                           ; preds = %ifcont79
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont82
@@ -1229,7 +1216,6 @@ ifcont88:                                         ; preds = %ifcont86
 
 then89:                                           ; preds = %ifcont88
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @118, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont91
@@ -1238,7 +1224,6 @@ else90:                                           ; preds = %ifcont88
   br label %ifcont91
 
 ifcont91:                                         ; preds = %else90, %then89
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont91
@@ -1252,8 +1237,6 @@ FINALIZE_SYMTABLE_arrays_01:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-arrays_101-8ed52ae.json
+++ b/tests/reference/llvm-arrays_101-8ed52ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_101-8ed52ae.stdout",
-    "stdout_hash": "b6ab2fc045ee295176a290250162447b7cd50477c259d1646c9e344d",
+    "stdout_hash": "e47b569a10decbcbc702427fef904935053ebb500e42bc4ba602be6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_101-8ed52ae.stdout
+++ b/tests/reference/llvm-arrays_101-8ed52ae.stdout
@@ -283,7 +283,6 @@ ifcont21:                                         ; preds = %loop.end19
 
 then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -332,7 +331,6 @@ ifcont26:                                         ; preds = %ifcont24
 
 then27:                                           ; preds = %ifcont26
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -513,7 +511,6 @@ loop.end49:                                       ; preds = %loop.head30
 
 then50:                                           ; preds = %loop.end49
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont52
@@ -524,7 +521,6 @@ else51:                                           ; preds = %loop.end49
 ifcont52:                                         ; preds = %else51, %then50
   %181 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %181, i32 2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont52
@@ -556,8 +552,6 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "acc3c09002cc559f4c0a489ed30ef46d7deada9b46909503ff434dbe",
+    "stdout_hash": "127399bb887d1a8d774a6cb08bc13ffdfb4d301583eff42ae198af35",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -253,7 +253,6 @@ free_nonnull20:                                   ; preds = %free_done18
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done21
@@ -273,7 +272,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "e69d941ca90318e97c1b5c8c3cdf28f3264910c925ff6355f3d82906",
+    "stdout_hash": "1ebf7f17ce66f5096a74a7d33cdfaae116eafe028e35ffd59695a465",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -91,7 +91,6 @@ free_done3:                                       ; preds = %free_nonnull2, %ifc
 
 then4:                                            ; preds = %free_done3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -100,7 +99,6 @@ else5:                                            ; preds = %free_done3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont6
@@ -122,8 +120,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "2de379031ad58e4dd721b77af06ade8227e15a36379ba90963842b7e",
+    "stdout_hash": "9d7130166129af1f524202cbd78a6be580090339b1d744492d81de05",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -140,7 +140,6 @@ free_done3:                                       ; preds = %free_nonnull2, %FIN
 
 then:                                             ; preds = %free_done3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -149,7 +148,6 @@ else:                                             ; preds = %free_done3
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -177,8 +175,6 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 declare void @llvm.stackrestore(i8*) #0
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-automatic_allocation_02-2a7afc4.stdout",
-    "stdout_hash": "8ea290aa50a63db682345e8559b868841e06e7cc88e51b1274aa0fce",
+    "stdout_hash": "b939c255c15436c2e1c1cb2273439c322e751adfb021213248ee9ee6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
@@ -316,7 +316,6 @@ ifcont19:                                         ; preds = %ifcont17
 
 then20:                                           ; preds = %ifcont19
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont22
@@ -368,7 +367,6 @@ ifcont24:                                         ; preds = %ifcont22
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -424,7 +422,6 @@ ifcont29:                                         ; preds = %ifcont27
 
 then30:                                           ; preds = %ifcont29
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont32
@@ -477,7 +474,6 @@ ifcont34:                                         ; preds = %ifcont32
 
 then35:                                           ; preds = %ifcont34
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -558,7 +554,6 @@ else48:                                           ; preds = %ifcont46
   br label %ifcont49
 
 ifcont49:                                         ; preds = %else48, %then47
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont49
@@ -609,8 +604,6 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "f35db68fd8718245f9ebee425795bdb5ea8c1e603006f98e1945388a",
+    "stdout_hash": "1a6ff89da800ede6f6c3fe8f60b266176fe0cc2e57205a146e728028",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -43,7 +43,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -63,7 +62,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "fcd7733fc548b3665fb32ede5ac4d1e10eb24a706b03c81cdd41f614",
+    "stdout_hash": "a33b4ffbac1870bbb75678899849882e5e00f257f1811f4650d7cfc4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -41,7 +41,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -61,7 +60,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bindc1-345b88c.json
+++ b/tests/reference/llvm-bindc1-345b88c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc1-345b88c.stdout",
-    "stdout_hash": "4deb91260a7d0f648d23599000e5ad9d4127f9bc42707f301cf77ca5",
+    "stdout_hash": "f264ec349f68b07483409f26d5fdda4fba244898749371d0f872c61c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc1-345b88c.stdout
+++ b/tests/reference/llvm-bindc1-345b88c.stdout
@@ -10,7 +10,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32*, i32** %x, align 8
   %3 = bitcast i32* %2 to void*
   store void* %3, void** %p, align 8
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -22,7 +21,5 @@ FINALIZE_SYMTABLE_bindc1:                         ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "25615f111e5c36db2b967732869eff08686182e882092af757de3580",
+    "stdout_hash": "2c25697b99d75433d5d40dadf5db911b2e57053352ea0258cef5b1b6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -78,7 +78,6 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -98,7 +97,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "1cc9722f19e08bf2b7658495085d55776215204f58384c190bf46437",
+    "stdout_hash": "11576c92aa8df61b800fe3300dec08c9b2c393d951a1709ae03c1e7a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -53,7 +53,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -96,7 +95,6 @@ free_done4:                                       ; preds = %free_nonnull3, %ifc
 
 then5:                                            ; preds = %free_done4
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont7
@@ -105,7 +103,6 @@ else6:                                            ; preds = %free_done4
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont7
@@ -127,8 +124,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "1c1653af7694ba4ca217293f20b602c63a4648bbf7e7f25ddf34cee0",
+    "stdout_hash": "c89ad0517a626fcec575b88d790a90b710bdc45b85cc4dc94a7bfab4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -95,7 +95,6 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done6
@@ -115,7 +114,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "5f224947b260141eef2e5fc717a5e45db4cf48cb8f92f2de008d4eaf",
+    "stdout_hash": "4af03b26023a1363c9fafdb1273ae5b50cbbe2b9b0536d1e0ea81372",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -43,7 +43,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -58,7 +57,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -73,7 +71,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -88,7 +85,6 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -103,7 +99,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -118,7 +113,6 @@ ifcont12:                                         ; preds = %else11, %then10
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -149,7 +143,6 @@ free_nonnull:                                     ; preds = %ifcont15
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont15
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -163,8 +156,6 @@ FINALIZE_SYMTABLE_boz_01:                         ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "389d81012c1bf3dc6d1df6af1896c4e0b62332133537713f14d8201a",
+    "stdout_hash": "d5e1ac929fe3bae200e1bb2819f007aa396a235ea5ad7a6d91df2e02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -77,7 +77,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -104,8 +103,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 
@@ -180,7 +177,6 @@ ifcont:                                           ; preds = %.entry
   %40 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %39, i32 2
   %41 = load void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %40, align 8
   call void %41(%module_call_subroutine_without_type_01.mytype_class* %37)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "decb3394100c5cbcf5958fba05497d04ca90245d8c98977162e4ab8a",
+    "stdout_hash": "84af55aee9f1c87f275baf5ac5ac4842b65fc2cb157e108d01e4b2b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -99,7 +99,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_callback_01_foo(float* %call_arg_value, float* %call_arg_value1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -111,7 +110,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "48757e6889bda26d89a82ff90a28416f61c43fd29e22cbc715a67da4",
+    "stdout_hash": "55967e57a3bf6af25776c881e1122dba72e8f2735e470bf2e45d645d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -149,7 +149,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 2.000000e+00, float* %call_arg_value1, align 4
   %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)
   store float %2, float* @main.res, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -161,7 +160,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "061f692b6f214106c9caa061390e6f94c82d7ceeeffe7febe568fcba",
+    "stdout_hash": "1c05bb02fb2638c6b16b6db9da4a99a436b619522e5c67e0d03af93a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -158,7 +158,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.500000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_callback_03_foo2(float* %call_arg_value, float* %call_arg_value1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -170,7 +169,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_04-0d9515f.json
+++ b/tests/reference/llvm-callback_04-0d9515f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_04-0d9515f.stdout",
-    "stdout_hash": "5742b14b641bca7ae86341926e37cba414f35c0cbcbe4490b6342799",
+    "stdout_hash": "34e33f3566b8ba396e41defa59976bca3b31138ef6bc64db2ed1695c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_04-0d9515f.stdout
+++ b/tests/reference/llvm-callback_04-0d9515f.stdout
@@ -59,7 +59,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_dr)
   call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_fortran)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -71,7 +70,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "fe5f25833574f2c6bdac020da18fc2cd64ab14d7dfee4045d5f5bfd3",
+    "stdout_hash": "f7ea44b18837cffdc2e79467bc1a67e7cac8cf052c4d27b5f2e2ad2c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -94,7 +94,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_callback_05_px_call1(i32* @main.x)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -106,7 +105,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "fb40dcac95343849992913c00376a77f9335a8d37c209925e48d3c3a",
+    "stdout_hash": "ba5495a511888f1c6ddfd21efff49f983b0bbab7a502e0101119d618",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -101,7 +101,6 @@ ifcont9:                                          ; preds = %ifcont8, %then
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -150,7 +149,6 @@ ifcont18:                                         ; preds = %ifcont17, %then13
 
 then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -159,7 +157,6 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont21
@@ -175,8 +172,6 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "6b0401bb4c53d9a5c6b21a0fc1a2ab1f6c34afe152dcde36fde64968",
+    "stdout_hash": "56b1fe7ce972fd9f6f3716ad55c8e88a9e47e520462842979e5795ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -243,7 +243,6 @@ free_done:                                        ; preds = %free_nonnull, %ifco
 
 then16:                                           ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -486,7 +485,6 @@ free_nonnull59:                                   ; preds = %ifcont57
   br label %free_done60
 
 free_done60:                                      ; preds = %free_nonnull59, %ifcont57
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done60
@@ -508,8 +506,6 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "c522a4604eaec032a05905ec79ae61bce08bc82d49d0ef0b09425e33",
+    "stdout_hash": "48fd9bfc7c33b3159bd7d04f4fc2bd71e68ae3a5717b04e3e47096ff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -152,7 +152,6 @@ free_nonnull11:                                   ; preds = %ifcont9
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done12
@@ -172,7 +171,5 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "4f3dec1fa50a8732c532b77e9c06ae7f5671dba301afff628e92b697",
+    "stdout_hash": "0e9bdad88b6bd7f2e164539891ac3f8b0d590641a282d14795e6e973",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -159,7 +159,6 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %2, i32 0, i32 1
   store %class_circle1.circle* %c, %class_circle1.circle** %10, align 8
   call void @__module_class_circle1_circle_print(%class_circle1.circle_class* %2)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -171,8 +170,6 @@ FINALIZE_SYMTABLE_circle_test:                    ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "3d2e711b263abb1e1d97b7d8187aa3ca56bcbdaa6bc4ffc3dbd77949",
+    "stdout_hash": "8f51ab84d4083ff417fbe78d5bc41a1e935018d854132bf6d3a39446",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -165,7 +165,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_class_circle2__xx_lcompilers_changed_main_xx()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -177,8 +176,6 @@ FINALIZE_SYMTABLE_circle_test:                    ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "b7141ba4d15e2dd561a65e2ce526b285c57cdb29a8f390c901e57b1d",
+    "stdout_hash": "40c737fd69cd288dac8166c013b1aba535039d2a33a93d8269febd0f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -156,7 +156,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
 
 then:                                             ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -165,7 +164,6 @@ else:                                             ; preds = %free_done6
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -187,8 +185,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "f4cd62302950f608e93f7715741f878fd2db28d58fc965f09140c4db",
+    "stdout_hash": "85b0545d15de8d4d965e494fa133caa4ac00a9f3cb10fddb72a78940",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -77,7 +77,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -86,7 +85,6 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -153,8 +151,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-classes2-f926d51.json
+++ b/tests/reference/llvm-classes2-f926d51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes2-f926d51.stdout",
-    "stdout_hash": "207a4761c7eff81b08ccaef138824d416b377a58797ee51c038932a7",
+    "stdout_hash": "8b8ccb240ebbf52bf68762901ed9d0d72fdc0fa8f3f29454fcbb8e47",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes2-f926d51.stdout
+++ b/tests/reference/llvm-classes2-f926d51.stdout
@@ -94,7 +94,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -103,7 +102,6 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont3
@@ -207,8 +205,6 @@ entry:
 }
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-common_linkage_separate_compilation_01-4003f83.stdout",
-    "stdout_hash": "010bc7f0b561ec494ef281b4dbf2412cb504b5250cfa966105664f5b",
+    "stdout_hash": "38a90be4cdaf0439a7f3502614fda09b39bdbdf1b7a8395afda5ea56",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
@@ -18,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -27,7 +26,6 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -41,8 +39,6 @@ FINALIZE_SYMTABLE_common_linkage_separate_compilation_01: ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-complex1-0e93fa9.json
+++ b/tests/reference/llvm-complex1-0e93fa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex1-0e93fa9.stdout",
-    "stdout_hash": "e73f6ca10a67c0bbb193eb740011a60dd63fbf6aa1809942306959e2",
+    "stdout_hash": "f31cd9d8c70b56fafc39264944766167b08dfa38c006b96e17d8190b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex1-0e93fa9.stdout
+++ b/tests/reference/llvm-complex1-0e93fa9.stdout
@@ -8,7 +8,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %x = alloca %complex_4, align 8
   store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -20,7 +19,5 @@ FINALIZE_SYMTABLE_complex1:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "ef32429fc951a060ab74c7692eb0ed722b65f2e77c32c6a4415c8f3c",
+    "stdout_hash": "092fd7c9c6d05a2c1b3a9d09ca4baee014d0b7bf56180d86d1aeebad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -116,7 +116,6 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done6
@@ -136,7 +135,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "2470d8d7234e9f6066798e4ba6ac2a1e43797fde0590e55c2fe653fb",
+    "stdout_hash": "22e7192b55026e977398c53ecc2cd8ca2a9ac1eb63b851bbf25d2233",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -200,7 +200,6 @@ free_nonnull11:                                   ; preds = %complex_div_cont9
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %complex_div_cont9
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done12
@@ -223,8 +222,6 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "fa752e1f6be2d0ee47f256771e21d5ac00bfaf988f32e0cb69608120",
+    "stdout_hash": "cf8869d3785c1a23e6a0ac96cbc9ff373caf4a903607b4b394666e76",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -41,7 +41,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -61,7 +60,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "ee7ca987304ccf9c7cb1394c6cc793c1f769010f70af61fd2e008b57",
+    "stdout_hash": "b1ce69237625dba109ae4bfcd11ec4984577167b6fc50440ec72d64d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -45,7 +45,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -65,7 +64,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "db365025939bdfec08167a6e455395af63c74cf02b637d936925c438",
+    "stdout_hash": "03e0bd99805dd99aa5afc1dc8bd08a1772c040fa83565de1a60bae8e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -122,7 +122,6 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done6
@@ -142,7 +141,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "cf010bf81273a2e9c2abebc5ee7d643bb323b2ef4e7b74dfad8c50fb",
+    "stdout_hash": "53b890bedee43c46112aa6a112c085c295345feac1fe9b8ea0bafa0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -53,7 +53,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -75,7 +74,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "d637cfbb430dbc5d656b1fa54ccc1ff6bcf6e3a63209c21167c63f2d",
+    "stdout_hash": "1cd5bfcd3d539779c8b69a4c869459145400336ebbcb29f1cac98c88",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -118,7 +118,6 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done6
@@ -138,7 +137,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "3c0da734bd55e13e314a2cb06613a6e5717910501220397f584b62d9",
+    "stdout_hash": "5553c3ae225cc0d3f4b564ca206da51baa3f28e277420172e5c938a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -41,7 +41,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -61,7 +60,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "506dbff4206696754333514ff5f7da504bbce6b7d9abe6e5e76b0350",
+    "stdout_hash": "2ef57f047bd55871b0444681eb2d1974e675d5ff4425f026dffd4855",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -378,7 +378,6 @@ free_done:                                        ; preds = %free_nonnull, %ifco
 
 then1:                                            ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont2
@@ -387,7 +386,6 @@ else:                                             ; preds = %free_done
   br label %ifcont2
 
 ifcont2:                                          ; preds = %else, %then1
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont2
@@ -419,7 +417,5 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare i32 @str_compare(i8*, i64, i8*, i64)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "a05ad32ea2b812a88b86e7ffdb75645649d3b3108565f43a37914512",
+    "stdout_hash": "d2dd68ecc3c53682199acc747ef121d26ff3fbf75251137229658eb2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -96,7 +96,6 @@ ifcont5:                                          ; preds = %ifcont3
 
 then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -105,7 +104,6 @@ else7:                                            ; preds = %ifcont5
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont8
@@ -137,8 +135,6 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "c759bd92e0e00c81521fcc18349319f47eb7413efad8d0951c0a19ad",
+    "stdout_hash": "9cafc67c4a75fc413f3e7b261a442071ad368fc9d5e88c859dfde4c7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -26,7 +26,6 @@ loop.body:                                        ; preds = %loop.head
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -54,7 +53,5 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "c60da644ff3c882383c389860bab9d3c8d1c687a15854372343aadd0",
+    "stdout_hash": "877b98f7a158e496331050f703587930a50a2469aebf9c1e948ce6dd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -93,7 +93,6 @@ loop.end:                                         ; preds = %loop.head
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -151,7 +150,6 @@ loop.end3:                                        ; preds = %loop.head1
 
 then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -209,7 +207,6 @@ loop.end12:                                       ; preds = %loop.head10
 
 then13:                                           ; preds = %loop.end12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -267,7 +264,6 @@ loop.end21:                                       ; preds = %loop.head19
 
 then22:                                           ; preds = %loop.end21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -325,7 +321,6 @@ loop.end30:                                       ; preds = %loop.head28
 
 then31:                                           ; preds = %loop.end30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -383,7 +378,6 @@ loop.end39:                                       ; preds = %loop.head37
 
 then40:                                           ; preds = %loop.end39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -441,7 +435,6 @@ loop.end48:                                       ; preds = %loop.head46
 
 then49:                                           ; preds = %loop.end48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -499,7 +492,6 @@ loop.end57:                                       ; preds = %loop.head55
 
 then58:                                           ; preds = %loop.end57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont60
@@ -557,7 +549,6 @@ loop.end66:                                       ; preds = %loop.head64
 
 then67:                                           ; preds = %loop.end66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -615,7 +606,6 @@ loop.end75:                                       ; preds = %loop.head73
 
 then76:                                           ; preds = %loop.end75
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont78
@@ -673,7 +663,6 @@ loop.end84:                                       ; preds = %loop.head82
 
 then85:                                           ; preds = %loop.end84
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont87
@@ -704,7 +693,6 @@ free_nonnull89:                                   ; preds = %ifcont87
   br label %free_done90
 
 free_done90:                                      ; preds = %free_nonnull89, %ifcont87
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done90
@@ -718,8 +706,6 @@ FINALIZE_SYMTABLE_doloop_01:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "f8fa31e30b8c6d3e2bb4601e07c188fd97037e51e616499eef78bb84",
+    "stdout_hash": "bcd699342375575e6ad81bf45acf72cc327d4f2e6c7b81e8c0e241fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -64,7 +64,6 @@ loop.end:                                         ; preds = %loop.head
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -142,7 +141,6 @@ loop.end6:                                        ; preds = %loop.head1
 
 then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -219,7 +217,6 @@ loop.end18:                                       ; preds = %loop.head13
 
 then19:                                           ; preds = %loop.end18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -250,7 +247,6 @@ free_nonnull23:                                   ; preds = %ifcont21
   br label %free_done24
 
 free_done24:                                      ; preds = %free_nonnull23, %ifcont21
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done24
@@ -264,8 +260,6 @@ FINALIZE_SYMTABLE_doloop_02:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "62d21cd904dc9c12497102ea4468ed570ecddcbd6c95884741e35ffe",
+    "stdout_hash": "9737648b5f2803a765ed7c8a905eb798a53124a3e982e7eb0f3ef48c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -78,7 +78,6 @@ loop.end:                                         ; preds = %then1, %loop.head
 
 then4:                                            ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -150,7 +149,6 @@ loop.end13:                                       ; preds = %then9, %loop.head7
 
 then14:                                           ; preds = %loop.end13
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont16
@@ -222,7 +220,6 @@ loop.end25:                                       ; preds = %loop.head20
 
 then26:                                           ; preds = %loop.end25
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont28
@@ -253,7 +250,6 @@ free_nonnull30:                                   ; preds = %ifcont28
   br label %free_done31
 
 free_done31:                                      ; preds = %free_nonnull30, %ifcont28
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done31
@@ -267,8 +263,6 @@ FINALIZE_SYMTABLE_doloop_03:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "6f1ca0c330677c6a6368b055c506ac7c5122d48cf348b2be6abeabf4",
+    "stdout_hash": "8d34c3643620e6e3d524ceec286bb700def634f32de01955843055a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -76,7 +76,6 @@ loop.end:                                         ; preds = %loop.head
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -152,7 +151,6 @@ loop.end3:                                        ; preds = %loop.head1
 
 then4:                                            ; preds = %loop.end3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -224,7 +222,6 @@ a.end:                                            ; preds = %then10, %a.head
 
 then13:                                           ; preds = %a.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -274,7 +271,6 @@ b.end:                                            ; preds = %then16, %b.head
 
 then20:                                           ; preds = %b.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont22
@@ -321,7 +317,6 @@ c.end:                                            ; preds = %then23, %c.head
 
 then27:                                           ; preds = %c.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -367,7 +362,6 @@ goto_target:                                      ; preds = %loop.body31
   br label %loop.head30
 
 loop.end32:                                       ; preds = %loop.head30
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end32
@@ -381,8 +375,6 @@ FINALIZE_SYMTABLE_doloop_04:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-execute_command_line-0e9cd63.json
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-execute_command_line-0e9cd63.stdout",
-    "stdout_hash": "96613adccf0263e968c48996aadb6577f8d2f7e572c18e821d7d9ca7",
+    "stdout_hash": "48e5d9e8f836c72f10c8f0b8c717a3bdc39d390f677fbc7c14c10533",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-execute_command_line-0e9cd63.stdout
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.stdout
@@ -60,7 +60,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lcompilers_execute_command_line_(%string_descriptor* @string_const, i32* %call_arg_value)
   store i32 1, i32* %call_arg_value, align 4
   call void @_lcompilers_execute_command_line_1(%string_descriptor* @string_const.2, i32* %call_arg_value)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -72,7 +71,5 @@ FINALIZE_SYMTABLE_execute_command_line:           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "5e56885baae5a616f82f2739d28a6bdda5e7277ea2391d94ae1f0afb",
+    "stdout_hash": "dabb5e3cd2527db06ed424eb74ef517ddef167b56f21f03613a4ce2d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -16,7 +16,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -25,7 +24,6 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -39,8 +37,6 @@ FINALIZE_SYMTABLE_expr_05:                        ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "1a26d1c115699331290676809283a76c293264de9b10ee43da1a59d8",
+    "stdout_hash": "c685ddfe4bbed4a0816048dad345d16d82831b6d9f8a1d1cfb27ee09",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -74,7 +74,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @b()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -86,7 +85,5 @@ FINALIZE_SYMTABLE_external_03:                    ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "49f2216f0d5943f0563626ec8ced1d980311a1d96302b14afe4f96fa",
+    "stdout_hash": "a0e88e14f95b03dfa7828aebb67019cc7334c4c9514215ae0e58c045",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -223,7 +223,6 @@ ifcont:                                           ; preds = %else, %then
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %ifcont
@@ -392,8 +391,6 @@ entry:
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-finalize_02-cfb24d5.json
+++ b/tests/reference/llvm-finalize_02-cfb24d5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_02-cfb24d5.stdout",
-    "stdout_hash": "c8761e58ebab6f83f54a28ad2cbac00f0eaf931133a4fc9aca8a7f5b",
+    "stdout_hash": "32b9eede0a55c4dcdc8145012da38d64e1f0dc5e1aa7ba01c7e9eb9b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.stdout
+++ b/tests/reference/llvm-finalize_02-cfb24d5.stdout
@@ -17,7 +17,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 200, i32* %call_arg_value, align 4
   call void @ss(i32* %call_arg_value)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -396,7 +395,5 @@ entry:
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "12303ad942055d1ea93d35e87e49f4b40f4aca20ccca4d088dbad4b8",
+    "stdout_hash": "aff08bec650224c3d077b96f35080dfbb0f11216ad635a9bd7796de1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -37,7 +37,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -57,7 +56,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-functions_14-f13c087.json
+++ b/tests/reference/llvm-functions_14-f13c087.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-functions_14-f13c087.stdout",
-    "stdout_hash": "cfd9f05dbbd3f70f5ad55439af4574f85db8216e503bbf8189feeb4e",
+    "stdout_hash": "128bc9020dc9b0ff9c32a34079b5b4f84d16ab40e66c422e955d8695",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-functions_14-f13c087.stdout
+++ b/tests/reference/llvm-functions_14-f13c087.stdout
@@ -17,7 +17,6 @@ declare i32 @expr()
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -29,7 +28,5 @@ FINALIZE_SYMTABLE_functions_14:                   ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "db8432fdfde6cef466b2cfe272759e33d8bcfddd10a7067a3f04cefb",
+    "stdout_hash": "c253b0a865ed866aa76afab2a49b5a1ff3051330e10e0ceb1db78950",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -170,7 +170,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -186,7 +185,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -237,7 +235,6 @@ free_done6:                                       ; preds = %free_nonnull5, %ifc
 
 then7:                                            ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -253,7 +250,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -262,7 +258,6 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont12
@@ -341,8 +336,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "f14a9840d9129dc2bcef64583c9532ea5c1f210a3136d86c219625d6",
+    "stdout_hash": "4d32ca9a55cfcc0d653ee9b94bdb7eb7d3a8ff11e7bcebb1d8b5f317",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -225,7 +225,6 @@ then5:                                            ; preds = %ifcont4
 
 ifcont6:                                          ; preds = %ifcont4
   call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont6
@@ -325,7 +324,6 @@ define void @implicit_interface_check(i32* %arr1, i32* %m, i32* %c) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -340,7 +338,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -396,7 +393,6 @@ ifcont5:                                          ; preds = %ifcont3
 
 then6:                                            ; preds = %ifcont5
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -452,7 +448,6 @@ ifcont10:                                         ; preds = %ifcont8
 
 then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -508,7 +503,6 @@ ifcont15:                                         ; preds = %ifcont13
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -541,8 +535,6 @@ declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i3
 declare void @exit(i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "ba38de689b3800e5af39c57bf9a825e936f013823ee73a9e85bf3947",
+    "stdout_hash": "b0a62a8c0b03251f8a8c8bfd99431c2f4f8e60ee0cb11f8fdf31c311",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -74,7 +74,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -94,7 +93,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "f940032aa5196e6e1cf9b12e116348623f7200bac49c65c34d458b2c",
+    "stdout_hash": "d943ab877a6d933341904487cbbb8178a70870718c6eb2b97a52d619",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -35,7 +35,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -55,7 +54,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "6648d88398528d597e55334ea9a0a5d10eedcb2716c9aef628067fd0",
+    "stdout_hash": "73cf2be451838ee0eb802cd3a4d6fc0265cef59857d7ca5006bb9c0d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -39,7 +39,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -59,7 +58,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "1d7c7c6c1f4f5bc3765c301d549afbb9e577611a7283c8bd2b776acf",
+    "stdout_hash": "3079986b92c4c4b10e05b21077d354b35504c14d2a481812743fda23",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -79,7 +79,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 0.000000e+00, float* %call_arg_value, align 4
   store float 2.000000e+00, float* %call_arg_value1, align 4
   call void @__module_dflt_intent_foo(float* %call_arg_value, float* %call_arg_value1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -91,7 +90,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-interface_12-2e5ecb8.json
+++ b/tests/reference/llvm-interface_12-2e5ecb8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-interface_12-2e5ecb8.stdout",
-    "stdout_hash": "7aeb6b6defbfe569bec9ee2b57d0f5420cc6e0f2017c9664330671da",
+    "stdout_hash": "00de97b3475680f4a21fdae5a1807e1d257d5bcee425ac0febc14c62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-interface_12-2e5ecb8.stdout
+++ b/tests/reference/llvm-interface_12-2e5ecb8.stdout
@@ -18,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @find_fit(void ([1 x float]*)* @expression)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -41,7 +40,5 @@ FINALIZE_SYMTABLE_expression:                     ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "09f6bfbb8fb554dd54feb5a8f12be79c073bdbab6515ac231a1410d2",
+    "stdout_hash": "ec07433bc86ec51756f13c942cca0316665e7d7fa003514de37f9e1f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -93,7 +93,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -110,7 +109,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -127,7 +125,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -140,7 +137,6 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -166,7 +162,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then11:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -175,7 +170,6 @@ else12:                                           ; preds = %ifcont9
   br label %ifcont13
 
 ifcont13:                                         ; preds = %else12, %then11
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont13
@@ -200,8 +194,6 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 declare float @llvm.fabs.f32(float) #0
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "27fe8e456afea34409ef97597bf2004788e82da72023951de5c3d6cf",
+    "stdout_hash": "92853dd46cb85dfc40d826bbe8ab51aaf6cadafdf8f2d4c971b5502a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -57,7 +57,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -74,7 +73,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -98,7 +96,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then5:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont7
@@ -119,7 +116,6 @@ ifcont7:                                          ; preds = %else6, %then5
 
 then8:                                            ; preds = %ifcont7
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont10
@@ -165,7 +161,6 @@ free_done:                                        ; preds = %free_nonnull, %ifco
 
 then11:                                           ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -174,7 +169,6 @@ else12:                                           ; preds = %free_done
   br label %ifcont13
 
 ifcont13:                                         ; preds = %else12, %then11
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont13
@@ -191,8 +185,6 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare float @llvm.fabs.f32(float) #0
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "9a7016c1a86ffe920da55b2cf6e64d3740d7c7064e122535ad09f7ed",
+    "stdout_hash": "5c0499330ef195702eab3e7483ab1c8320d82b5ae16bfd3a949e0e0f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -87,7 +87,6 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done6
@@ -107,7 +106,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "ba951d17e21903550c8ab45e0935f0c55d48f5c3a049c1a7be036da2",
+    "stdout_hash": "3ceb3b08a6149200107165d42ceec1adba41970aa3ef0617c61585fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -193,7 +193,6 @@ free_nonnull17:                                   ; preds = %free_done15
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done18
@@ -213,7 +212,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-issue532-d63b703.json
+++ b/tests/reference/llvm-issue532-d63b703.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-issue532-d63b703.stdout",
-    "stdout_hash": "3632643f880ca7cb190b971a64e33195d3244224719631ed235a86f2",
+    "stdout_hash": "000c0285d33ffe77f8b13f16cb9a74eebbec4358eeb678aec86195a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-issue532-d63b703.stdout
+++ b/tests/reference/llvm-issue532-d63b703.stdout
@@ -4,7 +4,6 @@ source_filename = "LFortran"
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -16,7 +15,5 @@ FINALIZE_SYMTABLE_issue532:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "f671c343ccb667254ee139524bc0cf468745c16aa11ac35093f3b0ad",
+    "stdout_hash": "e7edda7bc8dea881b6aeaeccd5f7d3223e0bf7b8153f48f7162ce041",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -977,7 +977,6 @@ ifcont10:                                         ; preds = %free_done
 
 then11:                                           ; preds = %ifcont10
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -1028,7 +1027,6 @@ ifcont15:                                         ; preds = %ifcont13
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -1037,7 +1035,6 @@ else17:                                           ; preds = %ifcont15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont18
@@ -1058,8 +1055,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare double @llvm.fabs.f64(double) #1
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "6a0a47d5d254ff07a548b6a430bd51a53168ce2b0c6ebf4738af71fd",
+    "stdout_hash": "10f5b32150b2f73381123f2eb43135312586653c962a8583c531b793",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -37,7 +37,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -57,7 +56,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-logical2-94a2259.json
+++ b/tests/reference/llvm-logical2-94a2259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical2-94a2259.stdout",
-    "stdout_hash": "d293adb803ba0e1e9e482316102254a8c1cddc109cc7c4952bc91e81",
+    "stdout_hash": "4bfa00f6bc477e49cb0e4f9b169f34d61bef210e56cfcadd0c6c6eeb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical2-94a2259.stdout
+++ b/tests/reference/llvm-logical2-94a2259.stdout
@@ -36,7 +36,6 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -50,7 +49,5 @@ FINALIZE_SYMTABLE_logical2:                       ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-logical3-4bbf8ea.json
+++ b/tests/reference/llvm-logical3-4bbf8ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical3-4bbf8ea.stdout",
-    "stdout_hash": "1802abe547c768bcb53a2ecbb58ec0ef9ccd9924f6b9b8f51bfce1da",
+    "stdout_hash": "f62845afeb37a3c297e66da63529f73b74338a7e587213abee338459",
     "stderr": "llvm-logical3-4bbf8ea.stderr",
     "stderr_hash": "d7e28e54d198e14f86c18ab4c4ad128018b9bc6523fb945b05607a57",
     "returncode": 0

--- a/tests/reference/llvm-logical3-4bbf8ea.stdout
+++ b/tests/reference/llvm-logical3-4bbf8ea.stdout
@@ -112,7 +112,6 @@ then:                                             ; preds = %.entry
   %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -138,7 +137,6 @@ else2:                                            ; preds = %ifcont
   %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %13, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -159,7 +157,6 @@ else5:                                            ; preds = %ifcont3
   %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %19, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -183,7 +180,6 @@ else8:                                            ; preds = %ifcont6
   %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %26, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -204,7 +200,6 @@ else11:                                           ; preds = %ifcont9
   %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %32, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -221,7 +216,6 @@ then13:                                           ; preds = %ifcont12
   %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %38, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -249,7 +243,6 @@ else17:                                           ; preds = %ifcont15
   %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %45, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -270,7 +263,6 @@ else20:                                           ; preds = %ifcont18
   %51 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.30, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %51, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -286,7 +278,6 @@ then22:                                           ; preds = %ifcont21
   %56 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.32, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %56, i32 30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -297,7 +288,6 @@ else23:                                           ; preds = %ifcont21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont24
@@ -313,8 +303,6 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "073cffa5af15c33dfc7b942dc55c97db4c6681189dd52cbe8bd7fc07",
+    "stdout_hash": "b773988b23c82ad7f5455c2e08caa06a5dd43959b8e3cddb6ec6afad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -39,7 +39,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -59,7 +58,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-mangle_underscore_external_01-c26c50a.json
+++ b/tests/reference/llvm-mangle_underscore_external_01-c26c50a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-mangle_underscore_external_01-c26c50a.stdout",
-    "stdout_hash": "2abe0a06fc81e3ab092af8b1088c2f64f489a91eebd8cc2daf2cc907",
+    "stdout_hash": "ae0915dc96df06cf833caacfe3a41fe629daa19ad9e3d0fa6c5b91c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-mangle_underscore_external_01-c26c50a.stdout
+++ b/tests/reference/llvm-mangle_underscore_external_01-c26c50a.stdout
@@ -5,7 +5,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @foo_()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -19,7 +18,5 @@ FINALIZE_SYMTABLE_mangle_underscore_external_01:  ; preds = %return
 declare void @foo_()
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_01-1b129c3.json
+++ b/tests/reference/llvm-modules_01-1b129c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_01-1b129c3.stdout",
-    "stdout_hash": "2be81a2bf73e200df075f39eaef1dd7482c5e01023a89271ca6f955a",
+    "stdout_hash": "705d7b4697655234119f9a997105dd49885ad4976a000763dccf739a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_01-1b129c3.stdout
+++ b/tests/reference/llvm-modules_01-1b129c3.stdout
@@ -27,7 +27,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_modules_01_a_b()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -39,7 +38,5 @@ FINALIZE_SYMTABLE_modules_01:                     ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "fb8209d8b194d190004eb9e4d80735d0005f20fa7decdd51dbc554dc",
+    "stdout_hash": "05e7b37cd870d53f81f9e863de86992f914b20e474bd52601ba5e0b3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -58,7 +58,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -76,7 +75,5 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "0b06e5ef3d3e1535210ba16cbb7fa0b127947cd03f2b7e28f079256e",
+    "stdout_hash": "ca1e01dc48d8cd3e74bc8471c45b13a53efb00d6a6d3c5bf84cf641b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -85,7 +85,6 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   call void @__module_modules_11_module11_access_internally()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -97,7 +96,5 @@ FINALIZE_SYMTABLE_access_externally:              ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "f0d3851f4feffbd093f6f7f996b404969097a295f0976d18a2ea431d",
+    "stdout_hash": "3d0e5bb410acb768b8719e1b0562510fd91bc6924228273b2f8b1b82",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -65,7 +65,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -85,7 +84,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "4c891af220c9dd5c8b68218291f02f0f5362ea0b287c7e355fef4945",
+    "stdout_hash": "c550e297fe3e726ec02fdece1368851d9de76259465dfc1eae7fd70d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -496,7 +496,6 @@ define i32 @main(i32 %0, i8** %1) {
   store %modules_36_fpm_main_01.fpm_run_settings* %settings, %modules_36_fpm_main_01.fpm_run_settings** %22, align 8
   store i32 1, i32* %call_arg_value, align 4
   call void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings_class* %2, i32* %call_arg_value)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -691,8 +690,6 @@ entry:
 }
 
 declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64)
-
-declare void @_lpython_free_argv()
 
 define internal void @finalize_StructType__fpm_run_settings_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings* %0) {
 entry:

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "1a004d468297ff0c0112af814d44eb4ba04d85add2b8bb46950871ef",
+    "stdout_hash": "52835f599646343e6566282b0dee2b5a152fdc858def9c5d9100742e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -55,7 +55,6 @@ define i32 @main(i32 %0, i8** %1) {
   %c = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
   store i32 %2, i32* %c, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -67,7 +66,5 @@ FINALIZE_SYMTABLE_nested_01:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "e0610981ab3d1cc61eaca429596d1e71d5cfdc03a74dde7c54bd0806",
+    "stdout_hash": "82634e9ba02cf5b9d812637923cfac64d593b9aba10435cfb9dc9df3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -73,7 +73,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_02_a_b()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -85,7 +84,5 @@ FINALIZE_SYMTABLE_nested_02:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "135e22e395c43429961f871488abbaa7c87399a7cd73c92d2ef55af3",
+    "stdout_hash": "384ca2db8f0e965e4e3422f16ad9c0ebaa77db939c304140bdce6bb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -105,7 +105,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_03_a_b()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -117,7 +116,5 @@ FINALIZE_SYMTABLE_nested_03:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "26aafa6e9653747b2e9223a65afa5de44879699dfb869e41e8d68045",
+    "stdout_hash": "0fbf14fd6d64ae25f970c0927aa8cb7b96cde519f1f83c897d9cc7f3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -149,7 +149,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 5, i32* %call_arg_value, align 4
   %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
   store i32 %2, i32* %test, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -161,7 +160,5 @@ FINALIZE_SYMTABLE_nested_04:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "c77f5c85c188c72e09f03cc8922787fe97ed3f156a3584e35399d728",
+    "stdout_hash": "dbf37e6ba777a8efb7fb2415c384673fcbd9d0697d449aa651be7229",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -207,7 +207,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @__module_nested_05_a_b()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -219,7 +218,5 @@ FINALIZE_SYMTABLE_nested_05:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "ce54e8a63051dca90096c4ce792228f09f1360901e0a7ff98596d856",
+    "stdout_hash": "494508374688cfb81851869da584b6652618f6c72933bcefcaab894d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -105,7 +105,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store float 6.000000e+00, float* %call_arg_value, align 4
   call void @__module_nested_06_a_b(float* %call_arg_value)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -117,7 +116,5 @@ FINALIZE_SYMTABLE_nested_06:                      ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "4cd8a83c534f103dcdc9feea91d2eac1bf8291973ed69b3a90404550",
+    "stdout_hash": "9859ef0a38879b24a06d655cdd6ca2fbc0d30e5fe89e3a6579f1070d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -15,7 +15,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %2, align 4
   store i32* null, i32** %p1, align 8
   store i32* null, i32** %p2, align 8
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -27,7 +26,5 @@ FINALIZE_SYMTABLE_nullify_01:                     ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "877debf1d97182b5c992552d24f790cc9fe72cbf904129511e57de7d",
+    "stdout_hash": "0822af9cadb6e387a6d44371ac8ef0c3eecd1f998a4e8df794ce562a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -18,7 +18,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 2, i32* %3, align 4
   store float* null, float** %p1, align 8
   store i32* null, i32** %p2, align 8
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -30,7 +29,5 @@ FINALIZE_SYMTABLE_nullify_02:                     ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "3637afa8abfb8f2d9272fe1b14a1e87ad7f9f3536b6b12e04b10591a",
+    "stdout_hash": "f01a5bb0de5d6df647c66c0b5786445e15f52fa1f9604c4996a30719",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -313,7 +313,6 @@ free_nonnull20:                                   ; preds = %free_done18
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done21
@@ -333,7 +332,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "aaed128b690020986cdb30f843f52cb5a9fac4d70af398d03ce30c63",
+    "stdout_hash": "298733903e8d899bc6691275dad0a3ad75c535e359fd2081a1250552",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -83,7 +83,6 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -103,7 +102,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "7dd7355ac2a832073724e25571dd9aed7fae6c0ce469f370b708af92",
+    "stdout_hash": "0464893de0398bd2c8539bc6ceb50e6a2f636fe879baf06b9765ea97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -316,7 +316,6 @@ free_nonnull20:                                   ; preds = %free_done18
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done21
@@ -336,7 +335,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "968f71fd5c9eff96447da7c74582eb9edfe3a47df84a2315494fb818",
+    "stdout_hash": "e6840f33159c3aa5a22a6c6c616980e9d2e7d7f1f11c56ff01fa2212",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -87,7 +87,6 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -117,7 +116,5 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lfortran_file_write(i32, i32*, i8*, i64, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "2fda6b02f8156f3cbaefb47f6000cc70515d67696f30d58dc8613e33",
+    "stdout_hash": "615ae4a1250635b3ea866eeea79bccb41b32ad21fa1f809cc3d73743",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -64,7 +64,6 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -84,7 +83,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "bba0626d2857e6a10e67e418b7de81d2d8c24116f78dddc97cb79752",
+    "stdout_hash": "30c4177f9298338b5c03811bdd74577c50cfe4cbfa4cb6c606637833",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -60,7 +60,6 @@ free_done:                                        ; preds = %free_nonnull, %loop
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %loop.end
@@ -114,7 +113,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program_cmake_01-caf8f48.json
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_cmake_01-caf8f48.stdout",
-    "stdout_hash": "93f247365e0532b1bc577be07eda21bb63f34ddb0f774a70515e9469",
+    "stdout_hash": "1589d23a4e90e8061c6409d65d4c108d034c9046293404de58003d16",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_cmake_01-caf8f48.stdout
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.stdout
@@ -13,7 +13,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -27,7 +26,5 @@ FINALIZE_SYMTABLE_testfortran:                    ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "a3a342bc91b12cc0aa2c89114abccb85ff2ed8d736e947316077496d",
+    "stdout_hash": "709354c76b64bffb2e85ae851958e71b8b8b6537489857125de6a1be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -39,7 +39,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -59,7 +58,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "ab12258e7a458bc406bda1b27929ab044e25f386fb89f2dde4dc7a43",
+    "stdout_hash": "60ef45ff3ddaa54aaada2318dfac298674aee5924716dd33df1d9aa1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -40,7 +40,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -60,7 +59,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "98dde0e71a1b804667a3d18c946c7691f1548f61bc1f78ed409e6e27",
+    "stdout_hash": "fadf86c0fffae5a6f2f41b31a1efdb0b8c9d180c0186348dba957152",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -121,7 +121,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   store i32 10, i32* @__module_recursion_01_n, align 4
   call void @__module_recursion_01_sub1(i32* @__module_recursion_01_x)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -133,7 +132,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "402e8589ace4a1a89786641a89dab1284c4bda9493643ed8c1c9a874",
+    "stdout_hash": "e29b84038e0dbcc867cf44ffef4a3916f8f8f2794d3dd94d6cae1d80",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -227,7 +227,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -239,7 +238,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "30956edabd03ae0694ebaf50aeb60753ffaf74cf756f944ec7384013",
+    "stdout_hash": "5387db8576ccd38dbafc6b82fef903a424cb4d16a9117b6df48583a2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -244,7 +244,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -256,7 +255,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "0cec88d73c40c1efe0790d47b6c2af3546e47b4ca9eab1f0384bee3a",
+    "stdout_hash": "e46b281a5386a6df3ac8d057d0e3bc3dd780480d007bccef854f8050",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -24,7 +24,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 %2, i32* %main_out, align 4
   %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -75,7 +74,5 @@ FINALIZE_SYMTABLE_main1:                          ; preds = %return
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "09745e8f446198f1317d6f71f5bd57df1f942f9748bb31def7a633e5",
+    "stdout_hash": "7297fb85463aa0559d8e25015ac97ec3e3c21e3ccfc5ea2c1db305be",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -205,7 +205,6 @@ free_nonnull8:                                    ; preds = %free_done6
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done9
@@ -223,7 +222,5 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "64578f550f94464dc2b63f165443d6e356d5ed32917160d579806118",
+    "stdout_hash": "0b86df41467fa9379dfdcd5c70920d34411c27fd8e98349ac7123733",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -23,7 +23,6 @@ define i32 @main(i32 %0, i8** %1) {
   call void @main1(i32* @main.main_out)
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -72,7 +71,5 @@ FINALIZE_SYMTABLE_main1:                          ; preds = %return
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_05-b1ab26b.json
+++ b/tests/reference/llvm-return_05-b1ab26b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_05-b1ab26b.stdout",
-    "stdout_hash": "4131ffe800620bfb620cdc0ed0cdc5e8605b6b59f4061dde02584679",
+    "stdout_hash": "05c3e2c4c2cb7394ca4a345dac101f5a6d91ae047d6fa9de72a64509",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_05-b1ab26b.stdout
+++ b/tests/reference/llvm-return_05-b1ab26b.stdout
@@ -27,7 +27,6 @@ define i32 @main(i32 %0, i8** %1) {
 unreachable_after_return:                         ; No predecessors!
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -41,7 +40,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_06-ec98b0b.json
+++ b/tests/reference/llvm-return_06-ec98b0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_06-ec98b0b.stdout",
-    "stdout_hash": "c3134298de8186a464efae20dc113cc04ee255f42eaf9be82d2c5bd2",
+    "stdout_hash": "36005cf489f35f0df595282bcabc4cd0c4cc18ee5776573d4e0374d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_06-ec98b0b.stdout
+++ b/tests/reference/llvm-return_06-ec98b0b.stdout
@@ -7,7 +7,6 @@ define i32 @main(i32 %0, i8** %1) {
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -19,7 +18,5 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "7f1dd00b387debe8fef36ad13d38754adee5a9585269d73fc6348628",
+    "stdout_hash": "829a2920d6b813313252982a52f372f5b5f3ff11a3be295561f3c546",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -402,7 +402,6 @@ ifcont12:                                         ; preds = %free_done
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -783,7 +782,6 @@ ifcont39:                                         ; preds = %free_done37
 
 then40:                                           ; preds = %ifcont39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -841,7 +839,6 @@ ifcont44:                                         ; preds = %ifcont42
 
 then45:                                           ; preds = %ifcont44
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -876,7 +873,6 @@ else48:                                           ; preds = %ifcont26
   br label %ifcont49
 
 ifcont49:                                         ; preds = %"FINALIZE_SYMTABLE_~select_type_block_5", %"FINALIZE_SYMTABLE_~select_type_block_4", %"FINALIZE_SYMTABLE_~select_type_block_3"
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont49
@@ -1053,8 +1049,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "f52c64db46b913ff418c339bba2002141e980630e1c95c11fb522eca",
+    "stdout_hash": "80b037c94245cb7c89117282b5fcc8f5d0898e47d59a52d75bf6cc70",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -35,7 +35,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -55,7 +54,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "202d31aef797077811157dadf34fb8f80f9ab6deec51cff93ba4aa66",
+    "stdout_hash": "21e70aa6e7a846a0b7ba567baedebadc4ba0cc31dd3e6fa6dca254b0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -16,7 +16,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @STOP, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 0)
   br label %ifcont
@@ -25,7 +24,6 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -39,8 +37,6 @@ FINALIZE_SYMTABLE_stop:                           ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "2c6086d73586c4dedd06e4db61a3b99aeec39d9af18c83403e81d345",
+    "stdout_hash": "733b5f07fb331c9bfd913e1216a72bc720be461fad73343547f95eeb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -40,7 +40,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -60,7 +59,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "e5871044c75674fcb30ee4b87e36d6d38e5a05571ba111667d432d6e",
+    "stdout_hash": "09bc0617972b251f8380d110a115a4310f924d6b5bf0b143ed191d56",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -105,7 +105,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %48 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
   %49 = load i8*, i8** %48, align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %49, i32 25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -153,7 +152,5 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "ed259ba68b5982817f5a7c5f2e2626de30e3097d76bb19a0892092bf",
+    "stdout_hash": "5303198f6c3d41fb3fba600272dc136195193b392fffbf7e18c9b9c0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -406,7 +406,6 @@ ifcont7:                                          ; preds = %ifcont5
   %136 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
   %137 = load i8*, i8** %136, align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %137, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont7
@@ -488,7 +487,5 @@ declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
 declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
 
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "bcd639df406a359bebf8f9e731d7fa996ce0b174c2518faf4b3bbe70",
+    "stdout_hash": "22b20269eeca3db6dec377222fc26c403173d6f39c60e083af1ec0fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -217,7 +217,6 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
 
 then:                                             ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -226,7 +225,6 @@ else:                                             ; preds = %free_done6
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -260,8 +258,6 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "fd2fcd9876a82e67beb3eec7fcf6f7eede1da06b50be35bfa610c98e",
+    "stdout_hash": "d5bdfe02b3e44eed43e1e3cbb3480da06f65e596b2a5edbc3fc5083c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -411,7 +411,6 @@ free_done:                                        ; preds = %free_nonnull, %else
   br label %ifcont
 
 ifcont:                                           ; preds = %free_done, %then
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -447,7 +446,5 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, ...)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "b53478b1e811d220a32f98cf3d9bbf20264a6b6ef364184ac2b9991c",
+    "stdout_hash": "21d2f66b1d905e478c05ffa81d4300870346f8b509c28a8a188e90d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -28,7 +28,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -41,7 +40,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -54,7 +52,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -91,7 +88,6 @@ free_nonnull:                                     ; preds = %ifcont6
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -105,8 +101,6 @@ FINALIZE_SYMTABLE_string_13:                      ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-string_54-06ad64c.json
+++ b/tests/reference/llvm-string_54-06ad64c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_54-06ad64c.stdout",
-    "stdout_hash": "7a604435bf28d4f460b8413b68ff3818119ebe86ee556482a2c559dc",
+    "stdout_hash": "7dfc945b3ad9ba1fda3b65c422034cc1df253179774691d19f1d356a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_54-06ad64c.stdout
+++ b/tests/reference/llvm-string_54-06ad64c.stdout
@@ -45,7 +45,6 @@ define i32 @main(i32 %0, i8** %1) {
   %x = alloca i32, align 4
   store i32 10, i32* %x, align 4
   call void @__module_string_54_mod_foo_sub(i32* %x, %string_descriptor* %char)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -67,8 +66,6 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 declare i8* @_lfortran_malloc_alloc(i8*, i64)
 
 declare i8* @_lfortran_get_default_allocator()
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "dcf77f3d7b0a27848ff0e080b5d365eaad90c4a5a3c66e1f692fdf8f",
+    "stdout_hash": "d0282b0f170454abe2b69bb29da7fcab6ccbef34b4a45871c2724c8d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -50,7 +50,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -88,7 +87,6 @@ free_done:                                        ; preds = %free_nonnull, %ifco
 
 then1:                                            ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -103,7 +101,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -119,7 +116,6 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -158,7 +154,6 @@ free_done12:                                      ; preds = %free_nonnull11, %if
 
 then13:                                           ; preds = %free_done12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -174,7 +169,6 @@ ifcont15:                                         ; preds = %else14, %then13
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -213,7 +207,6 @@ free_done21:                                      ; preds = %free_nonnull20, %if
 
 then22:                                           ; preds = %free_done21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -229,7 +222,6 @@ ifcont24:                                         ; preds = %else23, %then22
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -270,7 +262,6 @@ free_done30:                                      ; preds = %free_nonnull29, %if
 
 then31:                                           ; preds = %free_done30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -279,7 +270,6 @@ else32:                                           ; preds = %free_done30
   br label %ifcont33
 
 ifcont33:                                         ; preds = %else32, %then31
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont33
@@ -307,8 +297,6 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "ae2636152899730fea9ee9654307601a832c13ca7a849a9099feb1fc",
+    "stdout_hash": "2157469e6b27dd6d2d0acf39176789a5c0dcf24ccc7922b87eef0c1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -63,7 +63,6 @@ free_done:                                        ; preds = %free_nonnull, %.ent
 
 then:                                             ; preds = %free_done
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -78,7 +77,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -116,7 +114,6 @@ free_done6:                                       ; preds = %free_nonnull5, %ifc
 
 then7:                                            ; preds = %free_done6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -131,7 +128,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -169,7 +165,6 @@ free_done15:                                      ; preds = %free_nonnull14, %if
 
 then16:                                           ; preds = %free_done15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -184,7 +179,6 @@ ifcont18:                                         ; preds = %else17, %then16
 
 then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -193,7 +187,6 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont21
@@ -255,8 +248,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "107638c70fbc808f825606cac98301b9a009d692da248896685c4030",
+    "stdout_hash": "b0df80f6eea71824f8a6d1c8098dafa4b9634f328a2a34d2c922ca28",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -11,7 +11,6 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @print_int()
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -67,7 +66,5 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_01-642cab3.json
+++ b/tests/reference/llvm-types_01-642cab3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_01-642cab3.stdout",
-    "stdout_hash": "d7ac36a0ead9b8be19ab35e15c5fa6f40806dd8f939cdb0018a5e006",
+    "stdout_hash": "c434e9bd6cd6b68c105be79ac45553310b09e4eff6c3588700930595",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_01-642cab3.stdout
+++ b/tests/reference/llvm-types_01-642cab3.stdout
@@ -10,7 +10,6 @@ define i32 @main(i32 %0, i8** %1) {
   store float 1.000000e+00, float* %r, align 4
   store float 2.000000e+00, float* %r, align 4
   store float 3.000000e+00, float* %r, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -22,7 +21,5 @@ FINALIZE_SYMTABLE_types_01:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "0f324db0fba661b8b3895cd94010f38a7491c1949f1b5aa8b5d7e1c6",
+    "stdout_hash": "41cb57c088ef9a2ca61bf4618704de534ed4780b0e67a3b1d9b3ca1b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -11,7 +11,6 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = load i32, i32* %i, align 4
   %3 = sitofp i32 %2 to float
   store float %3, float* %r, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -23,7 +22,5 @@ FINALIZE_SYMTABLE_types_02:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "b1a0e89009ec510d69de7bc92aa46a6ca3eeee39b275bec7615d2886",
+    "stdout_hash": "fb103a04802e4c6b473d34b23cd19451e1821f9cd7e41293e84f2cd3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -64,7 +64,6 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -84,7 +83,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "b528139b26549f88e64d119dd1c04ba733f89e35d34ea254cd094f5e",
+    "stdout_hash": "3b70966460ca4098689947096badb8d614e8a90bdafcb2c368541d1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -85,7 +85,6 @@ define i32 @main(i32 %0, i8** %1) {
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
   store float %61, float* %x, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -97,7 +96,5 @@ FINALIZE_SYMTABLE_types_04:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "6ff42992741826500f584ae9784b33f28986c12cac2d3e044bd0958e",
+    "stdout_hash": "5987aba8efb3f059add30169cc77ab3bfd038d877de8c8a24e8272fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -20,7 +20,6 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 0, i32* %i, align 4
   store i32 0, i32* %i, align 4
   store i32 0, i32* %i, align 4
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -32,7 +31,5 @@ FINALIZE_SYMTABLE_types_05:                       ; preds = %return
 }
 
 declare void @_lpython_call_initial_functions(i32, i8**)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "d6fc6659ba0cab3cc14ed2069c75903208c03ff046ca3a7fc7cea4a4",
+    "stdout_hash": "01209a3df2f6b8c81e1d01697333dfb168eb764de90b15413208c04f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -65,7 +65,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -81,7 +80,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -98,7 +96,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -115,7 +112,6 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -131,7 +127,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -147,7 +142,6 @@ ifcont12:                                         ; preds = %else11, %then10
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -164,7 +158,6 @@ ifcont15:                                         ; preds = %else14, %then13
 
 then16:                                           ; preds = %ifcont15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -181,7 +174,6 @@ ifcont18:                                         ; preds = %else17, %then16
 
 then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -197,7 +189,6 @@ ifcont21:                                         ; preds = %else20, %then19
 
 then22:                                           ; preds = %ifcont21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -213,7 +204,6 @@ ifcont24:                                         ; preds = %else23, %then22
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -230,7 +220,6 @@ ifcont27:                                         ; preds = %else26, %then25
 
 then28:                                           ; preds = %ifcont27
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont30
@@ -247,7 +236,6 @@ ifcont30:                                         ; preds = %else29, %then28
 
 then31:                                           ; preds = %ifcont30
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -264,7 +252,6 @@ ifcont33:                                         ; preds = %else32, %then31
 
 then34:                                           ; preds = %ifcont33
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont36
@@ -281,7 +268,6 @@ ifcont36:                                         ; preds = %else35, %then34
 
 then37:                                           ; preds = %ifcont36
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -299,7 +285,6 @@ ifcont39:                                         ; preds = %else38, %then37
 
 then40:                                           ; preds = %ifcont39
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -317,7 +302,6 @@ ifcont42:                                         ; preds = %else41, %then40
 
 then43:                                           ; preds = %ifcont42
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont45
@@ -334,7 +318,6 @@ ifcont45:                                         ; preds = %else44, %then43
 
 then46:                                           ; preds = %ifcont45
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont48
@@ -351,7 +334,6 @@ ifcont48:                                         ; preds = %else47, %then46
 
 then49:                                           ; preds = %ifcont48
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -369,7 +351,6 @@ ifcont51:                                         ; preds = %else50, %then49
 
 then52:                                           ; preds = %ifcont51
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont54
@@ -387,7 +368,6 @@ ifcont54:                                         ; preds = %else53, %then52
 
 then55:                                           ; preds = %ifcont54
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont57
@@ -404,7 +384,6 @@ ifcont57:                                         ; preds = %else56, %then55
 
 then58:                                           ; preds = %ifcont57
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont60
@@ -421,7 +400,6 @@ ifcont60:                                         ; preds = %else59, %then58
 
 then61:                                           ; preds = %ifcont60
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont63
@@ -439,7 +417,6 @@ ifcont63:                                         ; preds = %else62, %then61
 
 then64:                                           ; preds = %ifcont63
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont66
@@ -457,7 +434,6 @@ ifcont66:                                         ; preds = %else65, %then64
 
 then67:                                           ; preds = %ifcont66
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -466,7 +442,6 @@ else68:                                           ; preds = %ifcont66
   br label %ifcont69
 
 ifcont69:                                         ; preds = %else68, %then67
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont69
@@ -480,8 +455,6 @@ FINALIZE_SYMTABLE_types_06:                       ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "20d3809cf4b801b79322f81dfd1f49ad3c4ce6c6cc2255d2e1a0fbbd",
+    "stdout_hash": "205e8b88fdba9728727c7c8c35aa82e8e56dedf92b13244edaf655f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -143,7 +143,6 @@ else4:                                            ; preds = %else2
   br label %ifcont
 
 ifcont:                                           ; preds = %"FINALIZE_SYMTABLE_~select_type_block_3", %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -203,8 +202,6 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 ; Function Attrs: nounwind
 declare void @llvm.stackrestore(i8*) #1
-
-declare void @_lpython_free_argv()
 
 define internal void @"finalize_allocatable__StructType_Class__~unlimited_polymorphic_type"(%"~unlimited_polymorphic_type"* %0, i1 %1) {
 entry:

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "069b79fbc1e1fd21e8469b92124a7127c53a7ec42d157e3035cb9387",
+    "stdout_hash": "b717cb813465314380deef1d92964afe025eb144e15c374af74d9208",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -27,7 +27,6 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -47,7 +46,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -67,7 +65,6 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -89,7 +86,6 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -98,7 +94,6 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont9
@@ -112,8 +107,6 @@ FINALIZE_SYMTABLE_variables_03:                   ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-volatile_02-2beae13.json
+++ b/tests/reference/llvm-volatile_02-2beae13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_02-2beae13.stdout",
-    "stdout_hash": "208c2ca6303aa054a46219d8279804d6816b3d56c8839d58e83d4b1f",
+    "stdout_hash": "1b4deedd6a5918c3c736592c7cf59512b40bee40f198067926990cec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_02-2beae13.stdout
+++ b/tests/reference/llvm-volatile_02-2beae13.stdout
@@ -35,7 +35,6 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %free_done
@@ -55,7 +54,5 @@ declare i8* @_lfortran_get_default_allocator()
 declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-volatile_03-914e4e5.json
+++ b/tests/reference/llvm-volatile_03-914e4e5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_03-914e4e5.stdout",
-    "stdout_hash": "1e77b47e53ff667b90976aefc5b91af6c452c73f38ad05cdf20ac606",
+    "stdout_hash": "f99cb45b0f14035799c0aa9cbf0bb0ea35bbdd4420ee119e5e96a07b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_03-914e4e5.stdout
+++ b/tests/reference/llvm-volatile_03-914e4e5.stdout
@@ -21,7 +21,6 @@ define i32 @main(i32 %0, i8** %1) {
   %7 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 0
   %8 = load i8*, i8** %7, align 8
   call void @_lfortran_strcpy_alloc(i8* %2, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @y, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @y, i32 0, i32 1), i8 0, i8 0, i8* %8, i64 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -45,8 +44,6 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "a8001f52c758649bfef287f45433d9085c165b3480cf457f6db9cc9d",
+    "stdout_hash": "941c7954e2a24690174f025020b04eaefaec31e9e204551c3bb54f1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -46,7 +46,6 @@ loop.end:                                         ; preds = %loop.head
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -61,7 +60,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -96,7 +94,6 @@ loop.end6:                                        ; preds = %loop.head4
 
 then7:                                            ; preds = %loop.end6
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -111,7 +108,6 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -146,7 +142,6 @@ loop.end15:                                       ; preds = %loop.head13
 
 then16:                                           ; preds = %loop.end15
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -161,7 +156,6 @@ ifcont18:                                         ; preds = %else17, %then16
 
 then19:                                           ; preds = %ifcont18
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -170,7 +164,6 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont21
@@ -184,8 +177,6 @@ FINALIZE_SYMTABLE_while_01:                       ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "42a36e8b783aeb8384ffb5aa60af24691c1b6a3896df9e8c6baba548",
+    "stdout_hash": "e90696686925843524a8b03b305dff30de25cb3f647eb19c2e50802f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -46,7 +46,6 @@ loop.end:                                         ; preds = %loop.head
 
 then:                                             ; preds = %loop.end
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -61,7 +60,6 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -110,7 +108,6 @@ loop.end9:                                        ; preds = %then6, %loop.head4
 
 then10:                                           ; preds = %loop.end9
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -125,7 +122,6 @@ ifcont12:                                         ; preds = %else11, %then10
 
 then13:                                           ; preds = %ifcont12
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -174,7 +170,6 @@ loop.end21:                                       ; preds = %loop.head16
 
 then22:                                           ; preds = %loop.end21
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -189,7 +184,6 @@ ifcont24:                                         ; preds = %else23, %then22
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  call void @_lpython_free_argv()
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -198,7 +192,6 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %ifcont27
@@ -212,8 +205,6 @@ FINALIZE_SYMTABLE_while_02:                       ; preds = %return
 declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "da1ca9d58e6f3788e4fc826d8ba081e46ae01270c2e28b588b31fd75",
+    "stdout_hash": "3bc1865d539e50db8d5d9b3505026316dcc5fd1cf12a768b5e270fa4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -30,7 +30,6 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = load i32*, i32** %8, align 8
   %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void (i32, i32*, i8*, i64, ...) @_lfortran_file_write(i32 %7, i32* %9, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i64 4, i8* %10, i64 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i64 1)
-  call void @_lpython_free_argv()
   br label %return
 
 return:                                           ; preds = %.entry
@@ -54,8 +53,6 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_file_write(i32, i32*, i8*, i64, ...)
-
-declare void @_lpython_free_argv()
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 


### PR DESCRIPTION
Replace dynamic allocation of command-line arguments with fixed static buffers (256 args × 4096 bytes). This eliminates all malloc/free calls for argv storage, removing the need for _lpython_free_argv cleanup at every exit point.

- _lpython_set_argv() copies into static buffers
- _lpython_free_argv() is now a no-op (kept for ABI compat)
- Remove _lpython_free_argv calls from LLVM codegen
- Remove _lpython_free_argv call from alloc_finalize