### PR TITLE
fix: add missing 'intrinsic' attribute to module use in asr_to_fortran

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2871,7 +2871,7 @@ RUN(NAME test_ieee_arithmetic_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME test_ieee_arithmetic_fast_01 LABELS gfortran llvm)
-RUN(NAME iso_fortran_env_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME iso_fortran_env_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME iso_fortran_env_02 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME iso_fortran_env_03 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME iso_fortran_env_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -3215,7 +3215,7 @@ RUN(NAME write_fortran_02 LABELS gfortran llvm fortran)
 
 RUN(NAME do_loop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
-RUN(NAME iso_c_binding_01 LABELS gfortran llvm)
+RUN(NAME iso_c_binding_01 LABELS gfortran llvm fortran)
 RUN(NAME iso_c_binding_02 LABELS gfortran llvm)
 
 RUN(NAME array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)

--- a/integration_tests/intrinsic_c_test.f90
+++ b/integration_tests/intrinsic_c_test.f90
@@ -1,6 +1,0 @@
-program test_c_binding
-  use, intrinsic :: iso_c_binding, only: c_int
-  implicit none
-  integer(c_int) :: i = 42
-  print *, i
-end program

--- a/integration_tests/intrinsic_fortran_env_test.f90
+++ b/integration_tests/intrinsic_fortran_env_test.f90
@@ -1,6 +1,0 @@
-program test_fortran_env
-  use, intrinsic :: iso_fortran_env, only: real64
-  implicit none
-  real(real64) :: x = 3.14
-  print *, x
-end program

--- a/integration_tests/iso_c_binding_01.f90
+++ b/integration_tests/iso_c_binding_01.f90
@@ -1,5 +1,5 @@
 program iso_c_binding_01
-      use iso_c_binding
+      use, intrinsic :: iso_c_binding
       character(len=2, kind=c_char), parameter :: a = 'a'
       if (a /= 'a') error stop
       if (len(a) /= 2) error stop

--- a/integration_tests/iso_fortran_env_01.f90
+++ b/integration_tests/iso_fortran_env_01.f90
@@ -1,5 +1,5 @@
 program iso_fortran_env_01
-    use iso_fortran_env, only: numeric_storage_size, character_storage_size, iostat_eor
+    use, intrinsic :: iso_fortran_env, only: numeric_storage_size, character_storage_size, iostat_eor
     print *, "numeric_storage_size: ", numeric_storage_size
     if (numeric_storage_size /= 32) error stop
 


### PR DESCRIPTION
Fixes #2816 

Modified to generate ", intrinsic ::" attribute when using the --show-fortran flag.