### PR TITLE
fix: join fixed-form continuations in SELECT CASE bodies

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -449,6 +449,7 @@ RUN(NAME print_arr_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME crlf_fixed_form LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_select_case_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/fixed_form_select_case_02.f90
+++ b/integration_tests/fixed_form_select_case_02.f90
@@ -1,0 +1,17 @@
+      program fixed_form_select_case_02
+          integer :: i, j
+          i = 1
+          j = 0
+          select case (i)
+          case (1)
+              call sub
+     $            (j)
+          end select
+          if (j /= 42) error stop
+          print *, j
+      contains
+          subroutine sub(x)
+              integer, intent(inout) :: x
+              x = 42
+          end subroutine sub
+      end program

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1576,8 +1576,11 @@ struct FixedFormRecursiveDescent {
                 push_token_advance(cur, "case");
                 push_token_advance(cur, "default");
                 tokenize_line(cur);
-            } else {
+            } else if (next_is(cur, "case")) {
+                push_token_advance(cur, "case");
                 tokenize_line(cur);
+            } else {
+                lex_body_statement(cur);
             }
         }
         push_token_advance(cur, "endselect");


### PR DESCRIPTION
## Summary
Route body statements in a fixed-form `SELECT CASE` through `lex_body_statement` so col-6 continuation lines are joined. Previously `lex_selectcase` tokenised each physical line with raw `tokenize_line`, rejecting any `CALL` whose argument list sat on a continuation line.

Fixes #11116

**Stage:** Parser (tokenizer)

## Why
Common legacy-F77 pattern in plasma / engineering codes:

```
      CALL program_stop
     $        ("Cannot recognize convert_type = "//TRIM(convert_type))
```

gfortran and ifort accept this; `lfortran --fixed-form` errored with `syntax error: Newline is unexpected here`. `IF`/`ENDIF` bodies already work because they dispatch through `lex_body_statement`; `SELECT CASE` bodies didn't.

## Changes
- [`src/lfortran/parser/fixedform_tokenizer.cpp#L1569-L1588`](https://github.com/lfortran/lfortran/blob/b6b032c8d079b22ac33986c3c5999722693e52ef/src/lfortran/parser/fixedform_tokenizer.cpp#L1569-L1588): Split the else branch of `lex_selectcase` into (a) `case (...)` header lines (still single-line tokenise) and (b) everything else, which now dispatches through `lex_body_statement` — same pattern `IF` and `DO` bodies already use.

## Tests
- [`integration_tests/fixed_form_select_case_02.f90`](https://github.com/lfortran/lfortran/blob/b6b032c8d079b22ac33986c3c5999722693e52ef/integration_tests/fixed_form_select_case_02.f90): MRE — `CALL sub` with parenthesised arg list on a col-6 continuation line inside `case (1)`. Asserts `j == 42` via `error stop`. Registered next to `fixed_form_select_case_01` with labels `gfortran llvm`.

## Verification

### Test fails on main
```
$ git checkout upstream/main && scripts/lf.sh build
$ scripts/lf.sh itest -b llvm -t fixed_form_select_case_02 -s
Building 1 test(s): fixed_form_select_case_02_LLVM_GOC
Building Fortran object CMakeFiles/fixed_form_select_case_02_LLVM_GOC.dir/fixed_form_select_case_02.f90.o
syntax error: Newline is unexpected here
 --> integration_tests/fixed_form_select_case_02.f90:8:22
  |
8 |      $            (j)
  |                      ^
make[3]: *** [CMakeFiles/fixed_form_select_case_02_LLVM_GOC.dir/build.make:75: CMakeFiles/fixed_form_select_case_02_LLVM_GOC.dir/fixed_form_select_case_02.f90.o] Error 1
make: *** [Makefile:615: fixed_form_select_case_02_LLVM_GOC] Error 2
```

### Test passes after fix
```
$ git checkout fix/fixed-form-call-continuation-in-select-case && scripts/lf.sh build
$ scripts/lf.sh itest -b llvm -t fixed_form_select_case_02 -s
Building 1 test(s): fixed_form_select_case_02_LLVM_GOC
    Start 38: fixed_form_select_case_02_LLVM_GOC
1/1 Test #38: fixed_form_select_case_02_LLVM_GOC ...   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1
```

### No regressions in full LLVM integration suite
```
$ scripts/lf.sh itest -b llvm
100% tests passed, 0 tests failed out of 3363
```