### PR TITLE
Remove implicit-self offset patterns from passes and codegen

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3119,16 +3119,15 @@ class ReplaceFunctionParamWithArg: public ASR::BaseExprReplacer<ReplaceFunctionP
     Allocator& al;
     ASR::call_arg_t* m_args;
     size_t n_args;
-    bool is_method;
 
     public:
 
-    ReplaceFunctionParamWithArg(Allocator& al_, ASR::call_arg_t* m_args_, size_t n_args_, bool is_method_ = false) :
-        al(al_), m_args(m_args_), n_args(n_args_), is_method(is_method_) {}
+    ReplaceFunctionParamWithArg(Allocator& al_, ASR::call_arg_t* m_args_, size_t n_args_) :
+        al(al_), m_args(m_args_), n_args(n_args_) {}
 
     void replace_FunctionParam(ASR::FunctionParam_t *x) {
         if (current_expr) {
-            size_t n = x->m_param_number - is_method;
+            size_t n = x->m_param_number;
             if (n >= n_args) {
                 LCOMPILERS_ASSERT("FunctionParam param number not in range.");
             };
@@ -7161,16 +7160,8 @@ ASR::Cast_t* cast_string_to_array(Allocator &al, ASR::expr_t* const string_expr,
 
 static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
     ASR::call_arg_t* a_args, size_t n_args, ASR::expr_t* a_dt, ASR::stmt_t** cast_stmt,
-    bool implicit_argument_casting, bool nopass, bool self_already_in_args = false, SymbolTable* current_scope = nullptr, std::optional<std::reference_wrapper<SetChar>> current_function_dependencies = std::nullopt) {
-    bool is_method = (a_dt != nullptr) && (!nopass);
+    bool implicit_argument_casting, SymbolTable* current_scope = nullptr, std::optional<std::reference_wrapper<SetChar>> current_function_dependencies = std::nullopt) {
     ASR::symbol_t* a_name_ = ASRUtils::symbol_get_past_external(a_name);
-    if( ASR::is_a<ASR::Variable_t>(*a_name_) ) {
-        is_method = false;
-    }
-    // When self is already explicitly in args, args align 1:1 with params.
-    if (self_already_in_args) {
-        is_method = false;
-    }
     ASR::FunctionType_t* func_type = get_FunctionType(a_name);
     // Skip arg processing for implicit interfaces (no declared parameter types)
     if (func_type->n_arg_types == 0) {
@@ -7179,18 +7170,18 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
     ASR::Function_t* func = ASRUtils::get_function(a_name);
 
     for( size_t i = 0; i < n_args; i++ ) {
-        if( i + is_method >= func_type->n_arg_types ) {
+        if( i >= func_type->n_arg_types ) {
             break;
         }
         if( a_args[i].m_value == nullptr ) {
             continue;
         }
         ASR::expr_t* arg = a_args[i].m_value;
-        [[maybe_unused]] ASR::expr_t* orig_arg = func->m_args[i + is_method];
+        [[maybe_unused]] ASR::expr_t* orig_arg = func->m_args[i];
         ASR::ttype_t* arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
         ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
-            ASRUtils::type_get_past_pointer(func_type->m_arg_types[i + is_method]));
+            ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
         // cast string source based on the dest
         if( ASRUtils::is_string_only(orig_arg_type) &&
             ASRUtils::is_string_only(arg_type) &&
@@ -7198,7 +7189,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             arg = a_args[i].m_value = 
                 create_string_physical_cast(al, arg, 
                     get_string_type(orig_arg_type)->m_physical_type,
-                    is_allocatable(func_type->m_arg_types[i + is_method]));
+                    is_allocatable(func_type->m_arg_types[i]));
         }
 
         if( func_type->m_abi != ASR::abiType::BindC &&
@@ -7258,7 +7249,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 // Pass actual argument expression to `check_equal_type()` if the expression is
                 // `ASR::FunctionParam_t`.
                 ASR::expr_t* arg_expr = arg;
-                ASR::expr_t* orig_arg_expr = func->m_args[i + is_method];
+                ASR::expr_t* orig_arg_expr = func->m_args[i];
                 if (ASR::is_a<ASR::FunctionParam_t>(*arg_expr)) {
                     ASR::FunctionParam_t* func_param = ASR::down_cast<ASR::FunctionParam_t>(arg_expr);
                     arg_expr = func->m_args[func_param->m_param_number];
@@ -7432,25 +7423,9 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                     orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::DescriptorArray;
                 } else if (current_scope) {
                     // Replace FunctionParam in dimensions and check whether its symbols are accessible from current_scope
-                    // When is_method is true, FunctionParam(0) refers to 'self' (a_dt),
-                    // but a_args doesn't include 'self'. We need to construct a full
-                    // args array with a_dt prepended so FunctionParam indices match.
-                    ASR::call_arg_t* full_args = a_args;
-                    size_t full_n_args = n_args;
-                    Vec<ASR::call_arg_t> full_args_vec;
-                    if (is_method && a_dt) {
-                        full_args_vec.reserve(al, n_args + 1);
-                        ASR::call_arg_t self_arg;
-                        self_arg.loc = a_dt->base.loc;
-                        self_arg.m_value = a_dt;
-                        full_args_vec.push_back(al, self_arg);
-                        for (size_t j = 0; j < n_args; j++) {
-                            full_args_vec.push_back(al, a_args[j]);
-                        }
-                        full_args = full_args_vec.p;
-                        full_n_args = full_args_vec.n;
-                    }
-                    ReplaceFunctionParamWithArg r(al, full_args, full_n_args, false);
+                    // Self is already in a_args (at the PASS position), so
+                    // FunctionParam indices align 1:1 with a_args indices.
+                    ReplaceFunctionParamWithArg r(al, a_args, n_args);
                     SetChar temp_function_dependencies;
                     CheckSymbolReplacer c(al, current_scope, temp_function_dependencies);
                     bool valid_symbols = true;
@@ -7494,7 +7469,7 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 // Only wrap if not already wrapped (physical_cast_type may
                 // already include Pointer/Allocatable).
                 // Skip for BindC — CFI descriptors use single-pointer semantics.
-                ASR::ttype_t* raw_param_type = func_type->m_arg_types[i + is_method];
+                ASR::ttype_t* raw_param_type = func_type->m_arg_types[i];
                 if (is_orig_assumed_rank &&
                     func_type->m_abi != ASR::abiType::BindC &&
                     ASR::is_a<ASR::Allocatable_t>(*raw_param_type) &&
@@ -7596,11 +7571,35 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
 
     bool nopass = ASRUtils::get_class_proc_nopass_val(a_name);
     bool a_is_method = (a_dt != nullptr) && (!nopass);
+    // Detect if self is already in args: either explicitly told, or
+    // by checking if args[0] matches dt, or if n_args already equals
+    // the function's formal parameter count.
     bool self_already_in_args = self_in_args || (a_is_method && n_args > 0 &&
         a_args[0].m_value != nullptr && is_self_argument(a_args[0].m_value, a_dt));
+    if (a_is_method && !self_already_in_args) {
+        ASR::FunctionType_t* func_type = get_FunctionType(a_name);
+        if (func_type->n_arg_types > 0 && n_args >= func_type->n_arg_types) {
+            self_already_in_args = true;
+        }
+    }
+
+    // Prepend self to args BEFORE Call_t_body so args align 1:1 with formals
+    if (a_is_method && !self_already_in_args) {
+        Vec<ASR::call_arg_t> new_args;
+        new_args.reserve(al, n_args + 1);
+        ASR::call_arg_t self_arg;
+        self_arg.loc = a_dt->base.loc;
+        self_arg.m_value = a_dt;
+        new_args.push_back(al, self_arg);
+        for (size_t i = 0; i < n_args; i++) {
+            new_args.push_back(al, a_args[i]);
+        }
+        a_args = new_args.p;
+        n_args = new_args.size();
+    }
 
     Call_t_body(al, a_name, a_args, n_args, a_dt, nullptr, implicit_argument_casting,
-        nopass, self_already_in_args, current_scope, current_function_dependencies);
+        current_scope, current_function_dependencies);
 
     if( ASRUtils::is_array(a_type) && ASRUtils::is_elemental(a_name) &&
         !ASRUtils::is_fixed_size_array(a_type) &&
@@ -7644,20 +7643,6 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
         }
     }
 
-    if (a_is_method && !self_already_in_args) {
-        Vec<ASR::call_arg_t> new_args;
-        new_args.reserve(al, n_args + 1);
-        ASR::call_arg_t self_arg;
-        self_arg.loc = a_dt->base.loc;
-        self_arg.m_value = a_dt;
-        new_args.push_back(al, self_arg);
-        for (size_t i = 0; i < n_args; i++) {
-            new_args.push_back(al, a_args[i]);
-        }
-        a_args = new_args.p;
-        n_args = new_args.size();
-    }
-
     return ASR::make_FunctionCall_t(al, a_loc, a_name, a_original_name,
             a_args, n_args, a_type, a_value, a_dt);
 }
@@ -7669,12 +7654,18 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
 
     bool nopass = ASRUtils::get_class_proc_nopass_val(a_name);
     bool a_is_method = (a_dt != nullptr) && (!nopass);
+    // Detect if self is already in args: either explicitly told, or
+    // by checking if args[0] matches dt, or if n_args already equals
+    // the function's formal parameter count.
     bool self_already_in_args = self_in_args || (a_is_method && n_args > 0 &&
         a_args[0].m_value != nullptr && is_self_argument(a_args[0].m_value, a_dt));
+    if (a_is_method && !self_already_in_args) {
+        ASR::FunctionType_t* func_type = get_FunctionType(a_name);
+        if (func_type->n_arg_types > 0 && n_args >= func_type->n_arg_types) {
+            self_already_in_args = true;
+        }
+    }
     ASR::expr_t* self_expr = a_dt;
-
-    Call_t_body(al, a_name, a_args, n_args, a_dt, cast_stmt, implicit_argument_casting,
-         nopass, self_already_in_args, current_scope, current_function_dependencies);
 
     if( a_dt && ASR::is_a<ASR::Variable_t>(
         *ASRUtils::symbol_get_past_external(a_name)) &&
@@ -7684,6 +7675,7 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
             a_dt, a_name, ASRUtils::duplicate_type(al, ASRUtils::symbol_type(a_name)), nullptr));
     }
 
+    // Prepend self to args BEFORE Call_t_body so args align 1:1 with formals
     if (a_is_method && !self_already_in_args) {
         Vec<ASR::call_arg_t> new_args;
         new_args.reserve(al, n_args + 1);
@@ -7697,6 +7689,9 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
         a_args = new_args.p;
         n_args = new_args.size();
     }
+
+    Call_t_body(al, a_name, a_args, n_args, a_dt, cast_stmt, implicit_argument_casting,
+         current_scope, current_function_dependencies);
 
     return ASR::make_SubroutineCall_t(al, a_loc, a_name, a_original_name, a_args, n_args, a_dt, a_strict_bounds_checking);
 }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18211,7 +18211,7 @@ public:
     }
 
     template <typename T>
