### PR TITLE
Fix %re/%im on complex inside select type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1911,6 +1911,7 @@ RUN(NAME select_type_43 LABELS gfortran llvm)
 RUN(NAME select_type_44 LABELS gfortran llvm)
 RUN(NAME select_type_45 LABELS gfortran llvm)
 RUN(NAME select_type_46 LABELS gfortran llvm)
+RUN(NAME select_type_47 LABELS gfortran llvm)
 
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/select_type_47.f90
+++ b/integration_tests/select_type_47.f90
@@ -1,0 +1,31 @@
+program select_type_47
+implicit none
+call test_re_im((1.0, 2.0))
+call test_re_im_dp(dcmplx(3.0d0, 4.0d0))
+contains
+subroutine test_re_im(a)
+    class(*), intent(in) :: a
+    select type (a)
+    type is (complex(4))
+        print *, a%re
+        print *, a%im
+        if (abs(a%re - 1.0) > 1e-5) error stop 1
+        if (abs(a%im - 2.0) > 1e-5) error stop 2
+    class default
+        error stop 3
+    end select
+end subroutine
+
+subroutine test_re_im_dp(a)
+    class(*), intent(in) :: a
+    select type (a)
+    type is (complex(8))
+        print *, a%re
+        print *, a%im
+        if (abs(a%re - 3.0d0) > 1d-10) error stop 4
+        if (abs(a%im - 4.0d0) > 1d-10) error stop 5
+    class default
+        error stop 6
+    end select
+end subroutine
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11939,6 +11939,11 @@ public:
                 }
             } else {
                 ASR::expr_t *val = ASRUtils::EXPR(ASR::make_Var_t(al, loc, v));
+                if (select_type_override_type) {
+                    val = ASRUtils::EXPR(ASR::make_Cast_t(al, loc, val,
+                        ASR::cast_kindType::ClassToIntrinsic,
+                        select_type_override_type, nullptr, nullptr));
+                }
                 ASR::ttype_t *real_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc,
                     ASRUtils::extract_kind_from_ttype_t(v_variable_m_type)));
                 


### PR DESCRIPTION
Insert a ClassToIntrinsic Cast on the polymorphic variable in the semantics (ast_common_visitor.h) when resolving %re/%im inside a select type block, so that ComplexRe/ComplexIm receive a properly typed complex argument. This removes the need for the LLVM codegen workaround that manually unwrapped the polymorphic box.

An integration test (select_type_47) is added covering both complex(4) and complex(8) with %re and %im inside select type.