### PR TITLE
enh: handle `order` argument in `reshape` at runtime

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -771,7 +771,6 @@ RUN(NAME arrays_reshape_31 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran
 RUN(NAME arrays_reshape_32 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME arrays_reshape_33 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME arrays_reshape_34 LABELS gfortran llvm)
-RUN(NAME arrays_reshape_40 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_35 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_36 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_37 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/arrays_reshape_40.f90
+++ b/integration_tests/arrays_reshape_40.f90
@@ -1,8 +1,13 @@
 program arrays_reshape_40
-implicit none
-double precision :: A(2,2)
-integer :: x(4), b_rt(2, 2), ord2(2)
-integer :: c(8), d(2, 2, 2), d_rt(2, 2, 2), ord3(3)
+    implicit none
+    double precision :: A(2,2)
+    integer :: x(4), b_rt(2, 2), ord2(2)
+    integer :: c(8), d(2, 2, 2), d_rt(2, 2, 2), ord3(3)
+    integer, allocatable :: xa(:)
+    integer, allocatable :: order_alloc(:)
+    integer :: b_alloc_ct(2, 2), b_alloc_rt(2, 2)
+    real :: src2(2, 2), packed2(2, 2)
+    integer :: iperm(2)
 
     x = [1, 2, 3, 4]
     ord2 = [2, 1]
@@ -39,18 +44,57 @@ integer :: c(8), d(2, 2, 2), d_rt(2, 2, 2), ord3(3)
     if (d_rt(1, 2, 2) /= 6) error stop
     if (d_rt(2, 2, 2) /= 8) error stop
     
-! reshape with order=[2,1] where source elements are expressions (not literals)
-A = reshape([1d0+0d0, 2d0+0d0, 3d0+0d0, 4d0+0d0], shape=[2,2], order=[2,1])
+    ! reshape with order=[2,1] where source elements are expressions (not literals)
+    A = reshape([1d0+0d0, 2d0+0d0, 3d0+0d0, 4d0+0d0], shape=[2,2], order=[2,1])
+    
+    ! With order=[2,1], elements fill row-major:
+    !   A(1,1)=1, A(1,2)=2, A(2,1)=3, A(2,2)=4
+    print *, A(1,1)
+    print *, A(1,2)
+    print *, A(2,1)
+    print *, A(2,2)
+    if (abs(A(1,1) - 1d0) > 1d-10) error stop 1
+    if (abs(A(1,2) - 2d0) > 1d-10) error stop 2
+    if (abs(A(2,1) - 3d0) > 1d-10) error stop 3
+    if (abs(A(2,2) - 4d0) > 1d-10) error stop 4
 
-! With order=[2,1], elements fill row-major:
-!   A(1,1)=1, A(1,2)=2, A(2,1)=3, A(2,2)=4
-print *, A(1,1)
-print *, A(1,2)
-print *, A(2,1)
-print *, A(2,2)
-if (abs(A(1,1) - 1d0) > 1d-10) error stop 1
-if (abs(A(1,2) - 2d0) > 1d-10) error stop 2
-if (abs(A(2,1) - 3d0) > 1d-10) error stop 3
-if (abs(A(2,2) - 4d0) > 1d-10) error stop 4
+    ! allocatable source array + compile-time order
+    allocate(xa(4))
+    xa = [1, 2, 3, 4]
+    b_alloc_ct = reshape(xa, [2, 2], order=[2, 1])
+    if (b_alloc_ct(1, 1) /= 1) error stop
+    if (b_alloc_ct(2, 1) /= 3) error stop
+    if (b_alloc_ct(1, 2) /= 2) error stop
+    if (b_alloc_ct(2, 2) /= 4) error stop
+
+    ! allocatable source array + runtime order
+    allocate(order_alloc(2))
+    order_alloc = [2, 1]
+    b_alloc_rt = reshape(xa, [2, 2], order=order_alloc)
+    if (b_alloc_rt(1, 1) /= 1) error stop
+    if (b_alloc_rt(2, 1) /= 3) error stop
+    if (b_alloc_rt(1, 2) /= 2) error stop
+    if (b_alloc_rt(2, 2) /= 4) error stop
+
+    ! subroutine test: real, intent(in) :: a(:,:)
+    src2 = reshape([1.0, 2.0, 3.0, 4.0], [2, 2])
+    iperm = [2, 1]
+    call pack_with_order(src2, iperm, packed2)
+    if (abs(packed2(1, 1) - 1.0) > 1e-6) error stop
+    if (abs(packed2(2, 1) - 3.0) > 1e-6) error stop
+    if (abs(packed2(1, 2) - 2.0) > 1e-6) error stop
+    if (abs(packed2(2, 2) - 4.0) > 1e-6) error stop
+
+contains
+
+    subroutine pack_with_order(a, iperm, apack)
+        real, intent(in) :: a(:,:)
+        integer, intent(in) :: iperm(2)
+        real, intent(out) :: apack(2,2)
+        integer :: spack(2) 
+        spack = [2, 2]
+
+        apack = reshape(a, shape=spack, order=iperm)
+    end subroutine pack_with_order
 
 end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -12390,16 +12390,6 @@ public:
             this->visit_expr(*order);
             order_expr = ASRUtils::EXPR(tmp);
             order_for_eval = ASRUtils::expr_value(order_expr);
-            // if (ASR::is_a<ASR::ArrayConstructor_t>(*order_for_eval) &&
-            //     ASR::down_cast<ASR::ArrayConstructor_t>(order_for_eval)->m_value != nullptr) {
-            //     order_for_eval = ASR::down_cast<ASR::ArrayConstructor_t>(order_for_eval)->m_value;
-            // }
-            // if (!ASR::is_a<ASR::ArrayConstant_t>(*order_for_eval)) {
-            //     ASR::expr_t* order_value = ASRUtils::expr_value(order_for_eval);
-            //     if (order_value != nullptr) {
-            //         order_for_eval = ASRUtils::get_past_array_physical_cast(order_value);
-            //     }
-            // }
         }
         if (pad != nullptr){
             this->visit_expr(*pad);

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -2742,14 +2742,6 @@ public:
             visit_expr(*x.m_pad);
             r += src;
         }
-        if (x.m_order) {
-            r += ", ";
-            if (!x.m_pad) {
-                r += "order=";
-            }
-            visit_expr(*x.m_order);
-            r += src;
-        }
         r += ")";
         src = r;
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4092,9 +4092,14 @@ public:
                 llvm::Type* result_desc_type = llvm_utils->get_type_from_ttype_t_util(
                     x.m_array, ASRUtils::type_get_past_allocatable_pointer(asr_result_type),
                     module.get());
+                llvm::Value* order = nullptr;
+                if (x.m_order != nullptr) {
+                    this->visit_expr(*x.m_order);
+                    order = tmp;
+                }
                 tmp = arr_descr->reshape(array_type, array, llvm_data_type, shape_type, shape, asr_shape_type, module.get(),
                     const_cast<ASR::expr_t*>(x.m_array), asr_data_type,
-                    result_desc_type);
+                    result_desc_type, order, x.m_order);
                 break;
             }
             case ASR::array_physical_typeType::FixedSizeArray: {
@@ -4169,7 +4174,7 @@ public:
                         ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_order))));
                     llvm::Type* llvm_order_type = llvm_utils->get_el_type(x.m_order, order_elem_type, module.get());
                     llvm::Type* order_array_type = llvm_utils->get_type_from_ttype_t_util(
-                        x.m_order, ASRUtils::expr_type(x.m_order), module.get());
+                        x.m_order, ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(x.m_order)), module.get());
 
                     llvm::Value* order_data_base = order_base;
                     ASR::array_physical_typeType order_physical_type = ASRUtils::extract_physical_type(ASRUtils::expr_type(x.m_order));
