### PR TITLE
Memory-leak(Initial impl) : Create finalize fn for upoly types and register in type's VTable

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1908,7 +1908,7 @@ RUN(NAME select_type_37 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_DETECT_
 RUN(NAME select_type_38 LABELS gfortran llvm)
 RUN(NAME select_type_39 LABELS gfortran llvm)
 RUN(NAME select_type_40 LABELS gfortran llvm)
-RUN(NAME select_type_41 LABELS gfortran llvm)
+RUN(NAME select_type_41 LABELS gfortran llvm NO_DETECT_LEAK)
 
 RUN(NAME select_type_42 LABELS gfortran llvm)
 RUN(NAME select_type_43 LABELS gfortran llvm)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -345,6 +345,7 @@ public:
 
     SymbolTable* current_scope;
     std::unique_ptr<LLVMUtils> llvm_utils;
+    LLVMFinalize llvm_symtab_finalizer;
     std::unique_ptr<LLVMList> list_api;
     std::unique_ptr<LLVMStruct> struct_api;
     std::unique_ptr<LLVMTuple> tuple_api;
@@ -353,7 +354,6 @@ public:
     std::unique_ptr<LLVMSetInterface> set_api_lp;
     std::unique_ptr<LLVMSetInterface> set_api_sc;
     std::unique_ptr<LLVMArrUtils::Descriptor> arr_descr;
-    LLVMFinalize llvm_symtab_finalizer;
     Vec<llvm::Value*> strings_to_be_deallocated;
     Vec<llvm::Value*> heap_fixed_size_arrays;  // Heap-allocated large fixed-size arrays for cleanup
     bool in_block_context = false;  // Flag to track if we're inside a BLOCK construct
@@ -444,11 +444,12 @@ public:
         current_der_type_name, name2dertype, name2dercontext, struct_type_stack,
         dertype2parent, name2memidx, compiler_options, arr_arg_type_cache,
         fname2arg_type, llvm_symtab)),
+    llvm_symtab_finalizer(*this, llvm_utils, builder, al, llvm_symtab_fn),
     list_api(std::make_unique<LLVMList>(context, llvm_utils.get(), builder.get())),
     struct_api(std::make_unique<LLVMStruct>(context, llvm_utils.get(), builder.get(), llvm_symtab_fn,
                 [this](ASR::Struct_t* s, llvm::Value* v, ASR::ttype_t* t, bool flag) {
                         allocate_array_members_of_struct(s, v, t, flag);
-                })),
+                }, llvm_symtab_finalizer)),
     tuple_api(std::make_unique<LLVMTuple>(context, llvm_utils.get(), builder.get())),
     dict_api_lp(std::make_unique<LLVMDictOptimizedLinearProbing>(context, llvm_utils.get(), builder.get())),
     dict_api_sc(std::make_unique<LLVMDictSeparateChaining>(context, llvm_utils.get(), builder.get())),
@@ -456,8 +457,7 @@ public:
     set_api_sc(std::make_unique<LLVMSetSeparateChaining>(context, llvm_utils.get(), builder.get())),
     arr_descr(LLVMArrUtils::Descriptor::get_descriptor(context,
               builder.get(), llvm_utils.get(),
-              LLVMArrUtils::DESCR_TYPE::_SimpleCMODescriptor, compiler_options_)),
-    llvm_symtab_finalizer(*this, llvm_utils, builder, al, llvm_symtab_fn)
+              LLVMArrUtils::DESCR_TYPE::_SimpleCMODescriptor, compiler_options_))
     {
         LLVM::set_memory_debug(compiler_options.detect_leaks);
         llvm_utils->tuple_api = tuple_api.get();

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6986,6 +6986,11 @@ public:
                     builder->CreateStore(
                         llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(inner_ptr_type)),
                         struct_ptr_field);
