### PR TITLE
Fix segfault in allocate with class source

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2411,6 +2411,7 @@ RUN(NAME allocate_62 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_63 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME allocate_64 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocate_65 LABELS gfortran llvm)
+RUN(NAME allocate_66 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_66.f90
+++ b/integration_tests/allocate_66.f90
@@ -1,0 +1,13 @@
+program allocate_66
+   implicit none
+   type :: T
+      integer :: x = 0
+   end type T
+   class(T), allocatable :: obj
+   allocate(obj, source = get_return())
+contains
+   function get_return() result(r)
+      class(T), allocatable :: r
+      allocate(r)
+   end function get_return
+end program allocate_66

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1867,6 +1867,17 @@ public:
                                 source_wrapper_type->getPointerTo(), source_handle);
                         }
 
+                        llvm::Value* is_source_not_allocated = builder->CreateICmpEQ(
+                            builder->CreatePtrToInt(source_handle, llvm::Type::getInt64Ty(context)),
+                            llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), 0));
+                        llvm_utils->generate_runtime_error(is_source_not_allocated,
+                            "allocate with source= requires an allocated/associated polymorphic source expression",
+                            {LLVMUtils::RuntimeLabel(
+                                "source expression is not allocated/associated",
+                                {m_source->base.loc}, {})},
+                            infile,
+                            location_manager);
+
                         llvm::FunctionType* alloc_fn_type = llvm::FunctionType::get(
                             llvm::Type::getVoidTy(context), { llvm_utils->i8_ptr->getPointerTo() }, false);
                         llvm::PointerType* alloc_fn_ptr_type = llvm::PointerType::get(alloc_fn_type, 0);

--- a/tests/errors/allocate_02.f90
+++ b/tests/errors/allocate_02.f90
@@ -1,0 +1,12 @@
+program allocate_66
+   implicit none
+   type :: T
+      integer :: x = 0
+   end type T
+   class(T), allocatable :: obj
+   allocate(obj, source = get_return())
+contains
+   function get_return() result(r)
+      class(T), allocatable :: r
+   end function get_return
+end program allocate_66

--- a/tests/reference/run-allocate_02-9086fdf.json
+++ b/tests/reference/run-allocate_02-9086fdf.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-allocate_02-9086fdf",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/allocate_02.f90",
+    "infile_hash": "9f5d3f4ea32ef514ce130d1862079e1c7ae51f2c8d1ad6b5f070cb90",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-allocate_02-9086fdf.stderr",
+    "stderr_hash": "350b2c0840d488deb87c23e616dc33053401756a12e152c0166973ce",
+    "returncode": 1
+}

--- a/tests/reference/run-allocate_02-9086fdf.stderr
+++ b/tests/reference/run-allocate_02-9086fdf.stderr
@@ -1,0 +1,5 @@
+runtime error: allocate with source= requires an allocated/associated polymorphic source expression
+ --> tests/errors/allocate_02.f90:7:4
+  |
+7 |    allocate(obj, source = get_return())
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source expression is not allocated/associated

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1568,6 +1568,10 @@ filename = "errors/allocate_01.f90"
 run = true
 
 [[test]]
+filename = "errors/allocate_02.f90"
+run = true
+
+[[test]]
 filename = "errors/allocated_04.f90"
 run = true
 


### PR DESCRIPTION
When allocate(x, source=expr) is used with a polymorphic (class) source expression that is not allocated, the LLVM codegen unconditionally dereferences the source pointer to access the vtable, causing a segmentation fault.

Add a null check on the source handle before vtable access. If the source is not allocated/associated, emit a clear runtime error instead of crashing.

Reference test added to test the runtime failure: tests/errors/allocate_02.f90

Integrartion test added to ensure it passes if allocated: integration_tests/allocate_66.f90

Fixes #11093.