### PR TITLE
fix(runtime): handle null and repeat tokens in list-directed scalar reads

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3301,6 +3301,7 @@ RUN(NAME read_71 LABELS gfortran llvm)
 RUN(NAME read_72 LABELS gfortran llvm)
 RUN(NAME read_73 LABELS gfortran llvm)
 RUN(NAME read_74 LABELS gfortran llvm)
+RUN(NAME read_75 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_75.f90
+++ b/integration_tests/read_75.f90
@@ -11,7 +11,7 @@ program read_75
   double precision :: d1, d2, d3
   complex :: c1, c2, c3
 
-  open (42, file='fort.42', status='replace', form='formatted')
+  open (42, file='read_75.dat', status='replace', form='formatted')
   write (42,'(a)') cdata
   rewind (42)
   d1 = 1.0d0

--- a/integration_tests/read_75.f90
+++ b/integration_tests/read_75.f90
@@ -1,0 +1,32 @@
+program read_75
+  implicit none
+
+  ! Test list-directed read with null values and repeat-count syntax.
+  ! Input: ", (2.0, 3.0),,6.0D0, 2*,"
+  !   d1 -> null (keep 1.0), c1 -> (2.0,3.0), c2 -> null (keep (4.0,5.0)),
+  !   d2 -> 6.0, c3 -> null via 2* (keep (7.0,8.0)), d3 -> null via 2* (keep 9.0)
+
+  character(*), parameter :: cdata = ", (2.0, 3.0),,6.0D0, 2*,"
+
+  double precision :: d1, d2, d3
+  complex :: c1, c2, c3
+
+  open (42, file='fort.42', status='replace', form='formatted')
+  write (42,'(a)') cdata
+  rewind (42)
+  d1 = 1.0d0
+  c2 = (4.0, 5.0)
+  c3 = (7.0, 8.0)
+  d3 = 9.0d0
+  read (42, *) d1, c1, c2, d2, c3, d3
+
+  if (abs(d1 - 1.0d0) > 0.0001d0) error stop "d1 failed"
+  if (abs(real(c1) - 2.0) > 0.0001 .or. abs(aimag(c1) - 3.0) > 0.0001) error stop "c1 failed"
+  if (abs(real(c2) - 4.0) > 0.0001 .or. abs(aimag(c2) - 5.0) > 0.0001) error stop "c2 failed"
+  if (abs(d2 - 6.0d0) > 0.0001d0) error stop "d2 failed"
+  if (abs(real(c3) - 7.0) > 0.0001 .or. abs(aimag(c3) - 8.0) > 0.0001) error stop "c3 failed"
+  if (abs(d3 - 9.0d0) > 0.0001d0) error stop "d3 failed"
+
+  close (42, status='delete')
+  print *, "ok"
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -6886,6 +6886,36 @@ static void skip_list_directed_comma(FILE *filep) {
     if (c != EOF) ungetc(c, filep);
 }
 
+// List-directed read: track remaining null-value repeats per unit.
+#define LF_LIST_DIR_MAX_UNITS 1024
+static int lf_list_dir_null_remaining[LF_LIST_DIR_MAX_UNITS] = {0};
+
+static int list_directed_check_null_repeat(int32_t unit_num) {
+    if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS
+            && lf_list_dir_null_remaining[unit_num] > 0) {
+        lf_list_dir_null_remaining[unit_num]--;
+        return 1;
+    }
+    return 0;
+}
+
+// Detect "n*" null-repeat token (digits + star + nothing after).
+static int list_directed_parse_null_repeat(const char *token) {
+    int i = 0;
+    while (token[i] >= '0' && token[i] <= '9') i++;
+    if (i == 0 || token[i] != '*' || token[i+1] != '\0') return 0;
+    return atoi(token);
+}
+
+// Consume an optional trailing comma (the separator after a value).
+// This positions the stream so the next read call sees the start of its value.
+static void skip_trailing_comma(FILE *filep) {
+    int c;
+    while ((c = fgetc(filep)) != EOF && (c == ' ' || c == '\t')) {}
+    if (c == ',') return; // consumed
+    if (c != EOF) ungetc(c, filep); // not a comma, push back
+}
+
 static bool read_next_nonblank_stdin_line(char *buffer, size_t bufsize, int32_t *iostat)
 {
     while (true) {
@@ -7258,7 +7288,11 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
         } while (c != EOF && !isspace(c) && c != ',' && c != '/');
         
         token[len] = '\0';
-        if (c != EOF) ungetc(c, filep);
+        if (c == ',') {
+            // Consume trailing separator so the next read starts at the next value.
+        } else if (c != EOF) {
+            ungetc(c, filep);
+        }
         
         // Check token
         char *check_ptr = token;
@@ -7905,22 +7939,17 @@ static int parse_fortran_double(const char* buffer, double* result) {
 // Read a complete complex number expression from file, handling whitespace
 // within parentheses. Fortran list-directed format allows arbitrary whitespace
 // inside (real, imag) format, e.g., "( 0.1000E+01, 0.2000E+01)".
-// Returns 1 on success, 0 on failure (EOF or error).
+// Returns: 1 = success, 0 = EOF/error, -1 = null value
 static int read_complex_expr(FILE *filep, char *buffer, size_t bufsize) {
     int ch;
     size_t i = 0;
-
-    // Skip leading whitespace
     while ((ch = fgetc(filep)) != EOF && isspace(ch));
-
-    if (ch == ',') {
-        while ((ch = fgetc(filep)) != EOF && isspace(ch));
-    }
-
     if (ch == EOF) return 0;
-
+    // Leading comma = null value
+    if (ch == ',') {
+        return -1;
+    }
     if (ch == '(') {
-        // Read the entire parenthesized expression
         buffer[i++] = (char)ch;
         while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF) {
             buffer[i++] = (char)ch;
@@ -7929,14 +7958,13 @@ static int read_complex_expr(FILE *filep, char *buffer, size_t bufsize) {
         buffer[i] = '\0';
         return (ch == ')') ? 1 : 0;
     } else {
-        // Not a parenthesized expression, read as whitespace-delimited token
         buffer[i++] = (char)ch;
-        while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF && !isspace(ch)) {
+        while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF && !isspace(ch) && ch != ',') {
             buffer[i++] = (char)ch;
         }
         buffer[i] = '\0';
-        // Push back the whitespace character if we read one
-        if (ch != EOF && isspace(ch)) {
+        // Don't ungetc the comma - it's consumed as trailing separator
+        if (ch != EOF && ch != ',') {
             ungetc(ch, filep);
         }
         return 1;
@@ -7988,43 +8016,49 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
             exit(1);
         }
     } else {
+        if (list_directed_check_null_repeat(unit_num)) {
+            return;
+        }
         int c;
         while ((c = fgetc(filep)) != EOF && isspace(c)) {}
-        
         if (c == EOF) {
              if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
              fprintf(stderr, "Error: Invalid float input from file (EOF).\n");
              exit(1);
         }
-        
         if (c == ',') {
-             while ((c = fgetc(filep)) != EOF && isspace(c)) {}
-             if (c == EOF) {
-                  if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
-                  fprintf(stderr, "Error: Invalid float input from file (EOF).\n");
-                  exit(1);
-             }
+            return;
         }
-        
-        if (c == ',' || c == '/') {
-             ungetc(c, filep);
-             return; 
+        if (c == '/') {
+            ungetc(c, filep);
+            return;
         }
-        
         char buffer[100];
         int len = 0;
         do {
             if (len < 99) buffer[len++] = (char)c;
             c = fgetc(filep);
         } while (c != EOF && !isspace(c) && c != ',' && c != '/');
-        
         buffer[len] = '\0';
-        if (c != EOF) ungetc(c, filep);
-
+        if (c == ',') {
+            // trailing comma consumed
+        } else if (c != EOF) {
+            ungetc(c, filep);
+        }
+        int null_count = list_directed_parse_null_repeat(buffer);
+        if (null_count > 0) {
+            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            }
+            return;
+        }
         if (!parse_fortran_float(buffer, p)) {
             if (iostat) { *iostat = 1; return; }
             fprintf(stderr, "Error: Invalid input from file.\n");
             exit(1);
+        }
+        if (c != ',') {
+            skip_trailing_comma(filep);
         }
     }
 }
@@ -8062,11 +8096,25 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
             exit(1);
         }
     } else {
+        if (list_directed_check_null_repeat(unit_num)) {
+            return;
+        }
         char buffer[200];
-        if (!read_complex_expr(filep, buffer, sizeof(buffer))) {
+        int rc = read_complex_expr(filep, buffer, sizeof(buffer));
+        if (rc == -1) {
+            return; // null value
+        }
+        if (rc == 0) {
             if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
             fprintf(stderr, "Error: Invalid input for complex float from file.\n");
             exit(1);
+        }
+        int null_count = list_directed_parse_null_repeat(buffer);
+        if (null_count > 0) {
+            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            }
+            return;
         }
         convert_fortran_d_exponent(buffer);
         char *start = strchr(buffer, '(');
@@ -8091,7 +8139,6 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 exit(1);
             }
         } else {
-            // No parentheses: treat as two whitespace-separated numbers
             p->re = strtof(buffer, NULL);
             if (fscanf(filep, "%f", &p->im) != 1) {
                 if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
@@ -8099,6 +8146,8 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 exit(1);
             }
         }
