### PR TITLE
Fix sourced allocation deserialization with cross-module struct

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2278,6 +2278,7 @@ RUN(NAME allocate_57 LABELS gfortran llvm)
 RUN(NAME allocate_58 LABELS gfortran llvm)
 RUN(NAME allocate_59 LABELS gfortran llvm)
 RUN(NAME allocate_60 LABELS gfortran llvm)
+RUN(NAME allocate_61 LABELS gfortran llvm EXTRAFILES allocate_61_mod.f90 allocate_61_mod2.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_61.f90
+++ b/integration_tests/allocate_61.f90
@@ -1,0 +1,10 @@
+program allocate_61
+   use allocate_61_allocmod, only: alloc_source
+   use allocate_61_mymod, only: w
+   implicit none
+   type(w) :: obj
+   call alloc_source(obj)
+   if (.not. allocated(obj%a)) error stop
+   if (obj%a%x /= 10) error stop
+   print *, "PASS"
+end program

--- a/integration_tests/allocate_61_mod.f90
+++ b/integration_tests/allocate_61_mod.f90
@@ -1,0 +1,14 @@
+module allocate_61_mymod
+   implicit none
+   type :: t
+      integer :: x = 42
+   end type
+   type :: w
+      type(t), allocatable :: a
+   end type
+contains
+   function make_t() result(res)
+      type(t) :: res
+      res%x = 10
+   end function
+end module

--- a/integration_tests/allocate_61_mod2.f90
+++ b/integration_tests/allocate_61_mod2.f90
@@ -1,0 +1,9 @@
+module allocate_61_allocmod
+   use allocate_61_mymod, only: w, make_t
+   implicit none
+contains
+   subroutine alloc_source(x)
+      type(w), intent(inout) :: x
+      allocate(x%a, source=make_t())
+   end subroutine
+end module

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2935,12 +2935,7 @@ public:
                 al, variable_dependencies_vec, source_type);
             ASR::symbol_t* type_decl = ASRUtils::get_struct_sym_from_struct_expr(source);
             if (type_decl != nullptr) {
-                std::string decl_name = ASRUtils::symbol_name(type_decl);
-                ASR::symbol_t* resolved = current_scope->resolve_symbol(decl_name);
-                if (resolved != nullptr &&
-                        ASRUtils::symbol_get_past_external(resolved) == type_decl) {
-                    type_decl = resolved;
-                }
+                type_decl = ASRUtils::import_struct_type(al, type_decl, current_scope);
             }
             ASR::asr_t* tmp_sym = ASRUtils::make_Variable_t_util(
                 al, x.base.base.loc, current_scope, s2c(al, tmp_name),


### PR DESCRIPTION
The sourced allocation codepath created a temporary variable whose type_declaration pointed directly to a struct symbol in another module's symbol table, without creating an ExternalSymbol in the current module. This caused deserialization to fail when loading the modfile, because the referenced symbol table had not been deserialized yet.

Use import_struct_type() to properly create an ExternalSymbol for the struct type, matching the pattern already used elsewhere in the same file.

Fixes #10735. Integration test added.