### PR TITLE
Fix uninitialized access_id and fgetc char bug in _lfortran_empty_read

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -9660,7 +9660,7 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat) {
 
     bool unit_file_bin;
     int access_id;
-    FILE* fp = get_file_pointer_from_unit(unit_num, &unit_file_bin, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    FILE* fp = get_file_pointer_from_unit(unit_num, &unit_file_bin, &access_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     if (!fp) {
         fprintf(stderr, "No file found with given unit\n");
         exit(1);
@@ -9668,7 +9668,7 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat) {
 
     if (!unit_file_bin) {
         // The contents of `c` are ignored
-        char c = fgetc(fp);
+        int c = fgetc(fp);
         while (c != '\n' && c != EOF) {
             c = fgetc(fp);
         }


### PR DESCRIPTION
The access_id variable was declared but never initialized (NULL was passed to get_file_pointer_from_unit instead of &access_id). In release builds, the optimizer exploited this UB, causing the text-file code path to execute for binary stream files. This made _lfortran_empty_read consume extra bytes after each read() statement, corrupting the file position.

Also fixed char c = fgetc(fp) to int c, since fgetc returns int to distinguish EOF (-1) from the byte 0xFF.