+        // Consume trailing comma
+        skip_trailing_comma(filep);
     }
 }
 
@@ -8135,11 +8184,25 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
             exit(1);
         }
     } else {
+        if (list_directed_check_null_repeat(unit_num)) {
+            return;
+        }
         char buffer[200];
-        if (!read_complex_expr(filep, buffer, sizeof(buffer))) {
+        int rc = read_complex_expr(filep, buffer, sizeof(buffer));
+        if (rc == -1) {
+            return;
+        }
+        if (rc == 0) {
             if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
             fprintf(stderr, "Error: Invalid input for complex double from file.\n");
             exit(1);
+        }
+        int null_count = list_directed_parse_null_repeat(buffer);
+        if (null_count > 0) {
+            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            }
+            return;
         }
         convert_fortran_d_exponent(buffer);
         char *start = strchr(buffer, '(');
@@ -8164,7 +8227,6 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 exit(1);
             }
         } else {
-            // No parentheses: treat as two whitespace-separated numbers
             p->re = strtod(buffer, NULL);
             if (fscanf(filep, "%lf", &p->im) != 1) {
                 if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
@@ -8172,6 +8234,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 exit(1);
             }
         }
+        skip_trailing_comma(filep);
     }
 }
 
@@ -8595,43 +8658,51 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
             exit(1);
         }
     } else {
+        if (list_directed_check_null_repeat(unit_num)) {
+            return;
+        }
         int c;
         while ((c = fgetc(filep)) != EOF && isspace(c)) {}
-
         if (c == EOF) {
             if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
             fprintf(stderr, "Error: Failed to read double from file.\n");
             exit(1);
         }
-
+        // Leading comma = null value
         if (c == ',') {
-            while ((c = fgetc(filep)) != EOF && isspace(c)) {}
-            if (c == EOF) {
-                if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
-                fprintf(stderr, "Error: Failed to read double from file.\n");
-                exit(1);
-            }
+            return;
         }
-
-        if (c == ',' || c == '/') {
+        if (c == '/') {
             ungetc(c, filep);
             return;
         }
-
         char buffer[100];
         int len = 0;
         do {
             if (len < 99) buffer[len++] = (char)c;
             c = fgetc(filep);
         } while (c != EOF && !isspace(c) && c != ',' && c != '/');
-
         buffer[len] = '\0';
-        if (c != EOF) ungetc(c, filep);
-
+        if (c == ',') {
+            // Trailing comma consumed (separator for next value)
+        } else if (c != EOF) {
+            ungetc(c, filep);
+        }
+        int null_count = list_directed_parse_null_repeat(buffer);
+        if (null_count > 0) {
+            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            }
+            return;
+        }
         if (!parse_fortran_double(buffer, p)) {
             if (iostat) { *iostat = 1; return; }
             fprintf(stderr, "Error: Invalid input from file.\n");
             exit(1);
+        }
+        // If we didn't consume a trailing comma in the loop, try now
+        if (c != ',') {
+            skip_trailing_comma(filep);
         }
     }
 }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5201,10 +5201,18 @@ struct UNIT_FILE unit_to_file[MAXUNITS];
 static int32_t seq_char_pending[MAXUNITS];
 static int32_t seq_char_record_len[MAXUNITS];
 
