### PR TITLE
fix (fixed-form tokenizer): handle assignments after all other tokens

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2017,6 +2017,7 @@ RUN(NAME implicit_typing_05 LABELS gfortran llvm  EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_07 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_08 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
+RUN(NAME implicit_typing_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing --fixed-form GFORTRAN_ARGS -ffixed-form)
 
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_09.f90
+++ b/integration_tests/implicit_typing_09.f90
@@ -1,0 +1,70 @@
+        module implicit_typing_09_mthdef
+cx
+                integer(kind=4), parameter :: isngl=4
+                integer(kind=4), parameter :: idble=8
+                integer(kind=4), parameter :: rsngl=4
+                integer(kind=4), parameter :: rdble=8
+                integer(kind=4), parameter :: rquad=16
+c
+                integer(kind=4), parameter :: iknd=isngl
+                integer(kind=4), parameter :: rknd=rdble
+cy
+        end module
+
+        program implicit_typing_09
+                use implicit_typing_09_mthdef
+cx
+                implicit real(kind=rsngl) (a-c)
+                implicit integer(kind=iknd) (i-k)
+                implicit real(kind=4) (l-n)
+                
+                a = 1.323459_rsngl
+                b = 2.0_rsngl
+                c = a + b
+                
+                i = 5
+                j = 10
+                k = i + j
+                
+                l = 1.0
+                m = 3.0
+                n = l + m
+                                
+                if (abs(c - 3.323459_rsngl) > 1.0e-6) error stop 1
+                if (k /= 15) error stop 2
+
+                if (abs(n - 4.0) > 1.0e-6) error stop 3
+
+                call test_implicit_real_subroutine()
+                print *, test_implicit_complex()
+            
+            contains
+
+                subroutine test_implicit_real_subroutine()
+                use implicit_typing_09_mthdef
+                implicit real(kind=idble) (q-s)
+                
+                q = 1.23456789d0
+                r = 9.87654321d0
+                s = q + r
+                
+                if (abs(s - 11.11111110d0) > 1.0d-6) error stop 4
+                
+                end subroutine
+
+                integer function test_implicit_complex()
+                use implicit_typing_09_mthdef
+                implicit complex(kind=rdble) (t-v)
+                
+                t = cmplx(1.0, 2.0)
+                u = cmplx(3.0, 4.0)
+                v = t + u
+
+                if (abs(real(v) - 4.0) > 1.0d-6) error stop 5
+                if (abs(aimag(v) - 6.0) > 1.0d-6) error stop 6
+
+                test_implicit_complex = 1
+                
+                end function
+
+        end program

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1090,6 +1090,13 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        // assignment
+        // TODO: this is fragile
+        if (is_possible_assignment(cur, cur)) {
+            tokenize_line(cur);
+            return true;
+        }
+
         if (lex_io(cur)) return true;
         if (next_is(cur, "if(")) {
             lex_cond(cur);
@@ -1266,13 +1273,6 @@ struct FixedFormRecursiveDescent {
         if (next_is(cur, "cycle")){
             push_token_advance(cur, "cycle");
             tokenize_line(cur);
-        }
-
-        // assignment
-        // TODO: this is fragile, check after all tokens
-        if (contains(cur, nline, '=')) {
-            tokenize_line(cur);
-            return true;
         }
 
         if (l != -1) {

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -276,6 +276,7 @@ static const std::unordered_map<std::string, yytokentype> &identifier_token_map(
 const std::vector<std::string> declarators{
             "integer*",
             "integer",
+            "parameter",
 	    "real*",
             "real",
 	    "complex*",
@@ -1003,7 +1004,9 @@ struct FixedFormRecursiveDescent {
                         };
                         if (*cur != ')') {
                             // Missing right parenthesis
-                            return false;
+                            // Return true here because it is still a subroutine call starting with the "call" keyword.
+                            // We report the error later in the parser.
+                            return true;
                         }
                         cur++;
                     }
@@ -1014,6 +1017,9 @@ struct FixedFormRecursiveDescent {
                 if (next_is_eol(cur) || *cur == ';') {
                     return true;
                 }
+                // Return true here because it is still a subroutine call starting with the "call" keyword.
+                // We report the error later in the parser.
+                return true;
             }
         }
         return false;
@@ -1090,6 +1096,11 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
+        if (is_do_loop(cur)) {
+            lex_do(cur);
+            return true;
+        }
+
         // assignment
         // TODO: this is fragile
         if (is_possible_assignment(cur, cur)) {
@@ -1103,10 +1114,6 @@ struct FixedFormRecursiveDescent {
             return true;
         }
         unsigned char *nline = cur; next_line(nline);
-        if (is_do_loop(cur)) {
-            lex_do(cur);
-            return true;
-        }
 
         if (next_is(cur, "doconcurrent(")) {
             lex_do_concurrent(cur);

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1127,13 +1127,6 @@ struct FixedFormRecursiveDescent {
             return true;
         }
 
-        // assignment
-        // TODO: this is fragile
-        if (contains(cur, nline, '=')) {
-            tokenize_line(cur);
-            return true;
-        }
-
         // `GOTO (X,Z,Y) M` translates to (roughly)
         // `IF (M .EQ. 1) THEN;  GOTO X; ELSE IF (M .EQ. 2) GOTO Z; IF (M .EQ. 3) GOTO Y; ENDIF`
         if (next_is(cur, "goto(")) {
@@ -1273,6 +1266,13 @@ struct FixedFormRecursiveDescent {
         if (next_is(cur, "cycle")){
             push_token_advance(cur, "cycle");
             tokenize_line(cur);
+        }
+
+        // assignment
+        // TODO: this is fragile, check after all tokens
+        if (contains(cur, nline, '=')) {
+            tokenize_line(cur);
+            return true;
         }
 
         if (l != -1) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -388,6 +388,22 @@ public:
                 if ( !compiler_options.continue_compilation ) throw e;
             }
         }
+        if (compiler_options.implicit_typing) {
+            Location a_loc = x.base.base.loc;
+            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            process_implicit_statements(x, implicit_dictionary);
+            implicit_stack.push_back(implicit_dictionary);
+        } else {
+            for (size_t i=0;i<x.n_implicit;i++) {
+                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
+                    diag.add(diag::Diagnostic(
+                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
+                }
+            }
+        }
         for (size_t i=0; i<x.n_decl; i++) {
             try {
                 if ( AST::is_a<AST::Interface_t>(*x.m_decl[i]) ) {
@@ -473,22 +489,6 @@ public:
     }
 
     void visit_Module(const AST::Module_t &x) {
-        if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
-            process_implicit_statements(x, implicit_dictionary);
-            implicit_stack.push_back(implicit_dictionary);
-        } else {
-            for (size_t i=0;i<x.n_implicit;i++) {
-                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
-                    diag.add(diag::Diagnostic(
-                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
-                        diag::Level::Error, diag::Stage::Semantic, {
-                            diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
-                }
-            }
-        }
         in_module = true;
         visit_ModuleSubmoduleCommon<AST::Module_t, ASR::Module_t>(x);
         ASR::symbol_t *t = ASR::down_cast<ASR::symbol_t>(tmp);
@@ -560,6 +560,19 @@ public:
         generic_procedures.clear();
         current_module_dependencies.reserve(al, 4);
         Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
+        
+        simd_variables.clear();
+        bool is_global_save_enabled_copy = is_global_save_enabled;
+        check_if_global_save_is_enabled( x );
+        in_program = true;
+        for (size_t i=0; i<x.n_use; i++) {
+            try {
+                visit_unit_decl1(*x.m_use[i]);
+            } catch (SemanticAbort &e) {
+                if ( !compiler_options.continue_compilation ) throw e;
+            }
+        }
+
         if (compiler_options.implicit_typing) {
             Location a_loc = x.base.base.loc;
             populate_implicit_dictionary(a_loc, implicit_dictionary);
@@ -575,17 +588,7 @@ public:
                 }
             }
         }
-        simd_variables.clear();
-        bool is_global_save_enabled_copy = is_global_save_enabled;
-        check_if_global_save_is_enabled( x );
-        in_program = true;
-        for (size_t i=0; i<x.n_use; i++) {
-            try {
-                visit_unit_decl1(*x.m_use[i]);
-            } catch (SemanticAbort &e) {
-                if ( !compiler_options.continue_compilation ) throw e;
-            }
-        }
+        
         for (size_t i=0; i<x.n_decl; i++) {
             if (is_equivalence_declaration(x.m_decl[i])) continue;
             if (is_common_declaration(x.m_decl[i])) continue;
@@ -1192,21 +1195,6 @@ public:
         in_Subroutine = true;
         SetChar current_function_dependencies_copy = current_function_dependencies;
         current_function_dependencies.clear(al);
-        if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
-            process_implicit_statements(x, implicit_dictionary);
-        } else {
-            for (size_t i=0;i<x.n_implicit;i++) {
-                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
-                    diag.add(diag::Diagnostic(
-                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
-                        diag::Level::Error, diag::Stage::Semantic, {
-                            diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
-                }
-            }
-        }
         simd_variables.clear();
         ASR::accessType s_access = dflt_access;
         ASR::deftypeType deftype = ASR::deftypeType::Implementation;
@@ -1283,6 +1271,21 @@ public:
                 visit_unit_decl1(*x.m_use[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
+            }
+        }
+        if (compiler_options.implicit_typing) {
+            Location a_loc = x.base.base.loc;
+            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            process_implicit_statements(x, implicit_dictionary);
+        } else {
+            for (size_t i=0;i<x.n_implicit;i++) {
+                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
+                    diag.add(diag::Diagnostic(
+                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
+                }
             }
         }
         Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
@@ -1691,21 +1694,6 @@ public:
         in_Subroutine = true;
         SetChar current_function_dependencies_copy = current_function_dependencies;
         current_function_dependencies.clear(al);
-        if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
-            process_implicit_statements(x, implicit_dictionary);
-        } else {
-            for (size_t i=0;i<x.n_implicit;i++) {
-                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
-                    diag.add(diag::Diagnostic(
-                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
-                        diag::Level::Error, diag::Stage::Semantic, {
-                            diag::Label("", {x.m_implicit[i]->base.loc})}));
-                    throw SemanticAbort();
-                }
-            }
-        }
         simd_variables.clear();
         // Extract local (including dummy) variables first
         current_symbol = (int64_t) ASR::symbolType::Function;
@@ -1782,6 +1770,21 @@ public:
                 visit_unit_decl1(*x.m_use[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
+            }
+        }
+        if (compiler_options.implicit_typing) {
+            Location a_loc = x.base.base.loc;
+            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            process_implicit_statements(x, implicit_dictionary);
+        } else {
+            for (size_t i=0;i<x.n_implicit;i++) {
+                if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
+                    diag.add(diag::Diagnostic(
+                        "Implicit typing is not allowed, enable it by using --implicit-typing ",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {x.m_implicit[i]->base.loc})}));
+                    throw SemanticAbort();
+                }
             }
         }
         Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);


### PR DESCRIPTION
Fixes #11096 
Towards #11090 

* Fixed form tokenizer was incorrectly processing simple variable fields like `kind=4` as assignments, leading to incorrect token generation. For more info, please refer https://github.com/lfortran/lfortran/issues/11096#issuecomment-4254427821. We fix it by handling assignment statements before some statements in Fixed-Form Fortran.
* Correctly handle incorrect subroutine call syntax and `parameter` variable declarations
These were previously being handled through an incorrect use of the fragile assignment check inside the tokenizer. Coincidentally, the tests did not catch it because the subroutine call and variable declaration contained a "=" sign. For an example, see test `tests/fixed_form_call3.f`.
* Implicitly declared variables were unable to access variables imported from other modules for fields like `kind`. This was due to the implicit variables being processed before `use` statements. We fix this by handling `use` statements before to enable access.
