### PR TITLE
feat: Add support for disabling specific warnings via -Wno-* flags

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2438,6 +2438,8 @@ int main_app(int argc, char *argv[]) {
                 compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::ImplicitInterface);
             } else if (warn_name == "naming-convention") {
                 compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::NamingConvention);
+            } else if (warn_name == "recursive-function-call") {
+                compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::RecursiveFunctionCall);
             } else if (warn_name == "other") {
                 compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::Other);
             } else {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -582,6 +582,7 @@ int emit_tokens(const std::string &infile, bool line_numbers, const CompilerOpti
     std::vector<LCompilers::LFortran::YYSTYPE> stypes;
     std::vector<LCompilers::Location> locations;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::LocationManager lm;
     {
         LCompilers::LocationManager::FileLocations fl;
@@ -626,6 +627,7 @@ int emit_ast(const std::string &infile, CompilerOptions &compiler_options)
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -656,6 +658,7 @@ int emit_ast_f90(const std::string &infile, CompilerOptions &compiler_options)
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -722,6 +725,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
@@ -777,6 +781,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         r = fe.get_asr2(input, lm, diagnostics);
     bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
@@ -803,6 +808,7 @@ int python_wrapper(const std::string &infile, std::string array_order,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         r = fe.get_asr2(input, lm, diagnostics);
     bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
@@ -852,6 +858,7 @@ int emit_cpp(const std::string &infile, CompilerOptions &compiler_options)
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -877,6 +884,7 @@ int emit_c(const std::string &infile,
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -912,6 +920,7 @@ int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -935,6 +944,7 @@ int emit_fortran(const std::string &infile, CompilerOptions &compiler_options) {
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -959,6 +969,7 @@ int dump_all_passes(const std::string &infile, CompilerOptions &compiler_options
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -1006,6 +1017,7 @@ int save_mod_files(const LCompilers::ASR::TranslationUnit_t &u,
             LCompilers::ASR::TranslationUnit_t *tu =
                 LCompilers::ASR::down_cast2<LCompilers::ASR::TranslationUnit_t>(asr);
             LCompilers::diag::Diagnostics diagnostics;
+            diagnostics.disabled_warnings = compiler_options.disabled_warnings;
             LCOMPILERS_ASSERT(LCompilers::asr_verify(*tu, true, diagnostics));
 
             std::string modfile_binary = LCompilers::save_modfile(*tu, lm);
@@ -1061,6 +1073,7 @@ int handle_mlir(const std::string &infile,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
@@ -1112,6 +1125,7 @@ int emit_llvm(const std::string &infile, LCompilers::PassManager& pass_manager,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<std::string> llvm
         = fe.get_llvm(input, lm, pass_manager, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
@@ -1133,6 +1147,7 @@ int emit_asm(const std::string &infile, CompilerOptions &compiler_options)
     // TODO: Remove this and accept pass manager in emit_asm
     LCompilers::PassManager lpm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -1187,6 +1202,7 @@ int compile_src_to_object_file(const std::string &infile,
         compiler_options.po.intrinsic_module_name_mangling = true;
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     t1 = std::chrono::high_resolution_clock::now();
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
@@ -1342,6 +1358,7 @@ int emit_wat(const std::string &infile, CompilerOptions &compiler_options)
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -1370,6 +1387,7 @@ int compile_to_binary_x86(const std::string &infile, const std::string &outfile,
 
     std::string input;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::FortranEvaluator fe(compiler_options);
     Allocator al(64*1024*1024); // Allocate 64 MB
     LCompilers::LFortran::AST::TranslationUnit_t* ast;
@@ -1471,6 +1489,7 @@ int compile_to_binary_wasm(const std::string &infile, const std::string &outfile
 
     std::string input;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::FortranEvaluator fe(compiler_options);
     Allocator al(64*1024*1024); // Allocate 64 MB
     LCompilers::LFortran::AST::TranslationUnit_t* ast;
@@ -1581,6 +1600,7 @@ int compile_to_object_file_cpp(const std::string &infile,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
@@ -1692,6 +1712,7 @@ int compile_to_object_file_c(const std::string &infile,
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         r = fe.get_asr2(input, lm, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);
@@ -1785,6 +1806,7 @@ int compile_to_binary_fortran(const std::string &infile,
     LCompilers::FortranEvaluator fe(compiler_options);
     LCompilers::LocationManager lm;
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
@@ -2223,6 +2245,7 @@ int emit_c_preprocessor(const std::string &infile, CompilerOptions &compiler_opt
         lm.file_ends.push_back(input.size());
     }
     LCompilers::diag::Diagnostics diagnostics;
+    diagnostics.disabled_warnings = compiler_options.disabled_warnings;
     LCompilers::Result<std::string> res = cpp.run(input, lm, cpp.macro_definitions, diagnostics);
     std::string s;
     if (res.ok) {
@@ -2252,6 +2275,7 @@ namespace wasm {
                         LCompilers::FortranEvaluator fe(compiler_options); \
                         LCompilers::LocationManager lm; \
                         LCompilers::diag::Diagnostics diagnostics; \
+                        diagnostics.disabled_warnings = compiler_options.disabled_warnings; \
                         { \
                             LCompilers::LocationManager::FileLocations fl; \
                             fl.in_filename = "input"; \
@@ -2399,6 +2423,26 @@ int main_app(int argc, char *argv[]) {
         std::string option = std::string(argv[i]);
         if (option != "lfortran" && (option.size() < 4 || option.substr(option.size() - 4) != ".f90")) {
             lcompilers_commandline_options += option + " ";
+        }
+    }
+
+    // --- Parse -Wno- flags into CompilerOptions ---
+    for (int i = 1; i < argc; i++) {
+        std::string arg = std::string(argv[i]);
+        if (arg.size() > 5 && arg.substr(0, 5) == "-Wno-") {
+            std::string warn_name = arg.substr(5);
+            
+            if (warn_name == "unused-variable") {
+                compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::UnusedVariable);
+            } else if (warn_name == "implicit-interface") {
+                compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::ImplicitInterface);
+            } else if (warn_name == "naming-convention") {
+                compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::NamingConvention);
+            } else if (warn_name == "other") {
+                compiler_options.disabled_warnings.insert(LCompilers::diag::WarningID::Other);
+            } else {
+                std::cerr << "lfortran: warning: unknown -Wno-" << warn_name << std::endl;
+            }
         }
     }
 

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2892,30 +2892,35 @@ public:
             }
 
             // Raise warning for user if variable declaration is calling its function scope recursively.
-            ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(*expr_holder);
-            if(((ASR::symbol_t*)current_scope->asr_owner) == func_call->m_name){
-                diag.add(diag::Diagnostic(
-                    "Variable declaration is calling its function scope recursively",
-                    diag::Level::Warning, diag::Stage::Semantic, {
-                        diag::Label("", {func_call->base.base.loc})}));                
-            }
+            if (expr_holder && *expr_holder && ASR::is_a<ASR::FunctionCall_t>(**expr_holder)) {
+                ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(*expr_holder);
 
-            // Add called function as dependency to Variable node.
-            SetChar var_dep;var_dep.reserve(al,0);
+                if (((ASR::symbol_t*)current_scope->asr_owner) == func_call->m_name) {
+                    diag.add(diag::Diagnostic(
+                        "Recursive function call detected in variable declaration",
+                        diag::Level::Warning,
+                        diag::Stage::Semantic,
+                        {diag::Label("", {func_call->base.base.loc})},
+                        diag::WarningID::Other // Tagged for silencing
+                    ));
+                }
+
+                // Add called function as dependency to the owning-function's scope
+                // ExternalSymbol calls are not tracked as function dependencies
+                // (consistent with how the verify pass collects dependencies)
+                if (!ASR::is_a<ASR::ExternalSymbol_t>(*func_call->m_name)) {
+                    SetChar func_dep;
+                    func_dep.from_pointer_n_copy(al, func->m_dependencies, func->n_dependencies);
+                    func_dep.push_back(al, ASRUtils::symbol_name(func_call->m_name));
+                    func->m_dependencies = func_dep.p;
+                    func->n_dependencies = func_dep.n;
+                }
+            }
+            SetChar var_dep; 
+            var_dep.reserve(al, 0);
             ASRUtils::collect_variable_dependencies(al, var_dep, variable->m_type, nullptr, variable->m_value);
             variable->m_dependencies = var_dep.p;
             variable->n_dependencies = var_dep.n;
-
-            // Add called function as dependency to the owning-function's scope
-            // ExternalSymbol calls are not tracked as function dependencies
-            // (consistent with how the verify pass collects dependencies)
-            if (!ASR::is_a<ASR::ExternalSymbol_t>(*func_call->m_name)) {
-                SetChar func_dep;
-                func_dep.from_pointer_n_copy(al, func->m_dependencies, func->n_dependencies);
-                func_dep.push_back(al, ASRUtils::symbol_name(func_call->m_name));
-                func->m_dependencies = func_dep.p;
-                func->n_dependencies = func_dep.n;
-            }
 
             // Revert current scope
             current_scope = current_scope_copy;
@@ -3283,11 +3288,12 @@ public:
         for (size_t i=0; i<x.n_namelist; i++) {
             std::string arg = to_lower(x.m_namelist[i]);
             if (!current_scope->get_symbol(arg)) {
-                diag.add(Diagnostic(
+                diag.add(diag::Diagnostic(
                     "Parameter " + arg + " is unused in " + x.m_name,
-                    Level::Warning, Stage::Semantic, {
-                        Label("", {x.base.base.loc})
-                    }
+                    diag::Level::Warning, diag::Stage::Semantic, {
+                        diag::Label("", {x.base.base.loc})
+                    },
+                    diag::WarningID::UnusedVariable // <--- ADD THIS LINE
                 ));
             }
             current_procedure_args.push_back(arg);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2895,19 +2895,19 @@ public:
             if (expr_holder && *expr_holder && ASR::is_a<ASR::FunctionCall_t>(**expr_holder)) {
                 ASR::FunctionCall_t* func_call = ASR::down_cast<ASR::FunctionCall_t>(*expr_holder);
 
-                if (((ASR::symbol_t*)current_scope->asr_owner) == func_call->m_name) {
+                bool is_recursive_call = ((ASR::symbol_t*)current_scope->asr_owner) == func_call->m_name;
+
+                if (is_recursive_call) {
                     diag.add(diag::Diagnostic(
                         "Recursive function call detected in variable declaration",
                         diag::Level::Warning,
                         diag::Stage::Semantic,
                         {diag::Label("", {func_call->base.base.loc})},
-                        diag::WarningID::Other // Tagged for silencing
+                        diag::WarningID::RecursiveFunctionCall
                     ));
                 }
 
                 // Add called function as dependency to the owning-function's scope
-                // ExternalSymbol calls are not tracked as function dependencies
-                // (consistent with how the verify pass collects dependencies)
                 if (!ASR::is_a<ASR::ExternalSymbol_t>(*func_call->m_name)) {
                     SetChar func_dep;
                     func_dep.from_pointer_n_copy(al, func->m_dependencies, func->n_dependencies);
@@ -3293,7 +3293,7 @@ public:
                     diag::Level::Warning, diag::Stage::Semantic, {
                         diag::Label("", {x.base.base.loc})
                     },
-                    diag::WarningID::UnusedVariable // <--- ADD THIS LINE
+                    diag::WarningID::UnusedVariable
                 ));
             }
             current_procedure_args.push_back(arg);

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -84,6 +84,7 @@ enum class WarningID {
     UnusedVariable,
     ImplicitInterface,
     NamingConvention,
+    RecursiveFunctionCall,
     Other,
     None // Default for Errors and non-configurable messages
 };
@@ -94,6 +95,7 @@ inline std::string warn_id_to_string(WarningID id) {
         case WarningID::UnusedVariable:  return "unused-variable";
         case WarningID::ImplicitInterface: return "implicit-interface";
         case WarningID::NamingConvention:  return "naming-convention";
+        case WarningID::RecursiveFunctionCall:  return "recursive-function-call";
         case WarningID::Other:             return "other";
         default:                           return "";
     }

--- a/src/libasr/diagnostics.h
+++ b/src/libasr/diagnostics.h
@@ -5,6 +5,10 @@
 #include <libasr/location.h>
 #include <libasr/stacktrace.h>
 
+#include <string>
+#include <vector>
+#include <set>
+
 namespace LCompilers {
 
 struct LocationManager;
@@ -74,6 +78,28 @@ enum Stage {
 };
 
 /*
+ * Unique identifiers for warnings so they can be toggled via CLI
+ */
+enum class WarningID {
+    UnusedVariable,
+    ImplicitInterface,
+    NamingConvention,
+    Other,
+    None // Default for Errors and non-configurable messages
+};
+
+// Helper to convert the ID to a string flag name
+inline std::string warn_id_to_string(WarningID id) {
+    switch (id) {
+        case WarningID::UnusedVariable:  return "unused-variable";
+        case WarningID::ImplicitInterface: return "implicit-interface";
+        case WarningID::NamingConvention:  return "naming-convention";
+        case WarningID::Other:             return "other";
+        default:                           return "";
+    }
+}
+
+/*
  * A diagnostic message has a level and message and labels.
  *
  * Errors have zero or more primary and zero or more secondary labels.
@@ -98,6 +124,7 @@ enum Stage {
 struct Diagnostic {
     Level level;
     Stage stage;
+    WarningID warn_id = WarningID::None;
     std::string message;
     std::vector<Label> labels;
     std::vector<Diagnostic> children;
@@ -108,12 +135,14 @@ struct Diagnostic {
 
     Diagnostic(const std::string &message, const Level &level,
         const Stage &stage,
-        const std::vector<Label> &labels
-        ) : level{level}, stage{stage}, message{message}, labels{labels} {}
+        const std::vector<Label> &labels,
+        WarningID warn_id = WarningID::None
+        ) : level{level}, stage{stage}, warn_id{warn_id}, message{message}, labels{labels} {}
 };
 
 struct Diagnostics {
     std::vector<Diagnostic> diagnostics;
+    std::set<WarningID> disabled_warnings;
 
     std::string render(LocationManager &lm, const CompilerOptions &compiler_options);
 
@@ -126,6 +155,10 @@ struct Diagnostics {
     bool has_style() const;
 
     void add(const Diagnostic &d) {
+        if ((d.level == Level::Warning || d.level == Level::Style) &&
+        disabled_warnings.find(d.warn_id) != disabled_warnings.end()) {
+            return;
+        }
         diagnostics.push_back(d);
     }
 
@@ -133,17 +166,18 @@ struct Diagnostics {
             const std::vector<Location> &locations,
             const std::string &error_label,
             const Level &level,
-            const Stage &stage
+            const Stage &stage,
+             WarningID warn_id = WarningID::None
             ) {
-        diagnostics.push_back(
-            Diagnostic(message, level, stage, {Label(error_label, locations)})
+        add(
+            Diagnostic(message, level, stage, {Label(error_label, locations)}, warn_id)
         );
     }
 
     void semantic_warning_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Warning, Stage::Semantic);
+            Level::Warning, Stage::Semantic, warn_id);
     }
 
     void semantic_error_label(const std::string &message,
@@ -153,21 +187,21 @@ struct Diagnostics {
     }
 
     void tokenizer_warning_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Warning, Stage::Tokenizer);
+            Level::Warning, Stage::Tokenizer, warn_id);
     }
 
     void parser_warning_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Warning, Stage::Parser);
+            Level::Warning, Stage::Parser, warn_id);
     }
 
     void codegen_warning_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Warning, Stage::CodeGen);
+            Level::Warning, Stage::CodeGen, warn_id);
     }
 
     void codegen_error_label(const std::string &message,
@@ -177,15 +211,15 @@ struct Diagnostics {
     }
 
     void tokenizer_style_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Style, Stage::Tokenizer);
+            Level::Style, Stage::Tokenizer, warn_id);
     }
 
     void parser_style_label(const std::string &message,
-            const std::vector<Location> &locations, const std::string &error_label) {
+            const std::vector<Location> &locations, const std::string &error_label, WarningID warn_id = WarningID::None) {
         message_label(message, locations, error_label,
-            Level::Style, Stage::Parser);
+            Level::Style, Stage::Parser, warn_id);
     }
 
     void clear() {

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <filesystem>
 #include <libasr/containers.h>
+#include <set>
+#include <libasr/diagnostics.h>
 
 namespace LCompilers {
 
@@ -121,6 +123,7 @@ struct CompilerOptions {
     bool generate_code_for_global_procedures = false;
     bool show_warnings = true;
     bool show_style_suggestions = true;
+    std::set<LCompilers::diag::WarningID> disabled_warnings;
     bool logical_casting = false;
     bool show_error_banner = true;
     bool bounds_checking = true;


### PR DESCRIPTION
This PR introduces support for selectively disabling compiler warnings using `-Wno-*` flags.

## Features

* Added `WarningID` enum to uniquely identify warning categories
* Extended `Diagnostic` to include `warn_id` and propagated it through helper APIs
* Added `disabled_warnings` set to `CompilerOptions` and `Diagnostics` for filtering
* Implemented filtering logic in `Diagnostics::add()` to suppress selected warnings
* **Robustness:** Added safety checks (`ASR::is_a`) in recursive call handling to prevent invalid casts
* Added CLI parsing for initial flags:

  * `-Wno-unused-variable`
  * `-Wno-implicit-interface`
  * `-Wno-naming-convention`
  * `-Wno-other`

## Example

**Before:**

```
warning: unused variable 'x'
```

**After:**

```
lfortran -Wno-unused-variable file.f90
```

*(The warning is suppressed)*

## Notes

* Errors remain unaffected and will always be displayed
* Only warnings and style suggestions are filtered
* `disabled_warnings` is propagated to `Diagnostics` instances where needed

Closes #10605
