### PR TITLE
Fix fixed-form tokenizer for select case

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -432,6 +432,7 @@ RUN(NAME print_arr_04 LABELS llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --
 RUN(NAME print_arr_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME crlf_fixed_form LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_select_case_01.f90
+++ b/integration_tests/fixed_form_select_case_01.f90
@@ -1,0 +1,16 @@
+      program fixed_form_select_case_01
+          integer :: i, r
+          r = 0
+        do 50 i = 1, 5
+           select case ( i )
+              case (1)
+                 r = r + 1
+              case ( 2 : 3 )
+                 r = r + 10
+              case default
+                 r = r + 100
+           end select
+   50     continue
+          if (r /= 221) error stop
+          print *, r
+      end

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1089,6 +1089,11 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (next_is(cur, "selectcase(")) {
+            lex_selectcase(cur);
+            return true;
+        }
+
         if (is_function_call(cur)) {
             push_token_advance(cur, "call");
             tokenize_line(cur);
@@ -1547,6 +1552,24 @@ struct FixedFormRecursiveDescent {
         tokenize_line(cur); // tokenize rest of line where `select rank` starts
         while (!next_is(cur, "endselect\n")) {
             tokenize_line(cur);
+        }
+        push_token_advance(cur, "endselect");
+        tokenize_line(cur);
+    }
+
+    void lex_selectcase(unsigned char *&cur) {
+        auto end = cur; next_line(end);
+        push_token_advance(cur, "select");
+        push_token_advance(cur, "case");
+        tokenize_line(cur);
+        while (!next_is(cur, "endselect\n")) {
+            if (next_is(cur, "casedefault")) {
+                push_token_advance(cur, "case");
+                push_token_advance(cur, "default");
+                tokenize_line(cur);
+            } else {
+                tokenize_line(cur);
+            }
         }
         push_token_advance(cur, "endselect");
         tokenize_line(cur);


### PR DESCRIPTION
The fixed-form tokenizer's lex_body_statement() did not recognize select case as a valid executable statement, causing a tokenizer error when select case appeared inside a labeled do loop.

Add lex_selectcase() (following the existing lex_selectrank() pattern) to handle select case blocks, including the casedefault keyword which is formed when the prescanner removes whitespace from 'case default'.

An integration test is added.

Fixes #10847.