### PR TITLE
Fix fixed-form parsing of variables starting with IO keywords

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -450,6 +450,7 @@ RUN(NAME print_arr_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME crlf_fixed_form LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_io_keyword_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_io_keyword_01.f90
+++ b/integration_tests/fixed_form_io_keyword_01.f90
@@ -1,0 +1,14 @@
+      program fixed_form_io_keyword_01
+      integer printp, readi, writej, closek
+      common /rkcom3/ printp
+      save /rkcom3/
+      printp = 1
+      readi = 2
+      writej = 3
+      closek = 4
+      if (printp /= 1) error stop
+      if (readi /= 2) error stop
+      if (writej /= 3) error stop
+      if (closek /= 4) error stop
+      print *, printp, readi, writej, closek
+      end

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -906,9 +906,33 @@ struct FixedFormRecursiveDescent {
         return false;
     }
 
+    // Check if the line starting at `cur` is an assignment to a variable
+    // whose name starts with an IO keyword (e.g., PRINTP = 1 in fixed-form
+    // becomes printp=1 after prescanning). Returns true if there is a '='
+    // (not '==') before any ',' at parenthesis depth 0, indicating an
+    // assignment rather than an IO statement.
+    bool is_io_keyword_assignment(unsigned char *p) {
+        if (*p == '=' && *(p+1) != '=') return true;
+        if (!is_char(*p) && !is_digit(*p) && *p != '_') return false;
+        int depth = 0;
+        while (*p != '\n' && *p != '\0') {
+            if (*p == '(') depth++;
+            else if (*p == ')') depth--;
+            else if (depth == 0) {
+                if (*p == '=' && *(p+1) != '=') return true;
+                if (*p == ',') return false;
+            }
+            p++;
+        }
+        return false;
+    }
+
     bool lex_io(unsigned char *&cur) {
         for(const auto &io_str: io_names) {
             if (next_is(cur, io_str)) {
+                if (is_io_keyword_assignment(cur + io_str.size())) {
+                    return false;
+                }
                 if (io_str == "format") {
                     unsigned char *format_start = cur;
                     cur += io_str.size();


### PR DESCRIPTION
In fixed-form Fortran, the prescanner removes spaces and lowercases everything, so PRINTP = 1 becomes printp=1. The fixed-form tokenizer's lex_io() was matching 'print' as a prefix and incorrectly treating the line as a PRINT statement.

Add is_io_keyword_assignment() to check whether the text after an IO keyword prefix forms an assignment (identifier continuation followed by '=' at parenthesis depth 0 before any ','). If so, lex_io() returns false and lets the assignment handler process the line.

An integration test is added covering variables starting with print, read, write, and close keywords.

Fixes #11108.