### PR TITLE
Poison malloc/free/realloc/calloc after internal allocator definitions

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -479,6 +479,10 @@ LFORTRAN_API void _lfortran_internal_alloc_finalize(void)
 #endif
 }
 
+// All code below must use internal_malloc/internal_realloc/internal_free
+// instead of malloc/realloc/free to ensure proper memory tracking.
+#pragma GCC poison malloc free realloc calloc
+
 static int64_t lfortran_getline(char **lineptr, size_t *n, FILE *stream) {
     if (!lineptr || !n || !stream) {
         errno = EINVAL;


### PR DESCRIPTION
Enforce the use of internal_malloc/internal_realloc/internal_free in all code after the internal allocator implementation to ensure proper memory tracking.