### PR TITLE
fix: initialize `access_id` for FILE object with correct value

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2739,6 +2739,7 @@ RUN(NAME file_56 LABELS gfortran llvm)
 RUN(NAME file_57 LABELS gfortran llvm)
 RUN(NAME file_58 LABELS gfortran llvm)
 RUN(NAME file_59 LABELS gfortran llvm)
+RUN(NAME file_60 LABELS gfortran llvm)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_60.f90
+++ b/integration_tests/file_60.f90
@@ -1,0 +1,33 @@
+program file_60
+    implicit none
+    character(16) :: access, action, blank, delim, direct, form, formatted, name, pad, position, &
+                     read, readwrite, sequential, unformatted, write
+    logical :: exist, named, opened
+    integer :: iostat, number, lun = 42
+    character(*), parameter :: lfn = 'file_60.dat'
+
+    open (lun, file=lfn, status='old', iostat=iostat)
+    if (iostat == 0) close (lun, status='delete')
+
+    access = 'xxx'; action = 'xxx'; number = -42
+    
+    inquire (file=lfn, access=access, action=action, direct=direct, form=form, &
+             exist=exist, opened=opened, number=number, iostat=iostat)
+    
+    call pf (iostat == 0)
+    call pf (access == 'UNDEFINED')
+    call pf (.not. exist)
+    call pf (.not. opened)
+    call pf (number == -1)
+
+    ! INQUIRE BY UNIT
+    inquire (unit=lun, access=access, opened=opened, iostat=iostat)
+    call pf (iostat == 0)
+    call pf (.not. opened)
+
+contains
+    subroutine pf (l)
+        logical, intent(in) :: l
+        if (.not. l) error stop 'FAILED'
+    end subroutine
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5332,7 +5332,7 @@ FILE* get_file_pointer_from_unit(int32_t unit_num, bool *unit_file_bin, int *acc
     _lfortran_init_standard_units();
     // Initialize all output params to safe defaults for unconnected units
     if (unit_file_bin) *unit_file_bin = false;
-    if (access_id) *access_id = 0;
+    if (access_id) *access_id = -1;
     if (read_access) *read_access = true;
     if (write_access) *write_access = true;
     if (delim) *delim = 0;
@@ -6156,7 +6156,7 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
             }
         }
         if (access != NULL) {
-            char *access_str = "";
+            char *access_str = "UNDEFINED";
             if (access_id == 0) {
                 access_str = "SEQUENTIAL";
             } else if (access_id == 1) {
@@ -6371,7 +6371,7 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
             }
         }
         if (access != NULL) {
-            char *access_str = "";
+            char *access_str = "UNDEFINED";
             if (access_id == 0) {
                 access_str = "SEQUENTIAL";
             } else if (access_id == 1) {


### PR DESCRIPTION
Towards #10677 

Splitting the large test present in #10677 to smaller tests, each checking for a particular connection state and access method.