-    std::vector<llvm::Value*> convert_call_args(const T &x, bool is_method) {
+    std::vector<llvm::Value*> convert_call_args(const T &x, bool skip_self = false) {
         std::vector<llvm::Value *> args;
         convert_call_args_depth++;
         // Only reset alloca pool indices at outermost call to avoid
@@ -18219,10 +18219,10 @@ public:
         if (convert_call_args_depth == 1) {
             reset_call_arg_alloca_pool();
         }
-        // When is_method, self is in x.m_args[0] but is handled
-        // separately by the caller (with polymorphic conversion),
+        // When skip_self is true, self is in x.m_args[0] but is handled
+        // separately by the caller (with polymorphic type conversion),
         // so we skip it here.
-        size_t start_idx = is_method ? 1 : 0;
+        size_t start_idx = skip_self ? 1 : 0;
         for (size_t i=start_idx; i<x.n_args; i++) {
             ASR::symbol_t* func_subrout = symbol_get_past_external(x.m_name);
             ASR::abiType x_abi = (ASR::abiType) 0;
@@ -20482,7 +20482,7 @@ public:
 
             // Self is in x.m_args[0]; skip it in convert_call_args
             // and handle it manually with proper type conversion.
-            args = convert_call_args(x, is_method);
+            args = convert_call_args(x, is_method /* skip_self */);
             if (is_method) {
                 ASR::StructInstanceMember_t* sim =
                     ASR::down_cast<ASR::StructInstanceMember_t>(x.m_dt);
@@ -20636,7 +20636,7 @@ public:
                     fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, "_lpython_get_argv", module.get());
                 }
-                args = convert_call_args(x, is_method);
+                args = convert_call_args(x, is_method /* skip_self */);
                 LCOMPILERS_ASSERT(args.size() > 0);
                 tmp = builder->CreateCall(fn, {llvm_utils->CreateLoad2(
                     llvm::Type::getInt32Ty(context), args[0])});
@@ -20653,7 +20653,7 @@ public:
                     fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, "_lfortran_get_env_variable", module.get());
                 }
