### PR TITLE
fix: handle pass(arg) where arg is not the first parameter

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2216,6 +2216,7 @@ RUN(NAME derived_types_124 LABELS gfortran llvm)
 RUN(NAME derived_types_125 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_types_126 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_types_127 LABELS gfortran llvm)
+RUN(NAME derived_types_128 LABELS gfortran llvm)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_128.f90
+++ b/integration_tests/derived_types_128.f90
@@ -1,0 +1,53 @@
+module derived_types_128_mod
+    implicit none
+
+    type :: point
+        real :: x, y
+    contains
+        procedure, pass(self) :: add_default
+        procedure, pass(pt) :: add_named
+    end type point
+
+contains
+
+    function add_default(self, other) result(res)
+        class(point), intent(in) :: self, other
+        type(point) :: res
+        res%x = self%x + other%x
+        res%y = self%y + other%y
+    end function
+
+    function add_named(scale, pt) result(res)
+        real, intent(in) :: scale
+        class(point), intent(in) :: pt
+        type(point) :: res
+        res%x = pt%x * scale
+        res%y = pt%y * scale
+    end function
+
+end module derived_types_128_mod
+
+program derived_types_128
+    use derived_types_128_mod
+    implicit none
+
+    type(point) :: p1, p2, result
+
+    p1 = point(1.0, 2.0)
+    p2 = point(3.0, 4.0)
+
+    ! pass(self) where self is the first argument (default position)
+    result = p1%add_default(p2)
+    if (abs(result%x - 4.0) > 1e-6) error stop
+    if (abs(result%y - 6.0) > 1e-6) error stop
+
+    ! pass(pt) where pt is the second argument
+    ! p1%add_named(10.0) should pass: add_named(10.0, p1)
+    ! i.e., scale=10.0 and pt=p1
+    result = p1%add_named(10.0)
+    if (abs(result%x - 10.0) > 1e-6) error stop
+    if (abs(result%y - 20.0) > 1e-6) error stop
+
+    print *, "All tests passed."
+
+end program derived_types_128

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10229,10 +10229,22 @@ public:
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(v_class_proc->m_proc);
 
         if (!v_class_proc->m_is_nopass) {
+            size_t pass_idx = ASRUtils::get_pass_arg_index(v);
             ASR::call_arg_t self_arg;
             self_arg.loc = v_expr->base.loc;
             self_arg.m_value = v_expr;
-            args.push_front(al, self_arg);  // push self arg in case of class procedure
+            Vec<ASR::call_arg_t> full_args;
+            full_args.reserve(al, n_args + 1);
+            size_t explicit_i = 0;
+            for (size_t i = 0; i < n_args + 1; i++) {
+                if (i == pass_idx) {
+                    full_args.push_back(al, self_arg);
+                } else {
+                    full_args.push_back(al, args[explicit_i]);
+                    explicit_i++;
+                }
+            }
+            args = full_args;
         }
         ASR::expr_t* first_array_arg = ASRUtils::find_first_array_arg_if_elemental(func, args);
         if (first_array_arg) {
@@ -10248,13 +10260,24 @@ public:
         } else {
             type = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
             if (!v_class_proc->m_is_nopass) {
+                size_t pass_idx = ASRUtils::get_pass_arg_index(v);
                 ASR::call_arg_t self_arg;
                 self_arg.loc = v_expr->base.loc;
                 self_arg.m_value = v_expr;
+                Vec<ASR::call_arg_t> explicit_args;
+                explicit_args.reserve(al, n_args);
+                visit_expr_list(m_args, n_args, explicit_args);
                 args = {};
                 args.reserve(al, func->n_args);
-                visit_expr_list(m_args, n_args, args);
-                args.push_front(al, self_arg);  // push self arg to fulfill correct number of args in definition
+                size_t explicit_i = 0;
+                for (size_t i = 0; i < n_args + 1; i++) {
+                    if (i == pass_idx) {
+                        args.push_back(al, self_arg);
+                    } else {
+                        args.push_back(al, explicit_args[explicit_i]);
+                        explicit_i++;
+                    }
+                }
             }
             // Set the correct return type.
             type = handle_return_type(type, func->m_return_var->base.loc, args, func);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -889,6 +889,28 @@ static inline bool get_class_proc_nopass_val(ASR::symbol_t* func_sym) {
     return nopass;
 }
 
+// Returns the index of the pass argument in the function's formal parameter
+// list. Returns 0 when pass_arg is unspecified (default pass = first arg).
+static inline size_t get_pass_arg_index(ASR::symbol_t* a_name) {
+    ASR::symbol_t* sym = symbol_get_past_external(a_name);
+    if (!ASR::is_a<ASR::StructMethodDeclaration_t>(*sym)) {
+        return 0;
+    }
+    ASR::StructMethodDeclaration_t* clss_proc =
+        ASR::down_cast<ASR::StructMethodDeclaration_t>(sym);
+    if (clss_proc->m_self_argument == nullptr) {
+        return 0;
+    }
+    ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(clss_proc->m_proc);
+    for (size_t i = 0; i < func->n_args; i++) {
+        ASR::Variable_t* v = EXPR2VAR(func->m_args[i]);
+        if (strcmp(v->m_name, clss_proc->m_self_argument) == 0) {
+            return i;
+        }
+    }
+    return 0;
+}
+
 static inline void encode_dimensions(size_t n_dims, std::string& res,
     bool use_underscore_sep=false) {
     if( n_dims == 0 ) {
@@ -7583,16 +7605,23 @@ static inline ASR::asr_t* make_FunctionCall_t_util(
         }
     }
 
-    // Prepend self to args BEFORE Call_t_body so args align 1:1 with formals
+    // Insert self into args at the correct position (determined by pass
+    // attribute) BEFORE Call_t_body so args align 1:1 with formals.
     if (a_is_method && !self_already_in_args) {
+        size_t pass_idx = get_pass_arg_index(a_name);
         Vec<ASR::call_arg_t> new_args;
         new_args.reserve(al, n_args + 1);
         ASR::call_arg_t self_arg;
         self_arg.loc = a_dt->base.loc;
         self_arg.m_value = a_dt;
-        new_args.push_back(al, self_arg);
-        for (size_t i = 0; i < n_args; i++) {
-            new_args.push_back(al, a_args[i]);
+        size_t explicit_i = 0;
+        for (size_t i = 0; i < n_args + 1; i++) {
+            if (i == pass_idx) {
+                new_args.push_back(al, self_arg);
+            } else {
+                new_args.push_back(al, a_args[explicit_i]);
+                explicit_i++;
+            }
         }
         a_args = new_args.p;
         n_args = new_args.size();
@@ -7675,16 +7704,23 @@ static inline ASR::asr_t* make_SubroutineCall_t_util(
             a_dt, a_name, ASRUtils::duplicate_type(al, ASRUtils::symbol_type(a_name)), nullptr));
     }
 
-    // Prepend self to args BEFORE Call_t_body so args align 1:1 with formals
+    // Insert self into args at the correct position (determined by pass
+    // attribute) BEFORE Call_t_body so args align 1:1 with formals.
     if (a_is_method && !self_already_in_args) {
+        size_t pass_idx = get_pass_arg_index(a_name);
         Vec<ASR::call_arg_t> new_args;
         new_args.reserve(al, n_args + 1);
         ASR::call_arg_t self_arg;
         self_arg.loc = self_expr->base.loc;
         self_arg.m_value = self_expr;
-        new_args.push_back(al, self_arg);
-        for (size_t i = 0; i < n_args; i++) {
-            new_args.push_back(al, a_args[i]);
+        size_t explicit_i = 0;
+        for (size_t i = 0; i < n_args + 1; i++) {
+            if (i == pass_idx) {
+                new_args.push_back(al, self_arg);
+            } else {
+                new_args.push_back(al, a_args[explicit_i]);
+                explicit_i++;
+            }
         }
         a_args = new_args.p;
         n_args = new_args.size();

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18292,9 +18292,6 @@ public:
         if (convert_call_args_depth == 1) {
             reset_call_arg_alloca_pool();
         }
-        // When skip_self is true, self is in x.m_args[0] but is handled
-        // separately by the caller (with polymorphic type conversion),
-        // so we skip it here.
         size_t start_idx = skip_self ? 1 : 0;
         for (size_t i=start_idx; i<x.n_args; i++) {
             ASR::symbol_t* func_subrout = symbol_get_past_external(x.m_name);
@@ -18608,9 +18605,14 @@ public:
                             }
                         }
                     }
+                    // When the formal is a pointer type but the actual is not,
+                    // wrap the value with an extra pointer level. Skip this when
+                    // the formal is a class type — convert_to_polymorphic_arg
+                    // handles the pointer level during class wrapping.
                     if (orig_arg &&
                         LLVM::is_llvm_pointer(*orig_arg->m_type) &&
-                        !LLVM::is_llvm_pointer(*arg->m_type)) {
+                        !LLVM::is_llvm_pointer(*arg->m_type) &&
+                        !ASRUtils::is_class_type(ASRUtils::type_get_past_allocatable_pointer(orig_arg->m_type))) {
                         if (tmp->getType()->isIntegerTy(1) &&
                             ASRUtils::is_logical(*arg->m_type)) {
                             int kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
@@ -20586,15 +20588,12 @@ public:
             is_nopass = class_proc->m_is_nopass;
         }
         ASR::Function_t *s;
-        char* self_argument = nullptr;
-        llvm::Value* pass_arg = nullptr;
         if (ASR::is_a<ASR::Function_t>(*proc_sym)) {
             s = ASR::down_cast<ASR::Function_t>(proc_sym);
         } else if (ASR::is_a<ASR::StructMethodDeclaration_t>(*proc_sym)) {
             ASR::StructMethodDeclaration_t *clss_proc = ASR::down_cast<
                 ASR::StructMethodDeclaration_t>(proc_sym);
             s = ASR::down_cast<ASR::Function_t>(clss_proc->m_proc);
-            self_argument = clss_proc->m_self_argument;
             proc_sym = clss_proc->m_proc;
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym)) {
             ASR::symbol_t *type_decl = ASR::down_cast<ASR::Variable_t>(proc_sym)->m_type_declaration;
@@ -20610,81 +20609,9 @@ public:
         bool is_method = false;
         if (x.m_dt && (!is_nopass)) {
             is_method = true;
-            ASR::expr_t* dt_expr = x.m_dt;
-            if (ASR::is_a<ASR::Cast_t>(*dt_expr)) {
-                ASR::Cast_t* cast = ASR::down_cast<ASR::Cast_t>(dt_expr);
-                dt_expr = cast->m_arg;
-            }
-            if (ASR::is_a<ASR::Var_t>(*dt_expr)) {
-                ASR::Variable_t *caller = EXPR2VAR(dt_expr);
-                llvm::Value* dt;
-                if (caller->m_value && caller->m_storage == ASR::storage_typeType::Parameter) {
-                    // Parameter variables are not in llvm_symtab;
-                    // evaluate the value and store in a temporary
-                    this->visit_expr_wrapper(caller->m_value, true);
-                    llvm::Type* param_type = tmp->getType();
-                    dt = llvm_utils->CreateAlloca(param_type);
-                    builder->CreateStore(tmp, dt);
-                } else {
-                    std::uint32_t h = get_hash((ASR::asr_t*)caller);
-                    // declared variable in the current scope
-                    dt = llvm_symtab[h];
-                }
-                // Function class type
-                ASR::ttype_t* s_m_args0_type = ASRUtils::type_get_past_pointer(
-                                                ASRUtils::expr_type(s->m_args[0]));
-                // derived type declared type
-                ASR::ttype_t* dt_type = ASRUtils::type_get_past_allocatable(ASRUtils::type_get_past_pointer(caller->m_type));
-                dt = convert_to_polymorphic_arg(dt_expr, dt, s->m_args[0], s_m_args0_type, dt_type);
-                args.push_back(dt);
-            } else if (ASR::is_a<ASR::StructInstanceMember_t>(*dt_expr)) {
-                // Declared struct variable
-                this->visit_expr(*dt_expr);
-                llvm::Value* dt = tmp;
-                ASR::ttype_t* caller_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(dt_expr));
-
-                // Function's class type
-                ASR::ttype_t *s_m_args0_type;
-                ASR::expr_t* s_m_args0 = nullptr;
-                if (self_argument != nullptr) {
-                    ASR::symbol_t *class_sym = s->m_symtab->resolve_symbol(self_argument);
-                    ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(class_sym);
-                    s_m_args0 = ASRUtils::EXPR(ASR::make_Var_t(al, var->base.base.loc, &var->base));
-                    s_m_args0_type = ASRUtils::type_get_past_allocatable(
-                        ASRUtils::type_get_past_pointer(var->m_type));
-                    s_m_args0 = ASRUtils::EXPR(ASR::make_Var_t(al, var->base.base.loc, (ASR::symbol_t*) var));
-                } else {
-                    s_m_args0 = s->m_args[0];
-                    s_m_args0_type = ASRUtils::type_get_past_allocatable(
-                        ASRUtils::type_get_past_pointer(
-                        ASRUtils::expr_type(s->m_args[0])));
-                }
-
-                // Convert to polymorphic argument
-                llvm::Value* dt_polymorphic = convert_to_polymorphic_arg(dt_expr, dt, s_m_args0, s_m_args0_type, caller_type);
-
-                if (self_argument == nullptr) {
-                    args.push_back(dt_polymorphic);
-                } else {
-                    pass_arg = dt_polymorphic;
-                }
-            } else if (ASR::is_a<ASR::ArrayItem_t>(*dt_expr)){
-                this->visit_expr(*dt_expr);
-                llvm::Value* dt = tmp;
-                llvm::Value* dt_polymorphic = tmp;
-                dt_polymorphic = convert_to_polymorphic_arg(dt_expr, dt, s->m_args[0], ASRUtils::expr_type(s->m_args[0]),
-                                                ASRUtils::expr_type(dt_expr));
-                args.push_back(dt_polymorphic);
-            } else {
-                throw CodeGenError("SubroutineCall: StructType symbol type not supported");
-            }
         }
         if (is_runtime_polymorphism) {
-            if (is_nopass || args.empty()) {
-                visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name);
-            } else {
-                visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name);
-            }
+            visit_RuntimePolymorphicSubroutineCall(x, proc_sym_name);
             return;
         }
         std::string sub_name = s->m_name;
