### PR TITLE
Fix pointer bounds remapping segfault for allocatable targets

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -916,6 +916,7 @@ RUN(NAME pointer_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_11 LABELS gfortran llvm)
 
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/pointer_11.f90
+++ b/integration_tests/pointer_11.f90
@@ -1,0 +1,36 @@
+program pointer_11
+    implicit none
+    real, allocatable, target :: a(:)
+    real, pointer :: p(:)
+    integer :: i
+
+    allocate(a(5))
+    do i = 1, 5
+        a(i) = real(i * 10)
+    end do
+
+    ! Pointer bounds remapping: p(1:5) => a
+    p(1:5) => a
+    if (size(p) /= 5) error stop
+    do i = 1, 5
+        if (abs(p(i) - a(i)) > 1.0e-6) error stop
+    end do
+
+    ! Pointer bounds remapping with different lower bound: p(0:4) => a
+    p(0:4) => a
+    if (size(p) /= 5) error stop
+    if (lbound(p, 1) /= 0) error stop
+    if (ubound(p, 1) /= 4) error stop
+    do i = 0, 4
+        if (abs(p(i) - a(i + 1)) > 1.0e-6) error stop
+    end do
+
+    ! Pointer bounds remapping to a subsection: p(1:3) => a(1:3)
+    p(1:3) => a(1:3)
+    if (size(p) /= 3) error stop
+    do i = 1, 3
+        if (abs(p(i) - a(i)) > 1.0e-6) error stop
+    end do
+
+    print *, "PASS"
+end program pointer_11

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8218,11 +8218,6 @@ public:
                 if (ASRUtils::is_allocatable(v_type) || ASRUtils::is_pointer(v_type)) {
                     value_desc = llvm_utils->CreateLoad2(value_desc_type->getPointerTo(), value_desc);
                 }
-            } else if (ASR::is_a<ASR::Var_t>(*x.m_value)) {
-                if (ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_value)) ||
-                    ASRUtils::is_pointer(ASRUtils::expr_type(x.m_value))) {
-                    value_desc = llvm_utils->CreateLoad2(value_desc_type->getPointerTo(), value_desc);
-                }
             }
             value_data = arr_descr->get_pointer_to_data(value_desc_type, value_desc);
             value_data = llvm_utils->CreateLoad2(value_el_type->getPointerTo(), value_data);

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
@@ -4,6 +4,7 @@
 #include <libasr/pass/pass_utils.h>
 #include <libasr/containers.h>
 #include <map>
+#include <set>
 
 #include <libasr/pass/intrinsic_function_registry.h>
 
@@ -170,6 +171,7 @@ class PromoteAllocatableToNonAllocatable:
     public:
 
         std::map<SymbolTable*, std::vector<ASR::symbol_t*>>& scope2var;
+        std::set<ASR::symbol_t*> promoted_symbols;
 
         PromoteAllocatableToNonAllocatable(Allocator& al_,
             std::map<SymbolTable*, std::vector<ASR::symbol_t*>>& scope2var_):
@@ -227,6 +229,7 @@ class PromoteAllocatableToNonAllocatable:
                         }
                     alloc_variable->m_type = ASRUtils::make_Array_t_util(al, x.base.base.loc,
                     array_type, alloc_arg.m_dims, alloc_arg.n_dims);
+                    promoted_symbols.insert(ASR::down_cast<ASR::Var_t>(alloc_arg.m_a)->m_v);
                 } else if( ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(alloc_arg.m_a)) ||
                            ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(alloc_arg.m_a)) ) {
                     x_args.push_back(al, alloc_arg);
@@ -347,9 +350,12 @@ class FixArrayPhysicalCastVisitor: public ASR::CallReplacerOnExpressionsVisitor<
         Allocator& al;
         FixArrayPhysicalCast replacer;
         bool remove_original_stmt;
+        const std::set<ASR::symbol_t*>& promoted_symbols;
 
-        FixArrayPhysicalCastVisitor(Allocator& al_):
-            al(al_), replacer(al_), remove_original_stmt(false) {}
+        FixArrayPhysicalCastVisitor(Allocator& al_,
+            const std::set<ASR::symbol_t*>& promoted_symbols_):
+            al(al_), replacer(al_), remove_original_stmt(false),
+            promoted_symbols(promoted_symbols_) {}
 
         void call_replacer() {
             replacer.current_expr = current_expr;
@@ -378,6 +384,25 @@ class FixArrayPhysicalCastVisitor: public ASR::CallReplacerOnExpressionsVisitor<
                     ASR::array_physical_typeType::DescriptorArray,
                     ASRUtils::duplicate_type(al, ASRUtils::expr_type(x.m_value),
                     nullptr, ASR::array_physical_typeType::DescriptorArray, true), nullptr));
+            } else if (ASR::is_a<ASR::ArraySection_t>(*x.m_value)) {
+                ASR::ArraySection_t* as = ASR::down_cast<ASR::ArraySection_t>(
+                    const_cast<ASR::expr_t*>(x.m_value));
+                ASR::ttype_t* base_type = ASRUtils::expr_type(as->m_v);
+                ASR::ttype_t* section_type = ASRUtils::expr_type(x.m_value);
+                bool base_was_promoted = ASR::is_a<ASR::Var_t>(*as->m_v) &&
+                    promoted_symbols.count(ASR::down_cast<ASR::Var_t>(as->m_v)->m_v) > 0;
+                if (base_was_promoted &&
+                    ASRUtils::is_fixed_size_array(base_type) &&
+                    ASRUtils::extract_physical_type(section_type) ==
+                        ASR::array_physical_typeType::DescriptorArray) {
+                    as->m_v = ASRUtils::EXPR(ASRUtils::make_ArrayPhysicalCast_t_util(
+                        al, as->m_v->base.loc, as->m_v,
+                        ASRUtils::extract_physical_type(base_type),
+                        ASR::array_physical_typeType::DescriptorArray,
+                        ASRUtils::duplicate_type(al, base_type,
+                            nullptr, ASR::array_physical_typeType::DescriptorArray, true),
+                        nullptr));
+                }
             } else if( ASRUtils::is_fixed_size_array(
                         ASRUtils::expr_type(x.m_target)) ) {
                 remove_original_stmt = true;
@@ -437,7 +462,7 @@ void pass_promote_allocatable_to_nonallocatable(
     PromoteAllocatableToNonAllocatable promoter(al, scope2var);
     promoter.visit_TranslationUnit(unit);
     promoter.visit_TranslationUnit(unit);
-    FixArrayPhysicalCastVisitor fix_array_physical_cast(al);
+    FixArrayPhysicalCastVisitor fix_array_physical_cast(al, promoter.promoted_symbols);
     fix_array_physical_cast.visit_TranslationUnit(unit);
     FixMoveAssignment fix_move_assignment(al);
     fix_move_assignment.visit_TranslationUnit(unit);


### PR DESCRIPTION
The pointer bounds remapping syntax p(lb:ub) => a was generating incorrect LLVM IR when the value (a) was an allocatable array. The codegen in handle_pointer_section_target set ptr_loads=1 for allocatable types, which already loaded through the allocatable indirection. An additional explicit load for the Var_t case then read the data pointer field as a descriptor pointer, causing a segfault at runtime.

Remove the redundant load for the Var_t allocatable/pointer case.

An integration test (pointer_11) is added.