### PR TITLE
Use actual rank instead of hardcoded 15 for assumed-rank array descriptors

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7402,24 +7402,10 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 ASR::ttype_t* physical_cast_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(arg));
 
                 if (ASRUtils::is_pointer(physical_cast_type) &&
-                    orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray &&
-                    func_type->m_abi != ASR::abiType::BindC) {
-                    // Assumed-rank parameters use rank-15 descriptors.
-                    // Create 15 empty dimensions so the cast target type
-                    // matches the function's LLVM signature.
-                    // Skip for BindC — CFI descriptor conversion handles rank separately.
-                    dimension_.reserve(al, 15);
-                    for (int r = 0; r < 15; r++) {
-                        ASR::dimension_t dim;
-                        dim.loc = arg->base.loc;
-                        dim.m_start = nullptr;
-                        dim.m_length = nullptr;
-                        dimension_.push_back(al, dim);
-                    }
-                    dimensions = &dimension_;
-                    orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::DescriptorArray;
-                } else if (ASRUtils::is_pointer(physical_cast_type) &&
                     orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
+                    // Use the actual argument's dimensions for the descriptor.
+                    // Assumed-rank descriptors are passed by pointer, so the
+                    // callee reads the rank field — no need for 15-slot descriptors.
                     dimension_.from_pointer_n_copy(al, arg_array_t->m_dims, arg_array_t->n_dims);
                     dimensions = &dimension_;
                     orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::DescriptorArray;
@@ -7427,23 +7413,10 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                     dimensions = nullptr;
                 } else if (ASRUtils::is_fixed_size_array(orig_arg_array_t->m_dims, orig_arg_array_t->n_dims)) {
                     dimensions = &dimension_;
-                } else if (orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray &&
-                    func_type->m_abi != ASR::abiType::BindC) {
-                    // Assumed-rank parameters use rank-15 descriptors.
-                    // Create 15 empty dimensions so the cast target type
-                    // matches the function's LLVM signature.
-                    // Skip for BindC — CFI descriptor conversion handles rank separately.
-                    dimension_.reserve(al, 15);
-                    for (int r = 0; r < 15; r++) {
-                        ASR::dimension_t dim;
-                        dim.loc = arg->base.loc;
-                        dim.m_start = nullptr;
-                        dim.m_length = nullptr;
-                        dimension_.push_back(al, dim);
-                    }
-                    dimensions = &dimension_;
-                    orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::DescriptorArray;
                 } else if (orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
+                    // Use the actual argument's dimensions for the descriptor.
+                    // Assumed-rank descriptors are passed by pointer, so the
+                    // callee reads the rank field — no need for 15-slot descriptors.
                     dimension_.from_pointer_n_copy(al, arg_array_t->m_dims, arg_array_t->n_dims);
                     dimensions = &dimension_;
                     orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::DescriptorArray;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18964,9 +18964,11 @@ public:
                         ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_args[i].m_value))));
             }
 
