### PR TITLE
Fix list-directed read of double and complex from file

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3296,6 +3296,7 @@ RUN(NAME read_70 LABELS gfortran llvm)
 RUN(NAME read_71 LABELS gfortran llvm)
 RUN(NAME read_72 LABELS gfortran llvm)
 RUN(NAME read_73 LABELS gfortran llvm)
+RUN(NAME read_74 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_74.f90
+++ b/integration_tests/read_74.f90
@@ -1,0 +1,33 @@
+program read_74
+implicit none
+
+! Test list-directed read of multiple types from a file
+! with comma-separated values including D-exponent notation
+
+character(*), parameter :: cdata = "2, 2.5D0, 2.5D0, T, (3.0,4.0), 'TEST'"
+
+integer :: i1
+real :: r1
+double precision :: d1
+logical :: l1
+complex :: c1
+character(8) :: s1
+
+open (42, file='read_74.dat', status='replace', form='formatted')
+write (42,'(a)') cdata
+rewind (42)
+read (42, *) i1, r1, d1, l1, c1, s1
+
+if (i1 /= 2) error stop
+if (abs(r1 - 2.5) > 0.0001) error stop
+if (abs(d1 - 2.5d0) > 0.0001d0) error stop
+if (.not. l1) error stop
+if (abs(real(c1) - 3.0) > 0.0001) error stop
+if (abs(aimag(c1) - 4.0) > 0.0001) error stop
+if (s1 /= 'TEST') error stop
+
+print *, "PASS"
+
+close (42, status='delete')
+
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -7913,6 +7913,10 @@ static int read_complex_expr(FILE *filep, char *buffer, size_t bufsize) {
     // Skip leading whitespace
     while ((ch = fgetc(filep)) != EOF && isspace(ch));
 
+    if (ch == ',') {
+        while ((ch = fgetc(filep)) != EOF && isspace(ch));
+    }
+
     if (ch == EOF) return 0;
 
     if (ch == '(') {
@@ -8591,14 +8595,39 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
             exit(1);
         }
     } else {
-        // Read as string to handle Fortran D exponent notation
-        char buffer[100];
-        if (fscanf(filep, " %99[^ ,\t\n\r]", buffer) != 1) {
+        int c;
+        while ((c = fgetc(filep)) != EOF && isspace(c)) {}
+
+        if (c == EOF) {
             if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
             fprintf(stderr, "Error: Failed to read double from file.\n");
             exit(1);
         }
-        skip_list_directed_comma(filep);
+
+        if (c == ',') {
+            while ((c = fgetc(filep)) != EOF && isspace(c)) {}
+            if (c == EOF) {
+                if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
+                fprintf(stderr, "Error: Failed to read double from file.\n");
+                exit(1);
+            }
+        }
+
+        if (c == ',' || c == '/') {
+            ungetc(c, filep);
+            return;
+        }
+
+        char buffer[100];
+        int len = 0;
+        do {
+            if (len < 99) buffer[len++] = (char)c;
+            c = fgetc(filep);
+        } while (c != EOF && !isspace(c) && c != ',' && c != '/');
+
+        buffer[len] = '\0';
+        if (c != EOF) ungetc(c, filep);
+
         if (!parse_fortran_double(buffer, p)) {
             if (iostat) { *iostat = 1; return; }
             fprintf(stderr, "Error: Invalid input from file.\n");


### PR DESCRIPTION
The _lfortran_read_double function used fscanf with a format string that could not skip a leading comma left by a previous reader (e.g., _lfortran_read_float). This caused 'Failed to read double from file' when reading comma-separated values like '2, 2.5D0, 2.5D0, T, ...'.

Rewrote the formatted-read path in _lfortran_read_double to use character-by-character reading with leading comma handling, matching the approach already used by _lfortran_read_float, _lfortran_read_logical, and _lfortran_read_char.

Also fixed read_complex_expr to skip a leading comma separator before looking for the opening parenthesis of a complex literal.

Added integration test read_74.

Fixes #11084.