### PR TITLE
Fix proc ptr member passed as argument to proc ptr call

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1156,6 +1156,7 @@ RUN(NAME procedure_pointer_15 LABELS gfortran llvm EXTRA_ARGS --implicit-interfa
 RUN(NAME procedure_pointer_16 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME procedure_pointer_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME procedure_pointer_18 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME procedure_pointer_19 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME bindc_assumed_rank_01 LABELS gfortran llvm)
 
 

--- a/integration_tests/procedure_pointer_19.f90
+++ b/integration_tests/procedure_pointer_19.f90
@@ -1,0 +1,16 @@
+program procedure_pointer_19
+    implicit none
+    type :: t
+        procedure(), pointer, nopass :: caller => null()
+        procedure(), pointer, nopass :: f => null()
+    end type
+    type(t) :: x
+    x%caller => sub
+    x%f => sub
+    call x%caller(x%f)
+    print *, "ok"
+contains
+    subroutine sub(func)
+        procedure() :: func
+    end subroutine
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18706,6 +18706,15 @@ public:
                     ASRUtils::type_get_past_allocatable(
                         ASRUtils::expr_type(x.m_args[i].m_value)))) ) {
                 this->visit_expr_wrapper(x.m_args[i].m_value, true);
+                if (orig_arg && ASR::is_a<ASR::FunctionType_t>(
+                        *ASRUtils::type_get_past_pointer(orig_arg->m_type))) {
+                    llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
+                        ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
+                        orig_arg->m_type, module.get());
+                    if (tmp->getType() != expected_type) {
+                        tmp = builder->CreateBitCast(tmp, expected_type);
+                    }
+                }
             } else {
                 ASR::ttype_t* arg_type = expr_type(x.m_args[i].m_value);
                 this->visit_expr_wrapper(x.m_args[i].m_value);


### PR DESCRIPTION
When a procedure pointer struct member (e.g. x%f) was passed as an
argument to a call through another procedure pointer member (e.g.
x%caller), the LLVM codegen loaded the argument with its concrete
function type but the callee expected a different signature (e.g.
implicit interface). This caused an LLVM verification error: 'Call
parameter type does not match function signature'.

Add a bitcast in convert_call_args for FunctionType arguments from
non-Var expressions (like StructInstanceMember) to match the expected
parameter type, consistent with the existing bitcast for Var arguments.

Add integration test procedure_pointer_19.

Fixes #10824.