### PR TITLE
Fix INCLUDE statement handling in fixed-form Fortran

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -455,6 +455,7 @@ RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME include_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
 RUN(NAME include_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran INCLUDE_PATH include_03)
+RUN(NAME include_04 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form INCLUDE_PATH include_04)
 
 RUN(NAME use_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm fortran)
 RUN(NAME use_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c wasm fortran)

--- a/integration_tests/include_04.f90
+++ b/integration_tests/include_04.f90
@@ -1,0 +1,8 @@
+      program include_04
+      implicit none
+      INCLUDE 'vals.inc'
+      integer :: z
+      z = x + y
+      print *, z
+      if (z /= 52) error stop
+      end program include_04

--- a/integration_tests/include_04/vals.inc
+++ b/integration_tests/include_04/vals.inc
@@ -1,0 +1,2 @@
+      integer, parameter :: x = 42
+      integer, parameter :: y = 10

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1222,6 +1222,12 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (next_is(cur, "include")) {
+            push_token_advance(cur, "include");
+            tokenize_line(cur);
+            return true;
+        }
+
         if (next_is(cur, "stop")) {
             push_token_advance(cur, "stop");
             tokenize_line(cur);

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -436,6 +436,14 @@ bool is_digit(unsigned char ch) {
     return (ch >= '0' && ch <= '9');
 }
 
+bool str_compare_ci(const unsigned char *pos, const char *s) {
+    for (size_t i = 0; s[i] != '\0'; i++) {
+        if (pos[i] == '\0') return false;
+        if (tolower(pos[i]) != s[i]) return false;
+    }
+    return true;
+}
+
 enum LineType {
     Comment, Statement, LabeledStatement, Continuation, EndOfFile,
     ContinuationTab, StatementTab, Include,
@@ -487,7 +495,7 @@ LineType determine_line_type(const unsigned char *pos)
         }
         if (col <= 6) {
             return LineType::LabeledStatement;
-        } else if (str_compare(pos, "include")) {
+        } else if (str_compare_ci((const unsigned char*)pos, "include")) {
             return LineType::Include;
         } else {
             return LineType::Statement;
@@ -671,7 +679,8 @@ void process_include(std::string& out, const std::string& s,
 
 bool is_include(const std::string &s, uint32_t pos) {
     while (pos < s.size() && s[pos] == ' ') pos++;
-    if (pos + 6 < s.size() && s.substr(pos, 7) == "include") {
+    if (pos + 6 < s.size() && str_compare_ci(
+            (const unsigned char*)&s[pos], "include")) {
         pos += 7;
         while (pos < s.size() && s[pos] == ' ') pos++;
         if (pos < s.size() && ((s[pos] == '"') || (s[pos] == '\''))) {
@@ -780,7 +789,8 @@ std::string prescan(const std::string &s, LocationManager &lm,
                 }
                 case LineType::Include: {
                     while (pos < s.size() && s[pos] == ' ') pos++;
-                    LCOMPILERS_ASSERT(s.substr(pos, 7) == "include");
+                    LCOMPILERS_ASSERT(str_compare_ci(
+                        (const unsigned char*)&s[pos], "include"));
                     pos += 7;
                     while (pos < s.size() && s[pos] == ' ') pos++;
                     if ((s[pos] == '"') || (s[pos] == '\'')) {
@@ -816,7 +826,8 @@ std::string prescan(const std::string &s, LocationManager &lm,
             if (newline && is_include(s, pos)) {
                 int col = 0; // doesn't matter
                 while (pos < s.size() && s[pos] == ' ') pos++;
-                LCOMPILERS_ASSERT(pos + 6 < s.size() && s.substr(pos, 7) == "include")
+                LCOMPILERS_ASSERT(pos + 6 < s.size() && str_compare_ci(
+                    (const unsigned char*)&s[pos], "include"))
                 pos += 7;
                 while (pos < s.size() && s[pos] == ' ') pos++;
                 LCOMPILERS_ASSERT(pos < s.size() && ((s[pos] == '"') || (s[pos] == '\'')));


### PR DESCRIPTION
The prescanner's determine_line_type() used case-sensitive comparison to detect INCLUDE lines, so uppercase INCLUDE (common in fixed-form Fortran) was misclassified as a regular statement. The file contents were never substituted, causing a downstream tokenizer error.

Fix: add a case-insensitive str_compare_ci() helper and use it in determine_line_type(), the Include line handler, and the free-form is_include() function. Also add include handling to the fixed-form tokenizer's lex_body_statement() for robustness when prescanning is disabled.

Integration test include_04 added.