+// Pending list-directed null-repeat state per unit.
+static int32_t lf_list_dir_null_remaining[MAXUNITS];
+
 static inline void seq_char_state_reset(int32_t unit_num) {
     if (unit_num < 0 || unit_num >= MAXUNITS) return;
     seq_char_pending[unit_num] = 0;
     seq_char_record_len[unit_num] = 0;
+}
+
+static inline void list_dir_state_reset(int32_t unit_num) {
+    if (unit_num < 0 || unit_num >= MAXUNITS) return;
+    lf_list_dir_null_remaining[unit_num] = 0;
 }
 
 // Pre-connect standard Fortran units at program startup.
@@ -5283,6 +5291,7 @@ static int32_t count_newlines_up_to(FILE *fp, long end_pos) {
 void store_unit_file(int32_t unit_num, char* filename, FILE* filep, bool unit_file_bin, int access_id, bool read_access, bool write_access, int delim, bool blank_zero, int32_t record_length, int sign_mode, int decimal_mode, int encoding, int round_mode, int pad_mode) {
     _lfortran_init_standard_units();
     seq_char_state_reset(unit_num);
+    list_dir_state_reset(unit_num);
     for( int i = 0; i <= last_index_used; i++ ) {
         if( unit_to_file[i].unit == unit_num ) {
             // Update existing entry - only update filename if explicitly provided (not NULL)
@@ -5377,6 +5386,7 @@ char* get_file_name_from_unit(int32_t unit_num, bool *unit_file_bin) {
 
 void remove_from_unit_to_file(int32_t unit_num) {
     seq_char_state_reset(unit_num);
+    list_dir_state_reset(unit_num);
     int index = -1;
     for( int i = 0; i <= last_index_used; i++ ) {
         if( unit_to_file[i].unit == unit_num ) {
@@ -6740,6 +6750,7 @@ LFORTRAN_API void _lfortran_rewind(int32_t unit_num)
     }
     rewind(filep);
     seq_char_state_reset(unit_num);
+    list_dir_state_reset(unit_num);
 }
 
 LFORTRAN_API void _lfortran_endfile(int32_t unit_num)
@@ -6886,12 +6897,8 @@ static void skip_list_directed_comma(FILE *filep) {
     if (c != EOF) ungetc(c, filep);
 }
 
-// List-directed read: track remaining null-value repeats per unit.
-#define LF_LIST_DIR_MAX_UNITS 1024
-static int lf_list_dir_null_remaining[LF_LIST_DIR_MAX_UNITS] = {0};
-
 static int list_directed_check_null_repeat(int32_t unit_num) {
-    if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS
+    if (unit_num >= 0 && unit_num < MAXUNITS
             && lf_list_dir_null_remaining[unit_num] > 0) {
         lf_list_dir_null_remaining[unit_num]--;
         return 1;
@@ -8047,7 +8054,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+            if (unit_num >= 0 && unit_num < MAXUNITS) {
                 lf_list_dir_null_remaining[unit_num] = null_count - 1;
             }
             return;
@@ -8111,7 +8118,7 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+            if (unit_num >= 0 && unit_num < MAXUNITS) {
                 lf_list_dir_null_remaining[unit_num] = null_count - 1;
             }
             return;
@@ -8199,7 +8206,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+            if (unit_num >= 0 && unit_num < MAXUNITS) {
                 lf_list_dir_null_remaining[unit_num] = null_count - 1;
             }
             return;
@@ -8690,7 +8697,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < LF_LIST_DIR_MAX_UNITS) {
+            if (unit_num >= 0 && unit_num < MAXUNITS) {
                 lf_list_dir_null_remaining[unit_num] = null_count - 1;
             }
             return;


### PR DESCRIPTION
fix(runtime): handle null and repeat tokens in list-directed scalar reads

Correct parsing of list-directed input in lfortran_intrinsics.c where
leading separators and repeat-null tokens were previously mis-handled,
causing errors such as "Invalid input from file" for inputs with
comma/null sequences.

- add per-unit tracking for null-repeat tokens
- implement helpers to detect and consume pending null repeats
- treat leading commas as null values (leave variable unchanged)
- support n* null-repeat tokens in scalar reads
- ensure consistent handling of trailing separators
- update complex scalar parsing to return explicit null-value status
- consume trailing commas after logical reads to avoid stale separators
fixes #11094