+                } else { // Unlimited polymorphic type
+                    // Intialize type with NULL value (Zeroes)
+                    llvm::Type* const class_type = llvm_utils->getClassType(struct_t);
+                    builder->CreateStore(llvm::Constant::getNullValue(class_type), ptr);
+
                 }
             } else {
                 set_pointer_variable_to_null(v, llvm::ConstantPointerNull::get(

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3860,12 +3860,15 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
         LLVMUtils* llvm_utils_,
         llvm::IRBuilder<>* builder_, 
         std::map<uint64_t, llvm::Function*>& llvm_symtab_fn_,
-        std::function<void(ASR::Struct_t*, llvm::Value*, ASR::ttype_t*, bool)> allocate_arr_mem_struct):
+        std::function<void(ASR::Struct_t*, llvm::Value*, ASR::ttype_t*, bool)> allocate_arr_mem_struct,
+        LLVMFinalize &finalizer_instnace_):
         context(context_),
         llvm_utils(std::move(llvm_utils_)),
         builder(std::move(builder_)),
         llvm_symtab_fn(llvm_symtab_fn_), 
-        allocate_struct_array_members(allocate_arr_mem_struct){}
+        allocate_struct_array_members(allocate_arr_mem_struct),
+        finalizer_instnace(finalizer_instnace_)
+        {}
 
     LLVMDictInterface::LLVMDictInterface(llvm::LLVMContext& context_,
         LLVMUtils* llvm_utils_,
@@ -9458,11 +9461,13 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
         std::vector<llvm::Constant*> slots;
         llvm::Function* copy_function = define_intrinsic_type_copy_function(ttype, module);
         llvm::Function* allocate_function = define_intrinsic_type_allocate_function(ttype, module);
+        llvm::Function* finalize_function = finalizer_instnace.get_UPoly_finalize_fn(ttype, nullptr);
         slots.push_back(llvm::ConstantPointerNull::get(llvm_utils->i8_ptr));      // Reserved null ptr
         slots.push_back(llvm::ConstantExpr::getBitCast(intrinsic_type_info.at(
             ASRUtils::intrinsic_type_to_str_with_kind(ttype, kind)), llvm_utils->i8_ptr));  // Type Info
         slots.push_back(llvm::ConstantExpr::getBitCast(copy_function, llvm_utils->i8_ptr));
         slots.push_back(llvm::ConstantExpr::getBitCast(allocate_function, llvm_utils->i8_ptr));
+        slots.push_back(llvm::ConstantExpr::getBitCast(finalize_function, llvm_utils->i8_ptr));
 
         llvm::ArrayType *arrTy = llvm::ArrayType::get(llvm_utils->i8_ptr, slots.size());
         llvm::Constant *arrInit = llvm::ConstantArray::get(arrTy, slots);
@@ -9512,10 +9517,12 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
         llvm::Function* copy_function = define_struct_copy_function(struct_sym, module);
         // std::cout<<"Getting pointer to method for struct: "<<ASRUtils::symbol_name(struct_sym)<<std::endl;
         llvm::Function* allocate_array_members_function = define_allocate_struct_function(struct_sym, module);
+        llvm::Function* finalize_function = finalizer_instnace.get_UPoly_finalize_fn(struct_t);
         struct_vtab_function_offset[struct_sym]["_lfortran_struct_copy"] = slots.size() - 2;
         slots.push_back(llvm::ConstantExpr::getBitCast(copy_function, llvm_utils->i8_ptr));
         struct_vtab_function_offset[struct_sym]["_lfortran_allocate_struct_array_members"] = slots.size() - 2;
         slots.push_back(llvm::ConstantExpr::getBitCast(allocate_array_members_function, llvm_utils->i8_ptr));
+        slots.push_back(llvm::ConstantExpr::getBitCast(finalize_function, llvm_utils->i8_ptr));
         collect_vtable_function_impls(struct_sym, slots, module);
 
         llvm::ArrayType *arrTy = llvm::ArrayType::get(i8PtrTy, slots.size());

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -3,7 +3,11 @@
 
 #include "libasr/asr_utils.h"
 #include "libasr/assert.h"
+#include "libasr/containers.h"
 #include "libasr/exception.h"
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Type.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>
@@ -1129,6 +1133,7 @@ class ASRToLLVMVisitor;
                             // Keep unlimited polymorphic cleanup scoped to the
                             // allocatable deallocation flow to avoid finalizing
                             // aliased/non-owning class(*) values.
+            // TODO :: Remove this if block.
                             llvm::Type* const derived_llvm_type = get_llvm_type(t_past, struct_sym);
                             auto const vptr = llvm_utils_->CreateLoad2(
                                 llvm_utils_->vptr_type,
@@ -1139,12 +1144,12 @@ class ASRToLLVMVisitor;
                             auto const data_not_null = builder_->CreateICmpNE(
                                 data_ptr,
                                 llvm::ConstantPointerNull::get(llvm_utils_->i8_ptr));
-                            llvm_utils_->create_if_else(data_not_null, [this, vptr, data_ptr]() {
+                            llvm_utils_->create_if_else(data_not_null, [&]() {
                                 auto const type_tag = llvm_utils_->get_class_type_tag_from_vptr(vptr);
                                 auto const is_string = builder_->CreateICmpEQ(
                                     type_tag,
                                     llvm::ConstantInt::get(llvm::Type::getInt32Ty(builder_->getContext()), 5));
-                                llvm_utils_->create_if_else(is_string, [this, data_ptr]() {
+                                llvm_utils_->create_if_else(is_string, [&]() {
                                     auto const str_desc = builder_->CreateBitCast(
                                         data_ptr, llvm_utils_->string_descriptor->getPointerTo());
                                     auto const char_ptr = llvm_utils_->CreateLoad2(
@@ -1156,7 +1161,7 @@ class ASRToLLVMVisitor;
                                     llvm_utils_->create_if_else(char_not_null,
                                         [this, char_ptr]() { llvm_utils_->lfortran_free_nocheck(char_ptr); },
                                         [](){});
-                                }, [](){});
+                                }, [&](){finalize(ptr, t_past, struct_sym, in_struct);});
                                 llvm_utils_->lfortran_free_nocheck(data_ptr);
                             }, [](){});
                         } else {
@@ -1428,16 +1433,29 @@ class ASRToLLVMVisitor;
                 return;
             }
 
+            if (ASRUtils::is_class_type(t) && ASRUtils::is_unlimited_polymorphic_type(struct_sym)) {
+                // Call finalizer from VTable
+                llvm::Type* const uPoly_llvm_t = get_llvm_type(t, struct_sym);
+                llvm::FunctionType* const finalizer_fn_type = llvm::FunctionType::get(
+                    llvm::Type::getVoidTy(builder_->getContext()), {llvm_utils_->i8_ptr}, false);
+                llvm::Value* const dispatch_table = llvm_utils_->CreateLoad2(llvm_utils_->vptr_type,
+                                                llvm_utils_->create_gep2(uPoly_llvm_t, ptr, 0));
+                llvm::FunctionType const *fnTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(builder_->getContext()), {}, true);
+                llvm::Value* const finalizer_fn_i8ptr = llvm_utils_->CreateLoad2(
+                                                    llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
+                                                    llvm_utils_->CreateInBoundsGEP2(fnTy->getPointerTo(), dispatch_table, 
+                                                        {llvm::ConstantInt::get(llvm::Type::getInt32Ty(builder_->getContext()), 2, false)}));
+                llvm::Value* const finalizer_fn = builder_->CreateBitCast(finalizer_fn_i8ptr, finalizer_fn_type->getPointerTo());
+
+                llvm::Value* const data = llvm_utils_->CreateLoad2(llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
+                                llvm_utils_->create_gep2(uPoly_llvm_t, ptr, 1));
+                builder_->CreateCall(finalizer_fn_type, finalizer_fn, {data});
+                return;
+            } 
+
             const auto checkPoint_BB = 
             START_CACHE(cache_key, ptr);
-
-            if (ASRUtils::is_class_type(t) &&
-                    !ASRUtils::is_unlimited_polymorphic_type(struct_sym)) {
-                llvm::Type* const derived_llvm_type = get_llvm_type(t, struct_sym);
-                ptr = llvm_utils_->CreateLoad2(
-                    llvm_utils_->getStructType(struct_sym, llvm_utils_->module, true),
-                    llvm_utils_->create_gep2(derived_llvm_type, ptr, 1));
-            } else if (ASRUtils::is_class_type(t)) {
+            if (ASRUtils::is_class_type(t) && !ASRUtils::is_unlimited_polymorphic_type(struct_sym)) {
                 // {VTable*, struct*} -- Fetch struct
                 llvm::Type* const derived_llvm_type = get_llvm_type(t, struct_sym);
                 ptr = llvm_utils_->CreateLoad2(
@@ -2034,7 +2052,6 @@ class ASRToLLVMVisitor;
                 case ASR::Logical:
                     return false;
                 case ASR::StructType:{
-                    if(ASRUtils::is_unlimited_polymorphic_type(struct_sym)) { return false; /*Handled in allocatable cleanup flow*/ }
                     ASR::StructType_t* struc_t = ASR::down_cast<ASR::StructType_t>(t);
                     bool finalizable_struct = false;
                     finalizable_struct |= struc_t->m_is_unlimited_polymorphic;
@@ -2303,6 +2320,38 @@ class ASRToLLVMVisitor;
             check_all_caches_done_properly();
         }
 
+        llvm::Function* get_UPoly_finalize_fn(ASR::Struct_t* const struct_sym){
+            ASR::StructType_t* const struct_t = ASR::down_cast<ASR::StructType_t>(struct_sym->m_struct_signature);
+            return get_UPoly_finalize_fn(&struct_t->base, struct_sym);
+        }
+        llvm::Function* get_UPoly_finalize_fn(ASR::ttype_t* const type, ASR::Struct_t* const struct_sym){
+            const std::string cache_key = get_type_key(type, struct_sym)+"_for_UPoly";
+            if(is_cached(cache_key)){
+                return type_finalizer_cache_[cache_key];
+            }
+            /* Create function with agnostic argument type `i8*`*/
+            /* It will convert i8* to the appropriate type to operate on */
+
+            auto *const fn_type = llvm::FunctionType::get(
+                llvm::Type::getVoidTy(builder_->getContext()),
+                {llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo()}, false); /* void fn(i8* %ptr) */ 
+            auto *const fn = llvm::Function::Create(fn_type,
+                llvm::Function::InternalLinkage, "finalize_"+cache_key, llvm_utils_->module);
+            type_finalizer_cache_[cache_key] = fn;            
+                
+                
+            llvm::BasicBlock *const saved_BB = builder_->GetInsertBlock();
+            LCOMPILERS_ASSERT(saved_BB)
+            llvm::BasicBlock *const entry = llvm::BasicBlock::Create(builder_->getContext(), "entry", fn);
+            builder_->SetInsertPoint(entry);
+            // Convert the pointer to the appropiate type
+            // Go and finalize.
+
+            // Set terminal block + Revert
+            builder_->CreateRetVoid();
+            builder_->SetInsertPoint(saved_BB);
+            return fn;
+        }
     };
 
     class LLVMList {
@@ -2426,6 +2475,7 @@ class ASRToLLVMVisitor;
             std::map<ASR::symbol_t*, llvm::Type*> newclass2vtabtype;
             std::map<uint64_t, llvm::Function*>& llvm_symtab_fn;
             std::function<void(ASR::Struct_t*, llvm::Value*, ASR::ttype_t*, bool)> allocate_struct_array_members;
+            LLVMFinalize &finalizer_instnace;
 
         public:
             std::map<ASR::symbol_t*, llvm::Constant*> newclass2vtab;
@@ -2437,9 +2487,11 @@ class ASRToLLVMVisitor;
 
             LLVMStruct(llvm::LLVMContext& context_, LLVMUtils* llvm_utils,
                      llvm::IRBuilder<>* builder, std::map<uint64_t, llvm::Function*>& llvm_symtab_fn_,
-                      std::function<void(ASR::Struct_t*, llvm::Value*, ASR::ttype_t*, bool)> allocate_arr_mem_struct);
+                      std::function<void(ASR::Struct_t*, llvm::Value*, ASR::ttype_t*, bool)> allocate_arr_mem_struct,
+                      LLVMFinalize &finalizer_instance_);
     
             llvm::Constant* get_pointer_to_method(ASR::symbol_t* struct_sym, llvm::Module* module);
+            llvm::Function* get_Upoly_finalize_fn(ASR::Struct_t* struct_sym, llvm::Value* upoly_ptr);
             void store_class_vptr(ASR::symbol_t* struct_sym, llvm::Value* ptr, llvm::Module* module);
             void store_class_struct(ASR::Struct_t* class_sym, llvm::Value* class_ptr, llvm::Value* struct_ptr);
             void store_intrinsic_type_vptr(ASR::ttype_t* ttype, int kind, llvm::Value* ptr, llvm::Module* module);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -3,11 +3,7 @@
 
 #include "libasr/asr_utils.h"
 #include "libasr/assert.h"
-#include "libasr/containers.h"
 #include "libasr/exception.h"
-#include <llvm/IR/DerivedTypes.h>
-#include <llvm/IR/Function.h>
-#include <llvm/IR/Type.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>
@@ -1440,16 +1436,19 @@ class ASRToLLVMVisitor;
                     llvm::Type::getVoidTy(builder_->getContext()), {llvm_utils_->i8_ptr}, false);
                 llvm::Value* const dispatch_table = llvm_utils_->CreateLoad2(llvm_utils_->vptr_type,
                                                 llvm_utils_->create_gep2(uPoly_llvm_t, ptr, 0));
-                llvm::FunctionType const *fnTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(builder_->getContext()), {}, true);
-                llvm::Value* const finalizer_fn_i8ptr = llvm_utils_->CreateLoad2(
-                                                    llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
-                                                    llvm_utils_->CreateInBoundsGEP2(fnTy->getPointerTo(), dispatch_table, 
-                                                        {llvm::ConstantInt::get(llvm::Type::getInt32Ty(builder_->getContext()), 2, false)}));
-                llvm::Value* const finalizer_fn = builder_->CreateBitCast(finalizer_fn_i8ptr, finalizer_fn_type->getPointerTo());
+                
+                check_if_allocated_then_finalize(dispatch_table, llvm_utils_->vptr_type,[&](){
+                    llvm::FunctionType const *fnTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(builder_->getContext()), {}, true);
+                    llvm::Value* const finalizer_fn_i8ptr = llvm_utils_->CreateLoad2(
+                                                        llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
+                                                        llvm_utils_->CreateInBoundsGEP2(fnTy->getPointerTo(), dispatch_table, 
+                                                            {llvm::ConstantInt::get(llvm::Type::getInt32Ty(builder_->getContext()), 2, false)}));
+                    llvm::Value* const finalizer_fn = builder_->CreateBitCast(finalizer_fn_i8ptr, finalizer_fn_type->getPointerTo());
 
-                llvm::Value* const data = llvm_utils_->CreateLoad2(llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
-                                llvm_utils_->create_gep2(uPoly_llvm_t, ptr, 1));
-                builder_->CreateCall(finalizer_fn_type, finalizer_fn, {data});
+                    llvm::Value* const data = llvm_utils_->CreateLoad2(llvm::Type::getInt8Ty(builder_->getContext())->getPointerTo(),
+                                    llvm_utils_->create_gep2(uPoly_llvm_t, ptr, 1));
+                    builder_->CreateCall(finalizer_fn_type, finalizer_fn, {data});
+                });
                 return;
             } 
 
@@ -1670,6 +1669,7 @@ class ASRToLLVMVisitor;
             verify(data_ptr, expected_data_ptr_type);
             switch(data_type->type){
                 case ASR::StructType :{ // Loop and free
+                    if(ASRUtils::is_unlimited_polymorphic_type(struct_sym)){return;} // TODO
                     const std::string cache_key = "array_data_"+get_type_key(data_type, struct_sym);
                     llvm::Value* arr_size  = array_size();
                     if(is_cached(cache_key)){
@@ -1851,11 +1851,30 @@ class ASRToLLVMVisitor;
             return builder_->CreateCall(fn, fixed_args);
         }
 
-        /// Takes a finalization process and wrap it in allocated or not check to avoid nullptr dereference.
+        /**
+          * Takes a finalization process and wrap it in allocated or not check to avoid nullptr dereference.
+          * @param ptr pointer to SSA value that needs to be checked
+          * @param t ASR type reflecting the SSA value type
+          * @param struct_sym current struct if `t` is a StructType or related to a structtype (e.g. array of structs)
+          * @param fin the finalization process that will be executed if (allocated == TRUE)
+          */ 
+         
+         template <typename finProcess>
+         void check_if_allocated_then_finalize(llvm::Value* const ptr, ASR::ttype_t* const t, ASR::Struct_t* const struct_sym, finProcess fin){
+             auto const null_ptr_const = llvm::ConstantPointerNull::get(
+                 get_llvm_type(ASRUtils::type_get_past_allocatable_pointer(t), struct_sym)->getPointerTo());
+            llvm_utils_->create_if_else(builder_->CreateICmpNE(ptr, null_ptr_const), fin, [](){}, "is_allocated");
+        }
+        /**
+         * Takes a finalization process and wrap it in allocated or not check to avoid nullptr dereference.
+         * @param ptr pointer to SSA value that needs to be checked
+         * @param t llvm type of ptr.
+         * @param fin the finalization process that will be executed if (allocated == TRUE)
+         */ 
         template <typename finProcess>
-        void check_if_allocated_then_finalize(llvm::Value* const ptr, ASR::ttype_t* const t, ASR::Struct_t* const struct_sym, finProcess fin){
-            auto const null_ptr_const = llvm::ConstantPointerNull::get(
-                                            get_llvm_type(ASRUtils::type_get_past_allocatable_pointer(t), struct_sym)->getPointerTo());
+        void check_if_allocated_then_finalize(llvm::Value* const ptr, llvm::Type* const t, finProcess fin){
+            LCOMPILERS_ASSERT_MSG(t->isPointerTy(), "Expected a pointer type")
+            auto const null_ptr_const = llvm::ConstantPointerNull::get(llvm::dyn_cast<llvm::PointerType>(t));
             llvm_utils_->create_if_else(builder_->CreateICmpNE(ptr, null_ptr_const), fin, [](){}, "is_allocated");
         }
 

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "ce009d35ac5a3fca627069abdc1ef3c0cec3d5192928fa5c3331315d",
+    "stdout_hash": "7729336ba9c435078dd8632aec7839df23f096509d3fc0ec92d86272",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -17,7 +17,7 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_mytype = private unnamed_addr constant [7 x i8] c"mytype\00", align 1
 @_Type_Info_mytype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_mytype, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_mytype = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_mytype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (%module_call_subroutine_without_type_01.mytype_class*)* @__module_module_call_subroutine_without_type_01_get_i to i8*)] }, align 8
+@_VTable_mytype = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_mytype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__mytype_of_module_call_subroutine_without_type_01_for_UPoly to i8*), i8* bitcast (void (%module_call_subroutine_without_type_01.mytype_class*)* @__module_module_call_subroutine_without_type_01_get_i to i8*)] }, align 8
 @4 = private unnamed_addr constant [4 x i8] c"obj\00", align 1
 @5 = private unnamed_addr constant [63 x i8] c"tests/../integration_tests/call_subroutine_without_type_01.f90\00", align 1
 @6 = private unnamed_addr constant [22 x i8] c"'%s' unallocated here\00", align 1
