### PR TITLE
Fix CFI_dim_t field order to match Fortran standard

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5759,9 +5759,11 @@ public:
 
                         // Initialize dimension_descriptor (lower_bound=1, extent=1)
                         builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(64, 1)),
-                            llvm_utils->create_gep2(arr_descr->get_dimension_descriptor_type(), ptr_to_dim_desc, 1));
+                            llvm_utils->create_gep2(arr_descr->get_dimension_descriptor_type(), ptr_to_dim_desc,
+                                LLVMArrUtils::SimpleCMODescriptor::DIM_LOWER_BOUND));
                         builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(64, 1)),
-                            llvm_utils->create_gep2(arr_descr->get_dimension_descriptor_type(), ptr_to_dim_desc, 2));
+                            llvm_utils->create_gep2(arr_descr->get_dimension_descriptor_type(), ptr_to_dim_desc,
+                                LLVMArrUtils::SimpleCMODescriptor::DIM_EXTENT));
 
                         ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
                             ASRUtils::type_get_past_allocatable_pointer(v->m_type));
@@ -7154,7 +7156,8 @@ public:
                             llvm::Value* dim_ptr = llvm_utils->create_ptr_gep2(
                                 dim_type, dim_arr, r);
                             llvm::Value* stride_ptr = llvm_utils->create_gep2(
-                                dim_type, dim_ptr, 0);
+                                dim_type, dim_ptr,
+                                LLVMArrUtils::SimpleCMODescriptor::DIM_STRIDE);
                             llvm::Value* stride = llvm_utils->CreateLoad2(
                                 llvm::Type::getInt64Ty(context), stride_ptr);
                             stride = builder->CreateSDiv(stride, el_size_val);
@@ -7211,7 +7214,8 @@ public:
                                 llvm::Value* dim_ptr = llvm_utils->create_ptr_gep2(
                                     dim_type, dim_arr, r);
                                 llvm::Value* stride_ptr = llvm_utils->create_gep2(
-                                    dim_type, dim_ptr, 0);
+                                    dim_type, dim_ptr,
+                                    LLVMArrUtils::SimpleCMODescriptor::DIM_STRIDE);
                                 llvm::Value* stride = llvm_utils->CreateLoad2(
                                     llvm::Type::getInt64Ty(context), stride_ptr);
                                 stride = builder->CreateSDiv(stride, el_size_val);
@@ -7230,7 +7234,8 @@ public:
                                 llvm::Value* dim_ptr = llvm_utils->create_ptr_gep2(
                                     dim_type, dim_arr, r);
                                 llvm::Value* stride_ptr = llvm_utils->create_gep2(
-                                    dim_type, dim_ptr, 0);
+                                    dim_type, dim_ptr,
+                                    LLVMArrUtils::SimpleCMODescriptor::DIM_STRIDE);
                                 llvm::Value* stride = llvm_utils->CreateLoad2(
                                     llvm::Type::getInt64Ty(context), stride_ptr);
                                 stride = builder->CreateSDiv(stride, el_size_val);
@@ -7272,7 +7277,8 @@ public:
                 llvm::Value* dim_ptr = llvm_utils->create_ptr_gep2(
                     dim_type, dim_arr, r);
                 llvm::Value* stride_ptr = llvm_utils->create_gep2(
-                    dim_type, dim_ptr, 0);
+                    dim_type, dim_ptr,
+                    LLVMArrUtils::SimpleCMODescriptor::DIM_STRIDE);
                 llvm::Value* stride = llvm_utils->CreateLoad2(
                     llvm::Type::getInt64Ty(context), stride_ptr);
                 stride = builder->CreateMul(stride, el_size_val);
@@ -19100,7 +19106,8 @@ public:
                         llvm::Value* dim_ptr = llvm_utils->create_ptr_gep2(
                             dim_type, dim_arr, r);
                         llvm::Value* stride_ptr = llvm_utils->create_gep2(
-                            dim_type, dim_ptr, 0);
+                            dim_type, dim_ptr,
+                            LLVMArrUtils::SimpleCMODescriptor::DIM_STRIDE);
                         llvm::Value* stride = llvm_utils->CreateLoad2(
                             llvm::Type::getInt64Ty(context), stride_ptr);
                         stride = builder->CreateMul(stride, elem_size_val);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -123,13 +123,13 @@ namespace LCompilers {
         index_type(llvm::Type::getInt64Ty(_context)),
         dim_des(nullptr),
         co(co_) {
-            // CFI_dim_t: always i64 for stride, lower_bound, extent
+            // CFI_dim_t: always i64 for lower_bound, extent, stride
             dim_des = llvm::StructType::create(
                 context,
                 std::vector<llvm::Type*>(
-                    {llvm::Type::getInt64Ty(context),   // stride
-                     llvm::Type::getInt64Ty(context),   // lower_bound
-                     llvm::Type::getInt64Ty(context)}), // extent
+                    {llvm::Type::getInt64Ty(context),   // lower_bound
+                     llvm::Type::getInt64Ty(context),   // extent
+                     llvm::Type::getInt64Ty(context)}), // stride (sm)
                 "dimension_descriptor");
         }
 
@@ -308,7 +308,7 @@ namespace LCompilers {
 
         llvm::Value* SimpleCMODescriptor::
         get_dimension_size(llvm::Value* dim_des_arr, llvm::Value* dim, bool load) {
-            llvm::Value* dim_size = llvm_utils->create_gep2(dim_des, llvm_utils->create_ptr_gep2(dim_des, dim_des_arr, dim), 2);
+            llvm::Value* dim_size = llvm_utils->create_gep2(dim_des, llvm_utils->create_ptr_gep2(dim_des, dim_des_arr, dim), DIM_EXTENT);
             if( !load ) {
                 return dim_size;
             }
@@ -317,7 +317,7 @@ namespace LCompilers {
 
         llvm::Value* SimpleCMODescriptor::
         get_dimension_size(llvm::Value* dim_des_arr, bool load) {
-            llvm::Value* dim_size = llvm_utils->create_gep2(dim_des, dim_des_arr, 2);
+            llvm::Value* dim_size = llvm_utils->create_gep2(dim_des, dim_des_arr, DIM_EXTENT);
             if( !load ) {
                 return dim_size;
             }
@@ -336,9 +336,9 @@ namespace LCompilers {
             llvm::Value* prod = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
             for( int r = 0; r < n_dims; r++ ) {
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_val, r);
-                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, 0);
-                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, 1);
-                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, 2);
+                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE);
+                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND);
+                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT);
                 llvm::Value* first = builder->CreateSExtOrTrunc(load_if_pointer(llvm_dims[r].first, index_type, builder, llvm_utils), index_type);
                 llvm::Value* dim_size = builder->CreateSExtOrTrunc(load_if_pointer(llvm_dims[r].second, index_type, builder, llvm_utils), index_type);
                 // Fortran standard: negative extent means zero-size array
@@ -432,9 +432,9 @@ namespace LCompilers {
             llvm::Value* prod = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
             for( int r = 0; r < n_dims; r++ ) {
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_val, r);
-                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, 0);
-                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, 1);
-                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, 2);
+                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE);
+                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND);
+                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT);
                 llvm::Value* first = builder->CreateSExtOrTrunc(load_if_pointer(llvm_dims[r].first, index_type, builder, llvm_utils), index_type);
                 llvm::Value* dim_size = builder->CreateSExtOrTrunc(load_if_pointer(llvm_dims[r].second, index_type, builder, llvm_utils), index_type);
                 // Fortran standard: negative extent means zero-size array
