### PR TITLE
Fix re-exported operator losing imported overloads

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2008,6 +2008,7 @@ RUN(NAME custom_operator_15 LABELS gfortran llvm)
 RUN(NAME custom_operator_16 LABELS gfortran llvm)
 RUN(NAME custom_operator_17 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME custom_operator_18 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME custom_operator_19 LABELS gfortran llvm)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/custom_operator_19.f90
+++ b/integration_tests/custom_operator_19.f90
@@ -1,0 +1,50 @@
+module custom_operator_19_inner
+  implicit none
+  interface operator(.myop.)
+    module procedure int_myop
+  end interface
+contains
+  pure function int_myop(a, b) result(r)
+    integer, intent(in) :: a, b
+    logical :: r
+    r = (a == b)
+  end function
+end module
+
+module custom_operator_19_outer
+  use custom_operator_19_inner, only: operator(.myop.)
+  implicit none
+end module
+
+module custom_operator_19_user
+  use custom_operator_19_outer, only: operator(.myop.)
+  implicit none
+  interface operator(.myop.)
+    module procedure logical_myop
+  end interface
+contains
+  pure function logical_myop(a, b) result(r)
+    logical, intent(in) :: a, b
+    logical :: r
+    r = (a .eqv. b)
+  end function
+end module
+
+program custom_operator_19
+  use custom_operator_19_user
+  implicit none
+  integer :: x, y
+  logical :: p, q
+
+  x = 1; y = 1
+  if (.not. (x .myop. y)) error stop
+  x = 1; y = 2
+  if (x .myop. y) error stop
+
+  p = .true.; q = .true.
+  if (.not. (p .myop. q)) error stop
+  p = .true.; q = .false.
+  if (p .myop. q) error stop
+
+  print *, "PASS"
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3130,14 +3130,26 @@ public:
         // Check if the operator is already imported into the scope. If yes, include it's procedures
         // into the current `CustomOperator` symbol that we overwrite with.
         if (current_scope->get_symbol(generic_name) != nullptr) {
-            if (ASR::is_a<ASR::ExternalSymbol_t>(*current_scope->get_symbol(generic_name))) {
-                ASR::symbol_t* sym = ASR::down_cast<ASR::ExternalSymbol_t>(
-                                    current_scope->get_symbol(generic_name))->m_external;
+            ASR::symbol_t* existing = current_scope->get_symbol(generic_name);
+            ASR::CustomOperator_t* cop = nullptr;
+            if (ASR::is_a<ASR::ExternalSymbol_t>(*existing)) {
+                ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(existing);
                 if (ASR::is_a<ASR::CustomOperator_t>(*sym)) {
-                    ASR::CustomOperator_t *cop = ASR::down_cast<ASR::CustomOperator_t>(sym);
-                    for (size_t i = 0; i < cop->n_procs; i++) {
-                        std::string proc_name = std::string(ASRUtils::symbol_name(cop->m_procs[i])) + "@" + generic_name;
-                        symbols.push_back(al, resolve_symbol(loc, s2c(al, proc_name)));
+                    cop = ASR::down_cast<ASR::CustomOperator_t>(sym);
+                }
+            } else if (ASR::is_a<ASR::CustomOperator_t>(*existing)) {
+                cop = ASR::down_cast<ASR::CustomOperator_t>(existing);
+            }
+            if (cop != nullptr) {
+                for (size_t i = 0; i < cop->n_procs; i++) {
+                    std::string proc_name = std::string(ASRUtils::symbol_name(cop->m_procs[i])) + "@" + generic_name;
+                    ASR::symbol_t* proc_sym = current_scope->resolve_symbol(proc_name);
+                    if (proc_sym == nullptr) {
+                        proc_sym = current_scope->resolve_symbol(
+                            ASRUtils::symbol_name(cop->m_procs[i]));
+                    }
+                    if (proc_sym != nullptr) {
+                        symbols.push_back(al, proc_sym);
                     }
                 }
             }


### PR DESCRIPTION
When module A defines operator(.myop.), module B re-exports it via use, and module C imports from B and adds local overloads, LFortran lost the original overloads from A.

The root cause was in add_custom_operator: it only merged imported operator procedures when the existing symbol was an ExternalSymbol. However, when importing through an intermediate module, the use import already resolves the ExternalSymbol into a local CustomOperator via process_generic_proc_custom_op. When the local interface block then calls add_custom_operator, the existing symbol is already a CustomOperator (not ExternalSymbol), so the merge was skipped.

Fixed by also handling the case where the existing symbol is already a CustomOperator, and by using symbol_get_past_external to follow chains of ExternalSymbols. Also made procedure resolution more robust by falling back to the bare procedure name when the suffixed name is not found.

Integration test added.