@@ -171,7 +171,7 @@ define i32 @main(i32 %0, i8** %1) {
   store %module_call_subroutine_without_type_01.mytype* %10, %module_call_subroutine_without_type_01.mytype** %9, align 8
   %11 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %9, align 8
   %12 = bitcast %module_call_subroutine_without_type_01.mytype_class* %7 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
   %13 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %11, i32 0, i32 0
   %14 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
   %15 = ptrtoint %module_call_subroutine_without_type_01.mytype_class* %14 to i64
@@ -252,7 +252,7 @@ ifcont2:                                          ; preds = %ifcont
   %55 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
   %56 = bitcast %module_call_subroutine_without_type_01.mytype_class* %55 to void (%module_call_subroutine_without_type_01.mytype_class*)***
   %57 = load void (%module_call_subroutine_without_type_01.mytype_class*)**, void (%module_call_subroutine_without_type_01.mytype_class*)*** %56, align 8
-  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %57, i32 2
+  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %57, i32 3
   %59 = load void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %58, align 8
   call void %59(%module_call_subroutine_without_type_01.mytype_class* %55)
   br label %return
@@ -301,7 +301,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %module_call_subroutine_without_type_01.mytype_class*
   %5 = bitcast %module_call_subroutine_without_type_01.mytype_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -309,6 +309,11 @@ entry:
   %9 = bitcast i8* %8 to %module_call_subroutine_without_type_01.mytype*
   store %module_call_subroutine_without_type_01.mytype* %9, %module_call_subroutine_without_type_01.mytype** %6, align 8
   %10 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__mytype_of_module_call_subroutine_without_type_01_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "c7bf6167bd90d11d2efc8703e45c9007d7a116e5aa2f3302b8284034",
+    "stdout_hash": "1d559db32e670ec253bf4a196c6b9542c3019a3c69df006fb4144ae6",
     "stderr": "llvm-class_01-82031c0.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -9,7 +9,7 @@ target datalayout = "..."
 @__module_class_circle1_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (float (%class_circle1.circle_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_of_class_circle1_for_UPoly to i8*), i8* bitcast (float (%class_circle1.circle_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
@@ -46,7 +46,7 @@ define void @__module_class_circle1_circle_print(%class_circle1.circle_class* %t
   %area = alloca float, align 4
   %1 = bitcast %class_circle1.circle_class* %this to float (%class_circle1.circle_class*)***
   %2 = load float (%class_circle1.circle_class*)**, float (%class_circle1.circle_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %2, i32 2
+  %3 = getelementptr inbounds float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %2, i32 3
   %4 = load float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %3, align 8
   %5 = call float %4(%class_circle1.circle_class* %this)
   store float %5, float* %area, align 4
@@ -115,7 +115,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %class_circle1.circle_class*
   %5 = bitcast %class_circle1.circle_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -123,6 +123,11 @@ entry:
   %9 = bitcast i8* %8 to %class_circle1.circle*
   store %class_circle1.circle* %9, %class_circle1.circle** %6, align 8
   %10 = getelementptr %class_circle1.circle, %class_circle1.circle* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__circle_of_class_circle1_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -149,14 +154,14 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = getelementptr %class_circle1.circle, %class_circle1.circle* %c, i32 0, i32 0
   store float 1.500000e+00, float* %5, align 4
   %6 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %3, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
   %7 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %3, i32 0, i32 1
   store %class_circle1.circle* %c, %class_circle1.circle** %7, align 8
   call void @__module_class_circle1_circle_print(%class_circle1.circle_class* %3)
   %8 = getelementptr %class_circle1.circle, %class_circle1.circle* %c, i32 0, i32 0
   store float 2.000000e+00, float* %8, align 4
   %9 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %9, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %9, align 8
   %10 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %2, i32 0, i32 1
   store %class_circle1.circle* %c, %class_circle1.circle** %10, align 8
   call void @__module_class_circle1_circle_print(%class_circle1.circle_class* %2)

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "1cf6107962db50e8e66ffdfe98432939662d4a8bee0472caf867aa85",
+    "stdout_hash": "56d30d960439f255300750649a0fd13ba89a3e49ee67a17a6c9deb29",
     "stderr": "llvm-class_02-82c2f9c.stderr",
     "stderr_hash": "cbe4c6f9d712b9d5ee417de42e2ce3b69d43ea5a0b463256ad71acfe",
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -9,7 +9,7 @@ target datalayout = "..."
 @__module_class_circle2_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (float (%class_circle2.circle_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_of_class_circle2_for_UPoly to i8*), i8* bitcast (float (%class_circle2.circle_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
@@ -46,7 +46,7 @@ define void @__module_class_circle2_circle_print(%class_circle2.circle_class* %t
   %area = alloca float, align 4
   %1 = bitcast %class_circle2.circle_class* %this to float (%class_circle2.circle_class*)***
   %2 = load float (%class_circle2.circle_class*)**, float (%class_circle2.circle_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %2, i32 2
+  %3 = getelementptr inbounds float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %2, i32 3
   %4 = load float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %3, align 8
   %5 = call float %4(%class_circle2.circle_class* %this)
   store float %5, float* %area, align 4
@@ -96,7 +96,7 @@ define void @__module_class_circle2__xx_lcompilers_changed_main_xx() {
   %3 = getelementptr %class_circle2.circle, %class_circle2.circle* %c, i32 0, i32 0
   store float 1.500000e+00, float* %3, align 4
   %4 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %0, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
   %5 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %0, i32 0, i32 1
   store %class_circle2.circle* %c, %class_circle2.circle** %5, align 8
   call void @__module_class_circle2_circle_print(%class_circle2.circle_class* %0)
@@ -138,7 +138,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %class_circle2.circle_class*
   %5 = bitcast %class_circle2.circle_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -146,6 +146,11 @@ entry:
   %9 = bitcast i8* %8 to %class_circle2.circle*
   store %class_circle2.circle* %9, %class_circle2.circle** %6, align 8
   %10 = getelementptr %class_circle2.circle, %class_circle2.circle* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__circle_of_class_circle2_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "57c0c1b9ae2bece38c9bd70e25934251600d2473edfc9192c501632f",
+    "stdout_hash": "7274c8dbaf4a07b57106db26069df9d01258519115912aa8aee264b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -8,7 +8,7 @@ target datalayout = "..."
 
 @_Name_base = private unnamed_addr constant [5 x i8] c"base\00", align 1
 @_Type_Info_base = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @_Name_base, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_base = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_base to i8*), i8* bitcast (void (i8*, i8*)* @_copy_xx_base to i8*), i8* bitcast (void (i8**)* @_allocate_struct_xx_base to i8*), i8* bitcast (void (%xx.base_class*)* @__module_xx_show_x to i8*)] }, align 8
+@_VTable_base = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_base to i8*), i8* bitcast (void (i8*, i8*)* @_copy_xx_base to i8*), i8* bitcast (void (i8**)* @_allocate_struct_xx_base to i8*), i8* bitcast (void (i8*)* @finalize_StructType__base_of_xx_for_UPoly to i8*), i8* bitcast (void (%xx.base_class*)* @__module_xx_show_x to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -42,7 +42,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
   store i32 10, i32* %5, align 4
   %6 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
   %7 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 1
   store %xx.base* %b, %xx.base** %7, align 8
   call void @__module_xx_show_x(%xx.base_class* %3)
@@ -127,7 +127,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %xx.base_class*
   %5 = bitcast %xx.base_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %xx.base_class, %xx.base_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -135,6 +135,11 @@ entry:
   %9 = bitcast i8* %8 to %xx.base*
   store %xx.base* %9, %xx.base** %6, align 8
   %10 = getelementptr %xx.base, %xx.base* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__base_of_xx_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-classes2-f926d51.json
+++ b/tests/reference/llvm-classes2-f926d51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes2-f926d51.stdout",
-    "stdout_hash": "5c3961f5cf5a2a973a34681c3b78ddd21b51156fa5eddcaa35df85f7",
+    "stdout_hash": "dc2ca9f6cc2565c54f087b2a86e3fd8da7bd3b3d73e55a369416a5d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes2-f926d51.stdout
+++ b/tests/reference/llvm-classes2-f926d51.stdout
@@ -9,10 +9,10 @@ target datalayout = "..."
 
 @_Name_point = private unnamed_addr constant [6 x i8] c"point\00", align 1
 @_Type_Info_point = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_point, i32 0, i32 0), i8* null, i8* null }, align 8
-@_VTable_point = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point to i8*), i8* null] }, align 8
+@_VTable_point = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point_of_defs_for_UPoly to i8*), i8* null] }, align 8
 @_Name_point2d = private unnamed_addr constant [8 x i8] c"point2d\00", align 1
 @_Type_Info_point2d = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_Name_point2d, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*) }, align 8