@@ -524,9 +524,9 @@ namespace LCompilers {
             // generates code to check array dimensions before the array is allocated.
             for (int i = 0; i < n_dims; i++) {
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_first, i);
-                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)), llvm_utils->create_gep2(dim_des, dim_val, 0));
-                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), llvm_utils->create_gep2(dim_des, dim_val, 1));
-                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), llvm_utils->create_gep2(dim_des, dim_val, 2));
+                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND));
+                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT));
+                builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)), llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE));
             }
 
             set_rank(type, arr, llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)));
@@ -544,13 +544,13 @@ namespace LCompilers {
             llvm::Value* source_dim_des_arr = this->get_pointer_to_dimension_descriptor_array(type, source_arr);
             for( int r = 0; r < n_dims; r++ ) {
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_val, r);
-                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, 0);
+                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE);
                 llvm::Value* stride = this->get_stride(
                     this->get_pointer_to_dimension_descriptor(source_dim_des_arr,
                     llvm::ConstantInt::get(context, llvm::APInt(32, r))));
                 builder->CreateStore(stride, s_val);
-                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, 1);
-                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, 2);
+                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND);
+                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT);
                 if( lbs[r] == nullptr ) {
                     builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), l_val);
                 } else {
@@ -576,13 +576,13 @@ namespace LCompilers {
             llvm::Value* source_dim_des_arr = this->get_pointer_to_dimension_descriptor_array(source_arr_type, source_arr);
             for( int r = 0; r < n_dims; r++ ) {
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_val, r);
-                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, 0);
+                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE);
                 llvm::Value* stride = this->get_stride(
                     this->get_pointer_to_dimension_descriptor(source_dim_des_arr,
                     llvm::ConstantInt::get(context, llvm::APInt(32, r))));
                 builder->CreateStore(stride, s_val);
-                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, 1);
-                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, 2);
+                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND);
+                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT);
                 builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), l_val);
                 llvm::Value* dim_size = this->get_dimension_size(
                    this->get_pointer_to_dimension_descriptor(source_dim_des_arr,
@@ -786,7 +786,7 @@ namespace LCompilers {
         }
 
         llvm::Value* SimpleCMODescriptor::get_lower_bound(llvm::Value* dims, bool load) {
-            llvm::Value* lb = llvm_utils->create_gep2(dim_des, dims, 1);
+            llvm::Value* lb = llvm_utils->create_gep2(dim_des, dims, DIM_LOWER_BOUND);
             if( !load ) {
                 return lb;
             }
@@ -794,15 +794,15 @@ namespace LCompilers {
         }
 
         llvm::Value* SimpleCMODescriptor::get_upper_bound(llvm::Value* dims) {
-            llvm::Value* lb = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dims, 1));
-            llvm::Value* dim_size = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dims, 2));
+            llvm::Value* lb = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dims, DIM_LOWER_BOUND));
+            llvm::Value* dim_size = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dims, DIM_EXTENT));
             unsigned bit_width = index_type->getIntegerBitWidth();
             return builder->CreateSub(builder->CreateAdd(dim_size, lb),
                                       llvm::ConstantInt::get(context, llvm::APInt(bit_width, 1)));
         }
 
         llvm::Value* SimpleCMODescriptor::get_stride(llvm::Value* dims, bool load) {
-            llvm::Value* stride = llvm_utils->create_gep2(dim_des, dims, 0);
+            llvm::Value* stride = llvm_utils->create_gep2(dim_des, dims, DIM_STRIDE);
             if( !load ) {
                 return stride;
             }
@@ -819,8 +819,8 @@ namespace LCompilers {
                 llvm::Value* req_idx = m_args[r];
                 llvm::Value* curr_llvm_idx = req_idx;
                 llvm::Value* dim_des_ptr = llvm_utils->create_ptr_gep2(dim_des, dim_des_arr_ptr, r);
-                llvm::Value* lval = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, 1));
-                llvm::Value* length = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, 2));
+                llvm::Value* lval = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, DIM_LOWER_BOUND));
+                llvm::Value* length = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, DIM_EXTENT));
                 // Cast req_idx to index_type
                 req_idx = builder->CreateSExtOrTrunc(req_idx, index_type);
                 curr_llvm_idx = builder->CreateSub(req_idx, lval);
@@ -844,7 +844,7 @@ namespace LCompilers {
                                                      lval,
                                                      ubound);
                 }
-                llvm::Value* stride = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, 0));
+                llvm::Value* stride = llvm_utils->CreateLoad2(index_type, llvm_utils->create_gep2(dim_des, dim_des_ptr, DIM_STRIDE));
                 idx = builder->CreateAdd(idx, builder->CreateMul(stride, curr_llvm_idx));
             }
             llvm::Value* offset_val = this->get_offset(type, arr);
