### PR TITLE
Implement null preprocessing directive in CPP preprocessor

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3641,6 +3641,10 @@ RUN(NAME cpp_pre_12 LABELS gfortran llvm
     EXTRA_ARGS --cpp
     GFORTRAN_ARGS -cpp)
 
+RUN(NAME cpp_pre_13 LABELS gfortran llvm
+    EXTRA_ARGS --cpp
+    GFORTRAN_ARGS -cpp)
+
 RUN(NAME dabs_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME minpack_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/cpp_pre_13.f90
+++ b/integration_tests/cpp_pre_13.f90
@@ -1,0 +1,11 @@
+program cpp_pre_13
+implicit none
+! Test null preprocessing directive (C99 6.10.7 / C23 6.10.9)
+! A line with just "#" or "# /* comment */" should be silently ignored.
+#
+# /* this is a CPP comment. It is erased regardless of the base language */
+integer :: x
+x = 42
+if (x /= 42) error stop
+print *, "PASSED"
+end program

--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -400,6 +400,14 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                 output.append(token(tok, cur));
                 continue;
             }
+            // Null preprocessing directive (C99 6.10.7 / C23 6.10.9):
+            // A line containing only "#" (with optional whitespace and/or
+            // C-style comments) has no effect.
+            "#" whitespace? (comment whitespace?)* newline {
+                if (!branch_enabled) continue;
+                output.append("\n");
+                continue;
+            }
             "#" whitespace? "define" whitespace @t1 name @t2 (whitespace? | whitespace @t3 [^\n\x00]* @t4 ) newline  {
                 if (!branch_enabled) continue;
                 std::string macro_name = token(t1, t2), macro_subs;


### PR DESCRIPTION
Implement the C99/C23 null preprocessing directive (C23 6.10.9) in the CPP preprocessor. Lines containing only '#' with optional whitespace and/or C-style comments are now replaced with an empty line when using --cpp, instead of being passed through to the Fortran parser.

Without --cpp, '#' lines continue to produce the existing 'Unsupported macro' warning, consistent with the prior behavior.

Fixes #11069