### PR TITLE
Fix optional arg transform for procedure pointer calls with PASS

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1131,6 +1131,7 @@ RUN(NAME submodule_45 LABELS gfortran llvm)
 RUN(NAME submodule_46 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_12 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_13 LABELS gfortran llvm)
+RUN(NAME procedure_pointer_14 LABELS gfortran llvm)
 RUN(NAME bindc_assumed_rank_01 LABELS gfortran llvm)
 
 

--- a/integration_tests/procedure_pointer_14.f90
+++ b/integration_tests/procedure_pointer_14.f90
@@ -1,0 +1,35 @@
+program procedure_pointer_14
+    implicit none
+
+    type :: t
+        procedure(ifc), pointer :: ptr => null()
+    end type t
+
+    abstract interface
+        subroutine ifc(self, a)
+            import
+            class(t), intent(in) :: self
+            integer, optional, intent(in) :: a(:)
+        end subroutine ifc
+    end interface
+
+    type(t) :: x
+    integer :: a(3)
+    a = [10, 20, 30]
+    x%ptr => sub
+    call x%ptr(a)
+
+contains
+
+    subroutine sub(self, a)
+        class(t), intent(in) :: self
+        integer, optional, intent(in) :: a(:)
+        if (.not. present(a)) error stop
+        if (size(a) /= 3) error stop
+        if (a(1) /= 10) error stop
+        if (a(2) /= 20) error stop
+        if (a(3) /= 30) error stop
+        print *, "OK"
+    end subroutine sub
+
+end program procedure_pointer_14

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -346,8 +346,10 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
     }
 
     ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external(x.m_name);
+    bool is_proc_pointer_call = false;
     if (ASR::is_a<ASR::Variable_t>(*func_sym)) {
         // possible it is a `procedure(cb) :: call_back`
+        is_proc_pointer_call = true;
         ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(func_sym);
         LCOMPILERS_ASSERT(ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(v->m_type)));
         func_sym = ASRUtils::symbol_get_past_external(v->m_type_declaration);
@@ -392,6 +394,17 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
     // `x.n_args` (as it only represents the "FunctionCall" arguments)
     // hence to adjust for that, `is_method` introduces an offset
     int is_method = is_class_procedure && (!is_nopass);
+    // For procedure pointer calls through struct members, detect implicit
+    // PASS self by comparing the function's param count (which includes
+    // added is_present params) with the call's explicit arg count. The
+    // function gained one is_present param per optional arg; if the
+    // remaining difference is > 0, there is an implicit self argument.
+    if (!is_method && is_proc_pointer_call && x.m_dt) {
+        size_t num_optional = sym2optionalargidx.count(func_sym)
+            ? sym2optionalargidx[func_sym].size() : 0;
+        is_method = ((size_t)func->n_args > (size_t)x.n_args + num_optional)
+            ? 1 : 0;
+    }
 
     new_args.reserve(al, func->n_args);
     for( int i = 0, j = 0; j < (int)func->n_args; j++, i++ ) {


### PR DESCRIPTION
The transform_optional_argument_functions pass did not detect implicit PASS self arguments for procedure pointer calls through struct members. It only checked for StructMethodDeclaration, not Variable-based procedure pointer calls.

When a procedure pointer has optional array args and PASS semantics, the pass incorrectly set is_method=0, producing wrong arg count and is_present flags. This cascaded into pass_array_by_data misdetecting has_implicit_dt (because the inflated call arg count made the orig_func->n_args > x.n_args check evaluate to false).

Fix: for procedure pointer calls, detect PASS by comparing function param count (including added is_present params) with call arg count. If func->n_args > x.n_args + num_optional, there is an implicit self.

Fixes #10743