-                args = convert_call_args(x, is_method);
+                args = convert_call_args(x, is_method /* skip_self */);
                 LCOMPILERS_ASSERT(args.size() > 0);
                 tmp = builder->CreateCall(fn, { llvm_utils->CreateLoad2(character_type, args[0]) });
                 if (args.size() > 1)
@@ -20670,7 +20670,7 @@ public:
                     fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, "_lfortran_exec_command", module.get());
                 }
-                args = convert_call_args(x, is_method);
+                args = convert_call_args(x, is_method /* skip_self */);
                 LCOMPILERS_ASSERT(args.size() > 0);
                 tmp = builder->CreateCall(fn, { llvm_utils->CreateLoad2(character_type, args[0]) });
                 return;
@@ -20684,7 +20684,7 @@ public:
                     fn = llvm::Function::Create(function_type,
                         llvm::Function::ExternalLinkage, "_lfortran_sleep", module.get());
                 }
-                args = convert_call_args(x, is_method);
+                args = convert_call_args(x, is_method /* skip_self */);
                 LCOMPILERS_ASSERT(args.size() > 0);
                 tmp = builder->CreateCall(fn, { llvm_utils->CreateLoad2(llvm::Type::getInt32Ty(context), args[0]) });
                 return;
@@ -20708,7 +20708,7 @@ public:
                     ASRUtils::is_pointer(ASR::down_cast<ASR::Variable_t>(proc_sym)->m_type)) {
                 fn = llvm_utils->CreateLoad2(fntype->getPointerTo(), fn);
             }
