### PR TITLE
Support procedure() with implicit interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1920,6 +1920,7 @@ RUN(NAME implicit_interface_31 LABELS gfortran llvm EXTRA_ARGS --implicit-typing
 RUN(NAME implicit_interface_32 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_33 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_34 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_35 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_35.f90
+++ b/integration_tests/implicit_interface_35.f90
@@ -1,0 +1,25 @@
+program implicit_interface_35
+    procedure(), pointer :: ifunc => null()
+    procedure(), pointer :: xfunc => null()
+
+    ifunc => itriple
+    if (ifunc(4) /= 12) error stop
+    print *, ifunc(4)
+
+    xfunc => xhalf
+    if (abs(xfunc(6.0) - 3.0) > 1.0e-6) error stop
+    print *, xfunc(6.0)
+
+contains
+    function itriple(n)
+        integer, intent(in) :: n
+        integer :: itriple
+        itriple = n * 3
+    end function
+
+    function xhalf(x)
+        real, intent(in) :: x
+        real :: xhalf
+        xhalf = x / 2.0
+    end function
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8926,15 +8926,63 @@ public:
             }
         } else if (sym_type->m_type == AST::decl_typeType::TypeProcedure) {
             if (!sym_type->m_name) {
-                Location &attr_loc = sym_type->base.base.loc;
-                diag.add(Diagnostic(
-                    "Procedure declarations without an explicit interface (procedure()) are not yet supported. "
-                    "Please use procedure(interface_name) or declare an interface block.",
-                    Level::Error, Stage::Semantic, {
-                        Label("",{attr_loc})
-                    }));
-                throw SemanticAbort();
-            }
+                if (compiler_options.implicit_interface) {
+                    ASR::ttype_t *return_type = nullptr;
+                    std::string first_letter = std::string(1, sym[0]);
+                    if (implicit_dictionary.find(first_letter) != implicit_dictionary.end()
+                            && implicit_dictionary[first_letter] != nullptr) {
+                        return_type = implicit_dictionary[first_letter];
+                    } else {
+                        char first_char = sym[0];
+                        if (first_char >= 'i' && first_char <= 'n') {
+                            return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
+                        } else {
+                            return_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 4));
+                        }
+                    }
+                    Location &attr_loc = sym_type->base.base.loc;
+                    type = ASRUtils::TYPE(ASR::make_FunctionType_t(
+                        al, loc,
+                        nullptr, 0, return_type, ASR::abiType::Source,
+                        ASR::deftypeType::Interface, nullptr,
+                        false, false, false, false, false, nullptr, 0, false
+                        ));
+                    std::string iface_name = "__" + sym + "_iface_implicit";
+                    SymbolTable *parent_scope = current_scope->parent;
+                    ASR::symbol_t *existing = parent_scope->get_symbol(iface_name);
+                    if (!existing) {
+                        SymbolTable *fn_scope = al.make_new<SymbolTable>(parent_scope);
+                        existing = ASR::down_cast<ASR::symbol_t>(
+                            ASR::make_Function_t(
+                                al, attr_loc,
+                                fn_scope,
+                                s2c(al, iface_name),
+                                type,
+                                nullptr, 0,
+                                nullptr, 0,
+                                nullptr, 0,
+                                nullptr,
+                                ASR::accessType::Public,
+                                false,
+                                false,
+                                nullptr,
+                                nullptr, nullptr
+                            )
+                        );
+                        parent_scope->add_symbol(iface_name, existing);
+                    }
+                    type_declaration = existing;
+                } else {
+                    Location &attr_loc = sym_type->base.base.loc;
+                    diag.add(Diagnostic(
+                        "Procedure declarations without an explicit interface (procedure()) are not yet supported. "
+                        "Please use procedure(interface_name) or declare an interface block.",
+                        Level::Error, Stage::Semantic, {
+                            Label("",{attr_loc})
+                        }));
+                    throw SemanticAbort();
+                }
+            } else {
             std::string func_name = to_lower(sym_type->m_name);
             // procedure(type-spec) declares a procedure with implicit interface
             // and the given return type (e.g., procedure(integer) returns integer).
@@ -9027,6 +9075,7 @@ public:
                 LCOMPILERS_ASSERT(ASR::is_a<ASR::Function_t>(*v));
                 type = ASR::down_cast<ASR::Function_t>(v)->m_function_signature;
             }
+            } // else (named procedure interface)
             if (is_pointer) {
                 type = ASRUtils::TYPE(ASR::make_Pointer_t(al, loc, type));
             }


### PR DESCRIPTION
Handle procedure declarations without an explicit interface name (procedure(), pointer :: ifunc) when --implicit-interface is enabled. The return type is determined from implicit typing rules based on the variable name's first letter (i-n → integer, else → real).

Without --implicit-interface the existing error is preserved.

Integration test added.