@@ -4181,12 +4186,39 @@ public:
                         order_data_base = llvm_utils->create_gep2(order_array_type, order_base, 0);
                     }
 
-                    std::vector<int64_t> shape_values(n);
+                    ASR::ttype_t* shape_expr_type = ASRUtils::expr_type(x.m_shape);
+                    ASR::ttype_t* shape_elem_type = ASRUtils::type_get_past_array(
+                        ASRUtils::type_get_past_allocatable(
+                        ASRUtils::type_get_past_pointer(shape_expr_type)));
+                    llvm::Type* llvm_shape_type = llvm_utils->get_el_type(x.m_shape, shape_elem_type, module.get());
+                    llvm::Type* shape_array_type = llvm_utils->get_type_from_ttype_t_util(
+                        x.m_shape, shape_expr_type, module.get());
+
+                    llvm::Value* shape_data_base = shape;
+                    ASR::array_physical_typeType shape_physical_type = ASRUtils::extract_physical_type(shape_expr_type);
+                    if (shape_physical_type == ASR::array_physical_typeType::DescriptorArray) {
+                        shape_data_base = llvm_utils->create_gep2(shape_array_type, shape, 0);
+                        shape_data_base = llvm_utils->CreateLoad2(llvm_shape_type->getPointerTo(), shape_data_base);
+                    } else if (shape_physical_type == ASR::array_physical_typeType::FixedSizeArray &&
+                                !ASRUtils::expr_value(x.m_shape)) {
+                        shape_data_base = llvm_utils->create_gep2(shape_array_type, shape, 0);
+                    }
+
+                    std::vector<llvm::Value*> shape_values(n);
                     for (int64_t i = 0; i < n; i++) {
                         int64_t shape_i = -1;
                         bool shape_is_constant = ASRUtils::extract_value(result_dims[i].m_length, shape_i);
-                        LCOMPILERS_ASSERT(shape_is_constant);
-                        shape_values[i] = shape_i;
+                        if (shape_is_constant) {
+                            shape_values[i] = llvm::ConstantInt::get(context, llvm::APInt(64, shape_i));
+                        } else {
+                            llvm::Value* shape_i_val = llvm_utils->CreateLoad2(
+                                llvm_shape_type,
+                                llvm_utils->create_ptr_gep2(
+                                    llvm_shape_type,
+                                    shape_data_base,
+                                    llvm::ConstantInt::get(context, llvm::APInt(32, i))));
+                            shape_values[i] = builder->CreateSExtOrTrunc(shape_i_val, llvm::Type::getInt64Ty(context));
+                        }
                     }
 
                     llvm::Value* source_base = llvm_utils->create_gep2(src_target_type, array, 0);