-            args = convert_call_args(x, is_method);
+            args = convert_call_args(x, is_method /* skip_self */);
 
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym) &&
@@ -20722,7 +20722,7 @@ public:
             llvm::FunctionType* fntype = llvm_utils->get_function_type(*ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(v->m_type_declaration)), module.get());
             fn = llvm_utils->CreateLoad2(fntype->getPointerTo(), fn);
             std::string m_name = ASRUtils::symbol_name(x.m_name);
-            args = convert_call_args(x, is_method);
+            args = convert_call_args(x, is_method /* skip_self */);
 
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
@@ -20732,7 +20732,7 @@ public:
         } else {
             llvm::Function *fn = llvm_symtab_fn[h];
             std::string m_name = ASRUtils::symbol_name(x.m_name);
-            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method);
+            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method /* skip_self */);
             args.insert(args.end(), args2.begin(), args2.end());
             // check if type of each arg is same as type of each arg in subrout_called
             if (ASR::is_a<ASR::Function_t>(*symbol_get_past_external(x.m_name))) {
@@ -21028,7 +21028,7 @@ public:
             llvm_dt = builder->CreateBitCast(llvm_dt, target_struct_type->getPointerTo());
             args.push_back(llvm_dt);
         }
-        std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass);
+        std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass /* skip_self */);
         args.insert(args.end(), args2.begin(), args2.end());
 
         // Get VTable pointer
@@ -21109,7 +21109,7 @@ public:
                 args.push_back(llvm_dt);
             }
         }
-        std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass);
+        std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass /* skip_self */);
         args.insert(args.end(), args2.begin(), args2.end());
 
         // Get Runtime VTable Pointer
@@ -21381,7 +21381,7 @@ public:
                     ASRUtils::is_pointer(ASR::down_cast<ASR::Variable_t>(proc_sym)->m_type)) {
                 fn = llvm_utils->CreateLoad2(fntype->getPointerTo(), fn);
             }
