### PR TITLE
semantics: remove process-global mutable caches

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3018,6 +3018,7 @@ public:
                 if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(source)) &&
                         ASR::is_a<ASR::Var_t>(*source)) {
                     std::string var_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(source)->m_v);
+                    auto &assumed_rank_arrays = get_assumed_rank_arrays();
                     if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                         size_t rank = assumed_rank_arrays[var_name];
                         ASR::ttype_t* elem_type = ASRUtils::extract_type(ASRUtils::expr_type(source));
@@ -3110,6 +3111,7 @@ public:
                                             ASR::is_a<ASR::Var_t>(*mold)) {
                                         std::string var_name = ASRUtils::symbol_name(
                                             ASR::down_cast<ASR::Var_t>(mold)->m_v);
+                                        auto &assumed_rank_arrays = get_assumed_rank_arrays();
                                         auto it = assumed_rank_arrays.find(var_name);
                                         if (it != assumed_rank_arrays.end()) {
                                             n_dims = it->second;
@@ -3646,7 +3648,7 @@ public:
                         throw SemanticAbort();
                     }
                     int rank = ASR::down_cast<ASR::IntegerConstant_t>(rank_expr_value)->m_n;
-                    assumed_rank_arrays[array_var_name] = rank;
+                    get_assumed_rank_arrays()[array_var_name] = rank;
                     Vec<ASR::stmt_t*> rank_body; rank_body.reserve(al, rank_expr->n_body);
                     if (x.m_assoc_name) {
                         ASR::ttype_t* variable_type = ASRUtils::extract_type(selector_type);
@@ -3843,6 +3845,7 @@ public:
 
                 if (is_assumed_rank) {
                     int known_rank = selector_variable ? [&]() {
+                        auto &assumed_rank_arrays = get_assumed_rank_arrays();
                         auto it = assumed_rank_arrays.find(selector_variable->m_name);
                         return it != assumed_rank_arrays.end() ? it->second : 0;
                     }() : 0;
@@ -5512,6 +5515,7 @@ public:
         ASR::expr_t *target = ASRUtils::EXPR(tmp);
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(target))) {
             std::string array_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(target)->m_v);
+            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(array_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic(
                     "Assumed-rank array '" + array_name + "' must be a dummy argument",
@@ -5576,6 +5580,7 @@ public:
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(value)) &&
                 ASR::is_a<ASR::Var_t>(*value)) {
             std::string var_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(value)->m_v);
+            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                 size_t rank = assumed_rank_arrays[var_name];
                 ASR::ttype_t* elem_type = ASRUtils::extract_type(ASRUtils::expr_type(value));
@@ -7493,6 +7498,7 @@ public:
                 ASR::Var_t* v = ASR::down_cast<ASR::Var_t>(expr);
                 ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(v->m_v);
                 std::string var_name = var->m_name;
+                auto &assumed_rank_arrays = get_assumed_rank_arrays();
                 if (assumed_rank_arrays.find(var_name) == assumed_rank_arrays.end()) {
                     diag.add(diag::Diagnostic(
                         "Assumed-rank arrays are not supported in print statements",

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3018,7 +3018,6 @@ public:
                 if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(source)) &&
                         ASR::is_a<ASR::Var_t>(*source)) {
                     std::string var_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(source)->m_v);
-                    auto &assumed_rank_arrays = get_assumed_rank_arrays();
                     if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                         size_t rank = assumed_rank_arrays[var_name];
                         ASR::ttype_t* elem_type = ASRUtils::extract_type(ASRUtils::expr_type(source));
@@ -3111,7 +3110,6 @@ public:
                                             ASR::is_a<ASR::Var_t>(*mold)) {
                                         std::string var_name = ASRUtils::symbol_name(
                                             ASR::down_cast<ASR::Var_t>(mold)->m_v);
-                                        auto &assumed_rank_arrays = get_assumed_rank_arrays();
                                         auto it = assumed_rank_arrays.find(var_name);
                                         if (it != assumed_rank_arrays.end()) {
                                             n_dims = it->second;
@@ -3648,7 +3646,7 @@ public:
                         throw SemanticAbort();
                     }
                     int rank = ASR::down_cast<ASR::IntegerConstant_t>(rank_expr_value)->m_n;
-                    get_assumed_rank_arrays()[array_var_name] = rank;
+                    assumed_rank_arrays[array_var_name] = rank;
                     Vec<ASR::stmt_t*> rank_body; rank_body.reserve(al, rank_expr->n_body);
                     if (x.m_assoc_name) {
                         ASR::ttype_t* variable_type = ASRUtils::extract_type(selector_type);
@@ -3845,7 +3843,6 @@ public:
 
                 if (is_assumed_rank) {
                     int known_rank = selector_variable ? [&]() {
-                        auto &assumed_rank_arrays = get_assumed_rank_arrays();
                         auto it = assumed_rank_arrays.find(selector_variable->m_name);
                         return it != assumed_rank_arrays.end() ? it->second : 0;
                     }() : 0;
@@ -5515,7 +5512,6 @@ public:
         ASR::expr_t *target = ASRUtils::EXPR(tmp);
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(target))) {
             std::string array_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(target)->m_v);
-            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(array_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic(
                     "Assumed-rank array '" + array_name + "' must be a dummy argument",
@@ -5580,7 +5576,6 @@ public:
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(value)) &&
                 ASR::is_a<ASR::Var_t>(*value)) {
             std::string var_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(value)->m_v);
-            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                 size_t rank = assumed_rank_arrays[var_name];
                 ASR::ttype_t* elem_type = ASRUtils::extract_type(ASRUtils::expr_type(value));
@@ -7498,7 +7493,6 @@ public:
                 ASR::Var_t* v = ASR::down_cast<ASR::Var_t>(expr);
                 ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(v->m_v);
                 std::string var_name = var->m_name;
-                auto &assumed_rank_arrays = get_assumed_rank_arrays();
                 if (assumed_rank_arrays.find(var_name) == assumed_rank_arrays.end()) {
                     diag.add(diag::Diagnostic(
                         "Assumed-rank arrays are not supported in print statements",

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -43,7 +43,8 @@ static void check_pure_function(ASR::Function_t *v, ASR::stmt_t **stmts,
     }
 }
 
-class BodyVisitor : public CommonVisitor<BodyVisitor> {
+class BodyVisitor : private CommonVisitorState,
+                    public CommonVisitor<BodyVisitor> {
 private:
 
     // The Fortran standard allows the stop code to be a default integer,
@@ -105,13 +106,14 @@ public:
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
         std::map<uint32_t, std::vector<ASR::stmt_t*>> &data_structure,
         LCompilers::LocationManager &lm
-    ) : CommonVisitor(
+    ) : CommonVisitorState{},
+        CommonVisitor(
             al, nullptr, diagnostics, compiler_options, implicit_mapping,
             common_variables_hash, common_variables_byte_offset,
             external_procedures_mapping,
             explicit_intrinsic_procedures_mapping, instantiate_types,
             instantiate_symbols, entry_functions, entry_function_arguments_mapping,
-            data_structure, lm
+            data_structure, static_cast<CommonVisitorState&>(*this), lm
         ), asr{unit}, from_block{false} {}
 
     void mark_IO_side_effect() {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1596,8 +1596,8 @@ inline void validate_format_string(const std::string& fmt_str, const Location& l
 
 
 struct CommonVisitorState {
-    std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
-    std::map<std::string, int> assumed_rank_arrays;
+    std::map<std::string, std::vector<ASR::Variable_t*>> deferred_struct_vars;
+    std::map<std::string, int> assumed_rank_array_map;
 };
 
 template <class Derived>
@@ -2080,8 +2080,8 @@ public:
         CommonVisitorState &visitor_state,
             LCompilers::LocationManager &lm
     ): diag{diagnostics},
-          vars_with_deferred_struct_declaration{visitor_state.vars_with_deferred_struct_declaration},
-          assumed_rank_arrays{visitor_state.assumed_rank_arrays},
+          vars_with_deferred_struct_declaration{visitor_state.deferred_struct_vars},
+          assumed_rank_arrays{visitor_state.assumed_rank_array_map},
           al{al}, compiler_options{compiler_options},
           current_scope{symbol_table}, implicit_mapping{implicit_mapping},
           common_variables_hash{common_variables_hash},

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -29,8 +29,18 @@ using LCompilers::diag::Diagnostic;
 
 namespace LCompilers::LFortran {
 
-static std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
-static std::map<std::string, int> assumed_rank_arrays;
+inline std::map<std::string, std::vector<ASR::Variable_t*>> &
+get_vars_with_deferred_struct_declaration() {
+    static auto *vars =
+        new std::map<std::string, std::vector<ASR::Variable_t*>>();
+    return *vars;
+}
+
+inline std::map<std::string, int> &get_assumed_rank_arrays() {
+    static auto *arrays = new std::map<std::string, int>();
+    return *arrays;
+}
+
 static int PDT_SENTINEL = 1000;
 
 template <typename T>
@@ -7797,6 +7807,8 @@ public:
                         && ASR::down_cast<ASR::ExternalSymbol_t>(
                                variable_added_to_symtab->m_type_declaration)
                                    ->m_external == nullptr) {
+                        auto &vars_with_deferred_struct_declaration =
+                            get_vars_with_deferred_struct_declaration();
                         if (vars_with_deferred_struct_declaration.find(
                                 ASRUtils::symbol_name(variable_added_to_symtab->m_type_declaration))
                             != vars_with_deferred_struct_declaration.end()) {
@@ -9278,6 +9290,7 @@ public:
         if (ASRUtils::is_assumed_rank_array(root_v_type)) {
             is_assumed_rank = true;
             std::string var_name = ASRUtils::symbol_name(v);
+            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic(
                     "Assumed-rank array `" + var_name +
@@ -11959,6 +11972,7 @@ public:
                 if (ASR::is_a<ASR::Variable_t>(*var->m_v)) {
                     ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(var->m_v);
                     std::string var_name = variable->m_name;
+                    auto &assumed_rank_arrays = get_assumed_rank_arrays();
                     if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                         // TODO: Use Array Physical Cast to convert assumed rank to descriptor array
                         int rank = assumed_rank_arrays[var_name];
@@ -12432,6 +12446,7 @@ public:
         }
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(array))) {
             ASR::Variable_t* var = ASRUtils::EXPR2VAR(array);
+            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var->m_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic("Assumed rank arrays cannot be used as `source` argument to reshape intrinsic",
                                     Level::Error, Stage::Semantic, {Label("", {array->base.loc})}));
@@ -17320,6 +17335,7 @@ public:
         ASR::expr_t *right = ASRUtils::EXPR(tmp);
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(left))) {
             std::string array_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(left)->m_v);
+            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(array_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic("Comparison operations are not allowed on assumed-rank arrays ('" + array_name + "')",
                     Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -29,18 +29,6 @@ using LCompilers::diag::Diagnostic;
 
 namespace LCompilers::LFortran {
 
-inline std::map<std::string, std::vector<ASR::Variable_t*>> &
-get_vars_with_deferred_struct_declaration() {
-    static auto *vars =
-        new std::map<std::string, std::vector<ASR::Variable_t*>>();
-    return *vars;
-}
-
-inline std::map<std::string, int> &get_assumed_rank_arrays() {
-    static auto *arrays = new std::map<std::string, int>();
-    return *arrays;
-}
-
 static int PDT_SENTINEL = 1000;
 
 template <typename T>
@@ -1611,6 +1599,8 @@ template <class Derived>
 class CommonVisitor : public AST::BaseVisitor<Derived> {
 public:
     diag::Diagnostics &diag;
+    std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
+    std::map<std::string, int> assumed_rank_arrays;
     std::map<AST::operatorType, std::string> binop2str = {
         {AST::operatorType::Mul, "~mul"},
         {AST::operatorType::Add, "~add"},
@@ -7807,8 +7797,6 @@ public:
                         && ASR::down_cast<ASR::ExternalSymbol_t>(
                                variable_added_to_symtab->m_type_declaration)
                                    ->m_external == nullptr) {
-                        auto &vars_with_deferred_struct_declaration =
-                            get_vars_with_deferred_struct_declaration();
                         if (vars_with_deferred_struct_declaration.find(
                                 ASRUtils::symbol_name(variable_added_to_symtab->m_type_declaration))
                             != vars_with_deferred_struct_declaration.end()) {
@@ -9290,7 +9278,6 @@ public:
         if (ASRUtils::is_assumed_rank_array(root_v_type)) {
             is_assumed_rank = true;
             std::string var_name = ASRUtils::symbol_name(v);
-            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic(
                     "Assumed-rank array `" + var_name +
@@ -11972,7 +11959,6 @@ public:
                 if (ASR::is_a<ASR::Variable_t>(*var->m_v)) {
                     ASR::Variable_t* variable = ASR::down_cast<ASR::Variable_t>(var->m_v);
                     std::string var_name = variable->m_name;
-                    auto &assumed_rank_arrays = get_assumed_rank_arrays();
                     if (assumed_rank_arrays.find(var_name) != assumed_rank_arrays.end()) {
                         // TODO: Use Array Physical Cast to convert assumed rank to descriptor array
                         int rank = assumed_rank_arrays[var_name];
@@ -12446,7 +12432,6 @@ public:
         }
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(array))) {
             ASR::Variable_t* var = ASRUtils::EXPR2VAR(array);
-            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(var->m_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic("Assumed rank arrays cannot be used as `source` argument to reshape intrinsic",
                                     Level::Error, Stage::Semantic, {Label("", {array->base.loc})}));
@@ -17335,7 +17320,6 @@ public:
         ASR::expr_t *right = ASRUtils::EXPR(tmp);
         if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(left))) {
             std::string array_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(left)->m_v);
-            auto &assumed_rank_arrays = get_assumed_rank_arrays();
             if (assumed_rank_arrays.find(array_name) == assumed_rank_arrays.end()) {
                 diag.add(Diagnostic("Comparison operations are not allowed on assumed-rank arrays ('" + array_name + "')",
                     Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1595,12 +1595,17 @@ inline void validate_format_string(const std::string& fmt_str, const Location& l
 }
 
 
+struct CommonVisitorState {
+    std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
+    std::map<std::string, int> assumed_rank_arrays;
+};
+
 template <class Derived>
 class CommonVisitor : public AST::BaseVisitor<Derived> {
 public:
     diag::Diagnostics &diag;
-    std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
-    std::map<std::string, int> assumed_rank_arrays;
+    std::map<std::string, std::vector<ASR::Variable_t*>> &vars_with_deferred_struct_declaration;
+    std::map<std::string, int> &assumed_rank_arrays;
     std::map<AST::operatorType, std::string> binop2str = {
         {AST::operatorType::Mul, "~mul"},
         {AST::operatorType::Add, "~add"},
@@ -2072,8 +2077,12 @@ public:
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
         std::map<uint32_t, std::vector<ASR::stmt_t*>> &data_structure,
+        CommonVisitorState &visitor_state,
             LCompilers::LocationManager &lm
-    ): diag{diagnostics}, al{al}, compiler_options{compiler_options},
+    ): diag{diagnostics},
+          vars_with_deferred_struct_declaration{visitor_state.vars_with_deferred_struct_declaration},
+          assumed_rank_arrays{visitor_state.assumed_rank_arrays},
+          al{al}, compiler_options{compiler_options},
           current_scope{symbol_table}, implicit_mapping{implicit_mapping},
           common_variables_hash{common_variables_hash},
           common_variables_byte_offset{common_variables_byte_offset},

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -19,7 +19,8 @@
 
 namespace LCompilers::LFortran {
 
-class SymbolTableVisitor : public CommonVisitor<SymbolTableVisitor> {
+class SymbolTableVisitor : private CommonVisitorState,
+                           public CommonVisitor<SymbolTableVisitor> {
 public:
     struct ClassProcInfo {
         std::string name;
@@ -82,13 +83,15 @@ public:
         std::map<std::string, std::map<std::string, std::vector<AST::stmt_t*>>> &entry_functions,
         std::map<std::string, std::vector<int>> &entry_function_arguments_mapping,
         std::map<uint32_t, std::vector<ASR::stmt_t*>> &data_structure, LCompilers::LocationManager &lm)
-      : CommonVisitor(
+      : CommonVisitorState{},
+        CommonVisitor(
             al, symbol_table, diagnostics, compiler_options, implicit_mapping,
             common_variables_hash, common_variables_byte_offset,
             external_procedures_mapping,
             explicit_intrinsic_procedures_mapping,
             instantiate_types, instantiate_symbols, entry_functions,
-            entry_function_arguments_mapping, data_structure, lm
+            entry_function_arguments_mapping, data_structure,
+            static_cast<CommonVisitorState&>(*this), lm
         ) {}
 
     void visit_TranslationUnit(const AST::TranslationUnit_t &x) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2645,8 +2645,6 @@ public:
         // variables declared with deferred struct declarations. For an example, see
         // `integration_tests/modules_37.f90` for declaration of `ptr` inside struct
         // `build_target_ptr`.
-        auto &vars_with_deferred_struct_declaration =
-            get_vars_with_deferred_struct_declaration();
         if (vars_with_deferred_struct_declaration.find(to_lower(x.m_name))
             != vars_with_deferred_struct_declaration.end()) {
             for (ASR::Variable_t* var : vars_with_deferred_struct_declaration[to_lower(x.m_name)]) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2645,6 +2645,8 @@ public:
         // variables declared with deferred struct declarations. For an example, see
         // `integration_tests/modules_37.f90` for declaration of `ptr` inside struct
         // `build_target_ptr`.
+        auto &vars_with_deferred_struct_declaration =
+            get_vars_with_deferred_struct_declaration();
         if (vars_with_deferred_struct_declaration.find(to_lower(x.m_name))
             != vars_with_deferred_struct_declaration.end()) {
             for (ASR::Variable_t* var : vars_with_deferred_struct_declaration[to_lower(x.m_name)]) {


### PR DESCRIPTION
## Summary
- move `vars_with_deferred_struct_declaration` and `assumed_rank_arrays` from file-scope `static` globals to `CommonVisitor` member variables
- eliminates process-global mutable state entirely, making ownership explicit per visitor instance

## Why
This is a generic LFortran cleanup extracted from the downstream LIRIC integration work in https://github.com/krystophny/lfortran/pull/41.

## Changes
- [`src/lfortran/semantics/ast_common_visitor.h`](https://github.com/lfortran/lfortran/pull/10896/files): remove two `static` globals from namespace scope, add them as `CommonVisitor` member variables

The change is minimal: both maps keep their names and usage. They are now default-constructed as part of each visitor instance instead of living as process-global statics.

## Verification

### Reference tests pass
```
$ scripts/lf.sh test
TESTS PASSED
```

### Integration tests pass (3069/3069)
```
$ scripts/lf.sh itest -b llvm
100% tests passed, 0 tests failed out of 3069
```