### PR TITLE
Fix modfile deserialization of allocate source= tmp

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3840,6 +3840,7 @@ RUN(NAME separate_compilation_43 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_44 LABELS gfortran llvm EXTRAFILES separate_compilation_44a.f90 separate_compilation_44b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_45 LABELS gfortran llvm EXTRAFILES separate_compilation_45a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_46 LABELS gfortran llvm EXTRAFILES separate_compilation_46a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compilation_47a.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_47.f90
+++ b/integration_tests/separate_compilation_47.f90
@@ -1,0 +1,14 @@
+program separate_compilation_47
+   use separate_compilation_47a_mymod
+   implicit none
+   class(AbsType), allocatable :: val
+   val = myfunc()
+   if (val%x /= 42) error stop
+   select type(val)
+   type is (ConcreteType)
+      if (val%y /= 84) error stop
+   class default
+      error stop
+   end select
+   print *, "ok"
+end program separate_compilation_47

--- a/integration_tests/separate_compilation_47a.f90
+++ b/integration_tests/separate_compilation_47a.f90
@@ -1,0 +1,27 @@
+module separate_compilation_47a_absmod
+   type, abstract :: AbsType
+      integer :: x = 0
+   end type AbsType
+
+   type, extends(AbsType) :: ConcreteType
+      integer :: y = 0
+   end type ConcreteType
+end module separate_compilation_47a_absmod
+
+module separate_compilation_47a_mymod
+   use separate_compilation_47a_absmod
+contains
+   function myfunc() result(res)
+      class(AbsType), allocatable :: res
+      allocate(res, source=srcfunc())
+   end function myfunc
+   function srcfunc() result(obj)
+      class(AbsType), allocatable :: obj
+      allocate(ConcreteType :: obj)
+      obj%x = 42
+      select type(obj)
+      type is (ConcreteType)
+         obj%y = 84
+      end select
+   end function srcfunc
+end module separate_compilation_47a_mymod

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2933,6 +2933,14 @@ public:
             ASRUtils::collect_variable_dependencies(
                 al, variable_dependencies_vec, source_type);
             ASR::symbol_t* type_decl = ASRUtils::get_struct_sym_from_struct_expr(source);
+            if (type_decl != nullptr) {
+                std::string decl_name = ASRUtils::symbol_name(type_decl);
+                ASR::symbol_t* resolved = current_scope->resolve_symbol(decl_name);
+                if (resolved != nullptr &&
+                        ASRUtils::symbol_get_past_external(resolved) == type_decl) {
+                    type_decl = resolved;
+                }
+            }
             ASR::asr_t* tmp_sym = ASRUtils::make_Variable_t_util(
                 al, x.base.base.loc, current_scope, s2c(al, tmp_name),
                 variable_dependencies_vec.p, variable_dependencies_vec.size(),


### PR DESCRIPTION
When allocate(x, source=func()) creates a temporary variable for the function call result, get_struct_sym_from_struct_expr() strips the ExternalSymbol wrapper, causing the temporary's type_declaration to reference the actual struct in the external module's symbol table. This produces a cross-scope reference that fails during modfile deserialization.

Resolve the type_declaration to the accessible ExternalSymbol in the current scope chain before creating the temporary variable.

Added integration test separate_compilation_47.

Fixes #10723.