-            args = convert_call_args(x, is_method);
+            args = convert_call_args(x, is_method /* skip_self */);
 
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (ASRUtils::is_symbol_procedure_variable(ASRUtils::symbol_get_past_external(proc_sym)) && llvm_symtab.find(h) != llvm_symtab.end()) {
@@ -21392,7 +21392,7 @@ public:
                 s->m_function_signature, module.get());
             llvm::Value* fn = llvm_symtab[h];
             fn = llvm_utils->CreateLoad2(fn_type, fn);
-            args = convert_call_args(x, is_method);
+            args = convert_call_args(x, is_method /* skip_self */);
 
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
@@ -21401,7 +21401,7 @@ public:
         } else {
             llvm::Function *fn = llvm_symtab_fn[h];
             std::string m_name = std::string(((ASR::Function_t*)(&(x.m_name->base)))->m_name);
-            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method);
+            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method /* skip_self */);
             args.insert(args.end(), args2.begin(), args2.end());
             if (pass_arg) {
                 args.push_back(pass_arg);

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -285,13 +285,8 @@ ASR::expr_t* get_first_array_function_args(T* func) {
     int64_t first_array_arg_idx = -1;
     ASR::expr_t* first_array_arg = nullptr;
     if constexpr (std::is_same_v<T, ASR::FunctionCall_t>) {
-        ASR::symbol_t* call_func = ASRUtils::symbol_get_past_external(func->m_name);
-        if (ASR::is_a<ASR::StructMethodDeclaration_t>(*call_func)) {
-            bool is_no_pass = ASRUtils::get_class_proc_nopass_val(call_func);
-            if (!is_no_pass && ASRUtils::is_array(ASRUtils::expr_type(func->m_dt))) {
-                return func->m_dt;
-            }
-        }
+        // Self is already in args at the PASS position; no special
+        // m_dt handling needed. Just find the first array arg normally.
     }
     for (int64_t i = 0; i < (int64_t)func->n_args; i++) {
         ASR::ttype_t* func_arg_type;

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -880,7 +880,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
             visit_expr(*x.m_dt);
         }
         ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt,
-            nullptr, false, ASRUtils::get_class_proc_nopass_val(x.m_name));
+            nullptr, false);
     }
 
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
@@ -921,7 +921,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
 
 
         ASRUtils::Call_t_body(al, xx.m_name, xx.m_args, xx.n_args, x.m_dt,
-            nullptr, false, ASRUtils::get_class_proc_nopass_val(x.m_name));
+            nullptr, false);
     }
 
     void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t& x) {

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -962,20 +962,6 @@ class EditProcedureCallsVisitor : public ASR::ASRPassBaseWalkVisitor<EditProcedu
             }
             return true;
         }
