### PR TITLE
perf: reduce asr_verify frequency in Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ endif()
 set(WITH_LFORTRAN_ASSERT ${WITH_LFORTRAN_ASSERT_DEFAULT}
     CACHE BOOL "Enable LFORTRAN_ASSERT macro")
 
+
+# WITH_LFORTRAN_VERIFY_EVERY_PASS: run asr_verify after every single ASR pass
+# (slow, useful only when debugging a specific pass that corrupts the ASR tree).
+# By default, Debug builds verify once after all passes complete.
+set(WITH_LFORTRAN_VERIFY_EVERY_PASS no
+    CACHE BOOL "Run asr_verify after every ASR pass (slow, for debugging passes)")
 # LFORTRAN_STATIC_BIN
 set(LFORTRAN_STATIC_BIN no CACHE BOOL "Build LFortran as a static binary")
 
@@ -417,6 +423,7 @@ message("C compiler flags      : ${CMAKE_C_FLAGS_${BTYPE}}")
 message("C++ compiler flags    : ${CMAKE_CXX_FLAGS_${BTYPE}}")
 message("Installation prefix: ${CMAKE_INSTALL_PREFIX}")
 message("WITH_LFORTRAN_ASSERT: ${WITH_LFORTRAN_ASSERT}")
+message("WITH_LFORTRAN_VERIFY_EVERY_PASS: ${WITH_LFORTRAN_VERIFY_EVERY_PASS}")
 message("LFORTRAN_STATIC_BIN: ${LFORTRAN_STATIC_BIN}")
 message("LFORTRAN_BUILD_TO_WASM: ${LFORTRAN_BUILD_TO_WASM}")
 message("WITH_STACKTRACE: ${WITH_STACKTRACE}")

--- a/src/libasr/config.h.in
+++ b/src/libasr/config.h.in
@@ -4,6 +4,9 @@
 /* Define if you want to enable ASSERT testing in LFortran */
 #cmakedefine WITH_LFORTRAN_ASSERT
 
+/* Define to run asr_verify after every single ASR pass (slow) */
+#cmakedefine WITH_LFORTRAN_VERIFY_EVERY_PASS
+
 /* LFortran version */
 #cmakedefine LFORTRAN_VERSION "@LFORTRAN_VERSION@"
 #define LFORTRAN_MAJOR @CMAKE_PROJECT_VERSION_MAJOR@

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -187,7 +187,7 @@ namespace LCompilers {
                 }
                 auto t1 = std::chrono::high_resolution_clock::now();
                 _passes_db[passes[i]](al, *asr, pass_options);
-#if defined(WITH_LFORTRAN_ASSERT)
+#if defined(WITH_LFORTRAN_VERIFY_EVERY_PASS)
                 if (!asr_verify(*asr, true, diagnostics)) {
                     std::cerr << diagnostics.render2();
                     throw LCompilersException("Verify failed in the pass: "
@@ -211,6 +211,12 @@ namespace LCompilers {
                     std::cerr << "ASR Pass ends: '" << passes[i] << "'\n";
                 }
             }
+#if defined(WITH_LFORTRAN_ASSERT) && !defined(WITH_LFORTRAN_VERIFY_EVERY_PASS)
+            if (!asr_verify(*asr, true, diagnostics)) {
+                std::cerr << diagnostics.render2();
+                throw LCompilersException("Verify failed after all passes");
+            };
+#endif
         }
 
         void _parse_pass_arg(std::string& arg, std::vector<std::string>& passes) {
@@ -401,7 +407,7 @@ namespace LCompilers {
                         << "\n" << fortran_code.result << "\n";
                     outfile.close();
                 }
-#if defined(WITH_LFORTRAN_ASSERT)
+#if defined(WITH_LFORTRAN_VERIFY_EVERY_PASS)
                 if (!asr_verify(*asr, true, diagnostics)) {
                     std::cerr << diagnostics.render2();
                     throw LCompilersException("Verify failed in the pass: "
@@ -412,6 +418,12 @@ namespace LCompilers {
                     std::cerr << "ASR Pass ends: '" << passes[i] << "'\n";
                 }
             }
+#if defined(WITH_LFORTRAN_ASSERT) && !defined(WITH_LFORTRAN_VERIFY_EVERY_PASS)
+            if (!asr_verify(*asr, true, diagnostics)) {
+                std::cerr << diagnostics.render2();
+                throw LCompilersException("Verify failed after all passes");
+            };
+#endif
         }
 
         void use_default_passes(bool _c_skip_pass=false) {


### PR DESCRIPTION
## Summary
- Run `asr_verify()` once after all ASR passes instead of after every single pass
- Add `WITH_LFORTRAN_VERIFY_EVERY_PASS` CMake option for developers who need per-pass verification

## Why
In Debug builds (`WITH_LFORTRAN_ASSERT`), the pass manager runs `asr_verify()` after each of 29 passes. Each verification walks the entire ASR tree. This is the dominant cost in the ASR pass phase and accounts for ~60% of total compilation time in Debug mode.

The per-pass verification was added in commit `1030499` as a debug convenience to localize which pass corrupts the ASR tree. Moving to a single final verification still catches all corruption; the tradeoff is reduced debuggability (you know a pass corrupted ASR but not which one). The new CMake option `WITH_LFORTRAN_VERIFY_EVERY_PASS=yes` restores the per-pass behavior for developers debugging a specific pass.

**Stage:** Pass Manager

## Changes
- [`CMakeLists.txt`](https://github.com/lfortran/lfortran/pull/10897/files): add `WITH_LFORTRAN_VERIFY_EVERY_PASS` option (default `no`)
- [`src/libasr/config.h.in`](https://github.com/lfortran/lfortran/pull/10897/files): add `#cmakedefine WITH_LFORTRAN_VERIFY_EVERY_PASS`
- [`src/libasr/pass/pass_manager.h`](https://github.com/lfortran/lfortran/pull/10897/files): change per-pass verify guard from `WITH_LFORTRAN_ASSERT` to `WITH_LFORTRAN_VERIFY_EVERY_PASS`; add final-verify after all passes under `WITH_LFORTRAN_ASSERT && !WITH_LFORTRAN_VERIFY_EVERY_PASS`

## Verification

### Speedup evidence (Debug build, LLVM 11, Linux x86_64)

Per-file compilation (`-c`, `--time-report`, median of 3 runs):

| File | Before | After | Speedup |
|------|--------|-------|---------|
| `print_01.f90` (10 lines) | 14ms | 6.7ms | **52% faster** |
| `intrinsics_170.f90` (371 lines) | 445ms | 177ms | **60% faster** |
| `bindc_iso_fb_05.f90` (1279 lines) | 1490ms | 544ms | **63% faster** |

ASR passes phase (medium file): **149ms -> 20ms** (7.4x faster)

Integration test build (`make -j8`, 3069 tests): **3m47s -> 1m17s** (66% faster)

### Reference tests pass
```
$ scripts/lf.sh test
TESTS PASSED
```

### Integration tests pass (3069/3069)
```
$ scripts/lf.sh itest -b llvm
100% tests passed, 0 tests failed out of 3069
```

### Integration tests with --fast pass (3069/3069)
```
$ scripts/lf.sh itest -b llvm -f
100% tests passed, 0 tests failed out of 3069
```