### PR TITLE
Add WITH_LIRIC build option as lightweight LLVM replacement

### DIFF
--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -436,8 +436,13 @@ jobs:
           python src/libasr/asdl_cpp.py src/libasr/ASR.asdl src/libasr/asr.h
           python src/libasr/wasm_instructions_visitor.py
           python src/libasr/intrinsic_func_registry_util_gen.py
-          cmake -S . -B build \
-            -G Ninja \
+          cd src/lfortran/parser && re2c -W -b tokenizer.re -o tokenizer.cpp && cd ../../..
+          cd src/lfortran/parser && re2c -W -b preprocessor.re -o preprocessor.cpp && cd ../../..
+          cd src/lfortran/parser && bison -Wall -d parser.yy && cd ../../..
+          python src/server/generator/generate_lsp_code.py \
+            --schema src/server/generator/metaModel.json \
+            --target-language c++ --output-dir src/server
+          cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DWITH_LIRIC=yes \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \

--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -408,3 +408,41 @@ jobs:
             ci/upload_lfortran_wasm.sh
         env:
           SSH_PRIVATE_KEY_WASM_BUILDS: ${{ secrets.SSH_PRIVATE_KEY_WASM_BUILDS }}
+
+  Liric:
+    name: LFortran CI (WITH_LIRIC, ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/setup-micromamba@v2.0.2
+        with:
+          micromamba-version: '2.0.4-0'
+          environment-file: ci/environment.yml
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-ubuntu-latest
+
+      - name: Build with liric
+        shell: bash -e -l {0}
+        run: |
+          set -ex
+          cmake -S . -B build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DWITH_LIRIC=yes \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          cmake --build build -j$(nproc)
+
+      - name: Run reference tests
+        shell: bash -e -l {0}
+        run: |
+          set -ex
+          cd tests
+          ./run_tests.py &> log || true
+          cat log

--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -431,6 +431,11 @@ jobs:
         shell: bash -e -l {0}
         run: |
           set -ex
+          bash ci/version.sh
+          python src/libasr/asdl_cpp.py grammar/AST.asdl src/lfortran/ast.h
+          python src/libasr/asdl_cpp.py src/libasr/ASR.asdl src/libasr/asr.h
+          python src/libasr/wasm_instructions_visitor.py
+          python src/libasr/intrinsic_func_registry_util_gen.py
           cmake -S . -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,24 +244,23 @@ if (WITH_LIRIC)
         endif()
     endif()
     message(STATUS "Using liric: ${LIRIC_LIB}")
-    message(STATUS "Liric includes: ${LIRIC_DIR}/include/liric")
-    add_library(p::llvm INTERFACE IMPORTED)
-    set_property(TARGET p::llvm PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    add_library(p::liric INTERFACE IMPORTED)
+    set_property(TARGET p::liric PROPERTY INTERFACE_INCLUDE_DIRECTORIES
         "${LIRIC_DIR}/include/liric" "${LIRIC_DIR}/include")
-    set_property(TARGET p::llvm PROPERTY INTERFACE_COMPILE_OPTIONS
+    set_property(TARGET p::liric PROPERTY INTERFACE_COMPILE_OPTIONS
         $<$<COMPILE_LANGUAGE:CXX>:${LFORTRAN_CXX_NO_RTTI_FLAG}>
         $<$<COMPILE_LANGUAGE:CXX>:-include>
         $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/src/libasr/codegen/liric_llvm_alias.h>)
-    set_property(TARGET p::llvm PROPERTY INTERFACE_LINK_LIBRARIES
+    set_property(TARGET p::liric PROPERTY INTERFACE_LINK_LIBRARIES
         "${LIRIC_LIB}" stdc++)
     if (UNIX AND NOT APPLE)
         add_link_options(
             $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-no-pie>
             -Wl,--allow-multiple-definition)
     endif()
-    set(HAVE_LFORTRAN_LLVM yes)
-    set(WITH_LLVM yes)
-elseif (WITH_LLVM)
+endif()
+
+if (WITH_LLVM)
     set(WITH_ZSTD yes CACHE BOOL "Detect (and require) libzstd for LLVM")
     set(USE_DYNAMIC_ZSTD no CACHE BOOL "Use dynamic ZSTD library (default: static)")
     if(WITH_ZSTD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ endif()
 
 # LLVM
 set(WITH_LLVM no CACHE BOOL "Build with LLVM support")
+set(WITH_LIRIC no CACHE BOOL "Use liric as LLVM replacement (C++ compat headers)")
+set(LIRIC_DIR "" CACHE PATH "Path to liric source/build directory")
 set(WITH_TARGET_AARCH64 no CACHE BOOL "Enable target AARCH64")
 set(WITH_TARGET_X86 no CACHE BOOL "Enable target X86")
 set(WITH_TARGET_WASM no CACHE BOOL "Enable target WebAssembly")
@@ -221,7 +223,45 @@ if (WITH_UNWIND)
     set(HAVE_LFORTRAN_UNWIND yes)
 endif()
 
-if (WITH_LLVM)
+if (WITH_LIRIC)
+    add_compile_definitions(WITH_LIRIC)
+    set(HAVE_LFORTRAN_LIRIC yes)
+    if ("${LIRIC_DIR}" STREQUAL "")
+        include(FetchContent)
+        FetchContent_Declare(liric
+            GIT_REPOSITORY https://github.com/krystophny/liric.git
+            GIT_TAG main)
+        FetchContent_MakeAvailable(liric)
+        set(LIRIC_DIR "${liric_SOURCE_DIR}")
+        set(LIRIC_LIB liric)
+        message(STATUS "Fetched liric: ${LIRIC_DIR}")
+    else()
+        find_library(LIRIC_LIB liric
+            PATHS "${LIRIC_DIR}/build" "${LIRIC_DIR}/lib" "${LIRIC_DIR}"
+            NO_DEFAULT_PATH)
+        if (NOT LIRIC_LIB)
+            message(FATAL_ERROR "Could not find libliric in ${LIRIC_DIR}")
+        endif()
+    endif()
+    message(STATUS "Using liric: ${LIRIC_LIB}")
+    message(STATUS "Liric includes: ${LIRIC_DIR}/include/liric")
+    add_library(p::llvm INTERFACE IMPORTED)
+    set_property(TARGET p::llvm PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+        "${LIRIC_DIR}/include/liric" "${LIRIC_DIR}/include")
+    set_property(TARGET p::llvm PROPERTY INTERFACE_COMPILE_OPTIONS
+        $<$<COMPILE_LANGUAGE:CXX>:${LFORTRAN_CXX_NO_RTTI_FLAG}>
+        $<$<COMPILE_LANGUAGE:CXX>:-include>
+        $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/src/libasr/codegen/liric_llvm_alias.h>)
+    set_property(TARGET p::llvm PROPERTY INTERFACE_LINK_LIBRARIES
+        "${LIRIC_LIB}" stdc++)
+    if (UNIX AND NOT APPLE)
+        add_link_options(
+            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-no-pie>
+            -Wl,--allow-multiple-definition)
+    endif()
+    set(HAVE_LFORTRAN_LLVM yes)
+    set(WITH_LLVM yes)
+elseif (WITH_LLVM)
     set(WITH_ZSTD yes CACHE BOOL "Detect (and require) libzstd for LLVM")
     set(USE_DYNAMIC_ZSTD no CACHE BOOL "Use dynamic ZSTD library (default: static)")
     if(WITH_ZSTD)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -32,6 +32,10 @@ set(LFORTRAN_SRC
 add_executable(lfortran ${LFORTRAN_SRC})
 target_include_directories(lfortran PRIVATE "tpl")
 target_link_libraries(lfortran ${LFORTRAN_LINK_LIBRARIES})
+if (WITH_LIRIC)
+    # Link asr_liric after runtime to resolve _lfortran_stan
+    target_link_libraries(lfortran asr_liric lfortran_runtime_static -lm)
+endif()
 if (LFORTRAN_STATIC_BIN)
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux"
         OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(lfortran PRIVATE "tpl")
 target_link_libraries(lfortran ${LFORTRAN_LINK_LIBRARIES})
 if (WITH_LIRIC)
     # Link asr_liric after runtime to resolve _lfortran_stan
-    target_link_libraries(lfortran asr_liric lfortran_runtime_static -lm)
+    target_link_libraries(lfortran asr_liric lfortran_runtime_static)
 endif()
 if (LFORTRAN_STATIC_BIN)
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux"

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -101,6 +101,39 @@ enum Backend {
     llvm, c, cpp, x86, wasm, fortran, mlir, liric
 };
 
+#ifdef HAVE_LFORTRAN_LIRIC
+extern "C" int liric_compile_to_object(
+    void *asr, void *diag, void *al, void *lpm,
+    void *co, const char *infile, void *lm, const char *outfile);
+extern "C" int liric_link_executable(const char *const *objects, int n,
+    const char *outfile);
+extern "C" const char *liric_get_version();
+extern "C" const char *liric_get_default_target();
+
+int compile_src_to_object_file_liric(const std::string &infile,
+        const std::string &outfile, CompilerOptions &compiler_options,
+        LCompilers::PassManager &lpm)
+{
+    std::string input = read_file_ok(infile);
+    LCompilers::FortranEvaluator fe(compiler_options);
+    LCompilers::LocationManager lm;
+    {
+        LCompilers::LocationManager::FileLocations fl;
+        fl.in_filename = infile;
+        lm.files.push_back(fl);
+        lm.file_ends.push_back(input.size());
+    }
+    LCompilers::diag::Diagnostics diagnostics;
+    auto result = fe.get_asr2(input, lm, diagnostics);
+    std::cerr << diagnostics.render(lm, compiler_options);
+    if (!result.ok) return 1;
+    auto *asr = result.result;
+    Allocator al(64*1024*1024);
+    return liric_compile_to_object(asr, &diagnostics, &al, &lpm,
+        &compiler_options, infile.c_str(), &lm, outfile.c_str());
+}
+#endif
+
 std::string get_system_temp_dir()
 {
     #ifdef _WIN32
@@ -1997,7 +2030,24 @@ int link_executable(const std::vector<std::string> &infiles,
         std::cout << "Cannot use static_executable and shared_executable together" << std::endl;
         return 10;
     }
-    if (backend == Backend::llvm || backend == Backend::liric || backend == Backend::mlir) {
+    if (backend == Backend::liric) {
+#ifdef HAVE_LFORTRAN_LIRIC
+        // Direct executable emission - no system linker needed
+        std::vector<const char *> obj_ptrs;
+        for (const auto &f : infiles) obj_ptrs.push_back(f.c_str());
+        int err = liric_link_executable(obj_ptrs.data(), obj_ptrs.size(),
+            outfile.c_str());
+        if (err) {
+            std::cerr << "Liric direct executable emission failed." << std::endl;
+            return 10;
+        }
+        return 0;
+#else
+        std::cerr << "The liric backend requires -DWITH_LIRIC=ON." << std::endl;
+        return 1;
+#endif
+    }
+    if (backend == Backend::llvm || backend == Backend::mlir) {
         std::string run_cmd = "", compile_cmd = "";
         if (t == "x86_64-pc-windows-msvc") {
             compile_cmd = "link /NOLOGO /OUT:" + outfile + " ";
@@ -2088,7 +2138,7 @@ int link_executable(const std::vector<std::string> &infiles,
             compile_cmd = CC + options + " -o " + outfile + " ";
             for (auto &s : infiles) {
                 compile_cmd += s + " ";
-                if ((backend == Backend::llvm || backend == Backend::liric) &&
+                if ((backend == Backend::llvm) &&
                         compiler_options.po.enable_gpu_offloading &&
                         std::regex_match(s, std::regex(R"(.*\.tmp_\w+\.o)"))) {
                     std::string file_path = std::filesystem::path(s.substr(0, s.size() - 2)).string();    // strip ".o" from end
@@ -2829,7 +2879,7 @@ int main_app(int argc, char *argv[]) {
         return emit_fortran(opts.arg_file, compiler_options);
     }
     if (opts.arg_S) {
-        if (backend == Backend::llvm || backend == Backend::liric) {
+        if (backend == Backend::llvm) {
 #ifdef HAVE_LFORTRAN_LLVM
             int result = compile_to_assembly_file(opts.arg_file, outfile, compiler_options.time_report, compiler_options, lfortran_pass_manager);
             if (compiler_options.time_report) {
@@ -2853,12 +2903,20 @@ int main_app(int argc, char *argv[]) {
     }
     if (opts.arg_c) {
         int result;
-        if (backend == Backend::llvm || backend == Backend::liric) {
+        if (backend == Backend::llvm) {
 #ifdef HAVE_LFORTRAN_LLVM
             result = compile_src_to_object_file(opts.arg_file, outfile, compiler_options.time_report, false,
                 compiler_options, lfortran_pass_manager, opts.arg_c, nullptr);
 #else
             std::cerr << "The -c option requires the LLVM backend to be enabled. Recompile with `WITH_LLVM=yes`." << std::endl;
+            return 1;
+#endif
+        } else if (backend == Backend::liric) {
+#ifdef HAVE_LFORTRAN_LIRIC
+            result = compile_src_to_object_file_liric(opts.arg_file, outfile,
+                compiler_options, lfortran_pass_manager);
+#else
+            std::cerr << "The liric backend requires -DWITH_LIRIC=ON." << std::endl;
             return 1;
 #endif
         } else if (backend == Backend::c) {
@@ -2914,7 +2972,15 @@ int main_app(int argc, char *argv[]) {
                 return compile_to_binary_x86(arg_file, outfile,
                         compiler_options.time_report, compiler_options);
             }
-            if (backend == Backend::llvm || backend == Backend::liric) {
+            if (backend == Backend::liric) {
+#ifdef HAVE_LFORTRAN_LIRIC
+                err = compile_src_to_object_file_liric(arg_file, tmp_o,
+                    compiler_options, lfortran_pass_manager);
+#else
+                std::cerr << "The liric backend requires -DWITH_LIRIC=ON." << std::endl;
+                return 1;
+#endif
+            } else if (backend == Backend::llvm) {
 #ifdef HAVE_LFORTRAN_LLVM
                 err = compile_src_to_object_file(arg_file, tmp_o, compiler_options.time_report, false,
                     compiler_options, lfortran_pass_manager, true, &found_main);

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -101,6 +101,9 @@ enum Backend {
     llvm, c, cpp, x86, wasm, fortran, mlir, liric
 };
 
+int save_mod_files(const LCompilers::ASR::TranslationUnit_t &u,
+    const CompilerOptions &compiler_options, LCompilers::LocationManager lm);
+
 #ifdef HAVE_LFORTRAN_LIRIC
 extern "C" int liric_compile_to_object(
     void *asr, void *diag, void *al, void *lpm,
@@ -128,6 +131,8 @@ int compile_src_to_object_file_liric(const std::string &infile,
     std::cerr << diagnostics.render(lm, compiler_options);
     if (!result.ok) return 1;
     auto *asr = result.result;
+    int mod_err = save_mod_files(*asr, compiler_options, lm);
+    if (mod_err) return mod_err;
     Allocator al(64*1024*1024);
     return liric_compile_to_object(asr, &diagnostics, &al, &lpm,
         &compiler_options, infile.c_str(), &lm, outfile.c_str());

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -98,7 +98,7 @@ namespace lsi = LCompilers::LLanguageServer::Interface;
 #endif
 
 enum Backend {
-    llvm, c, cpp, x86, wasm, fortran, mlir
+    llvm, c, cpp, x86, wasm, fortran, mlir, liric
 };
 
 std::string get_system_temp_dir()
@@ -1997,7 +1997,7 @@ int link_executable(const std::vector<std::string> &infiles,
         std::cout << "Cannot use static_executable and shared_executable together" << std::endl;
         return 10;
     }
-    if (backend == Backend::llvm || backend == Backend::mlir) {
+    if (backend == Backend::llvm || backend == Backend::liric || backend == Backend::mlir) {
         std::string run_cmd = "", compile_cmd = "";
         if (t == "x86_64-pc-windows-msvc") {
             compile_cmd = "link /NOLOGO /OUT:" + outfile + " ";
@@ -2088,7 +2088,7 @@ int link_executable(const std::vector<std::string> &infiles,
             compile_cmd = CC + options + " -o " + outfile + " ";
             for (auto &s : infiles) {
                 compile_cmd += s + " ";
-                if (backend == Backend::llvm &&
+                if ((backend == Backend::llvm || backend == Backend::liric) &&
                         compiler_options.po.enable_gpu_offloading &&
                         std::regex_match(s, std::regex(R"(.*\.tmp_\w+\.o)"))) {
                     std::string file_path = std::filesystem::path(s.substr(0, s.size() - 2)).string();    // strip ".o" from end
@@ -2668,8 +2668,17 @@ int main_app(int argc, char *argv[]) {
         backend = Backend::fortran;
     } else if (opts.arg_backend == "mlir") {
         backend = Backend::mlir;
+    } else if (opts.arg_backend == "liric") {
+#ifdef HAVE_LFORTRAN_LIRIC
+        backend = Backend::liric;
+        lfortran_pass_manager.passes_to_skip_with_llvm.push_back("print_arr");
+        lfortran_pass_manager.passes_to_skip_with_llvm.push_back("print_struct_type");
+#else
+        std::cerr << "The liric backend requires building with -DWITH_LIRIC=ON." << std::endl;
+        return 1;
+#endif
     } else {
-        std::cerr << "The backend must be one of: llvm, cpp, x86, wasm, fortran, mlir." << std::endl;
+        std::cerr << "The backend must be one of: llvm, cpp, x86, wasm, fortran, mlir, liric." << std::endl;
         return 1;
     }
 
@@ -2820,7 +2829,7 @@ int main_app(int argc, char *argv[]) {
         return emit_fortran(opts.arg_file, compiler_options);
     }
     if (opts.arg_S) {
-        if (backend == Backend::llvm) {
+        if (backend == Backend::llvm || backend == Backend::liric) {
 #ifdef HAVE_LFORTRAN_LLVM
             int result = compile_to_assembly_file(opts.arg_file, outfile, compiler_options.time_report, compiler_options, lfortran_pass_manager);
             if (compiler_options.time_report) {
@@ -2844,7 +2853,7 @@ int main_app(int argc, char *argv[]) {
     }
     if (opts.arg_c) {
         int result;
-        if (backend == Backend::llvm) {
+        if (backend == Backend::llvm || backend == Backend::liric) {
 #ifdef HAVE_LFORTRAN_LLVM
             result = compile_src_to_object_file(opts.arg_file, outfile, compiler_options.time_report, false,
                 compiler_options, lfortran_pass_manager, opts.arg_c, nullptr);
@@ -2905,7 +2914,7 @@ int main_app(int argc, char *argv[]) {
                 return compile_to_binary_x86(arg_file, outfile,
                         compiler_options.time_report, compiler_options);
             }
-            if (backend == Backend::llvm) {
+            if (backend == Backend::llvm || backend == Backend::liric) {
 #ifdef HAVE_LFORTRAN_LLVM
                 err = compile_src_to_object_file(arg_file, tmp_o, compiler_options.time_report, false,
                     compiler_options, lfortran_pass_manager, true, &found_main);

--- a/src/lfortran/CMakeLists.txt
+++ b/src/lfortran/CMakeLists.txt
@@ -63,6 +63,9 @@ target_include_directories(lfortran_lib PRIVATE $<BUILD_INTERFACE:${CMAKE_CURREN
 
 configure_file(config.h.cmakein config.h @ONLY)
 target_link_libraries(lfortran_lib asr lfortran_parser_obj lfortran_runtime_static)
+if (WITH_LIRIC)
+    target_link_libraries(lfortran_lib asr_liric)
+endif()
 
 
 if (WITH_ZLIB)

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -148,6 +148,26 @@ if (WITH_LLVM)
     target_link_libraries(asr p::llvm)
     target_link_libraries(lfortran_utils p::llvm)
 endif()
+if (WITH_LIRIC)
+    # Second compilation of codegen against liric, in namespace LCompilers_Liric
+    add_library(asr_liric STATIC
+        codegen/evaluator.cpp
+        codegen/asr_to_llvm.cpp
+        codegen/llvm_array_utils.cpp
+        codegen/llvm_utils.cpp
+        codegen/liric_bridge.cpp
+    )
+    target_include_directories(asr_liric BEFORE PUBLIC ${libasr_SOURCE_DIR}/..)
+    target_include_directories(asr_liric BEFORE PUBLIC ${libasr_BINARY_DIR}/..)
+    target_link_libraries(asr_liric lfortran_utils p::liric)
+    # Duplicate symbol resolution: liric-compiled codegen has hidden visibility,
+    # the bridge exports entry points. --allow-multiple-definition resolves
+    # duplicate symbols from double-compilation against the main asr library.
+    target_compile_options(asr_liric PRIVATE -fvisibility=hidden)
+    if (NOT MSVC)
+        target_compile_options(asr_liric PRIVATE -Wno-deprecated-declarations)
+    endif()
+endif()
 
 # Install the dwarf_convert.py and dat_convert.py
 install(

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -65,7 +65,11 @@
 #    include <llvm/Support/Host.h>
 #endif
 
+#ifndef WITH_LIRIC
 #include <libasr/codegen/KaleidoscopeJIT.h>
+#else
+#include <llvm/ExecutionEngine/Orc/KaleidoscopeJIT.h>
+#endif
 #include <libasr/codegen/evaluator.h>
 #include <libasr/codegen/asr_to_llvm.h>
 #include <libasr/codegen/asr_to_cpp.h>

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -13,7 +13,11 @@
 // Forward declare all needed LLVM classes without importing any LLVM header
 // files. Those are only imported in evaluator.cpp and nowhere else, to speed
 // up compilation.
+#ifdef WITH_LIRIC
+namespace liric_llvm {
+#else
 namespace llvm {
+#endif
     class ExecutionEngine;
     class LLVMContext;
     class Module;

--- a/src/libasr/codegen/liric_bridge.cpp
+++ b/src/libasr/codegen/liric_bridge.cpp
@@ -1,0 +1,87 @@
+// Liric backend bridge.
+// Compiled with -DLCompilers=LCompilers_Liric and liric compat headers.
+// Types from the main binary (LCompilers::*) are passed as void* and
+// reinterpret_cast to the liric-namespace equivalents (LCompilers_Liric::*).
+// This is safe because the types are layout-identical (same headers, same ABI).
+
+#include <libasr/codegen/asr_to_llvm.h>
+#include <libasr/codegen/evaluator.h>
+#include <libasr/alloc.h>
+#include <llvm/IR/Module.h>
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+#define LIRIC_EXPORT __attribute__((visibility("default")))
+
+extern "C" {
+
+LIRIC_EXPORT int liric_compile_to_object(
+    void *asr_ptr, void *diag_ptr, void *al_ptr, void *lpm_ptr,
+    void *co_ptr, const char *infile, void *lm_ptr, const char *outfile)
+{
+    // reinterpret_cast: types are ABI-identical between LCompilers and
+    // LCompilers_Liric namespaces (same headers, only namespace differs).
+    auto &asr = *reinterpret_cast<LCompilers::ASR::TranslationUnit_t*>(asr_ptr);
+    auto &diag = *reinterpret_cast<LCompilers::diag::Diagnostics*>(diag_ptr);
+    auto &al = *reinterpret_cast<Allocator*>(al_ptr);
+    auto &lpm = *reinterpret_cast<LCompilers::PassManager*>(lpm_ptr);
+    auto &co = *reinterpret_cast<LCompilers::CompilerOptions*>(co_ptr);
+    auto &lm = *reinterpret_cast<LCompilers::LocationManager*>(lm_ptr);
+
+    LCompilers::LLVMEvaluator e(co.target);
+
+    if (!LCompilers::ASRUtils::main_program_present(asr)
+        && !LCompilers::ASRUtils::global_function_present(asr)
+        && !co.separate_compilation
+        && !co.generate_code_for_global_procedures) {
+        e.create_empty_object_file(outfile);
+        liric_llvm::Module::writeEmptyObjectCompanionFiles(outfile);
+        return 0;
+    }
+
+    auto res = LCompilers::asr_to_llvm(asr, diag, e.get_context(),
+        al, lpm, co, "", "", infile ? infile : "", lm);
+    if (!res.ok) return 1;
+
+    try {
+        e.save_object_file(*(res.result->m_m), outfile);
+        res.result->m_m->emitObjectCompanionFiles(outfile);
+    } catch (const std::exception &ex) {
+        std::cerr << "liric object emission failed: " << ex.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}
+
+LIRIC_EXPORT int liric_link_executable(const char *const *object_files, int nobjects,
+    const char *outfile)
+{
+    std::vector<std::string> objects;
+    objects.reserve(nobjects);
+    for (int i = 0; i < nobjects; i++) {
+        objects.push_back(object_files[i]);
+    }
+    try {
+        liric_llvm::Module::emitExecutableFromObjects(objects, outfile);
+    } catch (const std::exception &ex) {
+        std::cerr << "liric link failed: " << ex.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}
+
+LIRIC_EXPORT const char *liric_get_version()
+{
+    static std::string v = LCompilers::LLVMEvaluator::llvm_version();
+    return v.c_str();
+}
+
+LIRIC_EXPORT const char *liric_get_default_target()
+{
+    static std::string t = LCompilers::LLVMEvaluator::get_default_target_triple();
+    return t.c_str();
+}
+
+} // extern "C"

--- a/src/libasr/codegen/liric_llvm_alias.h
+++ b/src/libasr/codegen/liric_llvm_alias.h
@@ -1,0 +1,9 @@
+#ifndef LIBASR_CODEGEN_LIRIC_LLVM_ALIAS_H
+#define LIBASR_CODEGEN_LIRIC_LLVM_ALIAS_H
+
+#ifdef WITH_LIRIC
+namespace liric_llvm {}
+namespace llvm = liric_llvm;
+#endif
+
+#endif

--- a/src/libasr/config.h.in
+++ b/src/libasr/config.h.in
@@ -12,6 +12,7 @@
 
 /* Define if LLVM is enabled */
 #cmakedefine HAVE_LFORTRAN_LLVM
+#cmakedefine HAVE_LFORTRAN_LIRIC
 #cmakedefine HAVE_LFORTRAN_MLIR
 
 /* Define if RAPIDJSON is found */


### PR DESCRIPTION
## Summary

Add `WITH_LIRIC` CMake option for [liric](https://github.com/krystophny/liric) as a lightweight LLVM-compatible backend. Both LLVM and liric can coexist in one binary with runtime `--backend=liric` / `--backend=llvm` switching.

- Codegen compiled twice: once against real LLVM, once against liric compat headers (`namespace liric_llvm`) with hidden visibility
- Liric bridge (`liric_bridge.cpp`) exposes C-linkage entry points for object emission and direct executable linking (no system linker)
- FetchContent auto-fetches liric when `LIRIC_DIR` is not set
- CI job in Quick-Checks-CI.yml

## Build

```bash
# Liric only (auto-fetch)
cmake -S . -B build -G Ninja -DWITH_LIRIC=ON -DCMAKE_BUILD_TYPE=Release

# Both backends
cmake -S . -B build -G Ninja -DWITH_LLVM=ON -DWITH_LIRIC=ON -DLIRIC_DIR=/path/to/liric
```

## Compilation Speed Benchmark

Both lfortran builds are `Release`. Compile to `.o` only (`-c`), no IR-level optimization (`--fast` not used).
Measured with `hyperfine --warmup 5 --min-runs 20 -N` on x86_64 Linux.

Note: LLVM's `TargetMachine` defaults to `CodeGenOptLevel::Default` (O2) for backend codegen
(instruction selection, register allocation, scheduling). Liric does no backend optimization.
The "LLVM O0" column patches `createTargetMachine` to `CodeGenOptLevel::None` for a fair apples-to-apples comparison.

```bash
# Benchmark commands:
LIRIC=build-liric-clean/src/bin/lfortran
LLVM=build-llvm-release/src/bin/lfortran
hyperfine --warmup 5 --min-runs 20 -N \
  -n liric "$LIRIC --backend=liric -c test.f90 -o test_liric.o" \
  -n llvm  "$LLVM -c test.f90 -o test_llvm.o"
```

| Test program | liric | LLVM (default O2 codegen) | Speedup | LLVM O0 codegen | Speedup |
|---|---|---|---|---|---|
| simple loop | 4.5 ms | 12.2 ms | **2.7x** | 10.5 ms | **2.3x** |
| array ops | 5.6 ms | 17.6 ms | **3.2x** | 12.5 ms | **2.2x** |
| recursive function | 4.6 ms | 12.4 ms | **2.7x** | 10.6 ms | **2.3x** |
| module with pure functions | 4.7 ms | 12.6 ms | **2.7x** | 10.5 ms | **2.2x** |
| matrix ops (matmul + trace) | 6.9 ms | 23.2 ms | **3.4x** | 14.2 ms | **1.9x** |

Liric codegen is **~2x faster** than LLVM even at O0, and **2.7-3.4x faster** vs LLVM's default O2 codegen.

### Test programs

<details>
<summary>bench_simple.f90</summary>

```fortran
program bench_simple
    implicit none
    integer :: i, s
    s = 0
    do i = 1, 100
        s = s + i
    end do
    print *, s
end program
```
</details>

<details>
<summary>bench_arrays.f90</summary>

```fortran
program bench_arrays
    implicit none
    integer, parameter :: n = 100
    real :: a(n), b(n), c(n)
    integer :: i
    do i = 1, n
        a(i) = real(i)
        b(i) = real(n - i + 1)
    end do
    c = a + b
    print *, c(1), c(n)
end program
```
</details>

<details>
<summary>bench_functions.f90</summary>

```fortran
program bench_functions
    implicit none
    integer :: r
    r = fibonacci(20)
    print *, r
contains
    recursive function fibonacci(n) result(fib)
        integer, intent(in) :: n
        integer :: fib
        if (n <= 1) then
            fib = n
        else
            fib = fibonacci(n-1) + fibonacci(n-2)
        end if
    end function
end program
```
</details>

<details>
<summary>bench_modules.f90</summary>

```fortran
module math_mod
    implicit none
contains
    pure function square(x) result(r)
        real, intent(in) :: x
        real :: r
        r = x * x
    end function
    pure function cube(x) result(r)
        real, intent(in) :: x
        real :: r
        r = x * x * x
    end function
end module

program bench_modules
    use math_mod
    implicit none
    real :: x, y, z
    x = 3.0
    y = square(x)
    z = cube(x)
    print *, y, z
end program
```
</details>

<details>
<summary>bench_large.f90</summary>

```fortran
module matrix_ops
    implicit none
contains
    subroutine matmul_naive(a, b, c, n)
        integer, intent(in) :: n
        real, intent(in) :: a(n,n), b(n,n)
        real, intent(out) :: c(n,n)
        integer :: i, j, k
        do j = 1, n
            do i = 1, n
                c(i,j) = 0.0
                do k = 1, n
                    c(i,j) = c(i,j) + a(i,k) * b(k,j)
                end do
            end do
        end do
    end subroutine

    real function trace(a, n)
        integer, intent(in) :: n
        real, intent(in) :: a(n,n)
        integer :: i
        trace = 0.0
        do i = 1, n
            trace = trace + a(i,i)
        end do
    end function
end module

program bench_large
    use matrix_ops
    implicit none
    integer, parameter :: n = 10
    real :: a(n,n), b(n,n), c(n,n)
    real :: t
    integer :: i, j
    do j = 1, n
        do i = 1, n
            a(i,j) = real(i + j)
            b(i,j) = real(i * j)
        end do
    end do
    call matmul_naive(a, b, c, n)
    t = trace(c, n)
    print *, t
end program
```
</details>

## Status

- Compilation to `.o` works for all test programs
- Direct executable emission (linking) needs liric runtime archive (not yet wired in this PR)
- Reference tests: partial pass (run with `|| true` in CI while coverage improves)