-        /// Is StructMethodDeclaration with m_is_nopass = false (dt will be implicitly passed)
-        static bool is_structMethodDeclaration_with_pass(ASR::symbol_t* const sym){
-            ASR::symbol_t* const sym_past_ext = ASRUtils::symbol_get_past_external(sym);
-            if(!ASR::is_a<ASR::StructMethodDeclaration_t>(*sym_past_ext)) return false;
-            return !ASR::down_cast<ASR::StructMethodDeclaration_t>(sym_past_ext)->m_is_nopass;
-        }
-
-        static bool call_with_implicit_dt_passed(const ASR::SubroutineCall_t* const x){
-            return is_structMethodDeclaration_with_pass(x->m_name);
-        }
-
-        static bool call_with_implicit_dt_passed(const ASR::FunctionCall_t* const x){
-            return is_structMethodDeclaration_with_pass(x->m_name);
-        }
         
         static bool is_struct_method_declaration(ASR::symbol_t* const sym){
             return ASR::is_a<ASR::StructMethodDeclaration_t>(*ASRUtils::symbol_get_past_external(sym));
@@ -1109,8 +1095,6 @@ class EditProcedureCallsVisitor : public ASR::ASRPassBaseWalkVisitor<EditProcedu
                     if( ASR::is_a<ASR::Variable_t>(*arg->m_v) &&
                         ASR::down_cast<ASR::Variable_t>(arg->m_v)->m_presence
                             == ASR::presenceType::Optional ) {
-                        max_args += 1;
-                    } else if(call_with_implicit_dt_passed(&x)) {
                         max_args += 1;
                     } else {
                         min_args += 1;

--- a/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
+++ b/src/libasr/pass/promote_allocatable_to_nonallocatable.cpp
@@ -314,10 +314,6 @@ class FixArrayPhysicalCast: public ASR::BaseExprReplacer<FixArrayPhysicalCast> {
 
         void replace_FunctionCall(ASR::FunctionCall_t* x) {
             ASR::BaseExprReplacer<FixArrayPhysicalCast>::replace_FunctionCall(x);
-            // Skip reconstruction for method calls: self is already in args
-            // and make_FunctionCall_t_util would double-add it.
-            bool nopass = ASRUtils::get_class_proc_nopass_val(x->m_name);
-            if (x->m_dt && !nopass) return;
             ASR::expr_t* call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(
                 al, x->base.base.loc, x->m_name, x->m_original_name, x->m_args,
                 x->n_args, x->m_type, x->m_value, x->m_dt));
@@ -368,12 +364,9 @@ class FixArrayPhysicalCastVisitor: public ASR::CallReplacerOnExpressionsVisitor<
 
         void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
             ASR::CallReplacerOnExpressionsVisitor<FixArrayPhysicalCastVisitor>::visit_SubroutineCall(x);
-            bool nopass = ASRUtils::get_class_proc_nopass_val(x.m_name);
-            bool self_in_args = (x.m_dt && !nopass);
             ASR::stmt_t* call = ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(
                 al, x.base.base.loc, x.m_name, x.m_original_name, x.m_args,
-                x.n_args, x.m_dt, nullptr, false, nullptr, std::nullopt,
-                false, self_in_args));
+                x.n_args, x.m_dt, nullptr, false));
             ASR::SubroutineCall_t* subrout_call = ASR::down_cast<ASR::SubroutineCall_t>(call);
             ASR::SubroutineCall_t& xx = const_cast<ASR::SubroutineCall_t&>(x);
             xx.m_args = subrout_call->m_args;

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -634,12 +634,10 @@ class ReplaceFunctionCallsWithOptionalArguments: public ASR::BaseExprReplacer<Re
             new_func_calls.find(*current_expr) != new_func_calls.end() ) {
             return ;
         }
-        bool nopass = ASRUtils::get_class_proc_nopass_val(x->m_name);
-        bool self_in_args = (x->m_dt && !nopass);
         *current_expr = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al,
                             x->base.base.loc, x->m_name, x->m_original_name,
                             new_args.p, new_args.size(), x->m_type, x->m_value,
-                            x->m_dt, nullptr, std::nullopt, false, self_in_args));
+                            x->m_dt));
         new_func_calls.insert(*current_expr);
     }
 
@@ -738,13 +736,10 @@ class ReplaceSubroutineCallsWithOptionalArgumentsVisitor : public PassUtils::Pas
             if( !fill_new_args(new_args, al, x, current_scope, sym2optionalargidx, pass_result) ) {
                 return ;
             }
-            bool nopass = ASRUtils::get_class_proc_nopass_val(x.m_name);
-            bool self_in_args = (x.m_dt && !nopass);
             pass_result.push_back(al, ASRUtils::STMT(ASRUtils::make_SubroutineCall_t_util(al,
                                     x.base.base.loc, x.m_name, x.m_original_name,
                                     new_args.p, new_args.size(), x.m_dt,
-                                    nullptr, false, nullptr, std::nullopt,
-                                    false, self_in_args)));
+                                    nullptr, false)));
         }
 };
 


### PR DESCRIPTION
Prepend self to args BEFORE Call_t_body so args[i] always maps directly to func->m_args[i] with no offset computation.

asr_utils.h:
- Call_t_body: remove nopass/self_already_in_args params, remove all i+is_method offset logic, remove full_args dt-prepend block
- ReplaceFunctionParamWithArg: remove is_method offset (m_param_number used directly)
- make_*Call_t_util: move self prepend before Call_t_body; add robust self-detection via formal param count fallback

asr_to_llvm.cpp:
- convert_call_args: rename is_method to skip_self for clarity

Pass cleanups:
- pass_array_by_data: remove is_structMethodDeclaration_with_pass, call_with_implicit_dt_passed helpers
- transform_optional_argument_functions: remove self_in_args plumbing
- array_struct_temporary: remove m_dt+nopass array detection
- promote_allocatable_to_nonallocatable: remove self_in_args plumbing
- nested_vars: update Call_t_body calls to new signature