### PR TITLE
Fix proc pointer call with array arg in pass_array_by_data

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1129,6 +1129,7 @@ RUN(NAME iso_c_binding_04 LABELS gfortran llvm)
 RUN(NAME submodule_45 LABELS gfortran llvm)
 RUN(NAME submodule_46 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_12 LABELS gfortran llvm)
+RUN(NAME procedure_pointer_13 LABELS gfortran llvm)
 RUN(NAME bindc_assumed_rank_01 LABELS gfortran llvm)
 
 

--- a/integration_tests/procedure_pointer_13.f90
+++ b/integration_tests/procedure_pointer_13.f90
@@ -1,0 +1,34 @@
+program procedure_pointer_13
+    implicit none
+
+    type :: t
+        procedure(ifc), pointer :: ptr => null()
+    end type t
+
+    abstract interface
+        subroutine ifc(self, a)
+            import
+            class(t), intent(in) :: self
+            integer, intent(in) :: a(:)
+        end subroutine ifc
+    end interface
+
+    type(t) :: x
+    integer :: a(3)
+    a = [10, 20, 30]
+    x%ptr => sub
+    call x%ptr(a)
+
+contains
+
+    subroutine sub(self, a)
+        class(t), intent(in) :: self
+        integer, intent(in) :: a(:)
+        if (size(a) /= 3) error stop
+        if (a(1) /= 10) error stop
+        if (a(2) /= 20) error stop
+        if (a(3) /= 30) error stop
+        print *, "OK"
+    end subroutine sub
+
+end program procedure_pointer_13

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -1051,7 +1051,23 @@ class EditProcedureCallsVisitor : public ASR::ASRPassBaseWalkVisitor<EditProcedu
                         xx.m_name = new_x_name;
                         xx.m_original_name = new_x_name;
                         std::vector<size_t>& indices = v.proc2newproc[subrout_sym].second;
-                        Vec<ASR::call_arg_t> new_args = construct_new_args(subrout_sym, x.n_args, x.m_args, indices);
+                        // When called through a struct member with PASS
+                        // semantics, the implicit self argument occupies
+                        // index 0 in the function's parameter list, so we
+                        // need to offset indices accordingly. Detect this
+                        // by comparing the original function's parameter
+                        // count with the call's explicit argument count.
+                        ASR::Function_t* orig_func = ASR::down_cast<ASR::Function_t>(subrout_sym);
+                        bool has_implicit_dt = ((size_t)orig_func->n_args > (size_t)x.n_args);
+                        Vec<ASR::call_arg_t> new_args = construct_new_args(subrout_sym, x.n_args, x.m_args, indices, has_implicit_dt);
+                        xx.m_args = new_args.p;
+                        xx.n_args = new_args.size();
+                        return;
+                    } else if ( new_x_name == nullptr ) {
+                        std::vector<size_t>& indices = v.proc2newproc[subrout_sym].second;
+                        ASR::Function_t* orig_func = ASR::down_cast<ASR::Function_t>(subrout_sym);
+                        bool has_implicit_dt = ((size_t)orig_func->n_args > (size_t)x.n_args);
+                        Vec<ASR::call_arg_t> new_args = construct_new_args(subrout_sym, x.n_args, x.m_args, indices, has_implicit_dt);
                         xx.m_args = new_args.p;
                         xx.n_args = new_args.size();
                         return;


### PR DESCRIPTION
When calling a procedure pointer through a derived type member with PASS semantics (e.g. call x%ptr(a)), the implicit self/pass argument occupies index 0 in the function's parameter list but is not in the explicit call arguments. The pass_array_by_data pass uses indices to determine which function parameters should be passed by data (split into data pointer + dimension info). Without accounting for the implicit self offset, the indices check fails and array arguments are not properly split, causing an LLVM verification error ('Incorrect number of arguments passed to called function').

Detect the implicit pass argument by comparing the original function's parameter count with the call's explicit argument count, and pass the offset flag (dt_implicitPass) to construct_new_args accordingly. This correctly handles both PASS and NOPASS procedure pointers.

Fixes #10743.