### PR TITLE
fix: use .exe as default executable extension on Windows

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2682,7 +2682,11 @@ int main_app(int argc, char *argv[]) {
     } else if (opts.show_julia) {
         outfile = basename.replace_extension(".jl").string();
     } else {
-        outfile = basename.replace_extension(".out").string();
+        #ifdef _WIN32
+            outfile = basename.replace_extension(".exe").string();
+        #else
+            outfile = basename.replace_extension(".out").string();
+        #endif
     }
 
     lfortran_pass_manager.parse_pass_arg(opts.arg_pass, opts.skip_pass);


### PR DESCRIPTION
## Summary

Fixes the default executable extension on Windows.

Previously, when no `-o` flag was provided, LFortran always generated `.out`.
This updates the fallback behavior so Windows now uses `.exe`, while Linux/macOS continue using `.out`.

## Validation

Verified the fallback output naming behavior:

* default fallback still produces `.out`
* explicit `-o my_app.out` remains unchanged
* explicit `-o simple_name` remains unchanged
* multi-dot filename `physics.v1.f90` correctly produces `physics.v1.out`

Windows should now use `.exe` under `_WIN32`.

fixes #11012