-@_VTable_point2d = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point2d to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point2d to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point2d to i8*), i8* bitcast (float (%defs.point2d_class*)* @__module_defs_r2d to i8*)] }, align 8
+@_VTable_point2d = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point2d to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point2d to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point2d to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point2d_of_defs_for_UPoly to i8*), i8* bitcast (float (%defs.point2d_class*)* @__module_defs_r2d to i8*)] }, align 8
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -79,14 +79,14 @@ else:                                             ; preds = %.entry
 ifcont:                                           ; preds = %else, %then
   %13 = load %defs.point_class*, %defs.point_class** %ptr, align 8
   %14 = bitcast %defs.point_class* %13 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
   %15 = getelementptr %defs.point_class, %defs.point_class* %13, i32 0, i32 1
   %16 = bitcast %defs.point2d* %p2d to %defs.point*
   store %defs.point* %16, %defs.point** %15, align 8
   %17 = load %defs.point_class*, %defs.point_class** %ptr, align 8
   %18 = bitcast %defs.point_class* %17 to float (%defs.point_class*)***
   %19 = load float (%defs.point_class*)**, float (%defs.point_class*)*** %18, align 8
-  %20 = getelementptr inbounds float (%defs.point_class*)*, float (%defs.point_class*)** %19, i32 2
+  %20 = getelementptr inbounds float (%defs.point_class*)*, float (%defs.point_class*)** %19, i32 3
   %21 = load float (%defs.point_class*)*, float (%defs.point_class*)** %20, align 8
   %22 = call float %21(%defs.point_class* %17)
   store float %22, float* %res, align 4
