### PR TITLE
Add --free-all-memory flag (implied by --detect-leaks)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3764,6 +3764,7 @@ RUN(NAME types_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME types_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME types_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME types_24 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME free_all_memory_01 LABELS gfortran llvm EXTRA_ARGS --free-all-memory)
 RUN(NAME types_real_to_complex_cast LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME types_real_array_to_complex_array_cast LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 

--- a/integration_tests/free_all_memory_01.f90
+++ b/integration_tests/free_all_memory_01.f90
@@ -1,0 +1,9 @@
+program free_all_memory_01
+    implicit none
+
+    character(len=:), allocatable :: s
+
+    s = "hello"
+    if (.not. allocated(s)) error stop
+    if (len(s) /= 5) error stop
+end program free_all_memory_01

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -364,7 +364,8 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--ignore-pragma", compiler_options.ignore_pragma, "Ignores all the pragmas")->group(group_miscellaneous_options);
         app.add_flag("--stack-arrays", compiler_options.stack_arrays, "Allocate memory for arrays on stack")->group(group_miscellaneous_options);
         app.add_flag("--descriptor-index-64", compiler_options.descriptor_index_64, "Use 64-bit indices in array descriptors (implied by -fdefault-integer-8)")->group(group_miscellaneous_options);
-        app.add_flag("--detect-leaks", compiler_options.detect_leaks, "Print a memory leak report")->group(group_miscellaneous_options);
+        app.add_flag("--detect-leaks", compiler_options.detect_leaks, "Print a memory leak report (implies --free-all-memory)")->group(group_miscellaneous_options);
+        app.add_flag("--free-all-memory", compiler_options.free_all_memory, "Free all unused memory on program exit (useful for leak detection tools)")->group(group_miscellaneous_options);
         app.add_flag("--array-bounds-checking", compiler_options.po.bounds_checking, "Enables runtime array bounds checking")->group(group_miscellaneous_options);
         app.add_flag("--no-array-bounds-checking", disable_bounds_checking, "Disables runtime array bounds checking")->group(group_miscellaneous_options);
         app.add_flag("--strict-array-bounds-checking", compiler_options.po.strict_bounds_checking, "Enables strict runtime array bounds checking: Array passed into subroutine must exactly match the expected size")->group(group_miscellaneous_options);
@@ -577,6 +578,10 @@ namespace LCompilers::CommandLineInterface {
         // Propagate descriptor_index_64 to PassOptions
         if (compiler_options.descriptor_index_64) {
             compiler_options.po.descriptor_index_64 = true;
+        }
+
+        if (compiler_options.detect_leaks) {
+            compiler_options.free_all_memory = true;
         }
     }
 

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -152,6 +152,7 @@ struct CompilerOptions {
     std::vector<std::string> import_paths;
     Platform platform;
     bool detect_leaks = false;
+    bool free_all_memory = false;
 
     CompilerOptions () : platform{get_platform()} {};
 };


### PR DESCRIPTION
issue - #10916 
- Added new CLI Flag --free-all-memory to free all unused memory on program exit
- Updates --detect-leaks to imply --free-all-memory
- It keeps the current behavior unchanged so memory is still freed in any condition
