### PR TITLE
Install ISO_Fortran_binding.h and add --print-c-include-dir flag

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2563,6 +2563,11 @@ int main_app(int argc, char *argv[]) {
 #endif
     }
 
+    if (opts.print_c_include_dir) {
+        std::cout << LCompilers::LFortran::get_c_include_dir() << std::endl;
+        return 0;
+    }
+
     if(opts.static_link && opts.shared_link) {
         std::cerr << "Options '--static' and '--shared' cannot be used together" << std::endl;
         return 1;

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -330,6 +330,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--linker-path", opts.linker_path, "Use the linker from this path")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--target", compiler_options.target, "Generate code for the given target")->capture_default_str()->group(group_backend_codegen_options);
         app.add_flag("--print-targets", opts.print_targets, "Print the registered targets")->group(group_backend_codegen_options);
+        app.add_flag("--print-c-include-dir", opts.print_c_include_dir, "Print the directory containing ISO_Fortran_binding.h")->group(group_backend_codegen_options);
         app.add_flag("--wasm-html", compiler_options.wasm_html, "Generate HTML file using emscripten for LLVM->WASM")->group(group_backend_codegen_options);
         app.add_option("--emcc-embed", compiler_options.emcc_embed, "Embed a given file/directory using emscripten for LLVM->WASM")->group(group_backend_codegen_options);
         app.add_flag("--mlir-gpu-offloading", compiler_options.po.enable_gpu_offloading, "Enables gpu offloading using MLIR backend")->group(group_backend_codegen_options);

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -59,6 +59,7 @@ namespace LCompilers::CommandLineInterface {
         std::string linker{""};
         std::string linker_path{""};
         bool print_targets = false;
+        bool print_c_include_dir = false;
         bool fixed_form_infer = false;
         bool cpp = false;
         bool cpp_infer = false;

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -108,6 +108,21 @@ std::string get_runtime_library_c_header_dir()
     }
 }
 
+std::string get_c_include_dir()
+{
+    switch (execution_mode)
+    {
+        case ExecutionMode::LFortranDevelopment:
+            return lfortran_exec_path_dir + "/../libasr/runtime";
+        case ExecutionMode::LFortranCtest:
+            return lfortran_exec_path_dir + "/../../libasr/runtime";
+        case ExecutionMode::LFortranInstalled:
+            return lfortran_exec_path_dir + "/" + CMAKE_INSTALL_INCLUDEDIR_RELATIVE + "/lfortran";
+        default:
+            return "";
+    }
+}
+
 std::string get_dwarf_scripts_dir()
 {
     char *env_p = std::getenv("LFORTRAN_DWARF_SCRIPTS_DIR");

--- a/src/lfortran/utils.h
+++ b/src/lfortran/utils.h
@@ -17,6 +17,7 @@ void set_exec_path_and_mode(std::string &executable_path, int &dirname_length);
 std::string get_runtime_library_dir();
 std::string get_runtime_library_header_dir();
 std::string get_runtime_library_c_header_dir();
+std::string get_c_include_dir();
 std::string get_dwarf_scripts_dir();
 int32_t get_exit_status(int32_t err);
 std::string get_kokkos_includedir();

--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -82,3 +82,8 @@ install(
     FILES ../../../src/libasr/runtime/lfortran_intrinsics.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lfortran/impure
 )
+
+install(
+    FILES ../../../src/libasr/runtime/ISO_Fortran_binding.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lfortran
+)


### PR DESCRIPTION
Install LFortran's ISO_Fortran_binding.h to $prefix/include/lfortran/ during cmake install, fixing the missing header in the container package.

Add --print-c-include-dir flag so users can discover the path:

    cc -I$(lfortran --print-c-include-dir) -c my_c_file.c

Fixes #11079