### PR TITLE
fix: handle assumed-size array in implicit interface function call

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1993,6 +1993,7 @@ RUN(NAME implicit_interface_32 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_33 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_34 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_35 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
+RUN(NAME implicit_interface_36 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_36.f90
+++ b/integration_tests/implicit_interface_36.f90
@@ -1,0 +1,48 @@
+program implicit_interface_36
+  implicit none
+
+  external :: x
+  real :: x
+
+  integer :: i
+  real :: a(10)
+
+  a = [(i + 0.5, i = 1, 10)]
+
+  call sub_assumed(x, a)
+  call sub_fixed(x, a)
+
+end program implicit_interface_36
+
+subroutine sub_assumed(F, Y)
+
+  real F, FB
+  real Y(*)   ! Previously caused ICE
+
+  FB = F(Y)
+
+  if (abs(FB - 60.0) > 0.0001) then
+    error stop "assumed-size array argument failed"
+  end if
+
+end subroutine
+
+subroutine sub_fixed(F, Y)
+
+  real F, FB
+  real Y(10)
+ 
+  FB = F(Y)
+
+  if (abs(FB - 60.0) > 0.0001) then
+    error stop "fixed-size array argument failed"
+  end if
+
+end subroutine
+
+real function x(a)
+  real :: a(10)
+
+  x = sum(a)
+
+end function

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7801,6 +7801,16 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 ASRUtils::type_get_past_pointer(arg_type));
             ASR::Array_t* orig_arg_array_t = ASR::down_cast<ASR::Array_t>(
                 ASRUtils::type_get_past_pointer(orig_arg_type));
+            // When the actual argument is UnboundedPointerArray and the formal
+            // parameter was incorrectly changed to DescriptorArray (e.g. by
+            // type duplication that doesn't preserve UnboundedPointerArray),
+            // skip inserting a cast — the argument already matches the
+            // intended calling convention for assumed-size arrays.
+            if (arg_array_t->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray &&
+                orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::DescriptorArray &&
+                ASRUtils::is_dimension_empty(orig_arg_array_t->m_dims, orig_arg_array_t->n_dims)) {
+                orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::UnboundedPointerArray;
+            }
             bool is_orig_assumed_rank = false;
             if (orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
                 is_orig_assumed_rank = true;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3662,6 +3662,16 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
             if (dims == nullptr) {
                 dimsp = duplicate_dimensions(al, tnew->m_dims, tnew->n_dims);
                 dimsn = tnew->n_dims;
+                // UnboundedPointerArray cannot be reconstructed by
+                // make_Array_t_util auto-detection (it needs the
+                // is_dimension_star && is_argument flags only available during
+                // semantic analysis). Preserve it when duplicating with the
+                // same dimensions.
+                if (!override_physical_type &&
+                    tnew->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray) {
+                    physical_type = ASR::array_physical_typeType::UnboundedPointerArray;
+                    override_physical_type = true;
+                }
             }
             return ASRUtils::make_Array_t_util(al, tnew->base.base.loc,
                 duplicated_element_type, dimsp, dimsn, ASR::abiType::Source,
@@ -7801,16 +7811,6 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 ASRUtils::type_get_past_pointer(arg_type));
             ASR::Array_t* orig_arg_array_t = ASR::down_cast<ASR::Array_t>(
                 ASRUtils::type_get_past_pointer(orig_arg_type));
-            // When the actual argument is UnboundedPointerArray and the formal
-            // parameter was incorrectly changed to DescriptorArray (e.g. by
-            // type duplication that doesn't preserve UnboundedPointerArray),
-            // skip inserting a cast — the argument already matches the
-            // intended calling convention for assumed-size arrays.
-            if (arg_array_t->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray &&
-                orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::DescriptorArray &&
-                ASRUtils::is_dimension_empty(orig_arg_array_t->m_dims, orig_arg_array_t->n_dims)) {
-                orig_arg_array_t->m_physical_type = ASR::array_physical_typeType::UnboundedPointerArray;
-            }
             bool is_orig_assumed_rank = false;
             if (orig_arg_array_t->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
                 is_orig_assumed_rank = true;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11782,9 +11782,18 @@ public:
         builder->CreateStore(tmp_cast, data_ptr);
         ASR::dimension_t* m_dims = nullptr;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(m_type_for_dimensions, m_dims);
-        llvm::Type* llvm_typ = llvm_utils->get_type_from_ttype_t_util(expr,
-            ASRUtils::type_get_past_allocatable(m_type), module.get());
-        fill_array_details(llvm_typ, target, llvm_data_type, m_dims, n_dims, false, false);
+        bool dims_known = true;
+        for (int r = 0; r < n_dims; r++) {
+            if (m_dims[r].m_start == nullptr || m_dims[r].m_length == nullptr) {
+                dims_known = false;
+                break;
+            }
+        }
+        if (dims_known) {
+            llvm::Type* llvm_typ = llvm_utils->get_type_from_ttype_t_util(expr,
+                ASRUtils::type_get_past_allocatable(m_type), module.get());
+            fill_array_details(llvm_typ, target, llvm_data_type, m_dims, n_dims, false, false);
+        }
         // Set CFI descriptor fields (elem_len, type, attribute)
         ASR::ttype_t* elem_asr_type = ASRUtils::extract_type(array_ttype);
         llvm::DataLayout data_layout(module->getDataLayout());

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11782,18 +11782,9 @@ public:
         builder->CreateStore(tmp_cast, data_ptr);
         ASR::dimension_t* m_dims = nullptr;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(m_type_for_dimensions, m_dims);
-        bool dims_known = true;
-        for (int r = 0; r < n_dims; r++) {
-            if (m_dims[r].m_start == nullptr || m_dims[r].m_length == nullptr) {
-                dims_known = false;
-                break;
-            }
-        }
-        if (dims_known) {
-            llvm::Type* llvm_typ = llvm_utils->get_type_from_ttype_t_util(expr,
-                ASRUtils::type_get_past_allocatable(m_type), module.get());
-            fill_array_details(llvm_typ, target, llvm_data_type, m_dims, n_dims, false, false);
-        }
+        llvm::Type* llvm_typ = llvm_utils->get_type_from_ttype_t_util(expr,
+            ASRUtils::type_get_past_allocatable(m_type), module.get());
+        fill_array_details(llvm_typ, target, llvm_data_type, m_dims, n_dims, false, false);
         // Set CFI descriptor fields (elem_len, type, attribute)
         ASR::ttype_t* elem_asr_type = ASRUtils::extract_type(array_ttype);
         llvm::DataLayout data_layout(module->getDataLayout());


### PR DESCRIPTION
When an assumed-size array (e.g., real Y(*)) is passed through an implicit interface procedure argument, type duplication in ASR passes incorrectly changes UnboundedPointerArray to DescriptorArray because make_Array_t_util cannot detect assumed-size arrays from empty dimensions alone.

This causes an assertion failure (m_dim.m_start != nullptr) in the LLVM codegen when PointerToData_to_Descriptor tries to fill array details with null dimension bounds.

Fix:
- In Call_t_body, correct DescriptorArray back to UnboundedPointerArray when the actual argument is UnboundedPointerArray and the formal parameter has all-empty dimensions (indicating a corrupted type).
- In PointerToData_to_Descriptor, skip fill_array_details when dimension bounds are null as a safety net.