@@ -4205,8 +4237,7 @@ public:
                         // Decode result linear index i into result subscripts
                         // in normal Fortran column-major order.
                         for (int64_t j = 0; j < n; j++) {
-                            llvm::Value* shape_dim = llvm::ConstantInt::get(
-                                context, llvm::APInt(64, shape_values[j]));
+                            llvm::Value* shape_dim = shape_values[j];
 
                             llvm::Value* d_j = builder->CreateSRem(temp_val, shape_dim);
                             temp_val = builder->CreateSDiv(temp_val, shape_dim);
@@ -4235,12 +4266,12 @@ public:
                             llvm::Value* term = builder->CreateMul(I_dim, stride);
                             source_index = builder->CreateAdd(source_index, term);
 
-                            llvm::Value* shape_dim = llvm::ConstantInt::get(context, llvm::APInt(64, shape_values[0]));
+                            llvm::Value* shape_dim = shape_values[0];
                             for (int64_t k = 1; k < n; k++) {
                                 llvm::Value* cond = builder->CreateICmpEQ(dim,
                                     llvm::ConstantInt::get(context, llvm::APInt(64, k)));
                                 shape_dim = builder->CreateSelect(cond,
-                                    llvm::ConstantInt::get(context, llvm::APInt(64, shape_values[k])),
+                                    shape_values[k],
                                     shape_dim);
                             }
                             stride = builder->CreateMul(stride, shape_dim);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -1234,7 +1234,9 @@ namespace LCompilers {
                                                   llvm::Type* shape_type, llvm::Value* shape, ASR::ttype_t* asr_shape_type,
                                                   llvm::Module* module, ASR::expr_t* array_expr,
                                                   ASR::ttype_t* asr_data_type,
-                                                  llvm::Type* result_desc_type) {
+                                                  llvm::Type* result_desc_type,
+                                                  llvm::Value* order,
+                                                  ASR::expr_t* order_expr) {
             unsigned index_bit_width = index_type->getIntegerBitWidth();
             llvm::Type* result_type;
             if (result_desc_type) {
@@ -1261,8 +1263,9 @@ namespace LCompilers {
 
             bool is_struct_type = asr_data_type != nullptr &&
                 ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(asr_data_type));
+            bool has_order = (order != nullptr && order_expr != nullptr);
 
-            if (is_struct_type && array_expr != nullptr) {
+            if (!has_order && is_struct_type && array_expr != nullptr) {
                 // For derived types with allocatable components, do element-wise
                 // deep copy to avoid sharing allocatable component pointers.
                 // Zero-initialize dest buffer so allocatable members start as null.
@@ -1316,7 +1319,7 @@ namespace LCompilers {
                 builder->CreateBr(loopHead);
 
                 llvm_utils->start_new_block(loopEnd);
-            } else {
+            } else if (!has_order) {
                 llvm::DataLayout data_layout(module->getDataLayout());
                 uint64_t size = data_layout.getTypeAllocSize(llvm_data_type);
                 llvm::Value* llvm_size = llvm::ConstantInt::get(context, llvm::APInt(32, size));
@@ -1390,6 +1393,114 @@ namespace LCompilers {
 
                 // end
                 llvm_utils->start_new_block(loopend);
+
+                if (has_order) {
+                    int64_t rank = ASRUtils::get_fixed_size_of_array(asr_shape_type);
+                    LCOMPILERS_ASSERT(rank > 0);
+
+                    ASR::ttype_t* asr_order_type = ASRUtils::expr_type(order_expr);
+                    ASR::ttype_t* order_elem_type = ASRUtils::type_get_past_array(
+                        ASRUtils::type_get_past_allocatable(
+                        ASRUtils::type_get_past_pointer(asr_order_type)));
+                    llvm::Type* llvm_order_type = llvm_utils->get_el_type(order_expr, order_elem_type, module);
+                    llvm::Type* order_array_type = llvm_utils->get_type_from_ttype_t_util(
+                        order_expr, ASRUtils::type_get_past_allocatable_pointer(asr_order_type), module);
+
+                    llvm::Value* order_data_base = order;
+                    ASR::array_physical_typeType order_physical_type = ASRUtils::extract_physical_type(asr_order_type);
+                    if (order_physical_type == ASR::array_physical_typeType::DescriptorArray) {
+                        order_data_base = llvm_utils->create_gep2(order_array_type, order_data_base, 0);
+                        order_data_base = llvm_utils->CreateLoad2(llvm_order_type->getPointerTo(), order_data_base);
+                    } else if (order_physical_type == ASR::array_physical_typeType::FixedSizeArray && 
+                                !ASRUtils::expr_value(order_expr)) {
+                        order_data_base = llvm_utils->create_gep2(order_array_type, order_data_base, 0);
+                    }
+
+                    std::vector<llvm::Value*> shape_values(rank);
+                    for (int64_t i = 0; i < rank; i++) {
+                        llvm::Value* sv = llvm_utils->CreateLoad2(
+                            i32,
+                            llvm_utils->create_ptr_gep2(i32, shape_data,
+                                llvm::ConstantInt::get(context, llvm::APInt(32, i))));
+                        shape_values[i] = builder->CreateSExtOrTrunc(sv, index_type);
+                    }
+
+                    llvm::Value* src_data = llvm_utils->CreateLoad2(
+                        llvm_data_type->getPointerTo(), ptr2firstptr);
+                    llvm::Value* dest_data = llvm_utils->CreateLoad2(
+                        llvm_data_type->getPointerTo(), first_ptr);
+
+                    llvm::Value* I_arr = llvm_utils->CreateAlloca(
+                        *builder, llvm::Type::getInt64Ty(context),
+                        llvm::ConstantInt::get(context, llvm::APInt(32, rank)));
+
+                    llvm::BasicBlock *order_loop_head = llvm::BasicBlock::Create(context, "reshape_order.head");
+                    llvm::BasicBlock *order_loop_body = llvm::BasicBlock::Create(context, "reshape_order.body");
+                    llvm::BasicBlock *order_loop_end = llvm::BasicBlock::Create(context, "reshape_order.end");
+
+                    llvm::Value* idx = llvm_utils->CreateAlloca(*builder, index_type);
+                    builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)), idx);
+
+                    llvm_utils->start_new_block(order_loop_head);
+                    llvm::Value* idx_val = llvm_utils->CreateLoad2(index_type, idx);
+                    llvm::Value* cond2 = builder->CreateICmpSLT(idx_val,
+                        builder->CreateSExtOrTrunc(num_elements, index_type));
+                    builder->CreateCondBr(cond2, order_loop_body, order_loop_end);
+
+                    llvm_utils->start_new_block(order_loop_body);
+                    idx_val = llvm_utils->CreateLoad2(index_type, idx);
+                    llvm::Value* temp_val = idx_val;
+
+                    for (int64_t j = 0; j < rank; j++) {
+                        llvm::Value* d_j = builder->CreateSRem(temp_val, shape_values[j]);
+                        temp_val = builder->CreateSDiv(temp_val, shape_values[j]);
+                        llvm::Value* I_j_ptr = llvm_utils->create_ptr_gep2(
+                            llvm::Type::getInt64Ty(context), I_arr,
+                            llvm::ConstantInt::get(context, llvm::APInt(32, j)));
+                        builder->CreateStore(d_j, I_j_ptr);
+                    }
+
+                    llvm::Value* source_index = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0));
+                    llvm::Value* stride = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
+                    for (int64_t j = 0; j < rank; j++) {
+                        llvm::Value* order_j = llvm_utils->CreateLoad2(
+                            llvm_order_type,
+                            llvm_utils->create_ptr_gep2(
+                                llvm_order_type, order_data_base,
+                                llvm::ConstantInt::get(context, llvm::APInt(32, j))));
+                        order_j = builder->CreateSExtOrTrunc(order_j, index_type);
+                        llvm::Value* dim = builder->CreateSub(order_j,
+                            llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)));
+
+                        llvm::Value* I_dim_ptr = llvm_utils->create_ptr_gep2(
+                            llvm::Type::getInt64Ty(context), I_arr,
+                            builder->CreateSExtOrTrunc(dim, llvm::Type::getInt32Ty(context)));
+                        llvm::Value* I_dim = llvm_utils->CreateLoad2(
+                            llvm::Type::getInt64Ty(context), I_dim_ptr);
+                        source_index = builder->CreateAdd(source_index,
+                            builder->CreateMul(I_dim, stride));
+
+                        llvm::Value* shape_dim = shape_values[0];
+                        for (int64_t k = 1; k < rank; k++) {
+                            llvm::Value* dim_eq_k = builder->CreateICmpEQ(
+                                dim, llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, k)));
+                            shape_dim = builder->CreateSelect(dim_eq_k, shape_values[k], shape_dim);
+                        }
+                        stride = builder->CreateMul(stride, shape_dim);
+                    }
+
+                    llvm::Value* src_ptr = llvm_utils->create_ptr_gep2(llvm_data_type, src_data, source_index);
+                    llvm::Value* val = llvm_utils->CreateLoad2(llvm_data_type, src_ptr);
+                    llvm::Value* dst_ptr = llvm_utils->create_ptr_gep2(llvm_data_type, dest_data, idx_val);
+                    builder->CreateStore(val, dst_ptr);
+
+                    llvm::Value* idx_next = builder->CreateAdd(idx_val,
+                        llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)));
+                    builder->CreateStore(idx_next, idx);
+                    builder->CreateBr(order_loop_head);
+
+                    llvm_utils->start_new_block(order_loop_end);
+                }
             }
             return reshaped;
         }

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -319,7 +319,9 @@ namespace LCompilers {
                                      llvm::Type* shape_type, llvm::Value* shape, ASR::ttype_t* asr_shape_type,
                                      llvm::Module* module, ASR::expr_t* array_expr = nullptr,
                                      ASR::ttype_t* asr_data_type = nullptr,
-                                     llvm::Type* result_desc_type = nullptr) = 0;
+                                     llvm::Type* result_desc_type = nullptr,
+                                     llvm::Value* order = nullptr,
+                                     ASR::expr_t* order_expr = nullptr) = 0;
 
                 virtual
                 void copy_array(llvm::Type* src_ty, llvm::Value* src, llvm::Type* dest_ty, llvm::Value* dest,
@@ -596,7 +598,9 @@ namespace LCompilers {
                                      llvm::Type* shape_type, llvm::Value* shape, ASR::ttype_t* asr_shape_type,
                                      llvm::Module* module, ASR::expr_t* array_expr = nullptr,
                                      ASR::ttype_t* asr_data_type = nullptr,
-                                     llvm::Type* result_desc_type = nullptr);
+                                     llvm::Type* result_desc_type = nullptr,
+                                     llvm::Value* order = nullptr,
+                                     ASR::expr_t* order_expr = nullptr);
 
                 virtual
                 void copy_array(llvm::Type* src_ty, llvm::Value* src, llvm::Type* dest_ty, llvm::Value* dest,

--- a/tests/reference/asr-arrays_reshape_14-913f34e.json
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_reshape_14-913f34e.stdout",
-    "stdout_hash": "6474d56ab1c00ca85159bb9d3c91c8a8316fd2f03498ab7b3b5547b0",
+    "stdout_hash": "c2f2b201ab3cf8f5f42abca8314cbd75d6bad63114e1757505b01de4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_reshape_14-913f34e.stdout
+++ b/tests/reference/asr-arrays_reshape_14-913f34e.stdout
@@ -48,6 +48,7 @@
                                             ()
                                         )
                                         ()
