### PR TITLE
Fix fixed-form prescanner to skip tab characters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -449,6 +449,7 @@ RUN(NAME print_arr_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME crlf_fixed_form LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_comment_01.f90
+++ b/integration_tests/fixed_form_comment_01.f90
@@ -1,0 +1,5 @@
+c     comment line
+      integer a
+      a=1
+      if (a .ne. 1) error stop
+      end	

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -592,7 +592,7 @@ void copy_rest_of_line(std::string &out, const std::string &s, size_t &pos,
             skip_rest_of_line(s, pos);
             out += '\n';
             return;
-        } else if (s[pos] == ' ') {
+        } else if (s[pos] == ' ' || s[pos] == '\t') {
             // Skip white space in a fixed-form parser
             pos++;
             col++;


### PR DESCRIPTION
The fixed-form prescanner's copy_rest_of_line function was skipping
spaces but not tab characters within a line. This caused tabs (e.g.,
trailing tabs after 'end') to be preserved in the prescanned output,
which then prevented the fixed-form tokenizer from recognizing
constructs like implicit programs (is_implicit_program checks for
"end\n" but found "end\t\n").

Treat tab characters the same as spaces in copy_rest_of_line by
adding '\t' to the whitespace check.

Added integration test fixed_form_comment_01.

Fixes #11057.