-            // For bind(C) with type(*) dimension(..), bitcast the descriptor pointer
-            // to match the function signature (all descriptor types share the same layout)
-            if (x_abi == ASR::abiType::BindC && orig_arg &&
+            // For assumed-rank parameters, bitcast the descriptor pointer
+            // to match the function signature (all descriptor types share
+            // the same layout; the callee reads the rank field to determine
+            // how many dim entries are valid).
+            if (orig_arg &&
                     ASRUtils::is_assumed_rank_array(orig_arg->m_type)) {
                 llvm::Type* expected_desc_type = llvm_utils->get_type_from_ttype_t_util(
                     ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
@@ -19590,15 +19592,10 @@ public:
                         arg_expr, ASRUtils::extract_type(arg_type), module.get());
                     llvm::Type* array_type = llvm_utils->get_type_from_ttype_t_util(
                         s_m_args0, s_m_args0_type, module.get());
-                    int poly_n_dims = ASRUtils::extract_n_dims_from_ttype(s_m_args0_type);
-                    if (poly_n_dims == 0 && ASRUtils::is_assumed_rank_array(s_m_args0_type)) {
-                        poly_n_dims = ASRUtils::extract_n_dims_from_ttype(arg_type);
-                        if (poly_n_dims == 0) poly_n_dims = 15;
-                    }
-                    llvm::Value* unlimited_polymorphic_type_array = arr_descr->create_descriptor_alloca(
-                        array_type);
                     llvm::Type* array_data_type = llvm_utils->get_el_type(
                         s_m_args0, ASRUtils::extract_type(s_m_args0_type), module.get());
+                    llvm::Value* unlimited_polymorphic_type_array = arr_descr->create_descriptor_alloca(
+                        array_type);
                     llvm::Value* array_data = llvm_utils->CreateAlloca(*builder, array_data_type);
                     builder->CreateStore(
                         array_data, arr_descr->get_pointer_to_data(array_type, unlimited_polymorphic_type_array));
@@ -19728,11 +19725,6 @@ public:
                         ASR::down_cast<ASR::Struct_t>(target_struct_sym), module.get());
 
                     // Allocate the target class array descriptor
-                    int class_n_dims = ASRUtils::extract_n_dims_from_ttype(s_m_args0_type);
-                    if (class_n_dims == 0 && ASRUtils::is_assumed_rank_array(s_m_args0_type)) {
-                        class_n_dims = ASRUtils::extract_n_dims_from_ttype(arg_type);
-                        if (class_n_dims == 0) class_n_dims = 15;
-                    }
                     llvm::Value* class_array = arr_descr->create_descriptor_alloca(
                         target_array_type);
                     
@@ -19879,11 +19871,6 @@ public:
                 llvm::Value* array_data = llvm_utils->CreateAlloca(*builder, array_data_type);
 
                 // Create polymorphic array descriptor
-                int poly_n_dims2 = ASRUtils::extract_n_dims_from_ttype(s_m_args0_type);
-                if (poly_n_dims2 == 0 && ASRUtils::is_assumed_rank_array(s_m_args0_type)) {
-                    poly_n_dims2 = ASRUtils::extract_n_dims_from_ttype(arg_type);
-                    if (poly_n_dims2 == 0) poly_n_dims2 = 15;
-                }
                 llvm::Value* unlimited_polymorphic_type_array =
                     arr_descr->create_descriptor_alloca(
                         array_type);
@@ -20003,11 +19990,6 @@ public:
                     ASR::down_cast<ASR::Struct_t>(target_struct_sym), module.get());
 
                 // Allocate the target class array descriptor
-                int class_n_dims2 = ASRUtils::extract_n_dims_from_ttype(s_m_args0_type);
-                if (class_n_dims2 == 0 && ASRUtils::is_assumed_rank_array(s_m_args0_type)) {
-                    class_n_dims2 = ASRUtils::extract_n_dims_from_ttype(arg_type);
-                    if (class_n_dims2 == 0) class_n_dims2 = 15;
-                }
                 llvm::Value* class_array = arr_descr->create_descriptor_alloca(
                     target_array_type);
                 

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -213,6 +213,11 @@ namespace LCompilers {
         bool get_pointer) {
             int n_dims = ASRUtils::extract_n_dims_from_ttype(m_type_);
             if (n_dims == 0) {
+                // Assumed-rank callee parameter: use CFI_MAX_RANK (15) as
+                // conservative upper bound for the callee's descriptor type.
+                // Call sites allocate correctly-sized descriptors based on
+                // the actual argument rank (see asr_utils.h PhysicalCast
+                // and asr_to_llvm.cpp polymorphic descriptor handling).
                 n_dims = 15;
             }
             std::string array_key = ASRUtils::get_type_code(m_type_, false, false, true, expr);


### PR DESCRIPTION
At call sites, PhysicalCast for assumed-rank parameters now uses the actual argument dimensions instead of always allocating 15 empty dimension slots. Since descriptors are passed by pointer, the callee reads the rank field to determine how many dim entries are valid.

- asr_utils.h: use arg_array_t->m_dims at call sites, merging the redundant BindC/non-BindC branches
- asr_to_llvm.cpp: extend assumed-rank descriptor bitcast to all ABIs (not just BindC); remove 4 dead code blocks (poly_n_dims, class_n_dims, poly_n_dims2, class_n_dims2)
- llvm_array_utils.cpp: document that the n_dims=15 fallback in get_array_type() now only affects callee parameter types

Fixes #10775