@@ -155,13 +155,18 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %defs.point_class*
   %5 = bitcast %defs.point_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_point, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %defs.point_class, %defs.point_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
   %9 = bitcast i8* %8 to %defs.point*
   store %defs.point* %9, %defs.point** %6, align 8
+  ret void
+}
+
+define internal void @finalize_StructType__point_of_defs_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -209,7 +214,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %defs.point2d_class*
   %5 = bitcast %defs.point2d_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %defs.point2d_class, %defs.point2d_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
@@ -219,6 +224,11 @@ entry:
   %10 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 1
   %11 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 2
   %12 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__point2d_of_defs_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "fd8f90c9b5b51f6571060039ad451b68fa368e140b7f68282b1b8462",
+    "stdout_hash": "7a027cb91b73d77f93130ae2e6ad55548bdbe31ae7ef976761b65052",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -16,7 +16,7 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_complextype = private unnamed_addr constant [12 x i8] c"complextype\00", align 1
 @_Type_Info_complextype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_Name_complextype, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* null }, align 8
-@_VTable_complextype = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_complextype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_complex_module_complextype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_complex_module_complextype to i8*), i8* bitcast (void (%complex_module.complextype_class*, i32*, i32*, %complex_module.complextype*)* @__module_complex_module_integer_add_subrout to i8*), i8* bitcast (void (%complex_module.complextype_class*, float*, float*, %complex_module.complextype*)* @__module_complex_module_real_add_subrout to i8*)] }, align 8
+@_VTable_complextype = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_complextype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_complex_module_complextype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_complex_module_complextype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__complextype_of_complex_module_for_UPoly to i8*), i8* bitcast (void (%complex_module.complextype_class*, i32*, i32*, %complex_module.complextype*)* @__module_complex_module_integer_add_subrout to i8*), i8* bitcast (void (%complex_module.complextype_class*, float*, float*, %complex_module.complextype*)* @__module_complex_module_real_add_subrout to i8*)] }, align 8
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [6 x i8] c"R4,R4\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -132,7 +132,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = load float, float* %fptwo, align 4
   store float %12, float* %11, align 4
   %13 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
   %14 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 1
   store %complex_module.complextype* %c, %complex_module.complextype** %14, align 8
   call void @__module_complex_module_integer_add_subrout(%complex_module.complextype_class* %4, i32* %ione, i32* %izero, %complex_module.complextype* %a)
