### PR TITLE
Fix callback with reshape causing LLVM type mismatch

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2665,6 +2665,7 @@ RUN(NAME callback_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME callback_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME callback_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME callback_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME callback_06 LABELS gfortran llvm)
 
 RUN(NAME recursion_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME recursion_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/callback_06.f90
+++ b/integration_tests/callback_06.f90
@@ -1,0 +1,24 @@
+program callback_06
+  implicit none
+  integer, allocatable :: v(:)
+  allocate(v(2))
+  call run(f)
+  if (v(1) /= 1) error stop
+  if (v(2) /= 2) error stop
+  print *, v
+contains
+  subroutine run(F)
+    interface
+      subroutine cb(x)
+        integer, intent(in) :: x(:)
+      end subroutine
+    end interface
+    procedure(cb) :: F
+    call F([1, 2])
+  end subroutine
+
+  subroutine f(x)
+    integer, intent(in) :: x(:)
+    v = reshape(x, shape(v))
+  end subroutine
+end program

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -1538,10 +1538,91 @@ class RemoveArrayByDescriptorProceduresVisitor : public PassUtils::PassVisitor<R
         }
 };
 
+/*
+    When pass_array_by_data transforms a callback interface (e.g. `cb`) but the
+    actual function passed through it (e.g. `f`) cannot be transformed (its body
+    contains reshape), the procedure variable's type would be updated to the
+    transformed interface while the actual function keeps its original signature.
+    This causes an LLVM IR type mismatch at the call site.
+
+    This visitor detects such mismatches after PassArrayByDataProcedureVisitor
+    has populated proc2newproc, and removes the offending interface entries
+    before EditProcedureVisitor updates type declarations.
+ */
+class CallbackMismatchCleanup : public ASR::BaseWalkVisitor<CallbackMismatchCleanup> {
+public:
+    PassArrayByDataProcedureVisitor& v;
+    std::set<ASR::symbol_t*> to_remove;
+
+    CallbackMismatchCleanup(PassArrayByDataProcedureVisitor& v_) : v(v_) {}
+
+    void check_callback_args(ASR::symbol_t* callee_name,
+                             ASR::call_arg_t* args, size_t n_args) {
+        ASR::symbol_t* callee_sym = ASRUtils::symbol_get_past_external(callee_name);
+        if (!ASR::is_a<ASR::Function_t>(*callee_sym)) return;
+        ASR::Function_t* callee = ASR::down_cast<ASR::Function_t>(callee_sym);
+
+        for (size_t i = 0; i < n_args && i < callee->n_args; i++) {
+            if (!args[i].m_value) continue;
+            if (!ASR::is_a<ASR::Var_t>(*args[i].m_value)) continue;
+
+            ASR::symbol_t* arg_sym = ASR::down_cast<ASR::Var_t>(
+                args[i].m_value)->m_v;
+            ASR::symbol_t* arg_resolved = ASRUtils::symbol_get_past_external(
+                arg_sym);
+
+            // Is the argument a function being passed as a callback?
+            if (!ASR::is_a<ASR::Function_t>(*arg_resolved)) continue;
+            // Was this function NOT transformed?
+            if (v.proc2newproc.find(arg_resolved) != v.proc2newproc.end()) continue;
+
+            // Get the corresponding parameter's type_declaration (the interface)
+            if (!ASR::is_a<ASR::Var_t>(*callee->m_args[i])) continue;
+            ASR::symbol_t* param_sym = ASR::down_cast<ASR::Var_t>(
+                callee->m_args[i])->m_v;
+            if (!ASR::is_a<ASR::Variable_t>(*param_sym)) continue;
+            ASR::Variable_t* param = ASR::down_cast<ASR::Variable_t>(param_sym);
+            if (!param->m_type_declaration) continue;
+
+            ASR::symbol_t* type_decl = ASRUtils::symbol_get_past_external(
+                param->m_type_declaration);
+
+            // If the interface WAS transformed → mismatch
+            if (v.proc2newproc.find(type_decl) != v.proc2newproc.end()) {
+                to_remove.insert(type_decl);
+            }
+        }
+    }
+
+    void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
+        check_callback_args(x.m_name, x.m_args, x.n_args);
+        BaseWalkVisitor::visit_SubroutineCall(x);
+    }
+
+    void visit_FunctionCall(const ASR::FunctionCall_t& x) {
+        check_callback_args(x.m_name, x.m_args, x.n_args);
+        BaseWalkVisitor::visit_FunctionCall(x);
+    }
+
+    void apply() {
+        for (ASR::symbol_t* sym : to_remove) {
+            ASR::Function_t* new_func = ASR::down_cast<ASR::Function_t>(
+                v.proc2newproc[sym].first);
+            SymbolTable* scope = new_func->m_symtab->parent;
+            scope->erase_symbol(std::string(new_func->m_name));
+            v.newprocs.erase(v.proc2newproc[sym].first);
+            v.proc2newproc.erase(sym);
+        }
+    }
+};
+
 void pass_array_by_data(Allocator &al, ASR::TranslationUnit_t &unit,
                         const LCompilers::PassOptions& pass_options) {
     PassArrayByDataProcedureVisitor v(al, pass_options);
     v.visit_TranslationUnit(unit);
+    CallbackMismatchCleanup cleanup(v);
+    cleanup.visit_TranslationUnit(unit);
+    cleanup.apply();
     EditProcedureVisitor e(v);
     e.visit_TranslationUnit(unit);
     std::set<ASR::symbol_t*> not_to_be_erased;


### PR DESCRIPTION
The pass_array_by_data pass was transforming callback interface functions (e.g., procedure(cb) :: F) to use PointerArray arguments, but the actual function passed as a callback could not be transformed when its body contained reshape (insert_new_procedure returns nullptr because allow_reshape=false). This caused a type mismatch in LLVM IR between the expected callback signature and the actual function.

Add a CallbackMismatchCleanup pass that runs after all functions are processed. It walks call sites and detects when an untransformed function is passed as a callback to a transformed interface. In such cases it removes the interface from proc2newproc, preventing the procedure variable type update and keeping signatures consistent.

An integration test is added.

Fixes #11025.