+                                        ()
                                         (Array
                                             (Integer 4)
                                             [((IntegerConstant 1 (Integer 4) Decimal)
@@ -582,6 +583,7 @@
                                                 ()
                                             )
                                             ()
+                                            ()
                                             (Array
                                                 (Real 8)
                                                 [(()
@@ -758,6 +760,7 @@
                                                 )
                                                 ()
                                             )
+                                            ()
                                             ()
                                             (Array
                                                 (Real 8)
@@ -1281,6 +1284,7 @@
                                                 ()
                                             )
                                             ()
+                                            ()
                                             (Array
                                                 (Real 8)
                                                 [(()
@@ -1542,6 +1546,7 @@
                                                 )
                                                 ()
                                             )
+                                            ()
                                             ()
                                             (Array
                                                 (Real 8)

--- a/tests/reference/asr-declaration1-880025a.json
+++ b/tests/reference/asr-declaration1-880025a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-declaration1-880025a.stdout",
-    "stdout_hash": "41cf32e413d839b664a6d1f8c80c7471f02038b609f0d73192bfbc25",
+    "stdout_hash": "0f021614abba8287bc55e8abd8a16ead8f6c0a365ffe001658833aef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-declaration1-880025a.stdout
+++ b/tests/reference/asr-declaration1-880025a.stdout
@@ -50,6 +50,17 @@
                                             ()
                                         )
                                         ()
+                                        (ArrayConstant
+                                            8
+                                            [2, 1]
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                FixedSizeArray
+                                            )
+                                            ColMajor
+                                        )
                                         (Array
                                             (Integer 4)
                                             [((IntegerConstant 1 (Integer 4) Decimal)

--- a/tests/reference/asr-implied_do_loops2-98464d0.json
+++ b/tests/reference/asr-implied_do_loops2-98464d0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-implied_do_loops2-98464d0.stdout",
-    "stdout_hash": "2ecfded3c20ff47594b52136ff75d939fd4735ff9f5cc9e22013e0df",
+    "stdout_hash": "bd60b40e257f70ba748f788013caae545943fc9763fe95f5fe68282f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-implied_do_loops2-98464d0.stdout
+++ b/tests/reference/asr-implied_do_loops2-98464d0.stdout
@@ -147,6 +147,7 @@
                                 ()
                             )
                             ()
+                            ()
                             (Array
                                 (Integer 4)
                                 [((IntegerConstant 1 (Integer 4) Decimal)

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.json
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matrix_01_transpose-fb3276a.stdout",
-    "stdout_hash": "bc6920fb0e02adb745b26d756bfd9c20898f585984b90ff21508e0dc",
+    "stdout_hash": "3123ee64d4bacb423771ec658367707e826f9652a5d918c979359678",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
+++ b/tests/reference/asr-matrix_01_transpose-fb3276a.stdout
@@ -393,6 +393,7 @@
                                 ()
                             )
                             ()
+                            ()
                             (Array
                                 (Integer 4)
                                 [((IntegerConstant 1 (Integer 4) Decimal)
@@ -565,6 +566,7 @@
                                     )
                                     ()
                                 )
+                                ()
                                 ()
                                 (Array
                                     (Integer 4)
@@ -777,6 +779,7 @@
                                     )
                                     ()
                                 )
+                                ()
                                 ()
                                 (Array
                                     (Integer 4)
@@ -1047,6 +1050,7 @@
                                 )
                                 ()
                             )
+                            ()
                             ()
                             (Array
                                 (Complex 4)

--- a/tests/reference/asr-matrix_02_matmul-d389302.json
+++ b/tests/reference/asr-matrix_02_matmul-d389302.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-matrix_02_matmul-d389302.stdout",
-    "stdout_hash": "baa2e7a3f5a47cf8f48fcb06c0551a95df3ac032343d6ef797fe86ab",
+    "stdout_hash": "07d7d964d3ad93d5fd7f0dbec3b51d61ccdef614c2b0ebb96549db65",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-matrix_02_matmul-d389302.stdout
+++ b/tests/reference/asr-matrix_02_matmul-d389302.stdout
@@ -229,6 +229,7 @@
                                 ()
                             )
                             ()
+                            ()
                             (Array
                                 (Integer 4)
                                 [((IntegerConstant 1 (Integer 4) Decimal)
@@ -291,6 +292,7 @@
                                 )
                                 ()
                             )
+                            ()
                             ()
                             (Array
                                 (Real 4)


### PR DESCRIPTION
Needed for stdlib tests

### Algorithm Followed (Simple Flow)
For each output element index `i` from `0` to `target_size-1`:
1) Convert `i` to result subscripts `I[0..n-1]` using result shape in normal Fortran `order`.
2) Read permutation `order[0..n-1]`.
3) Build source linear index:
start `source_index = 0`, `stride = 1`

For each position `j` in permutation order:
```    
    dim = order[j] - 1
    source_index += I[dim] * stride
    stride *= shape[dim]
```
4) Get element from source array with modified offset value