### PR TITLE
Fix Metal VLA codegen: use device buffer workspace for variable-lengt…

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -63,6 +63,7 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 #include <libasr/codegen/llvm_compat.h>
 #include <libasr/codegen/asr_to_metal.h>
+#include <libasr/codegen/gpu_utils.h>
 
 namespace LCompilers {
 
@@ -18966,7 +18967,9 @@ public:
         // buffer parameter.  Here we allocate host-side memory for those
         // buffers, pass them to the kernel, and free them after launch.
         std::vector<llvm::Value*> vla_workspace_ptrs;
-        if (!compiler_options.gpu_vla_workspaces.empty()) {
+        std::vector<GpuVlaWorkspace> gpu_vla_workspaces =
+            analyze_gpu_vla_workspaces(*kernel_func);
+        if (!gpu_vla_workspaces.empty()) {
             // Evaluate grid/block sizes to know the total thread count
             this->visit_expr(*x.m_grid_size);
             llvm::Value *gs = tmp;
@@ -18981,7 +18984,7 @@ public:
             llvm::Function *malloc_fn =
                 get_gpu_runtime_func("malloc", malloc_ft);
 
-            for (auto &ws : compiler_options.gpu_vla_workspaces) {
+            for (auto &ws : gpu_vla_workspaces) {
                 llvm::Value *per_thread_elems =
                     llvm::ConstantInt::get(i64, 1);
                 for (auto &dim : ws.dims) {

--- a/src/libasr/codegen/asr_to_metal.cpp
+++ b/src/libasr/codegen/asr_to_metal.cpp
@@ -1,6 +1,7 @@
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 #include <libasr/codegen/asr_to_metal.h>
+#include <libasr/codegen/gpu_utils.h>
 #include <libasr/codegen/c_utils.h>
 #include <libasr/exception.h>
 #include <libasr/asr_utils.h>
@@ -23,14 +24,7 @@ public:
 
     // VLA info collected during kernel signature generation,
     // used by the BlockCall handler to emit device pointer offsets.
-    struct VlaInfo {
-        std::string var_name;
-        std::string elem_type_str;
-        int elem_size;
-        std::vector<ASR::expr_t*> dim_lengths;
-        int buffer_index;
-    };
-    std::vector<VlaInfo> current_vla_infos;
+    std::vector<GpuVlaWorkspace> current_vla_infos;
 
     ASRToMetalVisitor(CompilerOptions &co_) : indent_level(0), co(co_) {}
 
@@ -321,53 +315,9 @@ public:
             args.push_back({arg_name, type, is_array_type(type), is_st, sn});
         }
 
-        // Scan blocks in the kernel body for VLAs (arrays with non-constant
-        // dimensions).  Metal Shading Language does not support variable-length
-        // arrays, so we convert each VLA into a per-thread slice of an
-        // additional device buffer parameter.
-        current_vla_infos.clear();
-        for (size_t i = 0; i < x.n_body; i++) {
-            if (!ASR::is_a<ASR::BlockCall_t>(*x.m_body[i])) continue;
-            ASR::BlockCall_t *bc = ASR::down_cast<ASR::BlockCall_t>(
-                x.m_body[i]);
-            if (!ASR::is_a<ASR::Block_t>(*bc->m_m)) continue;
-            ASR::Block_t *block = ASR::down_cast<ASR::Block_t>(bc->m_m);
-            for (auto &item : block->m_symtab->get_scope()) {
-                if (!ASR::is_a<ASR::Variable_t>(*item.second)) continue;
-                ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(
-                    item.second);
-                if (!ASR::is_a<ASR::Array_t>(*var->m_type)) continue;
-                ASR::Array_t *arr = ASR::down_cast<ASR::Array_t>(
-                    var->m_type);
-                bool has_vla = false;
-                for (size_t d = 0; d < arr->n_dims; d++) {
-                    if (arr->m_dims[d].m_length &&
-                        !ASR::is_a<ASR::IntegerConstant_t>(
-                            *arr->m_dims[d].m_length)) {
-                        has_vla = true;
-                        break;
-                    }
-                }
-                if (!has_vla) continue;
-                VlaInfo info;
-                info.var_name = var->m_name;
-                info.elem_type_str = metal_type(arr->m_type);
-                if (ASR::is_a<ASR::Real_t>(*arr->m_type)) {
-                    info.elem_size = ASR::down_cast<ASR::Real_t>(
-                        arr->m_type)->m_kind;
-                } else if (ASR::is_a<ASR::Integer_t>(*arr->m_type)) {
-                    info.elem_size = ASR::down_cast<ASR::Integer_t>(
-                        arr->m_type)->m_kind;
-                } else {
-                    info.elem_size = 4;
-                }
-                info.buffer_index = -1; // assigned below
-                for (size_t d = 0; d < arr->n_dims; d++) {
-                    info.dim_lengths.push_back(arr->m_dims[d].m_length);
-                }
-                current_vla_infos.push_back(info);
-            }
-        }
+        // Analyze blocks in the kernel body for VLAs (arrays with
+        // non-constant dimensions) using the shared GPU utility.
+        current_vla_infos = analyze_gpu_vla_workspaces(x);
 
         // Emit kernel signature
         src << "kernel void " << name << "(\n";
@@ -392,43 +342,30 @@ public:
 
         // Emit VLA workspace buffer parameters
         for (size_t v = 0; v < current_vla_infos.size(); v++) {
-            current_vla_infos[v].buffer_index = buffer_idx;
-            // Build workspace descriptor for the LLVM codegen
-            CompilerOptions::GpuVlaWorkspace ws;
-            ws.buffer_index = buffer_idx;
-            ws.elem_size = current_vla_infos[v].elem_size;
-            for (size_t d = 0; d < current_vla_infos[v].dim_lengths.size();
-                    d++) {
-                ASR::expr_t *dim = current_vla_infos[v].dim_lengths[d];
-                CompilerOptions::GpuVlaDim vd;
-                if (dim && ASR::is_a<ASR::IntegerConstant_t>(*dim)) {
-                    vd.is_constant = true;
-                    vd.constant_value =
-                        ASR::down_cast<ASR::IntegerConstant_t>(dim)->m_n;
-                    vd.call_arg_index = 0;
-                } else if (dim && ASR::is_a<ASR::Var_t>(*dim)) {
-                    std::string dim_name = ASRUtils::symbol_name(
-                        ASR::down_cast<ASR::Var_t>(dim)->m_v);
-                    vd.is_constant = false;
-                    vd.constant_value = 0;
-                    vd.call_arg_index = 0;
-                    for (size_t a = 0; a < args.size(); a++) {
-                        if (args[a].name == dim_name) {
-                            vd.call_arg_index = a;
-                            break;
-                        }
-                    }
-                } else {
-                    vd.is_constant = true;
-                    vd.constant_value = 1;
-                    vd.call_arg_index = 0;
+            LCOMPILERS_ASSERT(current_vla_infos[v].buffer_index == buffer_idx);
+            ASR::Variable_t *vla_var = nullptr;
+            // Look up the variable to get its Metal type string
+            for (size_t bi = 0; bi < x.n_body; bi++) {
+                if (!ASR::is_a<ASR::BlockCall_t>(*x.m_body[bi])) continue;
+                ASR::BlockCall_t *bc = ASR::down_cast<ASR::BlockCall_t>(
+                    x.m_body[bi]);
+                if (!ASR::is_a<ASR::Block_t>(*bc->m_m)) continue;
+                ASR::Block_t *block = ASR::down_cast<ASR::Block_t>(bc->m_m);
+                ASR::symbol_t *sym = block->m_symtab->resolve_symbol(
+                    current_vla_infos[v].var_name);
+                if (sym && ASR::is_a<ASR::Variable_t>(*sym)) {
+                    vla_var = ASR::down_cast<ASR::Variable_t>(sym);
+                    break;
                 }
-                ws.dims.push_back(vd);
             }
-            co.gpu_vla_workspaces.push_back(ws);
+            std::string elem_type_str = "float";
+            if (vla_var && ASR::is_a<ASR::Array_t>(*vla_var->m_type)) {
+                elem_type_str = metal_type(
+                    ASR::down_cast<ASR::Array_t>(vla_var->m_type)->m_type);
+            }
 
             if (has_prev) src << ",\n";
-            src << "    device " << current_vla_infos[v].elem_type_str
+            src << "    device " << elem_type_str
                 << "* __vla_" << current_vla_infos[v].var_name
                 << " [[buffer(" << buffer_idx++ << ")]]";
             has_prev = true;
@@ -555,23 +492,30 @@ public:
                     std::string vname(v->m_name);
                     auto vla_it = std::find_if(
                         current_vla_infos.begin(), current_vla_infos.end(),
-                        [&](const VlaInfo &vi) {
-                            return vi.var_name == vname;
+                        [&](const GpuVlaWorkspace &ws) {
+                            return ws.var_name == vname;
                         });
                     if (vla_it != current_vla_infos.end()) {
+                        // Get the element type string from the variable
+                        std::string elem_type_str = "float";
+                        if (ASR::is_a<ASR::Array_t>(*v->m_type)) {
+                            elem_type_str = metal_type(
+                                ASR::down_cast<ASR::Array_t>(
+                                    v->m_type)->m_type);
+                        }
                         // Emit a device pointer into the per-thread slice
                         src << get_indent() << "device "
-                            << vla_it->elem_type_str << "* " << vname
+                            << elem_type_str << "* " << vname
                             << " = __vla_" << vname
                             << " + __thread_id * ";
-                        if (vla_it->dim_lengths.size() == 1) {
-                            visit_expr(vla_it->dim_lengths[0]);
+                        if (vla_it->dims.size() == 1) {
+                            visit_expr(vla_it->dims[0].dim_expr);
                         } else {
                             src << "(";
                             for (size_t d = 0;
-                                    d < vla_it->dim_lengths.size(); d++) {
+                                    d < vla_it->dims.size(); d++) {
                                 if (d > 0) src << " * ";
-                                visit_expr(vla_it->dim_lengths[d]);
+                                visit_expr(vla_it->dims[d].dim_expr);
                             }
                             src << ")";
                         }

--- a/src/libasr/codegen/gpu_utils.h
+++ b/src/libasr/codegen/gpu_utils.h
@@ -1,0 +1,125 @@
+#ifndef LFORTRAN_GPU_UTILS_H
+#define LFORTRAN_GPU_UTILS_H
+
+#include <libasr/asr.h>
+#include <libasr/asr_utils.h>
+
+#include <string>
+#include <vector>
+
+namespace LCompilers {
+
+// Describes one dimension of a VLA workspace buffer.
+struct GpuVlaDim {
+    bool is_constant;
+    int64_t constant_value;
+    size_t call_arg_index;
+    ASR::expr_t *dim_expr; // original ASR dimension expression
+};
+
+// Describes a VLA workspace buffer required by a GPU kernel.
+struct GpuVlaWorkspace {
+    std::string var_name;
+    int buffer_index;
+    int elem_size;
+    std::vector<GpuVlaDim> dims;
+};
+
+// Analyze a GPU kernel function for variable-length arrays in blocks.
+// Returns workspace metadata for each VLA found, with buffer indices
+// assigned sequentially starting after the kernel's regular arguments.
+inline std::vector<GpuVlaWorkspace> analyze_gpu_vla_workspaces(
+        const ASR::GpuKernelFunction_t &kernel) {
+    // Build the kernel argument name list for mapping dim vars to arg indices
+    std::vector<std::string> arg_names;
+    for (size_t i = 0; i < kernel.n_args; i++) {
+        ASR::Var_t *v = ASR::down_cast<ASR::Var_t>(kernel.m_args[i]);
+        ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(
+            ASRUtils::symbol_get_past_external(v->m_v));
+        arg_names.push_back(std::string(var->m_name));
+    }
+
+    // Buffer index starts after all regular kernel arguments
+    int buffer_idx = static_cast<int>(kernel.n_args);
+
+    std::vector<GpuVlaWorkspace> result;
+
+    // Scan BlockCall statements in the kernel body for VLAs
+    for (size_t i = 0; i < kernel.n_body; i++) {
+        if (!ASR::is_a<ASR::BlockCall_t>(*kernel.m_body[i])) continue;
+        ASR::BlockCall_t *bc = ASR::down_cast<ASR::BlockCall_t>(
+            kernel.m_body[i]);
+        if (!ASR::is_a<ASR::Block_t>(*bc->m_m)) continue;
+        ASR::Block_t *block = ASR::down_cast<ASR::Block_t>(bc->m_m);
+
+        for (auto &item : block->m_symtab->get_scope()) {
+            if (!ASR::is_a<ASR::Variable_t>(*item.second)) continue;
+            ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(
+                item.second);
+            if (!ASR::is_a<ASR::Array_t>(*var->m_type)) continue;
+            ASR::Array_t *arr = ASR::down_cast<ASR::Array_t>(var->m_type);
+
+            bool has_vla = false;
+            for (size_t d = 0; d < arr->n_dims; d++) {
+                if (arr->m_dims[d].m_length &&
+                        !ASR::is_a<ASR::IntegerConstant_t>(
+                            *arr->m_dims[d].m_length)) {
+                    has_vla = true;
+                    break;
+                }
+            }
+            if (!has_vla) continue;
+
+            GpuVlaWorkspace ws;
+            ws.var_name = var->m_name;
+            ws.buffer_index = buffer_idx++;
+
+            // Compute element size from the array element type
+            if (ASR::is_a<ASR::Real_t>(*arr->m_type)) {
+                ws.elem_size = ASR::down_cast<ASR::Real_t>(
+                    arr->m_type)->m_kind;
+            } else if (ASR::is_a<ASR::Integer_t>(*arr->m_type)) {
+                ws.elem_size = ASR::down_cast<ASR::Integer_t>(
+                    arr->m_type)->m_kind;
+            } else {
+                ws.elem_size = 4;
+            }
+
+            // Process each dimension
+            for (size_t d = 0; d < arr->n_dims; d++) {
+                ASR::expr_t *dim = arr->m_dims[d].m_length;
+                GpuVlaDim vd;
+                vd.dim_expr = dim;
+                if (dim && ASR::is_a<ASR::IntegerConstant_t>(*dim)) {
+                    vd.is_constant = true;
+                    vd.constant_value =
+                        ASR::down_cast<ASR::IntegerConstant_t>(dim)->m_n;
+                    vd.call_arg_index = 0;
+                } else if (dim && ASR::is_a<ASR::Var_t>(*dim)) {
+                    std::string dim_name = ASRUtils::symbol_name(
+                        ASR::down_cast<ASR::Var_t>(dim)->m_v);
+                    vd.is_constant = false;
+                    vd.constant_value = 0;
+                    vd.call_arg_index = 0;
+                    for (size_t a = 0; a < arg_names.size(); a++) {
+                        if (arg_names[a] == dim_name) {
+                            vd.call_arg_index = a;
+                            break;
+                        }
+                    }
+                } else {
+                    vd.is_constant = true;
+                    vd.constant_value = 1;
+                    vd.call_arg_index = 0;
+                }
+                ws.dims.push_back(vd);
+            }
+            result.push_back(std::move(ws));
+        }
+    }
+    return result;
+}
+
+} // namespace LCompilers
+
+#endif // LFORTRAN_GPU_UTILS_H

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -100,19 +100,6 @@ struct CompilerOptions {
     bool target_offload_enabled = false;
     std::string gpu_backend = "";
     std::string gpu_metal_source = "";
-    // Metadata for VLA workspace buffers in Metal GPU kernels.
-    // Populated by asr_to_metal, consumed by asr_to_llvm.
-    struct GpuVlaDim {
-        bool is_constant;
-        int64_t constant_value;
-        size_t call_arg_index;
-    };
-    struct GpuVlaWorkspace {
-        int buffer_index;
-        int elem_size;
-        std::vector<GpuVlaDim> dims;
-    };
-    std::vector<GpuVlaWorkspace> gpu_vla_workspaces;
     std::string openmp_lib_dir = "";
     bool lookup_name = false;
     bool rename_symbol = false;


### PR DESCRIPTION
…h arrays

Metal Shading Language does not support variable-length arrays (VLAs). When a do concurrent block contains a local array with a runtime-dependent dimension (e.g., real :: a(n)), the Metal codegen was emitting float a[n] which the Metal compiler rejects.

Fix: convert each block-local VLA into a per-thread slice of an additional device buffer parameter. The Metal codegen emits a device pointer offset (device float* a = __vla_a + __thread_id * n) instead of a stack VLA. The LLVM host-side codegen allocates the workspace buffer via malloc, passes it as an extra buffer arg, and frees it after kernel launch.

Also add missing _lcompilers_int_/_lcompilers_nint_ intrinsic handling in the Metal FunctionCall emitter.