@@ -196,7 +196,7 @@ else2:                                            ; preds = %ifcont
 
 ifcont3:                                          ; preds = %else2, %then1
   %38 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %38, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %38, align 8
   %39 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 1
   store %complex_module.complextype* %c, %complex_module.complextype** %39, align 8
   call void @__module_complex_module_real_add_subrout(%complex_module.complextype_class* %2, float* %fpzero, float* %negfpone, %complex_module.complextype* %a)
@@ -313,7 +313,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %complex_module.complextype_class*
   %5 = bitcast %complex_module.complextype_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
@@ -322,6 +322,11 @@ entry:
   store %complex_module.complextype* %9, %complex_module.complextype** %6, align 8
   %10 = getelementptr %complex_module.complextype, %complex_module.complextype* %9, i32 0, i32 1
   %11 = getelementptr %complex_module.complextype, %complex_module.complextype* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__complextype_of_complex_module_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,11 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
+<<<<<<< HEAD
     "stdout_hash": "5ade4631a225f27af4e00380ab612cc59ecc7bcf29dae679a860ebb7",
+=======
+    "stdout_hash": "63d1a3b6ac44fbacee6fa913bc56d330980c1290d2944c55ad511cac",
+>>>>>>> e701dc0177 (Initial Fix : Create finalize fn for upoly types and register in VTable)
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,11 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-<<<<<<< HEAD
-    "stdout_hash": "5ade4631a225f27af4e00380ab612cc59ecc7bcf29dae679a860ebb7",
-=======
-    "stdout_hash": "63d1a3b6ac44fbacee6fa913bc56d330980c1290d2944c55ad511cac",
->>>>>>> e701dc0177 (Initial Fix : Create finalize fn for upoly types and register in VTable)
+    "stdout_hash": "68ad00878d0075bb37c2f78d42848cdf967bab33b706f29eec5b5965",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -34,10 +34,10 @@ target datalayout = "..."
 @21 = private unnamed_addr constant [118 x i8] c"Runtime error: Array '%s' index out of bounds. Tried to access index %d of dimension %d, but valid range is %d to %d.\00", align 1
 @_Name_fpm_build_settings = private unnamed_addr constant [19 x i8] c"fpm_build_settings\00", align 1
 @_Type_Info_fpm_build_settings = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([19 x i8], [19 x i8]* @_Name_fpm_build_settings, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_fpm_build_settings = linkonce_odr unnamed_addr constant { [4 x i8*] } { [4 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_build_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings to i8*)] }, align 8
+@_VTable_fpm_build_settings = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_build_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings to i8*), i8* bitcast (void (i8*)* @finalize_StructType__fpm_build_settings_of_modules_36_fpm_main_01_for_UPoly to i8*)] }, align 8
 @_Name_fpm_run_settings = private unnamed_addr constant [17 x i8] c"fpm_run_settings\00", align 1
 @_Type_Info_fpm_run_settings = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([17 x i8], [17 x i8]* @_Name_fpm_run_settings, i32 0, i32 0), i8* inttoptr (i64 56 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*) }, align 8
-@_VTable_fpm_run_settings = linkonce_odr unnamed_addr constant { [4 x i8*] } { [4 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_run_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings to i8*)] }, align 8
+@_VTable_fpm_run_settings = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_run_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8*)* @finalize_StructType__fpm_run_settings_of_modules_36_fpm_main_01_for_UPoly to i8*)] }, align 8
 
 define i32 @_lcompilers_Any_4_1_0_logical____0(i32* %mask, i32* %__1mask) {
 .entry:
@@ -492,7 +492,7 @@ define i32 @main(i32 %0, i8** %1) {
   %20 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %19, i32 0, i32 0
   store i32 0, i32* %20, align 4
   %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %21, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %21, align 8
   %22 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %2, i32 0, i32 1
   store %modules_36_fpm_main_01.fpm_run_settings* %settings, %modules_36_fpm_main_01.fpm_run_settings** %22, align 8
   store i32 1, i32* %call_arg_value, align 4
@@ -544,7 +544,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_build_settings_class*
   %5 = bitcast %modules_36_fpm_main_01.fpm_build_settings_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_fpm_build_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_build_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings_class, %modules_36_fpm_main_01.fpm_build_settings_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -553,6 +553,11 @@ entry:
   store %modules_36_fpm_main_01.fpm_build_settings* %9, %modules_36_fpm_main_01.fpm_build_settings** %6, align 8
   %10 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %9, i32 0, i32 0
   store i32 0, i32* %10, align 4
+  ret void
+}
+
+define internal void @finalize_StructType__fpm_build_settings_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -652,7 +657,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_run_settings_class*
   %5 = bitcast %modules_36_fpm_main_01.fpm_run_settings_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 56)
