### PR TITLE
ASR, semantics: add iomsg support to REWIND

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2474,12 +2474,12 @@ public:
 
     void visit_Rewind(const AST::Rewind_t& x) {
         mark_IO_side_effect();
-        std::map<std::string, size_t> argname2idx = {{"unit", 0}, {"iostat", 1}, {"err", 2 }};
+        std::map<std::string, size_t> argname2idx = {{"unit", 0}, {"iostat", 1}, {"err", 2}, {"iomsg", 3}};
         std::vector<ASR::expr_t*> args;
         std::string node_name = "Rewind";
-        fill_args_for_rewind_inquire_flush(x, 3, args, 3, argname2idx, node_name);
-        ASR::expr_t *unit = args[0], *iostat = args[1], *err = args[2];
-        tmp = ASR::make_FileRewind_t(al, x.base.base.loc, x.m_label, unit, iostat, err);
+        fill_args_for_rewind_inquire_flush(x, 3, args, 4, argname2idx, node_name);
+        ASR::expr_t *unit = args[0], *iostat = args[1], *err = args[2], *iomsg = args[3];
+        tmp = ASR::make_FileRewind_t(al, x.base.base.loc, x.m_label, unit, iostat, err, iomsg);
     }
 
     void visit_Endfile(const AST::Endfile_t& x) {

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -56,7 +56,7 @@ stmt
     | FileClose(int label, expr? unit, expr? iostat, expr? iomsg, expr? err, expr? status)
     | FileRead(int label, expr? unit, expr? fmt, expr? iomsg, expr? iostat, expr? advance, expr? size, expr? id, expr? pos, expr* values, stmt? overloaded, bool is_formatted, symbol? nml, expr? rec, expr? pad)
     | FileBackspace(int label, expr? unit, expr? iostat, expr? err)
-    | FileRewind(int label, expr? unit, expr? iostat, expr? err)
+    | FileRewind(int label, expr? unit, expr? iostat, expr? err, expr? iomsg)
     | FileEndfile(int label, expr? unit, expr? iostat, expr? err)
     | FileInquire(int label, expr? unit, expr? file, expr? iostat, expr? err, expr? exist, expr? opened, expr? number, expr? named, expr? name, expr? access, expr? sequential, expr? direct, expr? form, expr? formatted, expr? unformatted, expr? recl, expr? nextrec, expr? blank, expr? position, expr? action, expr? read, expr? write, expr? readwrite, expr? delim, expr? pad, expr? flen, expr? blocksize, expr? convert, expr? carriagecontrol, expr? size, expr? pos, expr? iolength, expr* iolength_vars, expr? decimal, expr? sign, expr? encoding, expr? stream, expr? iomsg, expr? round, expr? pending, expr? asynchronous)
     | FileWrite(int label, expr? unit, expr? iomsg, expr? iostat, expr? id, expr* values, expr? separator, expr? end, stmt? overloaded, bool is_formatted, symbol? nml, expr? rec, expr? pos)

--- a/tests/reference/asr-rewind_inquire_flush-72b7f97.json
+++ b/tests/reference/asr-rewind_inquire_flush-72b7f97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-rewind_inquire_flush-72b7f97.stdout",
-    "stdout_hash": "a0993d187c6124073e1419642824c8106ee96e5b56bdfb02412789d2",
+    "stdout_hash": "b4737e6706ad62ac4a485b35ba11a713f79bf92e779028d96aff8ae1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-rewind_inquire_flush-72b7f97.stdout
+++ b/tests/reference/asr-rewind_inquire_flush-72b7f97.stdout
@@ -153,6 +153,7 @@
                         (IntegerConstant 9 (Integer 4) Decimal)
                         (Var 2 ios)
                         (IntegerConstant 10 (Integer 4) Decimal)
+                        ()
                     )
                     (FileInquire
                         0


### PR DESCRIPTION
Validated `M_strings` on latest `main` and confirmed the previously reported `INQUIRE(stream=)` issue is already resolved.

During continued package testing, `M_io.F90` exposed another compatibility gap:
`REWIND(unit=..., iostat=..., iomsg=...)` failed with `Invalid argument 'iomsg' supplied`.

This PR adds `iomsg` support for `REWIND` by:

* extending `FileRewind` ASR with an `iomsg` field
* updating `visit_Rewind()` semantic lowering to recognize and map `iomsg`

After this patch, the package successfully moves past semantic analysis and reaches a later unrelated LLVM verification issue.

Fixes #10884