@@ -1296,9 +1296,9 @@ namespace LCompilers {
                 llvm_utils->start_new_block(loopbody);
                 llvm::Value* r_val = llvm_utils->CreateLoad2(llvm_utils->getIntType(4), r);
                 llvm::Value* dim_val = llvm_utils->create_ptr_gep2(dim_des, dim_des_val, r_val);
-                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, 0);
-                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, 1);
-                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, 2);
+                llvm::Value* s_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_STRIDE);
+                llvm::Value* l_val = llvm_utils->create_gep2(dim_des, dim_val, DIM_LOWER_BOUND);
+                llvm::Value* dim_size_ptr = llvm_utils->create_gep2(dim_des, dim_val, DIM_EXTENT);
                 builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)), l_val);
                 builder->CreateStore(llvm_utils->CreateLoad2(index_type, prod), s_val);
                 llvm::Value* dim_size = builder->CreateSExtOrTrunc(llvm_utils->CreateLoad2(i32, llvm_utils->create_ptr_gep2(i32, shape_data, r_val)), index_type);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -366,6 +366,13 @@ namespace LCompilers {
 
         class SimpleCMODescriptor: public Descriptor {
 
+            public:
+
+                // CFI_dim_t sub-field indices (standard order)
+                static constexpr int DIM_LOWER_BOUND = 0;
+                static constexpr int DIM_EXTENT      = 1;
+                static constexpr int DIM_STRIDE      = 2;  // sm (stride multiplier)
+
             private:
 
                 llvm::LLVMContext& context;

--- a/src/libasr/runtime/ISO_Fortran_binding.h
+++ b/src/libasr/runtime/ISO_Fortran_binding.h
@@ -79,14 +79,13 @@ typedef int16_t CFI_type_t;
 /*
  * Per-dimension descriptor.
  *
- * LFortran's internal order is {stride, lower_bound, extent}.
- * We use the standard CFI names: sm (stride multiplier in bytes),
- * lower_bound, and extent.
+ * Standard order: {lower_bound, extent, sm}.
+ * Matches ISO/IEC 18508 (Fortran 2018) Table 18.5 and Flang.
  */
 typedef struct CFI_dim_t {
-    CFI_index_t sm;          /* stride multiplier in bytes */
     CFI_index_t lower_bound;
     CFI_index_t extent;      /* -1 for assumed size */
+    CFI_index_t sm;          /* stride multiplier in bytes */
 } CFI_dim_t;
 
 /*

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "9830000187019a12996b85634961607cc7f1c396fa80fc92085c61b8",
+    "stdout_hash": "c36fad050a45327ab7e1faca53feee84a485b0204ba59776c0c7c089",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -24,11 +24,11 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %3, i32 0, i32 0
   %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 0, i64* %6, align 4
+  store i64 1, i64* %6, align 4
   %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
   store i64 1, i64* %7, align 4
   %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 1, i64* %8, align 4
+  store i64 0, i64* %8, align 4
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 1, i8* %9, align 1
   %10 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -88,9 +88,9 @@ ifcont:                                           ; preds = %merge_allocated
   %36 = getelementptr %array, %array* %34, i32 0, i32 8
   %37 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %36, i32 0, i32 0
   %38 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 0
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
-  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
   store i64 1, i64* %39, align 4
   store i64 1, i64* %40, align 4
   store i64 1, i64* %41, align 4
@@ -194,9 +194,9 @@ ifcont10:                                         ; preds = %merge_allocated7
   %87 = getelementptr %array, %array* %85, i32 0, i32 8
   %88 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %87, i32 0, i32 0
   %89 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %88, i32 0
-  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 0
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 1
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 2
+  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 2
+  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 0
+  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 1
   store i64 1, i64* %90, align 4
   store i64 1, i64* %91, align 4
   store i64 1, i64* %92, align 4

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "b41b154e57998125312bca7e8b2de14491a9a0cde733d11c4c4f9cfe",
+    "stdout_hash": "592bb96fb46884a289d86cde3c1691911bd63ee17290436c47d4e55b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -242,25 +242,25 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %3, i32 0, i32 0
   %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 0, i64* %6, align 4
+  store i64 1, i64* %6, align 4
   %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
   store i64 1, i64* %7, align 4
   %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 1, i64* %8, align 4
+  store i64 0, i64* %8, align 4
   %9 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 1
   %10 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 0
-  store i64 0, i64* %10, align 4
+  store i64 1, i64* %10, align 4
   %11 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 1
   store i64 1, i64* %11, align 4
   %12 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 2
-  store i64 1, i64* %12, align 4
+  store i64 0, i64* %12, align 4
   %13 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 2
   %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 0
-  store i64 0, i64* %14, align 4
+  store i64 1, i64* %14, align 4
   %15 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 1
   store i64 1, i64* %15, align 4
   %16 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 2
-  store i64 1, i64* %16, align 4
+  store i64 0, i64* %16, align 4
   %17 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 3, i8* %17, align 1
   %18 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -322,23 +322,23 @@ ifcont:                                           ; preds = %merge_allocated
   %44 = getelementptr %array, %array* %42, i32 0, i32 8
   %45 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %44, i32 0, i32 0
   %46 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 0
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
+  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
+  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
   store i64 1, i64* %47, align 4
   store i64 1, i64* %48, align 4
   store i64 3, i64* %49, align 4
   %50 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 1
-  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 0
-  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 1
-  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 2
+  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 2
+  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 0
+  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 1
   store i64 3, i64* %51, align 4
   store i64 1, i64* %52, align 4
   store i64 3, i64* %53, align 4
   %54 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 2
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 0
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 1
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 2
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 2
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 0
+  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 1
   store i64 9, i64* %55, align 4
   store i64 1, i64* %56, align 4
   store i64 3, i64* %57, align 4
@@ -413,9 +413,9 @@ ifcont7:                                          ; preds = %merge_allocated4
   %88 = getelementptr %array, %array* %64, i32 0, i32 8
   %89 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %88, i32 0, i32 0
   %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 0
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
+  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
   %92 = load i64, i64* %91, align 4
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
+  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
   %94 = load i64, i64* %93, align 4
   %95 = sub i64 1, %92
   %96 = add i64 %92, %94
@@ -456,14 +456,14 @@ then8:                                            ; preds = %ifcont7
   unreachable
 
 ifcont9:                                          ; preds = %ifcont7
-  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
+  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
   %118 = load i64, i64* %117, align 4
   %119 = mul i64 %118, %95
   %120 = add i64 0, %119
   %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 1
-  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
+  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
   %123 = load i64, i64* %122, align 4
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
+  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
   %125 = load i64, i64* %124, align 4
   %126 = sub i64 1, %123
   %127 = add i64 %123, %125
@@ -504,14 +504,14 @@ then10:                                           ; preds = %ifcont9
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %148 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
+  %148 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
   %149 = load i64, i64* %148, align 4
   %150 = mul i64 %149, %126
   %151 = add i64 %120, %150
   %152 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 2
-  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 1
+  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 0
   %154 = load i64, i64* %153, align 4
-  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 2
+  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 1
   %156 = load i64, i64* %155, align 4
   %157 = sub i64 1, %154
   %158 = add i64 %154, %156
@@ -552,7 +552,7 @@ then12:                                           ; preds = %ifcont11
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %179 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 0
+  %179 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 2
   %180 = load i64, i64* %179, align 4
   %181 = mul i64 %180, %157
   %182 = add i64 %151, %181
@@ -617,9 +617,9 @@ ifcont18:                                         ; preds = %merge_allocated15
   %214 = getelementptr %array, %array* %190, i32 0, i32 8
   %215 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %214, i32 0, i32 0
   %216 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 0
-  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 1
+  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 0
   %218 = load i64, i64* %217, align 4
-  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 2
+  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 1
   %220 = load i64, i64* %219, align 4
   %221 = sub i64 1, %218
   %222 = add i64 %218, %220
@@ -660,14 +660,14 @@ then19:                                           ; preds = %ifcont18
   unreachable
 
 ifcont20:                                         ; preds = %ifcont18
-  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 0
+  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 2
   %244 = load i64, i64* %243, align 4
   %245 = mul i64 %244, %221
   %246 = add i64 0, %245
   %247 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 1
-  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 1
+  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 0
   %249 = load i64, i64* %248, align 4
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 2
+  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 1
   %251 = load i64, i64* %250, align 4
   %252 = sub i64 1, %249
   %253 = add i64 %249, %251
@@ -708,14 +708,14 @@ then21:                                           ; preds = %ifcont20
   unreachable
 
 ifcont22:                                         ; preds = %ifcont20
-  %274 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 0
+  %274 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 2
   %275 = load i64, i64* %274, align 4
   %276 = mul i64 %275, %252
   %277 = add i64 %246, %276
   %278 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 2
-  %279 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 1
+  %279 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 0
   %280 = load i64, i64* %279, align 4
-  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 2
+  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 1
   %282 = load i64, i64* %281, align 4
   %283 = sub i64 1, %280
   %284 = add i64 %280, %282
@@ -756,7 +756,7 @@ then23:                                           ; preds = %ifcont22
   unreachable
 
 ifcont24:                                         ; preds = %ifcont22
-  %305 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 0
+  %305 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 2
   %306 = load i64, i64* %305, align 4
   %307 = mul i64 %306, %283
   %308 = add i64 %277, %307
@@ -832,9 +832,9 @@ ifcont32:                                         ; preds = %merge_allocated29
   %342 = getelementptr %array, %array* %318, i32 0, i32 8
   %343 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %342, i32 0, i32 0
   %344 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 0
-  %345 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 1
+  %345 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 0
   %346 = load i64, i64* %345, align 4
-  %347 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 2
+  %347 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 1
   %348 = load i64, i64* %347, align 4
   %349 = sub i64 1, %346
   %350 = add i64 %346, %348
@@ -875,14 +875,14 @@ then33:                                           ; preds = %ifcont32
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %371 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 0
+  %371 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 2
   %372 = load i64, i64* %371, align 4
   %373 = mul i64 %372, %349
   %374 = add i64 0, %373
   %375 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 1
-  %376 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 1
+  %376 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 0
   %377 = load i64, i64* %376, align 4
-  %378 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 2
+  %378 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 1
   %379 = load i64, i64* %378, align 4
   %380 = sub i64 1, %377
   %381 = add i64 %377, %379
@@ -923,14 +923,14 @@ then35:                                           ; preds = %ifcont34
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %402 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 0
+  %402 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 2
   %403 = load i64, i64* %402, align 4
   %404 = mul i64 %403, %380
   %405 = add i64 %374, %404
   %406 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 2
-  %407 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 1
+  %407 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 0
   %408 = load i64, i64* %407, align 4
-  %409 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 2
+  %409 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 1
   %410 = load i64, i64* %409, align 4
   %411 = sub i64 1, %408
   %412 = add i64 %408, %410
@@ -971,7 +971,7 @@ then37:                                           ; preds = %ifcont36
   unreachable
 
 ifcont38:                                         ; preds = %ifcont36
-  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 0
+  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 2
   %434 = load i64, i64* %433, align 4
   %435 = mul i64 %434, %411
   %436 = add i64 %405, %435
@@ -1148,23 +1148,23 @@ ifcont14:                                         ; preds = %else13, %then12
   %52 = getelementptr %array, %array* %50, i32 0, i32 8
   %53 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %52, i32 0, i32 0
   %54 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %53, i32 0
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 0
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 1
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 2
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 2
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 0
+  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 1
   store i64 1, i64* %55, align 4
   store i64 1, i64* %56, align 4
   store i64 3, i64* %57, align 4
   %58 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %53, i32 1
-  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 0
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 1
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 2
+  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 2
+  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 0
+  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %58, i32 0, i32 1
   store i64 3, i64* %59, align 4
   store i64 1, i64* %60, align 4
   store i64 3, i64* %61, align 4
   %62 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %53, i32 2
-  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 0
-  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 1
-  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 2
+  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 2
+  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 0
+  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 1
   store i64 9, i64* %63, align 4
   store i64 1, i64* %64, align 4
   store i64 3, i64* %65, align 4
@@ -1224,9 +1224,9 @@ ifcont19:                                         ; preds = %merge_allocated16
   %94 = getelementptr %array, %array* %70, i32 0, i32 8
   %95 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %94, i32 0, i32 0
   %96 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %95, i32 0
-  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
+  %97 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
   %98 = load i64, i64* %97, align 4
-  %99 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 2
+  %99 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 1
   %100 = load i64, i64* %99, align 4
   %101 = sub i64 1, %98
   %102 = add i64 %98, %100
@@ -1267,14 +1267,14 @@ then20:                                           ; preds = %ifcont19
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 0
+  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %96, i32 0, i32 2
   %124 = load i64, i64* %123, align 4
   %125 = mul i64 %124, %101
   %126 = add i64 0, %125
   %127 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %95, i32 1
-  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 1
+  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 0
   %129 = load i64, i64* %128, align 4
-  %130 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 2
+  %130 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 1
   %131 = load i64, i64* %130, align 4
   %132 = sub i64 1, %129
   %133 = add i64 %129, %131
@@ -1315,14 +1315,14 @@ then22:                                           ; preds = %ifcont21
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 0
+  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 2
   %155 = load i64, i64* %154, align 4
   %156 = mul i64 %155, %132
   %157 = add i64 %126, %156
   %158 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %95, i32 2
-  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 1
+  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 0
   %160 = load i64, i64* %159, align 4
-  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 2
+  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 1
   %162 = load i64, i64* %161, align 4
   %163 = sub i64 1, %160
   %164 = add i64 %160, %162
@@ -1363,7 +1363,7 @@ then24:                                           ; preds = %ifcont23
   unreachable
 
 ifcont25:                                         ; preds = %ifcont23
-  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 0
+  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 2
   %186 = load i64, i64* %185, align 4
   %187 = mul i64 %186, %163
   %188 = add i64 %157, %187
@@ -1439,9 +1439,9 @@ ifcont:                                           ; preds = %merge_allocated
   %26 = getelementptr %array, %array* %2, i32 0, i32 8
   %27 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %26, i32 0, i32 0
   %28 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 0
-  %29 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 1
+  %29 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 0
   %30 = load i64, i64* %29, align 4
-  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 2
+  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 1
   %32 = load i64, i64* %31, align 4
   %33 = sub i64 1, %30
   %34 = add i64 %30, %32
@@ -1482,14 +1482,14 @@ then1:                                            ; preds = %ifcont
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 0
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 2
   %56 = load i64, i64* %55, align 4
   %57 = mul i64 %56, %33
   %58 = add i64 0, %57
   %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 1
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
+  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
   %61 = load i64, i64* %60, align 4
-  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 2
+  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
   %63 = load i64, i64* %62, align 4
   %64 = sub i64 1, %61
   %65 = add i64 %61, %63
@@ -1530,14 +1530,14 @@ then3:                                            ; preds = %ifcont2
   unreachable
 
 ifcont4:                                          ; preds = %ifcont2
-  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
+  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 2
   %87 = load i64, i64* %86, align 4
   %88 = mul i64 %87, %64
   %89 = add i64 %58, %88
   %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 2
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
+  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
   %92 = load i64, i64* %91, align 4
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
+  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
   %94 = load i64, i64* %93, align 4
   %95 = sub i64 1, %92
   %96 = add i64 %92, %94
@@ -1578,7 +1578,7 @@ then5:                                            ; preds = %ifcont4
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
+  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
   %118 = load i64, i64* %117, align 4
   %119 = mul i64 %118, %95
   %120 = add i64 %89, %119
@@ -1663,9 +1663,9 @@ ifcont11:                                         ; preds = %merge_allocated8
   %163 = getelementptr %array, %array* %139, i32 0, i32 8
   %164 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %163, i32 0, i32 0
   %165 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 0
-  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 1
+  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 0
   %167 = load i64, i64* %166, align 4
-  %168 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 2
+  %168 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 1
   %169 = load i64, i64* %168, align 4
   %170 = sub i64 1, %167
   %171 = add i64 %167, %169
@@ -1706,14 +1706,14 @@ then12:                                           ; preds = %ifcont11
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 0
+  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 2
   %193 = load i64, i64* %192, align 4
   %194 = mul i64 %193, %170
   %195 = add i64 0, %194
   %196 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 1
-  %197 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 1
+  %197 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 0
   %198 = load i64, i64* %197, align 4
-  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 2
+  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 1
   %200 = load i64, i64* %199, align 4
   %201 = sub i64 1, %198
   %202 = add i64 %198, %200
@@ -1754,14 +1754,14 @@ then14:                                           ; preds = %ifcont13
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %223 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 0
+  %223 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 2
   %224 = load i64, i64* %223, align 4
   %225 = mul i64 %224, %201
   %226 = add i64 %195, %225
   %227 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 2
-  %228 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 1
+  %228 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 0
   %229 = load i64, i64* %228, align 4
-  %230 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 2
+  %230 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 1
   %231 = load i64, i64* %230, align 4
   %232 = sub i64 1, %229
   %233 = add i64 %229, %231
@@ -1802,7 +1802,7 @@ then16:                                           ; preds = %ifcont15
   unreachable
 
 ifcont17:                                         ; preds = %ifcont15
-  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 0
+  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 2
   %255 = load i64, i64* %254, align 4
   %256 = mul i64 %255, %232
   %257 = add i64 %226, %256
@@ -1879,9 +1879,9 @@ ifcont24:                                         ; preds = %merge_allocated21
   %291 = getelementptr %array, %array* %267, i32 0, i32 8
   %292 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %291, i32 0, i32 0
   %293 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 0
-  %294 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 1
+  %294 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 0
   %295 = load i64, i64* %294, align 4
-  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 2
+  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 1
   %297 = load i64, i64* %296, align 4
   %298 = sub i64 1, %295
   %299 = add i64 %295, %297
@@ -1922,14 +1922,14 @@ then25:                                           ; preds = %ifcont24
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 0
+  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 2
   %321 = load i64, i64* %320, align 4
   %322 = mul i64 %321, %298
   %323 = add i64 0, %322
   %324 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 1
-  %325 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 1
+  %325 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 0
   %326 = load i64, i64* %325, align 4
-  %327 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 2
+  %327 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 1
   %328 = load i64, i64* %327, align 4
   %329 = sub i64 1, %326
   %330 = add i64 %326, %328
@@ -1970,14 +1970,14 @@ then27:                                           ; preds = %ifcont26
   unreachable
 
 ifcont28:                                         ; preds = %ifcont26
-  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 0
+  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 2
   %352 = load i64, i64* %351, align 4
   %353 = mul i64 %352, %329
   %354 = add i64 %323, %353
   %355 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 2
-  %356 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 1
+  %356 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 0
   %357 = load i64, i64* %356, align 4
-  %358 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 2
+  %358 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 1
   %359 = load i64, i64* %358, align 4
   %360 = sub i64 1, %357
   %361 = add i64 %357, %359
@@ -2018,7 +2018,7 @@ then29:                                           ; preds = %ifcont28
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 0
+  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 2
   %383 = load i64, i64* %382, align 4
   %384 = mul i64 %383, %360
   %385 = add i64 %354, %384
@@ -2103,9 +2103,9 @@ ifcont38:                                         ; preds = %merge_allocated35
   %428 = getelementptr %array, %array* %404, i32 0, i32 8
   %429 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %428, i32 0, i32 0
   %430 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 0
-  %431 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 1
+  %431 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 0
   %432 = load i64, i64* %431, align 4
-  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 2
+  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 1
   %434 = load i64, i64* %433, align 4
   %435 = sub i64 1, %432
   %436 = add i64 %432, %434
@@ -2146,14 +2146,14 @@ then39:                                           ; preds = %ifcont38
   unreachable
 
 ifcont40:                                         ; preds = %ifcont38
-  %457 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 0
+  %457 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 2
   %458 = load i64, i64* %457, align 4
   %459 = mul i64 %458, %435
   %460 = add i64 0, %459
   %461 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 1
-  %462 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 1
+  %462 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 0
   %463 = load i64, i64* %462, align 4
-  %464 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 2
+  %464 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 1
   %465 = load i64, i64* %464, align 4
   %466 = sub i64 1, %463
   %467 = add i64 %463, %465
@@ -2194,14 +2194,14 @@ then41:                                           ; preds = %ifcont40
   unreachable
 
 ifcont42:                                         ; preds = %ifcont40
-  %488 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 0
+  %488 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 2
   %489 = load i64, i64* %488, align 4
   %490 = mul i64 %489, %466
   %491 = add i64 %460, %490
   %492 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 2
-  %493 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 1
+  %493 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 0
   %494 = load i64, i64* %493, align 4
-  %495 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 2
+  %495 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 1
   %496 = load i64, i64* %495, align 4
   %497 = sub i64 1, %494
   %498 = add i64 %494, %496
@@ -2242,7 +2242,7 @@ then43:                                           ; preds = %ifcont42
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %519 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 0
+  %519 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 2
   %520 = load i64, i64* %519, align 4
   %521 = mul i64 %520, %497
   %522 = add i64 %491, %521
@@ -2317,9 +2317,9 @@ ifcont52:                                         ; preds = %merge_allocated49
   %555 = getelementptr %array, %array* %531, i32 0, i32 8
   %556 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %555, i32 0, i32 0
   %557 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 0
-  %558 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 1
+  %558 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 0
   %559 = load i64, i64* %558, align 4
-  %560 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 2
+  %560 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 1
   %561 = load i64, i64* %560, align 4
   %562 = sub i64 1, %559
   %563 = add i64 %559, %561
@@ -2360,14 +2360,14 @@ then53:                                           ; preds = %ifcont52
   unreachable
 
 ifcont54:                                         ; preds = %ifcont52
-  %584 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 0
+  %584 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 2
   %585 = load i64, i64* %584, align 4
   %586 = mul i64 %585, %562
   %587 = add i64 0, %586
   %588 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 1
-  %589 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 1
+  %589 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 0
   %590 = load i64, i64* %589, align 4
-  %591 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 2
+  %591 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 1
   %592 = load i64, i64* %591, align 4
   %593 = sub i64 1, %590
   %594 = add i64 %590, %592
@@ -2408,14 +2408,14 @@ then55:                                           ; preds = %ifcont54
   unreachable
 
 ifcont56:                                         ; preds = %ifcont54
-  %615 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 0
+  %615 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 2
   %616 = load i64, i64* %615, align 4
   %617 = mul i64 %616, %593
   %618 = add i64 %587, %617
   %619 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 2
-  %620 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 1
+  %620 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 0
   %621 = load i64, i64* %620, align 4
-  %622 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 2
+  %622 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 1
   %623 = load i64, i64* %622, align 4
   %624 = sub i64 1, %621
   %625 = add i64 %621, %623
@@ -2456,7 +2456,7 @@ then57:                                           ; preds = %ifcont56
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %646 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 0
+  %646 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 2
   %647 = load i64, i64* %646, align 4
   %648 = mul i64 %647, %624
   %649 = add i64 %618, %648
@@ -2614,9 +2614,9 @@ ifcont17:                                         ; preds = %merge_allocated14
   %53 = getelementptr %array, %array* %29, i32 0, i32 8
   %54 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %53, i32 0, i32 0
   %55 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 0
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
   %57 = load i64, i64* %56, align 4
-  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
+  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
   %59 = load i64, i64* %58, align 4
   %60 = sub i64 1, %57
   %61 = add i64 %57, %59
@@ -2657,14 +2657,14 @@ then18:                                           ; preds = %ifcont17
   unreachable
 
 ifcont19:                                         ; preds = %ifcont17
-  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
+  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
   %83 = load i64, i64* %82, align 4
   %84 = mul i64 %83, %60
   %85 = add i64 0, %84
   %86 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 1
-  %87 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 1
+  %87 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 0
   %88 = load i64, i64* %87, align 4
-  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 2
+  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 1
   %90 = load i64, i64* %89, align 4
   %91 = sub i64 1, %88
   %92 = add i64 %88, %90
@@ -2705,14 +2705,14 @@ then20:                                           ; preds = %ifcont19
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 0
+  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 2
   %114 = load i64, i64* %113, align 4
   %115 = mul i64 %114, %91
   %116 = add i64 %85, %115
   %117 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 2
-  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 1
+  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 0
   %119 = load i64, i64* %118, align 4
-  %120 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 2
+  %120 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 1
   %121 = load i64, i64* %120, align 4
   %122 = sub i64 1, %119
   %123 = add i64 %119, %121
@@ -2753,7 +2753,7 @@ then22:                                           ; preds = %ifcont21
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 0
+  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 2
   %145 = load i64, i64* %144, align 4
   %146 = mul i64 %145, %122
   %147 = add i64 %116, %146
@@ -2838,9 +2838,9 @@ ifcont28:                                         ; preds = %merge_allocated25
   %190 = getelementptr %array, %array* %166, i32 0, i32 8
   %191 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %190, i32 0, i32 0
   %192 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 0
-  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 1
+  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 0
   %194 = load i64, i64* %193, align 4
-  %195 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 2
+  %195 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 1
   %196 = load i64, i64* %195, align 4
   %197 = sub i64 1, %194
   %198 = add i64 %194, %196
@@ -2881,14 +2881,14 @@ then29:                                           ; preds = %ifcont28
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 0
+  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 2
   %220 = load i64, i64* %219, align 4
   %221 = mul i64 %220, %197
   %222 = add i64 0, %221
   %223 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 1
-  %224 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 1
+  %224 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 0
   %225 = load i64, i64* %224, align 4
-  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 2
+  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 1
   %227 = load i64, i64* %226, align 4
   %228 = sub i64 1, %225
   %229 = add i64 %225, %227
@@ -2929,14 +2929,14 @@ then31:                                           ; preds = %ifcont30
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 0
+  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 2
   %251 = load i64, i64* %250, align 4
   %252 = mul i64 %251, %228
   %253 = add i64 %222, %252
   %254 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 2
-  %255 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 1
+  %255 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 0
   %256 = load i64, i64* %255, align 4
-  %257 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 2
+  %257 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 1
   %258 = load i64, i64* %257, align 4
   %259 = sub i64 1, %256
   %260 = add i64 %256, %258
@@ -2977,7 +2977,7 @@ then33:                                           ; preds = %ifcont32
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 0
+  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 2
   %282 = load i64, i64* %281, align 4
   %283 = mul i64 %282, %259
   %284 = add i64 %253, %283
@@ -3052,9 +3052,9 @@ ifcont42:                                         ; preds = %merge_allocated39
   %317 = getelementptr %array, %array* %293, i32 0, i32 8
   %318 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %317, i32 0, i32 0
   %319 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 0
-  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 1
+  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 0
   %321 = load i64, i64* %320, align 4
-  %322 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 2
+  %322 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 1
   %323 = load i64, i64* %322, align 4
   %324 = sub i64 1, %321
   %325 = add i64 %321, %323
@@ -3095,14 +3095,14 @@ then43:                                           ; preds = %ifcont42
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %346 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 0
+  %346 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 2
   %347 = load i64, i64* %346, align 4
   %348 = mul i64 %347, %324
   %349 = add i64 0, %348
   %350 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 1
-  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 1
+  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 0
   %352 = load i64, i64* %351, align 4
-  %353 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 2
+  %353 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 1
   %354 = load i64, i64* %353, align 4
   %355 = sub i64 1, %352
   %356 = add i64 %352, %354
@@ -3143,14 +3143,14 @@ then45:                                           ; preds = %ifcont44
   unreachable
 
 ifcont46:                                         ; preds = %ifcont44
-  %377 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 0
+  %377 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 2
   %378 = load i64, i64* %377, align 4
   %379 = mul i64 %378, %355
   %380 = add i64 %349, %379
   %381 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 2
-  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 1
+  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 0
   %383 = load i64, i64* %382, align 4
-  %384 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 2
+  %384 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 1
   %385 = load i64, i64* %384, align 4
   %386 = sub i64 1, %383
   %387 = add i64 %383, %385
@@ -3191,7 +3191,7 @@ then47:                                           ; preds = %ifcont46
   unreachable
 
 ifcont48:                                         ; preds = %ifcont46
-  %408 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 0
+  %408 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 2
   %409 = load i64, i64* %408, align 4
   %410 = mul i64 %409, %386
   %411 = add i64 %380, %410

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "b43df4d57c7a80efd48a947f9b70e820cd2fefd7f889700e4a421f9b",
+    "stdout_hash": "65f6dafdda26f7cb2acc8d2a0884e17b2405a13281978b3756143e3b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -22,11 +22,11 @@ define void @__module_finalize_01_mod_ss() {
   %2 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %1, i32 0, i32 0
   %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
   %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 0, i64* %4, align 4
+  store i64 1, i64* %4, align 4
   %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
   store i64 1, i64* %5, align 4
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 1, i64* %6, align 4
+  store i64 0, i64* %6, align 4
   %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 1, i8* %7, align 1
   %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -85,9 +85,9 @@ ifcont:                                           ; preds = %merge_allocated
   %34 = getelementptr %array, %array* %32, i32 0, i32 8
   %35 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %34, i32 0, i32 0
   %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
+  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
+  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
   store i64 1, i64* %37, align 4
   store i64 1, i64* %38, align 4
   store i64 10, i64* %39, align 4
@@ -186,11 +186,11 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %3, i32 0, i32 0
   %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 0, i64* %6, align 4
+  store i64 1, i64* %6, align 4
   %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
   store i64 1, i64* %7, align 4
   %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 1, i64* %8, align 4
+  store i64 0, i64* %8, align 4
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 1, i8* %9, align 1
   %10 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -254,18 +254,18 @@ define void @internal_sub() {
   %2 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %1, i32 0, i32 0
   %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
   %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 0, i64* %4, align 4
+  store i64 1, i64* %4, align 4
   %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
   store i64 1, i64* %5, align 4
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 1, i64* %6, align 4
+  store i64 0, i64* %6, align 4
   %7 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 1
   %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 0
-  store i64 0, i64* %8, align 4
+  store i64 1, i64* %8, align 4
   %9 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 1
   store i64 1, i64* %9, align 4
   %10 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 2
-  store i64 1, i64* %10, align 4
+  store i64 0, i64* %10, align 4
   %11 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 3
   store i8 2, i8* %11, align 1
   %12 = getelementptr %array.0, %array.0* %arr_desc, i32 0, i32 0
@@ -284,11 +284,11 @@ bl.start:                                         ; preds = %.entry
   %15 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %14, i32 0, i32 0
   %16 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %15, i32 0
   %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 0
-  store i64 0, i64* %17, align 4
+  store i64 1, i64* %17, align 4
   %18 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 1
   store i64 1, i64* %18, align 4
   %19 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 2
-  store i64 1, i64* %19, align 4
+  store i64 0, i64* %19, align 4
   %20 = getelementptr %array, %array* %arr_desc1, i32 0, i32 3
   store i8 1, i8* %20, align 1
   %21 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.json
+++ b/tests/reference/llvm-finalize_02-cfb24d5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_02-cfb24d5.stdout",
-    "stdout_hash": "86958281e1ae986634e72f5c9358ddb7fd51cbc40600933e361fc76c",
+    "stdout_hash": "c4d65d4481d5e8866307825170160cfc7352d1fe5a303b896a8ceb6c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.stdout
+++ b/tests/reference/llvm-finalize_02-cfb24d5.stdout
@@ -38,11 +38,11 @@ define void @ss(i32* %nang) {
   %3 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %2, i32 0, i32 0
   %4 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %3, i32 0
   %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 0
-  store i64 0, i64* %5, align 4
+  store i64 1, i64* %5, align 4
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 1
   store i64 1, i64* %6, align 4
   %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 2
-  store i64 1, i64* %7, align 4
+  store i64 0, i64* %7, align 4
   %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 1, i8* %8, align 1
   %9 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -55,11 +55,11 @@ define void @ss(i32* %nang) {
   %11 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %10, i32 0, i32 0
   %12 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %11, i32 0
   %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 0
-  store i64 0, i64* %13, align 4
+  store i64 1, i64* %13, align 4
   %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 1
   store i64 1, i64* %14, align 4
   %15 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 2
-  store i64 1, i64* %15, align 4
+  store i64 0, i64* %15, align 4
   %16 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 3
   store i8 1, i8* %16, align 1
   %17 = getelementptr %array.0, %array.0* %arr_desc1, i32 0, i32 0
@@ -81,11 +81,11 @@ define void @ss(i32* %nang) {
   %22 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %21, i32 0, i32 0
   %23 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %22, i32 0
   %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 0
-  store i64 0, i64* %24, align 4
+  store i64 1, i64* %24, align 4
   %25 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 1
   store i64 1, i64* %25, align 4
   %26 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 2
-  store i64 1, i64* %26, align 4
+  store i64 0, i64* %26, align 4
   %27 = getelementptr %array.1, %array.1* %arr_desc2, i32 0, i32 3
   store i8 1, i8* %27, align 1
   store %array.1* %arr_desc2, %array.1** %arr_04, align 8
@@ -107,11 +107,11 @@ define void @ss(i32* %nang) {
   %35 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %34, i32 0, i32 0
   %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
   %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  store i64 0, i64* %37, align 4
+  store i64 1, i64* %37, align 4
   %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
   store i64 1, i64* %38, align 4
   %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  store i64 1, i64* %39, align 4
+  store i64 0, i64* %39, align 4
   %40 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 3
   store i8 1, i8* %40, align 1
   %41 = getelementptr %array.0, %array.0* %arr_desc3, i32 0, i32 0
@@ -133,11 +133,11 @@ define void @ss(i32* %nang) {
   %46 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %45, i32 0, i32 0
   %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
   %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 0
-  store i64 0, i64* %48, align 4
+  store i64 1, i64* %48, align 4
   %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
   store i64 1, i64* %49, align 4
   %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
-  store i64 1, i64* %50, align 4
+  store i64 0, i64* %50, align 4
   %51 = getelementptr %array.1, %array.1* %arr_desc4, i32 0, i32 3
   store i8 1, i8* %51, align 1
   store %array.1* %arr_desc4, %array.1** %arr_08, align 8
@@ -271,7 +271,7 @@ loop.body:                                        ; preds = %loop.head
   %14 = load i32, i32* %2, align 4
   %15 = load i64, i64* %3, align 4
   %16 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %8, i32 %14
-  %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 2
+  %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 1
   %18 = load i64, i64* %17, align 4
   %19 = mul i64 %15, %18
   store i64 %19, i64* %3, align 4

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "b0dcfaa4dd1d9c6eb6a5fb131221d9f1417b0c5b495cab6e32ae479d",
+    "stdout_hash": "6f014097449ee45def7bc314bb9a365644aa3e008698949e90c3792b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -64,11 +64,11 @@ define void @a(double* %w) {
   %2 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %1, i32 0, i32 0
   %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
   %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 0, i64* %4, align 4
+  store i64 1, i64* %4, align 4
   %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
   store i64 1, i64* %5, align 4
   %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 1, i64* %6, align 4
+  store i64 0, i64* %6, align 4
   %7 = getelementptr %array, %array* %arr_desc, i32 0, i32 3
   store i8 1, i8* %7, align 1
   %8 = getelementptr %array, %array* %arr_desc, i32 0, i32 0
@@ -81,11 +81,11 @@ define void @a(double* %w) {
   %10 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %9, i32 0, i32 0
   %11 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %10, i32 0
   %12 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 0
-  store i64 0, i64* %12, align 4
+  store i64 1, i64* %12, align 4
   %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 1
   store i64 1, i64* %13, align 4
   %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 2
-  store i64 1, i64* %14, align 4
+  store i64 0, i64* %14, align 4
   %15 = getelementptr %array, %array* %arr_desc1, i32 0, i32 3
   store i8 1, i8* %15, align 1
   %16 = getelementptr %array, %array* %arr_desc1, i32 0, i32 0
@@ -98,11 +98,11 @@ define void @a(double* %w) {
   %19 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %18, i32 0, i32 0
   %20 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %19, i32 0
   %21 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 0
-  store i64 0, i64* %21, align 4
+  store i64 1, i64* %21, align 4
   %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 1
   store i64 1, i64* %22, align 4
   %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 2
-  store i64 1, i64* %23, align 4
+  store i64 0, i64* %23, align 4
   %24 = getelementptr %array, %array* %array_section_descriptor, i32 0, i32 3
   store i8 1, i8* %24, align 1
   %25 = sext i32 %17 to i64
@@ -123,11 +123,11 @@ define void @a(double* %w) {
   %38 = icmp slt i64 %37, 0
   %39 = select i1 %38, i64 0, i64 %37
   %40 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %33, i32 0
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
   store i64 1, i64* %41, align 4
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
+  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
   store i64 1, i64* %42, align 4
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
+  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
   store i64 %39, i64* %43, align 4
   %44 = getelementptr %array, %array* %array_section_descriptor, i32 0, i32 3
   store i8 1, i8* %44, align 1
@@ -136,15 +136,15 @@ define void @a(double* %w) {
   %46 = getelementptr %array, %array* %45, i32 0, i32 8
   %47 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %46, i32 0, i32 0
   %48 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %47, i32 0
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 1
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 0
   %50 = load i64, i64* %49, align 4
-  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 0
+  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 2
   %52 = load i64, i64* %51, align 4
   %53 = icmp eq i64 %52, 1
   %54 = and i1 true, %53
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 1
+  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 0
   %56 = load i64, i64* %55, align 4
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 2
+  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %48, i32 0, i32 1
   %58 = load i64, i64* %57, align 4
   %59 = add i64 %58, %56
   %60 = sub i64 %59, 1
@@ -250,9 +250,9 @@ ifcont10:                                         ; preds = %merge_allocated7
   %108 = getelementptr %array, %array* %107, i32 0, i32 8
   %109 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %108, i32 0, i32 0
   %110 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %109, i32 0
-  %111 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 1
+  %111 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 0
   %112 = load i64, i64* %111, align 4
-  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 2
+  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %110, i32 0, i32 1
   %114 = load i64, i64* %113, align 4
   %115 = add i64 %114, %112
   %116 = sub i64 %115, 1
@@ -263,9 +263,9 @@ ifcont10:                                         ; preds = %merge_allocated7
   %120 = getelementptr %array, %array* %118, i32 0, i32 8
   %121 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %120, i32 0, i32 0
   %122 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %121, i32 0
-  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 0
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 1
-  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 2
+  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 2
+  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 0
+  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 1
   %126 = sext i32 %117 to i64
   %127 = icmp slt i64 %126, 0
   %128 = select i1 %127, i64 0, i64 %126
@@ -283,9 +283,9 @@ ifcont10:                                         ; preds = %merge_allocated7
   %136 = getelementptr %array, %array* %135, i32 0, i32 8
   %137 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %136, i32 0, i32 0
   %138 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %137, i32 0
-  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 1
+  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 0
   %140 = load i64, i64* %139, align 4
-  %141 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 2
+  %141 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 1
   %142 = load i64, i64* %141, align 4
   %143 = add i64 %142, %140
   %144 = sub i64 %143, 1
@@ -295,7 +295,7 @@ ifcont10:                                         ; preds = %merge_allocated7
   %147 = getelementptr %array, %array* %146, i32 0, i32 8
   %148 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %147, i32 0, i32 0
   %149 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %148, i32 0
-  %150 = getelementptr %dimension_descriptor, %dimension_descriptor* %149, i32 0, i32 1
+  %150 = getelementptr %dimension_descriptor, %dimension_descriptor* %149, i32 0, i32 0
   %151 = load i64, i64* %150, align 4
   %152 = trunc i64 %151 to i32
   %153 = sub i32 %152, 1
@@ -318,9 +318,9 @@ loop.body:                                        ; preds = %loop.head
   %162 = getelementptr %array, %array* %161, i32 0, i32 8
   %163 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %162, i32 0, i32 0
   %164 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 0
-  %165 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 1
+  %165 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 0
   %166 = load i64, i64* %165, align 4
-  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 2
+  %167 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 1
   %168 = load i64, i64* %167, align 4
   %169 = sext i32 %160 to i64
   %170 = sub i64 %169, %166
@@ -362,7 +362,7 @@ then11:                                           ; preds = %loop.body
   unreachable
 
 ifcont12:                                         ; preds = %loop.body
-  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 0
+  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 2
   %193 = load i64, i64* %192, align 4
   %194 = mul i64 %193, %170
   %195 = add i64 0, %194
@@ -377,9 +377,9 @@ ifcont12:                                         ; preds = %loop.body
   %204 = getelementptr %array, %array* %203, i32 0, i32 8
   %205 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %204, i32 0, i32 0
   %206 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %205, i32 0
-  %207 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 1
+  %207 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 0
   %208 = load i64, i64* %207, align 4
-  %209 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 2
+  %209 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 1
   %210 = load i64, i64* %209, align 4
   %211 = sext i32 %202 to i64
   %212 = sub i64 %211, %208
@@ -421,7 +421,7 @@ then13:                                           ; preds = %ifcont12
   unreachable
 
 ifcont14:                                         ; preds = %ifcont12
-  %234 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 0
+  %234 = getelementptr %dimension_descriptor, %dimension_descriptor* %206, i32 0, i32 2
   %235 = load i64, i64* %234, align 4
   %236 = mul i64 %235, %212
   %237 = add i64 0, %236
@@ -450,11 +450,11 @@ then16:                                           ; preds = %else15
   %250 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %249, i32 0, i32 0
   %251 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %250, i32 0
   %252 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 0
-  store i64 0, i64* %252, align 4
+  store i64 1, i64* %252, align 4
   %253 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 1
   store i64 1, i64* %253, align 4
   %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %251, i32 0, i32 2
-  store i64 1, i64* %254, align 4
+  store i64 0, i64* %254, align 4
   %255 = getelementptr %array, %array* %248, i32 0, i32 3
   store i8 1, i8* %255, align 1
   %256 = getelementptr %array, %array* %248, i32 0, i32 3
@@ -496,15 +496,15 @@ ifcont19:                                         ; preds = %ifcont18, %loop.end
   %277 = getelementptr %array, %array* %276, i32 0, i32 8
   %278 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %277, i32 0, i32 0
   %279 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %278, i32 0
-  %280 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 1
+  %280 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 0
   %281 = load i64, i64* %280, align 4
-  %282 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 0
+  %282 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 2
   %283 = load i64, i64* %282, align 4
   %284 = icmp eq i64 %283, 1
   %285 = and i1 true, %284
-  %286 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 1
+  %286 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 0
   %287 = load i64, i64* %286, align 4
-  %288 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 2
+  %288 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 1
   %289 = load i64, i64* %288, align 4
   %290 = add i64 %289, %287
   %291 = sub i64 %290, 1
@@ -534,9 +534,9 @@ then23:                                           ; preds = %merge_allocated21
   %305 = getelementptr %array, %array* %304, i32 0, i32 8
   %306 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %305, i32 0, i32 0
   %307 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %306, i32 0
-  %308 = getelementptr %dimension_descriptor, %dimension_descriptor* %307, i32 0, i32 1
+  %308 = getelementptr %dimension_descriptor, %dimension_descriptor* %307, i32 0, i32 0
   %309 = load i64, i64* %308, align 4
-  %310 = getelementptr %dimension_descriptor, %dimension_descriptor* %307, i32 0, i32 2
+  %310 = getelementptr %dimension_descriptor, %dimension_descriptor* %307, i32 0, i32 1
   %311 = load i64, i64* %310, align 4
   %312 = add i64 %311, %309
   %313 = sub i64 %312, 1
@@ -546,7 +546,7 @@ then23:                                           ; preds = %merge_allocated21
   %316 = getelementptr %array, %array* %315, i32 0, i32 8
   %317 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %316, i32 0, i32 0
   %318 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %317, i32 0
-  %319 = getelementptr %dimension_descriptor, %dimension_descriptor* %318, i32 0, i32 1
+  %319 = getelementptr %dimension_descriptor, %dimension_descriptor* %318, i32 0, i32 0
   %320 = load i64, i64* %319, align 4
   %321 = trunc i64 %320 to i32
   %322 = sub i32 %321, 1
@@ -569,9 +569,9 @@ loop.body25:                                      ; preds = %loop.head24
   %331 = getelementptr %array, %array* %330, i32 0, i32 8
   %332 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %331, i32 0, i32 0
   %333 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %332, i32 0
-  %334 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 1
+  %334 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 0
   %335 = load i64, i64* %334, align 4
-  %336 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 2
+  %336 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 1
   %337 = load i64, i64* %336, align 4
   %338 = sext i32 %329 to i64
   %339 = sub i64 %338, %335
@@ -613,7 +613,7 @@ then26:                                           ; preds = %loop.body25
   unreachable
 
 ifcont27:                                         ; preds = %loop.body25
-  %361 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 0
+  %361 = getelementptr %dimension_descriptor, %dimension_descriptor* %333, i32 0, i32 2
   %362 = load i64, i64* %361, align 4
   %363 = mul i64 %362, %339
   %364 = add i64 0, %363
@@ -628,9 +628,9 @@ ifcont27:                                         ; preds = %loop.body25
   %373 = getelementptr %array, %array* %372, i32 0, i32 8
   %374 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %373, i32 0, i32 0
   %375 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %374, i32 0
-  %376 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 1
+  %376 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 0
   %377 = load i64, i64* %376, align 4
-  %378 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 2
+  %378 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 1
   %379 = load i64, i64* %378, align 4
   %380 = sext i32 %371 to i64
   %381 = sub i64 %380, %377
@@ -672,7 +672,7 @@ then28:                                           ; preds = %ifcont27
   unreachable
 
 ifcont29:                                         ; preds = %ifcont27
-  %403 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 0
+  %403 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 2
   %404 = load i64, i64* %403, align 4
   %405 = mul i64 %404, %381
   %406 = add i64 0, %405
@@ -697,15 +697,15 @@ ifcont32:                                         ; preds = %else31, %loop.end30
   %415 = getelementptr %array, %array* %414, i32 0, i32 8
   %416 = getelementptr [15 x %dimension_descriptor], [15 x %dimension_descriptor]* %415, i32 0, i32 0
   %417 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %416, i32 0
-  %418 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 1
+  %418 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 0
   %419 = load i64, i64* %418, align 4
-  %420 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 0
+  %420 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 2
   %421 = load i64, i64* %420, align 4
   %422 = icmp eq i64 %421, 1
   %423 = and i1 true, %422
-  %424 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 1
+  %424 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 0
   %425 = load i64, i64* %424, align 4
-  %426 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 2
+  %426 = getelementptr %dimension_descriptor, %dimension_descriptor* %417, i32 0, i32 1
   %427 = load i64, i64* %426, align 4
   %428 = add i64 %427, %425
   %429 = sub i64 %428, 1


### PR DESCRIPTION
Reorder CFI_dim_t from {sm, lower_bound, extent} to the standard-required {lower_bound, extent, sm}, matching Flang and ISO/IEC 18508 Table 18.5.

- Reorder CFI_dim_t struct in ISO_Fortran_binding.h
- Add DIM_LOWER_BOUND, DIM_EXTENT, DIM_STRIDE named constants
- Replace all hardcoded dim GEP indices in llvm_array_utils.cpp
- Fix bind(C) stride byte-conversion indices in asr_to_llvm.cpp
- Update LLVM IR reference test outputs