@@ -687,6 +692,11 @@ entry:
   %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 0
   %27 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %26, i32 0, i32 0
   store i32 0, i32* %27, align 4
+  ret void
+}
+
+define internal void @finalize_StructType__fpm_run_settings_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "294e29cba60bebf370a27ad3ac1f9ac542e2fe76674230b895aeda92",
+    "stdout_hash": "66c7301286d24e9d9f9035f847dd75d43eb03559e3f5f785f1e0f556",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -12,13 +12,13 @@ target datalayout = "..."
 
 @_Name_shape = private unnamed_addr constant [6 x i8] c"shape\00", align 1
 @_Type_Info_shape = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_shape, i32 0, i32 0), i8* null, i8* null }, align 8
-@_VTable_shape = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_shape to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_shape to i8*), i8* null] }, align 8
+@_VTable_shape = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_shape to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_shape to i8*), i8* bitcast (void (i8*)* @finalize_StructType__shape_of_select_type_13_module_for_UPoly to i8*), i8* null] }, align 8
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_circle to i8*), i8* bitcast (float (%select_type_13_module.circle_class*)* @__module_select_type_13_module_circle_area to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.circle_class*)* @__module_select_type_13_module_circle_area to i8*)] }, align 8
 @_Name_rectangle = private unnamed_addr constant [10 x i8] c"rectangle\00", align 1
 @_Type_Info_rectangle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([10 x i8], [10 x i8]* @_Name_rectangle, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_rectangle = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_rectangle to i8*), i8* bitcast (float (%select_type_13_module.rectangle_class*)* @__module_select_type_13_module_rectangle_area to i8*)] }, align 8
+@_VTable_rectangle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__rectangle_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.rectangle_class*)* @__module_select_type_13_module_rectangle_area to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [20 x i8] c"Matched as rectangle"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* @string_const_data, i32 0, i32 0), i64 20 }>
@@ -165,7 +165,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = load %select_type_13_module.shape*, %select_type_13_module.shape** %9, align 8
   %12 = bitcast %select_type_13_module.shape* %11 to %select_type_13_module.circle*
   %13 = bitcast %select_type_13_module.shape_class* %7 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
   %14 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %12, i32 0, i32 1
   %15 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %12, i32 0, i32 0
   %16 = alloca i1, align 1
@@ -179,7 +179,7 @@ then:                                             ; preds = %ifcont
 
 then1:                                            ; preds = %.entry
   %20 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %20, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %20, align 8
   %21 = bitcast i32 (...)*** %20 to i8*
   %22 = call i8* @__lfortran_dynamic_cast(i8* %21, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
   %23 = icmp ne i8* %22, null
@@ -222,7 +222,7 @@ then3:                                            ; preds = %ifcont6
 
 then4:                                            ; preds = %else2
   %34 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %34, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %34, align 8
   %35 = bitcast i32 (...)*** %34 to i8*
   %36 = call i8* @__lfortran_dynamic_cast(i8* %35, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
   %37 = icmp ne i8* %36, null
@@ -453,7 +453,7 @@ ifcont17:                                         ; preds = %"FINALIZE_SYMTABLE_
   %147 = load %select_type_13_module.shape*, %select_type_13_module.shape** %145, align 8
   %148 = bitcast %select_type_13_module.shape* %147 to %select_type_13_module.rectangle*
   %149 = bitcast %select_type_13_module.shape_class* %143 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %149, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %149, align 8
   %150 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 1
   %151 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 2
   %152 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 0
@@ -468,7 +468,7 @@ then18:                                           ; preds = %ifcont21
 
 then19:                                           ; preds = %ifcont17
   %157 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %157, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %157, align 8
   %158 = bitcast i32 (...)*** %157 to i8*
   %159 = call i8* @__lfortran_dynamic_cast(i8* %158, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
   %160 = icmp ne i8* %159, null
@@ -511,7 +511,7 @@ then23:                                           ; preds = %ifcont26
 
 then24:                                           ; preds = %else22
   %171 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %171, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %171, align 8
   %172 = bitcast i32 (...)*** %171 to i8*
   %173 = call i8* @__lfortran_dynamic_cast(i8* %172, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
   %174 = icmp ne i8* %173, null
@@ -919,13 +919,18 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %select_type_13_module.shape_class*
   %5 = bitcast %select_type_13_module.shape_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
   %9 = bitcast i8* %8 to %select_type_13_module.shape*
   store %select_type_13_module.shape* %9, %select_type_13_module.shape** %6, align 8
+  ret void
+}
+
+define internal void @finalize_StructType__shape_of_select_type_13_module_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -960,7 +965,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %select_type_13_module.circle_class*
   %5 = bitcast %select_type_13_module.circle_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
@@ -969,6 +974,11 @@ entry:
   store %select_type_13_module.circle* %9, %select_type_13_module.circle** %6, align 8
   %10 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 1
   %11 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__circle_of_select_type_13_module_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -1016,7 +1026,7 @@ entry:
   %3 = load i8*, i8** %0, align 8
   %4 = bitcast i8* %3 to %select_type_13_module.rectangle_class*
   %5 = bitcast %select_type_13_module.rectangle_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
   %6 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
@@ -1026,6 +1036,11 @@ entry:
   %10 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 1
   %11 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 2
   %12 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 0
+  ret void
+}
+
+define internal void @finalize_StructType__rectangle_of_select_type_13_module_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "242cf3ad365daf8925bcb762f4a72b84d2c53c2843b8be8d5793a14a",
+    "stdout_hash": "d47fb0f564096db1f02ee193c6ee3e8b1833b8ff63ebd9fc20f8478e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "d47fb0f564096db1f02ee193c6ee3e8b1833b8ff63ebd9fc20f8478e",
+    "stdout_hash": "d611aeaf43669199b4bcdc372b996a9c85c7aee1677d92505bc44523",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -213,7 +213,7 @@ define internal void @"finalize_allocatable__StructType_Class__~unlimited_polymo
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
   %2 = icmp ne %"~unlimited_polymorphic_type"* %0, null
-  br i1 %2, label %is_allocated.then, label %is_allocated.else
+  br i1 %2, label %is_allocated.then, label %is_allocated.else8
 
 is_allocated.then:                                ; preds = %entry
   %3 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 0
@@ -221,7 +221,7 @@ is_allocated.then:                                ; preds = %entry
   %5 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
   %6 = load i8*, i8** %5, align 8
   %7 = icmp ne i8* %6, null
-  br i1 %7, label %then, label %else5
+  br i1 %7, label %then, label %else6
 
 then:                                             ; preds = %is_allocated.then
   %8 = bitcast i32 (...)** %4 to i8**
@@ -249,35 +249,45 @@ else:                                             ; preds = %then1
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then2
-  br label %ifcont4
+  br label %ifcont5
 
 else3:                                            ; preds = %then
   %20 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 0
   %21 = load i32 (...)**, i32 (...)*** %20, align 8
-  %22 = getelementptr inbounds i32 (...)*, i32 (...)** %21, i32 2
-  %23 = load i8*, i32 (...)** %22, align 8
-  %24 = bitcast i8* %23 to void (i8*)*
-  %25 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
-  %26 = load i8*, i8** %25, align 8
-  call void %24(i8* %26)
-  br label %ifcont4
+  %22 = icmp ne i32 (...)** %21, null
+  br i1 %22, label %is_allocated.then4, label %is_allocated.else
 
-ifcont4:                                          ; preds = %else3, %ifcont
+is_allocated.then4:                               ; preds = %else3
+  %23 = getelementptr inbounds i32 (...)*, i32 (...)** %21, i32 2
+  %24 = load i8*, i32 (...)** %23, align 8
+  %25 = bitcast i8* %24 to void (i8*)*
+  %26 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
+  %27 = load i8*, i8** %26, align 8
+  call void %25(i8* %27)
+  br label %is_allocated.ifcont
+
+is_allocated.else:                                ; preds = %else3
+  br label %is_allocated.ifcont
+
+is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then4
+  br label %ifcont5
+
+ifcont5:                                          ; preds = %is_allocated.ifcont, %ifcont
   call void @_lfortran_free_alloc(i8* %1, i8* %6)
-  br label %ifcont6
+  br label %ifcont7
 
-else5:                                            ; preds = %is_allocated.then
-  br label %ifcont6
+else6:                                            ; preds = %is_allocated.then
+  br label %ifcont7
 
-ifcont6:                                          ; preds = %else5, %ifcont4
-  %27 = bitcast %"~unlimited_polymorphic_type"* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %27)
-  br label %is_allocated.ifcont
+ifcont7:                                          ; preds = %else6, %ifcont5
+  %28 = bitcast %"~unlimited_polymorphic_type"* %0 to i8*
+  call void @_lfortran_free_alloc(i8* %1, i8* %28)
+  br label %is_allocated.ifcont9
 
-is_allocated.else:                                ; preds = %entry
-  br label %is_allocated.ifcont
+is_allocated.else8:                               ; preds = %entry
+  br label %is_allocated.ifcont9
 
-is_allocated.ifcont:                              ; preds = %is_allocated.else, %ifcont6
+is_allocated.ifcont9:                             ; preds = %is_allocated.else8, %ifcont7
   ret void
 }
 

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -6,7 +6,7 @@ target datalayout = "..."
 %"~unlimited_polymorphic_type" = type <{ i32 (...)**, i8* }>
 
 @_Type_Info_integer_8 = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* inttoptr (i32 8 to i8*), i8* inttoptr (i64 8 to i8*), i8* null }, align 8