@@ -20805,8 +20732,7 @@ public:
         } else {
             llvm::Function *fn = llvm_symtab_fn[h];
             std::string m_name = ASRUtils::symbol_name(x.m_name);
-            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method /* skip_self */);
-            args.insert(args.end(), args2.begin(), args2.end());
+            args = convert_call_args(x, false);
             // check if type of each arg is same as type of each arg in subrout_called
             if (ASR::is_a<ASR::Function_t>(*symbol_get_past_external(x.m_name))) {
                 ASR::Function_t* subrout_called = ASR::down_cast<ASR::Function_t>(symbol_get_past_external(x.m_name));
@@ -20833,9 +20759,6 @@ public:
                         }
                     }
                 }
-            }
-            if (pass_arg) {
-                args.push_back(pass_arg);
             }
             builder->CreateCall(fn, args);
             fixup_descriptor_after_cchar_bind_c_call(x, s, args);
@@ -21287,16 +21210,12 @@ public:
         }
 
         ASR::Function_t *s = nullptr;
-        std::string self_argument = "";
         if (ASR::is_a<ASR::Function_t>(*proc_sym)) {
             s = ASR::down_cast<ASR::Function_t>(proc_sym);
         } else if (ASR::is_a<ASR::StructMethodDeclaration_t>(*proc_sym)) {
             ASR::StructMethodDeclaration_t *clss_proc = ASR::down_cast<
                 ASR::StructMethodDeclaration_t>(proc_sym);
             s = ASR::down_cast<ASR::Function_t>(clss_proc->m_proc);
-            if (clss_proc->m_self_argument) {
-                self_argument = std::string(clss_proc->m_self_argument);
-            }
             proc_sym = clss_proc->m_proc;
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym)) {
             ASR::Variable_t* proc_var = ASR::down_cast<ASR::Variable_t>(proc_sym);
@@ -21315,86 +21234,8 @@ public:
             s = ASR::down_cast<ASR::Function_t>(symbol_get_past_external(x.m_name));
         }
         bool is_method = false;
