### PR TITLE
fix : false positive "DerivedType already defined" for member sharing type name

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2320,6 +2320,7 @@ RUN(NAME derived_types_132 LABELS gfortran llvm)
 RUN(NAME derived_types_133 LABELS gfortran llvm)
 RUN(NAME derived_types_134 LABELS gfortran llvm EXTRAFILES derived_types_134_module.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME derived_types_135 LABELS gfortran llvm)
+RUN(NAME derived_types_136 LABELS gfortran llvm)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_136.f90
+++ b/integration_tests/derived_types_136.f90
@@ -1,0 +1,10 @@
+program derived_types_136
+   implicit none
+   type :: foo
+      integer :: foo
+   end type foo
+   type(foo) :: x
+   x%foo = 42
+   if (x%foo /= 42) error stop
+   print *, "ok"
+end program derived_types_136

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2613,7 +2613,7 @@ public:
             visit_procedure_decl(*x.m_contains[i]);
         }
         std::string sym_name = to_lower(x.m_name);
-        if (current_scope->get_symbol(sym_name) != nullptr) {
+        if (parent_scope->get_symbol(sym_name) != nullptr) {
             diag.add(diag::Diagnostic(
                 "DerivedType already defined",
                 diag::Level::Error, diag::Stage::Semantic, {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2613,7 +2613,7 @@ public:
             visit_procedure_decl(*x.m_contains[i]);
         }
         std::string sym_name = to_lower(x.m_name);
-        if (parent_scope->get_symbol(sym_name) != nullptr) {
+        if (!compiler_options.implicit_typing && parent_scope->get_symbol(sym_name) != nullptr) {
             diag.add(diag::Diagnostic(
                 "DerivedType already defined",
                 diag::Level::Error, diag::Stage::Semantic, {


### PR DESCRIPTION
Bug: When a derived type had a component with the same name as the type
itself (e.g., `type :: foo` containing `integer :: foo`), LFortran
incorrectly raised "DerivedType already defined". This is valid Fortran
and compiles successfully with gfortran.
Root cause: In visit_DerivedType, the duplicate-name check on line 2616
used `current_scope->get_symbol(sym_name)`, but at that point
`current_scope` points to the struct's child symbol table (where member
variables are stored), not the parent scope where the type symbol is
actually registered. A member variable sharing the type's name was found
in the child scope, triggering the false positive.
Fix: Change the check from `current_scope` to `parent_scope`, which is
the correct scope to verify against since the DerivedType symbol is
added to the parent scope.

fixes #11098