-@_VTable_integer_8 = linkonce_odr unnamed_addr constant { [4 x i8*] } { [4 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_integer_8 to i8*), i8* bitcast (void (i8*, i8*)* @_copy_integer_8 to i8*), i8* bitcast (void (i8**)* @_allocate_integer_8 to i8*)] }, align 8
+@_VTable_integer_8 = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_integer_8 to i8*), i8* bitcast (void (i8*, i8*)* @_copy_integer_8 to i8*), i8* bitcast (void (i8**)* @_allocate_integer_8 to i8*), i8* bitcast (void (i8*)* @finalize_i64_for_UPoly to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [10 x i8] c"integer(8)"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data, i32 0, i32 0), i64 10 }>
@@ -47,7 +47,7 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = load i8*, i8** %8, align 8
   %10 = bitcast i8* %9 to i64*
   %11 = bitcast %"~unlimited_polymorphic_type"* %6 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %11, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %11, align 8
   %12 = load i64, i64* %x, align 8
   store i64 %12, i64* %10, align 8
   %13 = alloca i1, align 1
@@ -185,12 +185,17 @@ entry:
   store i8* %2, i8** %0, align 8
   %3 = bitcast i8* %2 to <{ i32 (...)**, i8* }>*
   %4 = bitcast <{ i32 (...)**, i8* }>* %3 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [4 x i8*] }, { [4 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
+  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
   %5 = call i8* @_lfortran_get_default_allocator()
   %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 8)
   call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 8, i1 false)
   %7 = getelementptr <{ i32 (...)**, i8* }>, <{ i32 (...)**, i8* }>* %3, i32 0, i32 1
   store i8* %6, i8** %7, align 8
+  ret void
+}
+
+define internal void @finalize_i64_for_UPoly(i8* %0) {
+entry:
   ret void
 }
 
@@ -247,6 +252,14 @@ ifcont:                                           ; preds = %else, %then2
   br label %ifcont4
 
 else3:                                            ; preds = %then
+  %20 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 0
+  %21 = load i32 (...)**, i32 (...)*** %20, align 8
+  %22 = getelementptr inbounds i32 (...)*, i32 (...)** %21, i32 2
+  %23 = load i8*, i32 (...)** %22, align 8
+  %24 = bitcast i8* %23 to void (i8*)*
+  %25 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
+  %26 = load i8*, i8** %25, align 8
+  call void %24(i8* %26)
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %ifcont
@@ -257,8 +270,8 @@ else5:                                            ; preds = %is_allocated.then
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont4
-  %20 = bitcast %"~unlimited_polymorphic_type"* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %20)
+  %27 = bitcast %"~unlimited_polymorphic_type"* %0 to i8*
+  call void @_lfortran_free_alloc(i8* %1, i8* %27)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry


### PR DESCRIPTION
### Goal of this PR 
**Finalize -> `class(*), allocatable :: x`.**
Start handling the case of finalizing an unlimited polymorphic type (the runtime type, not the descriptors).
**HOW :** We'll use similar approach to how we allocate and copy upoly types at runtime, by using functions.
We'll register the finalization type into each type VTable (e.g. `i32_VTable = [5 x i8*] = { .. , .. , copy , allocate , finalize_fn}`)
and call it at finalization. 
***
### What's in this PR
- Register initial finalization functions into type's VTable.
- Call that empty function at finalizatio process
***
### What's next
properly insert the finalization instructions into the finalization functions we registered. and making sure tests pass.