-        llvm::Value* pass_arg = nullptr;
         if (x.m_dt && (!is_nopass)) {
             is_method = true;
-            ASR::expr_t* dt_expr = x.m_dt;
-            if (ASR::is_a<ASR::Cast_t>(*dt_expr)) {
-                dt_expr = ASR::down_cast<ASR::Cast_t>(dt_expr)->m_arg;
-            }
-            if (ASR::is_a<ASR::Var_t>(*dt_expr)) {
-                ASR::Variable_t *caller = EXPR2VAR(dt_expr);
-                llvm::Value* dt;
-                if (caller->m_value && caller->m_storage == ASR::storage_typeType::Parameter) {
-                    this->visit_expr_wrapper(caller->m_value, true);
-                    llvm::Type* param_type = tmp->getType();
-                    dt = llvm_utils->CreateAlloca(param_type);
-                    builder->CreateStore(tmp, dt);
-                } else {
-                    std::uint32_t h = get_hash((ASR::asr_t*)caller);
-                    // declared variable in the current scope
-                    dt = llvm_symtab[h];
-                }
-                // Function class type
-                ASR::ttype_t* s_m_args0_type = ASRUtils::type_get_past_pointer(
-                                                ASRUtils::expr_type(s->m_args[0]));
-                // derived type declared type
-                ASR::ttype_t* dt_type = ASRUtils::type_get_past_allocatable_pointer(caller->m_type);
-                dt = convert_to_polymorphic_arg(dt_expr, dt, s->m_args[0], s_m_args0_type, dt_type);
-                args.push_back(dt);
-            } else if (ASR::is_a<ASR::StructInstanceMember_t>(*dt_expr)) {
-                // Declared struct variable
-                this->visit_expr(*dt_expr);
-                llvm::Value* dt = tmp;
-                ASR::ttype_t* caller_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(dt_expr));
-
-                // Function's class type
-                ASR::ttype_t *s_m_args0_type;
-                ASR::expr_t *s_m_args0 = nullptr;
-                if (self_argument.length() > 0) {
-                    ASR::symbol_t *class_sym = s->m_symtab->resolve_symbol(self_argument);
-                    ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(class_sym);
-                    s_m_args0 = ASRUtils::EXPR(ASR::make_Var_t(al, var->base.base.loc, &var->base));
-                    s_m_args0_type = ASRUtils::type_get_past_allocatable(
-                        ASRUtils::type_get_past_pointer(var->m_type));
-                    s_m_args0 = ASRUtils::EXPR(ASR::make_Var_t(al, var->base.base.loc, (ASR::symbol_t*) var));
-                } else {
-                    s_m_args0 = s->m_args[0];
-                    s_m_args0_type = ASRUtils::type_get_past_allocatable(
-                        ASRUtils::type_get_past_pointer(
-                        ASRUtils::expr_type(s->m_args[0])));
-                }
-
-                // Convert to polymorphic argument
-                llvm::Value* dt_polymorphic = convert_to_polymorphic_arg(dt_expr, dt, s_m_args0, s_m_args0_type, caller_type);
-
-                if (self_argument.length() == 0) {
-                    args.push_back(dt_polymorphic);
-                } else {
-                    pass_arg = dt_polymorphic;
-                }
-            } else if(ASR::is_a<ASR::ArrayItem_t>(*dt_expr)) {
-                this->visit_expr(*dt_expr);
-                llvm::Value* dt = tmp;
-                llvm::Value* dt_polymorphic = tmp;
-                dt_polymorphic = convert_to_polymorphic_arg(dt_expr, dt, s->m_args[0], ASRUtils::expr_type(s->m_args[0]),
-                                                ASRUtils::expr_type(dt_expr));
-                args.push_back(dt_polymorphic);
-            } else if(ASR::is_a<ASR::StructConstant_t>(*dt_expr) ||
-                      ASR::is_a<ASR::StructConstructor_t>(*dt_expr)) {
-                this->visit_expr_wrapper(dt_expr, true);
-                llvm::Type* param_type = tmp->getType();
-                llvm::Value* dt = llvm_utils->CreateAlloca(param_type);
-                builder->CreateStore(tmp, dt);
-                ASR::ttype_t* s_m_args0_type = ASRUtils::type_get_past_pointer(
-                                                ASRUtils::expr_type(s->m_args[0]));
-                ASR::ttype_t* dt_type = ASRUtils::type_get_past_allocatable_pointer(
-                                                ASRUtils::expr_type(dt_expr));
-                dt = convert_to_polymorphic_arg(dt_expr, dt, s->m_args[0], s_m_args0_type, dt_type);
-                args.push_back(dt);
-            } else {
-                throw CodeGenError("FunctionCall: StructType symbol type not supported");
-            }
         }
 
         bool intrinsic_function = ASRUtils::is_intrinsic_function2(s);
