### PR TITLE
Evaluate c_sizeof/sizeof to compile-time constant

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1193,6 +1193,7 @@ RUN(NAME submodule_44a LABELS gfortran llvm_submodule EXTRAFILES submodule_44b.f
 RUN(NAME c_sizeof_02 LABELS gfortran llvm)
 RUN(NAME c_sizeof_03 LABELS gfortran llvm)
 RUN(NAME c_sizeof_04 LABELS gfortran llvm)
+RUN(NAME c_sizeof_05 LABELS gfortran llvm)
 RUN(NAME sizeof_01 LABELS gfortran llvm)
 RUN(NAME iso_c_binding_04 LABELS gfortran llvm)
 RUN(NAME submodule_45 LABELS gfortran llvm)

--- a/integration_tests/c_sizeof_05.f90
+++ b/integration_tests/c_sizeof_05.f90
@@ -1,0 +1,16 @@
+program c_sizeof_05
+    use, intrinsic :: iso_c_binding
+    implicit none
+
+    integer(c_int) :: my_integer
+    integer(c_size_t), parameter :: byte_size = c_sizeof(my_integer)
+
+    real(c_double) :: my_double
+    integer(c_size_t), parameter :: double_size = c_sizeof(my_double)
+
+    print *, byte_size
+    if (byte_size /= 4) error stop
+    print *, double_size
+    if (double_size /= 8) error stop
+
+end program c_sizeof_05

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -14759,8 +14759,14 @@ public:
         ASR::ttype_t *arg_type = ASRUtils::expr_type(arg);
         ASR::ttype_t *size_type = ASRUtils::TYPE(
             ASR::make_Integer_t(al, x.base.base.loc, 8));
+        ASR::expr_t *value = nullptr;
+        int64_t type_size = ASRUtils::get_type_byte_size(arg_type);
+        if (type_size > 0) {
+            value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                al, x.base.base.loc, type_size, size_type));
+        }
         return ASR::make_SizeOfType_t(al, x.base.base.loc, arg_type,
-            size_type, nullptr);
+            size_type, value);
     }
 
     ASR::asr_t* create_SizeOf(const AST::FuncCallOrArray_t& x) {
@@ -14775,8 +14781,14 @@ public:
         ASR::ttype_t *arg_type = ASRUtils::expr_type(arg);
         ASR::ttype_t *size_type = ASRUtils::TYPE(
             ASR::make_Integer_t(al, x.base.base.loc, 8));
+        ASR::expr_t *value = nullptr;
+        int64_t type_size = ASRUtils::get_type_byte_size(arg_type);
+        if (type_size > 0) {
+            value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                al, x.base.base.loc, type_size, size_type));
+        }
         return ASR::make_SizeOfType_t(al, x.base.base.loc, arg_type,
-            size_type, nullptr);
+            size_type, value);
     }
 
     ASR::asr_t* handle_intrinsic_float_dfloat(Allocator &al, Vec<ASR::call_arg_t> args,

--- a/tests/reference/asr-sizeof_01-9e0775c.json
+++ b/tests/reference/asr-sizeof_01-9e0775c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-sizeof_01-9e0775c.stdout",
-    "stdout_hash": "2746f905d1d033a517eb4e0b821831daa9224cbc0e73a06f314ebbcf",
+    "stdout_hash": "45eb6d1b4fa501df013632a95b1b73a1ed49c0e113969f23938cb4ab",
     "stderr": "asr-sizeof_01-9e0775c.stderr",
     "stderr_hash": "37f448eb33d6ccc76ae5d1960db2fe93c9c3d8c3132b405870d5f6f1",
     "returncode": 0

--- a/tests/reference/asr-sizeof_01-9e0775c.stdout
+++ b/tests/reference/asr-sizeof_01-9e0775c.stdout
@@ -85,7 +85,7 @@
                         (SizeOfType
                             (Integer 4)
                             (Integer 8)
-                            ()
+                            (IntegerConstant 4 (Integer 8) Decimal)
                         )
                         ()
                         .false.


### PR DESCRIPTION
c_sizeof and sizeof were not computing a compile-time value for their SizeOfType ASR node, causing parameter initialization to fail with 'must reduce to a compile time constant'. Now uses ASRUtils::get_type_byte_size() to compute the value at semantics time when the type size is known.

An integration test (c_sizeof_05) was added.

Fixes #11112.