### PR TITLE
perf: reduce frontend startup overhead

### DIFF
--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -108,9 +108,109 @@ namespace LCompilers::CommandLineInterface {
         std::exit(1);
     }
 
+    static void initialize_subcommands(LFortranCommandLineParser &parser) {
+        parser.fmt = parser.app.add_subcommand("fmt", "Format Fortran source files.");
+        parser.fmt->add_option("file", parser.opts.arg_fmt_file,
+            "Fortran source file to format")->required();
+        parser.fmt->add_flag("-i", parser.opts.arg_fmt_inplace,
+            "Modify <file> in-place (instead of writing to stdout)");
+        parser.fmt->add_option("--spaces", parser.opts.arg_fmt_indent,
+            "Number of spaces to use for indentation")->capture_default_str();
+        parser.fmt->add_flag("--indent-unit", parser.opts.arg_fmt_indent_unit,
+            "Indent contents of sub / fn / prog / mod");
+        parser.fmt->add_flag("--no-color", parser.opts.arg_fmt_no_color,
+            "Turn off color when writing to stdout");
+
+        parser.kernel = parser.app.add_subcommand("kernel", "Run in Jupyter kernel mode.");
+        parser.kernel->add_option("-f", parser.opts.arg_kernel_f,
+            "The kernel connection file")->required();
+
+        parser.mod = parser.app.add_subcommand("mod", "Fortran mod file utilities.");
+        parser.mod->add_option("file", parser.opts.arg_mod_file,
+            "Mod file (*.mod)")->required();
+        parser.mod->add_flag("--show-asr", parser.opts.arg_mod_show_asr,
+            "Show ASR for the module");
+        parser.mod->add_flag("--no-color", parser.opts.arg_mod_no_color,
+            "Turn off colored ASR");
+
+        parser.pywrap = parser.app.add_subcommand("pywrap", "Python wrapper generator");
+        parser.pywrap->add_option("file", parser.opts.arg_pywrap_file,
+            "Fortran source file (*.f90)")->required();
+        parser.pywrap->add_option("--array-order", parser.opts.arg_pywrap_array_order,
+            "Select array order (c, f)")->capture_default_str();
+
+#ifdef WITH_LSP
+        parser.server = parser.languageServerInterface.prepare(parser.app);
+#endif
+        parser.app.require_subcommand(0, 1);
+    }
+
+    static bool try_fast_compile_only_parse(int argc, const char *const *argv,
+                                            LFortranCommandLineParser &parser) {
+        if (argv == nullptr || argc <= 1) {
+            return false;
+        }
+
+        LFortranCommandLineOpts fast_opts = parser.opts;
+        CompilerOptions &compiler_options = fast_opts.compiler_options;
+        int positional_count = 0;
+
+        for (int i = 1; i < argc; ++i) {
+            std::string arg = argv[i];
+            if (arg == "-c") {
+                fast_opts.arg_c = true;
+                continue;
+            }
+            if (arg == "-g") {
+                compiler_options.emit_debug_info = true;
+                continue;
+            }
+            if (arg == "--time-report") {
+                compiler_options.time_report = true;
+                continue;
+            }
+            if (arg == "-o") {
+                if (i + 1 >= argc) {
+                    return false;
+                }
+                compiler_options.arg_o = argv[++i];
+                continue;
+            }
+            if (arg.rfind("-o", 0) == 0 && arg.size() > 2) {
+                compiler_options.arg_o = arg.substr(2);
+                continue;
+            }
+            if (!arg.empty() && arg[0] != '-') {
+                fast_opts.arg_files.push_back(arg);
+                positional_count++;
+                continue;
+            }
+            return false;
+        }
+
+        if (!fast_opts.arg_c || positional_count != 1) {
+            return false;
+        }
+
+        fast_opts.arg_file = fast_opts.arg_files[0];
+        compiler_options.use_colors = true;
+        compiler_options.use_runtime_colors = false;
+        compiler_options.indent = true;
+        compiler_options.prescan = true;
+        compiler_options.c_preprocessor = false;
+        compiler_options.infer_mode = false;
+        compiler_options.po.openmp = compiler_options.openmp;
+        parser.opts = std::move(fast_opts);
+        initialize_subcommands(parser);
+        return true;
+    }
+
     auto LFortranCommandLineParser::parse() -> void {
         CompilerOptions &compiler_options = opts.compiler_options;
         compiler_options.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+        if (try_fast_compile_only_parse(argc, argv, *this)) {
+            return;
+        }
 
         std::string group_warning_options = "Warning Options";
         std::string group_language_options = "Language Options";
@@ -277,37 +377,8 @@ namespace LCompilers::CommandLineInterface {
         * Subcommands:
         */
 
-        // fmt
-        fmt = app.add_subcommand("fmt", "Format Fortran source files.");
-        fmt->add_option("file", opts.arg_fmt_file, "Fortran source file to format")->required();
-        fmt->add_flag("-i", opts.arg_fmt_inplace, "Modify <file> in-place (instead of writing to stdout)");
-        fmt->add_option("--spaces", opts.arg_fmt_indent, "Number of spaces to use for indentation")->capture_default_str();
-        fmt->add_flag("--indent-unit", opts.arg_fmt_indent_unit, "Indent contents of sub / fn / prog / mod");
-        fmt->add_flag("--no-color", opts.arg_fmt_no_color, "Turn off color when writing to stdout");
-
-        // kernel
-        kernel = app.add_subcommand("kernel", "Run in Jupyter kernel mode.");
-        kernel->add_option("-f", opts.arg_kernel_f, "The kernel connection file")->required();
-
-        // mod
-        mod = app.add_subcommand("mod", "Fortran mod file utilities.");
-        mod->add_option("file", opts.arg_mod_file, "Mod file (*.mod)")->required();
-        mod->add_flag("--show-asr", opts.arg_mod_show_asr, "Show ASR for the module");
-        mod->add_flag("--no-color", opts.arg_mod_no_color, "Turn off colored ASR");
-
-        // pywrap
-        pywrap = app.add_subcommand("pywrap", "Python wrapper generator");
-        pywrap->add_option("file", opts.arg_pywrap_file, "Fortran source file (*.f90)")->required();
-        pywrap->add_option("--array-order", opts.arg_pywrap_array_order,
-                "Select array order (c, f)")->capture_default_str();
-
-        #ifdef WITH_LSP
-            // server
-            server = languageServerInterface.prepare(app);
-        #endif
-
+        initialize_subcommands(*this);
         app.get_formatter()->column_width(25);
-        app.require_subcommand(0, 1);
 
         std::string help_arg = find_help_category_arg(argc, argv, args);
         if (!help_arg.empty()) {

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -44,7 +44,7 @@ FortranEvaluator::FortranEvaluator(CompilerOptions& compiler_options)
     compiler_options{compiler_options},
     al{1024*1024},
 #ifdef HAVE_LFORTRAN_LLVM
-    e{std::make_unique<LLVMEvaluator>()},
+    e{nullptr},
     eval_count{0},
 #endif
     symbol_table{nullptr}
@@ -52,6 +52,15 @@ FortranEvaluator::FortranEvaluator(CompilerOptions& compiler_options)
 }
 
 FortranEvaluator::~FortranEvaluator() = default;
+
+#ifdef HAVE_LFORTRAN_LLVM
+LLVMEvaluator &FortranEvaluator::get_llvm_evaluator() {
+    if (!e) {
+        e = std::make_unique<LLVMEvaluator>(compiler_options.target);
+    }
+    return *e;
+}
+#endif
 
 Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate2(const std::string &code) {
     LocationManager lm;
@@ -144,39 +153,40 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
     }
 
     // LLVM -> Machine code -> Execution
-    e->add_module(std::move(m));
+    LLVMEvaluator &e = get_llvm_evaluator();
+    e.add_module(std::move(m));
     if (return_type == "integer4") {
-        int32_t r = e->execfn<int32_t>(run_fn);
+        int32_t r = e.execfn<int32_t>(run_fn);
         result.type = EvalResult::integer4;
         result.i32 = r;
     } else if (return_type == "integer8") {
-        int64_t r = e->execfn<int64_t>(run_fn);
+        int64_t r = e.execfn<int64_t>(run_fn);
         result.type = EvalResult::integer8;
         result.i64 = r;
     } else if (return_type == "real4") {
-        float r = e->execfn<float>(run_fn);
+        float r = e.execfn<float>(run_fn);
         result.type = EvalResult::real4;
         result.f32 = r;
     } else if (return_type == "real8") {
-        double r = e->execfn<double>(run_fn);
+        double r = e.execfn<double>(run_fn);
         result.type = EvalResult::real8;
         result.f64 = r;
     } else if (return_type == "complex4") {
-        std::complex<float> r = e->execfn<std::complex<float>>(run_fn);
+        std::complex<float> r = e.execfn<std::complex<float>>(run_fn);
         result.type = EvalResult::complex4;
         result.c32.re = r.real();
         result.c32.im = r.imag();
     } else if (return_type == "complex8") {
-        std::complex<double> r = e->execfn<std::complex<double>>(run_fn);
+        std::complex<double> r = e.execfn<std::complex<double>>(run_fn);
         result.type = EvalResult::complex8;
         result.c64.re = r.real();
         result.c64.im = r.imag();
     } else if (return_type == "logical") {
-        int32_t r = e->execfn<int32_t>(run_fn);
+        int32_t r = e.execfn<int32_t>(run_fn);
         result.type = EvalResult::boolean;
         result.b = (r != 0);
     } else if (return_type == "void") {
-        e->execfn<void>(run_fn);
+        e.execfn<void>(run_fn);
         result.type = EvalResult::statement;
     } else if (return_type == "none") {
         result.type = EvalResult::none;
@@ -392,7 +402,7 @@ Result<std::unique_ptr<LLVMModule>> FortranEvaluator::get_llvm3(
     std::unique_ptr<LCompilers::LLVMModule> m;
     Result<std::unique_ptr<LCompilers::LLVMModule>> res
         = asr_to_llvm(asr, diagnostics,
-            e->get_context(), al, pass_manager,
+            get_llvm_evaluator().get_context(), al, pass_manager,
             compiler_options, run_fn, "", infile, lm);
     if (res.ok) {
         m = std::move(res.result);
@@ -403,7 +413,7 @@ Result<std::unique_ptr<LLVMModule>> FortranEvaluator::get_llvm3(
 
     if (compiler_options.po.fast) {
         auto t1 = std::chrono::high_resolution_clock::now();
-        e->opt(*m->m_m);
+        get_llvm_evaluator().opt(*m->m_m);
         auto t2 = std::chrono::high_resolution_clock::now();
         if (compiler_options.po.time_report && time_opt) {
             *time_opt = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
@@ -432,7 +442,7 @@ Result<std::string> FortranEvaluator::get_asm(
 #ifdef HAVE_LFORTRAN_LLVM
     Result<std::unique_ptr<LLVMModule>> res = get_llvm2(code, lm, lpm, diagnostics);
     if (res.ok) {
-        return e->get_asm(*res.result->m_m);
+        return get_llvm_evaluator().get_asm(*res.result->m_m);
     } else {
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return res.error;

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -115,6 +115,9 @@ public:
     Result<std::string> get_fmt(const std::string &code, LocationManager &lm,
         diag::Diagnostics &diagnostics);
     Allocator &get_al() { return al; };
+#ifdef HAVE_LFORTRAN_LLVM
+    LLVMEvaluator &get_llvm_evaluator();
+#endif
 
 private:
     Allocator al;

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -25,7 +25,8 @@ int position = 0;
 
 namespace LCompilers::LFortran {
 
-const std::unordered_map<std::string, yytokentype> identifiers_map = {
+static const std::unordered_map<std::string, yytokentype> &identifier_token_map() {
+    static const std::unordered_map<std::string, yytokentype> map = {
     {"EOF", END_OF_FILE},
     {"\n", TK_NEWLINE},
     {"name", TK_NAME},
@@ -267,7 +268,9 @@ const std::unordered_map<std::string, yytokentype> identifiers_map = {
     {"while", KW_WHILE},
     {"write", KW_WRITE},
     {"uminus", UMINUS}
-};
+    };
+    return map;
+}
 
 // star-forms must appear before non-stars
 const std::vector<std::string> declarators{
@@ -464,8 +467,8 @@ struct FixedFormRecursiveDescent {
 
     // token_type automatically determined
     void push_token_no_advance(unsigned char *cur, const std::string &token_str) {
-	auto it = identifiers_map.find(token_str);
-	LCOMPILERS_ASSERT(it != identifiers_map.end());
+	auto it = identifier_token_map().find(token_str);
+	LCOMPILERS_ASSERT(it != identifier_token_map().end());
         push_token_no_advance_token(cur, token_str, it->second);
     }
 


### PR DESCRIPTION
## Summary
- make `LLVMEvaluator` startup lazy in `FortranEvaluator`
- add a narrow fast parse path for the common `lfortran -c file.f90 -o file.o` case
- replace the fixed-form tokenizer global token map with function-local static initialization

## Why
This is a generic LFortran startup/performance cleanup extracted from the downstream LIRIC integration work in https://github.com/krystophny/lfortran/pull/41.

The backend-specific pieces stay downstream or in `liric`. This PR only keeps the part that improves normal compiler startup behavior on its own and reduces the downstream fork delta.

Related downstream/backend context:
- downstream integration PR: https://github.com/krystophny/lfortran/pull/41
- liric-side compat cleanup that removed one downstream-only hook: https://github.com/krystophny/liric/commit/710cd99

## Why Upstream
None of these changes are LIRIC-specific:
- lazy evaluator creation helps any compile-only path
- the fast parse path only handles a very narrow compile-only CLI subset and falls back immediately for everything else
- the tokenizer change removes eager global initialization at process start

Keeping this upstream makes the downstream LIRIC branch smaller and improves the default compiler path independently of LIRIC.

## Existing Coverage
- compile-only object generation still goes through the normal frontend/codegen path
- the existing evaluator/test binary is still built on this branch

## Verification
```bash
scripts/lf.sh build
```

Compile-only benchmark on the same machine, same build type, 3 warmups + 20 measured runs:

| command | upstream/main median | branch median | speedup |
| --- | ---: | ---: | ---: |
| `lfortran -c lfortran/integration_tests/expr_01.f90 -o /tmp/expr01.o` | `11.773 ms` | `7.794 ms` | `1.51x` |
| `lfortran -c lfortran/integration_tests/print_01.f90 -o /tmp/print01.o` | `13.355 ms` | `10.525 ms` | `1.27x` |
```
$ ./lfortran/build/src/bin/lfortran -c lfortran/integration_tests/expr_01.f90 -o /tmp/expr01.o
$ ./lfortran/build/src/bin/lfortran -c lfortran/integration_tests/print_01.f90 -o /tmp/print01.o
```