@@ -21474,11 +21315,7 @@ public:
         } else {
             llvm::Function *fn = llvm_symtab_fn[h];
             std::string m_name = std::string(((ASR::Function_t*)(&(x.m_name->base)))->m_name);
-            std::vector<llvm::Value *> args2 = convert_call_args(x, is_method /* skip_self */);
-            args.insert(args.end(), args2.begin(), args2.end());
-            if (pass_arg) {
-                args.push_back(pass_arg);
-            }
+            args = convert_call_args(x, false);
             ASR::ttype_t *return_var_type0 = EXPR2VAR(s->m_return_var)->m_type;
             if (ASRUtils::get_FunctionType(s)->m_abi == ASR::abiType::BindC) {
                 if (is_a<ASR::Complex_t>(*return_var_type0)) {

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "32d78af4d46f0bee3dadbbf03b99a1f97ad6a1981fb16731f803379f",
+    "stdout_hash": "963ae55b6c25132945f3aee24f66033af84849cf64a561efcc317018",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -444,7 +444,8 @@
                                         [(SubroutineCall
                                             8 1_toml_date_date_to_string
                                             ()
-                                            [((StructInstanceMember
+                                            [((Var 8 lhs))
+                                            ((StructInstanceMember
                                                 (Var 8 rhs)
                                                 8 1_toml_datetime_date
                                                 (Allocatable
@@ -458,8 +459,7 @@
                                                     )
                                                 )
                                                 ()
-                                            ))
-                                            ((Var 8 lhs))]
+                                            ))]
                                             (StructInstanceMember
                                                 (Var 8 rhs)
                                                 8 1_toml_datetime_date
@@ -509,7 +509,8 @@
                                             [(SubroutineCall
                                                 8 1_toml_time_time_to_string
                                                 ()
-                                                [((StructInstanceMember
+                                                [((Var 8 temporary))
+                                                ((StructInstanceMember
                                                     (Var 8 rhs)
                                                     8 1_toml_datetime_time
                                                     (Allocatable
@@ -529,8 +530,7 @@
                                                         )
                                                     )
                                                     ()
-                                                ))
-                                                ((Var 8 temporary))]
+                                                ))]
                                                 (StructInstanceMember
                                                     (Var 8 rhs)
                                                     8 1_toml_datetime_time

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "49c2ed2cf48b3e5d79a58c10b6f1c343d460ebf137336a6d19547428",
+    "stdout_hash": "cda9734de383e1b7afaca2d678366be380b2aeffedf0f9bf08f97314",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -444,7 +444,8 @@
                                         [(SubroutineCall
                                             12 1_toml_date_date_to_string
                                             ()
-                                            [((StructInstanceMember
+                                            [((Var 12 lhs))
+                                            ((StructInstanceMember
                                                 (Var 12 rhs)
                                                 12 1_toml_datetime_date
                                                 (Allocatable
@@ -458,8 +459,7 @@
                                                     )
                                                 )
                                                 ()
-                                            ))
-                                            ((Var 12 lhs))]
+                                            ))]
                                             (StructInstanceMember
                                                 (Var 12 rhs)
                                                 12 1_toml_datetime_date
@@ -509,7 +509,8 @@
                                             [(SubroutineCall
                                                 12 1_toml_time_time_to_string
                                                 ()
-                                                [((StructInstanceMember
+                                                [((Var 12 temporary))
+                                                ((StructInstanceMember
                                                     (Var 12 rhs)
                                                     12 1_toml_datetime_time
                                                     (Allocatable
@@ -529,8 +530,7 @@
                                                         )
                                                     )
                                                     ()
-                                                ))
-                                                ((Var 12 temporary))]
+                                                ))]
                                                 (StructInstanceMember
                                                     (Var 12 rhs)
                                                     12 1_toml_datetime_time

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "9a5de25a9abb8473f0a6375a9a88e09ed5a20ec3bd2f73e0ee2d89cb",
+    "stdout_hash": "30e74b0f79fbe5ec454619529c8eb8a8862f24a61fb24bc095109566",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -211,12 +211,11 @@ then1:                                            ; preds = %ifcont
 
 ifcont2:                                          ; preds = %ifcont
   %55 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %56 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %57 = bitcast %module_call_subroutine_without_type_01.mytype_class* %56 to void (%module_call_subroutine_without_type_01.mytype_class*)***
-  %58 = load void (%module_call_subroutine_without_type_01.mytype_class*)**, void (%module_call_subroutine_without_type_01.mytype_class*)*** %57, align 8
-  %59 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %58, i32 2
-  %60 = load void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %59, align 8
-  call void %60(%module_call_subroutine_without_type_01.mytype_class* %56)
+  %56 = bitcast %module_call_subroutine_without_type_01.mytype_class* %55 to void (%module_call_subroutine_without_type_01.mytype_class*)***
+  %57 = load void (%module_call_subroutine_without_type_01.mytype_class*)**, void (%module_call_subroutine_without_type_01.mytype_class*)*** %56, align 8
+  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %57, i32 2
+  %59 = load void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %58, align 8
+  call void %59(%module_call_subroutine_without_type_01.mytype_class* %55)
   br label %return
 
 return:                                           ; preds = %ifcont2
@@ -226,8 +225,8 @@ FINALIZE_SYMTABLE_call_subroutine_without_type_01: ; preds = %return
   br label %Finalize_Variable_obj
 
 Finalize_Variable_obj:                            ; preds = %FINALIZE_SYMTABLE_call_subroutine_without_type_01
-  %61 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  call void @finalize_allocatable__StructType_Class__mytype_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %61, i1 false)
+  %60 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
+  call void @finalize_allocatable__StructType_Class__mytype_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %60, i1 false)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }


### PR DESCRIPTION
When a type-bound procedure uses pass(arg) where the named argument is not the first parameter (e.g., procedure, pass(pt) :: add_named with add_named(scale, pt)), LFortran was always inserting the passed object at position 0 instead of at the correct parameter index.

Fix the argument insertion in three layers:
- asr_utils.h: add get_pass_arg_index() helper; fix make_FunctionCall_t_util and make_SubroutineCall_t_util to insert self at the correct position
- ast_common_visitor.h: fix create_StructMethodDeclaration to build intermediate arg lists with self at the correct position
- asr_to_llvm.cpp: fix convert_call_args to skip the correct arg index; fix visit_FunctionCall and visit_SubroutineCall to use the correct formal parameter for polymorphic conversion and insert the pass arg at the correct position

Test added.