### PR TITLE
Fix allocate with source calling function multiple times

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2260,6 +2260,7 @@ RUN(NAME allocate_56 LABELS gfortran llvm)
 RUN(NAME allocate_57 LABELS gfortran llvm)
 RUN(NAME allocate_58 LABELS gfortran llvm)
 RUN(NAME allocate_59 LABELS gfortran llvm)
+RUN(NAME allocate_60 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_60.f90
+++ b/integration_tests/allocate_60.f90
@@ -1,0 +1,29 @@
+program allocate_60
+implicit none
+
+type :: MyType
+    integer :: val = 0
+end type MyType
+
+type(MyType), allocatable :: arr(:)
+integer :: call_count
+
+call_count = 0
+allocate(arr, source = allocator())
+
+if (call_count /= 1) error stop
+if (size(arr) /= 9) error stop
+if (arr(1)%val /= 42) error stop
+if (arr(2)%val /= 0) error stop
+print *, "ok"
+
+contains
+
+function allocator() result(arr)
+    type(MyType), allocatable :: arr(:)
+    call_count = call_count + 1
+    allocate(arr(9))
+    arr(1) = MyType(42)
+end function allocator
+
+end program allocate_60

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2919,6 +2919,39 @@ public:
             }
         }
 
+        // When source is a FunctionCall, materialize it into a temporary
+        // variable so the function is called only once. Without this, the
+        // source expression is duplicated into ArrayBound, ArraySize,
+        // Allocate, and Assignment nodes, causing multiple evaluations.
+        if (source_cond && source != nullptr &&
+                ASR::is_a<ASR::FunctionCall_t>(*source)) {
+            ASR::ttype_t* source_type = ASRUtils::expr_type(source);
+            std::string tmp_name = current_scope->get_unique_name(
+                "__lfortran_allocate_source_tmp");
+            SetChar variable_dependencies_vec;
+            variable_dependencies_vec.reserve(al, 1);
+            ASRUtils::collect_variable_dependencies(
+                al, variable_dependencies_vec, source_type);
+            ASR::symbol_t* type_decl = ASRUtils::get_struct_sym_from_struct_expr(source);
+            ASR::asr_t* tmp_sym = ASRUtils::make_Variable_t_util(
+                al, x.base.base.loc, current_scope, s2c(al, tmp_name),
+                variable_dependencies_vec.p, variable_dependencies_vec.size(),
+                ASR::intentType::Local, nullptr, nullptr,
+                ASR::storage_typeType::Default, source_type, type_decl,
+                current_procedure_abi_type, ASR::Public,
+                ASR::presenceType::Required, false);
+            current_scope->add_symbol(tmp_name,
+                ASR::down_cast<ASR::symbol_t>(tmp_sym));
+            ASR::expr_t* tmp_var = ASRUtils::EXPR(ASR::make_Var_t(
+                al, x.base.base.loc, ASR::down_cast<ASR::symbol_t>(tmp_sym)));
+            ASR::stmt_t* assign_source = ASRUtils::STMT(
+                ASRUtils::make_Assignment_t_util(
+                    al, x.base.base.loc, tmp_var, source, nullptr,
+                    compiler_options.po.realloc_lhs_arrays, false));
+            current_body->push_back(al, assign_source);
+            source = tmp_var;
+        }
+
         if ( mold_cond || source_cond ) {
             Vec<ASR::alloc_arg_t> new_alloc_args_vec;
             new_alloc_args_vec.reserve(al, alloc_args_vec.size());


### PR DESCRIPTION
When allocate(arr, source=func_call()) was used, the function call expression was duplicated into ArrayBound, ArraySize, Allocate source, and Assignment nodes, causing the function to be evaluated 4 times instead of once.

The fix materializes the source expression into a temporary variable when it is a FunctionCall, so the function is called exactly once and the temporary is reused for dimension extraction, allocation, and data copying.

An integration test (allocate_60) is added to verify the fix.

Fixes #10698.