### PR TITLE
enh: add support for `read` without input-item-list

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3356,12 +3356,11 @@ RUN(NAME read_75 LABELS gfortran llvm)
 RUN(NAME read_76 LABELS gfortran llvm)
 RUN(NAME read_77 LABELS gfortran llvm)
 RUN(NAME read_78 LABELS gfortran llvm)
-
 RUN(NAME read_79 LABELS gfortran llvm)
 RUN(NAME read_80 LABELS gfortran llvm)
-
 RUN(NAME read_81 LABELS gfortran llvm)
 RUN(NAME read_82 LABELS gfortran llvm)
+RUN(NAME read_83 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_83.f90
+++ b/integration_tests/read_83.f90
@@ -1,0 +1,24 @@
+program read_83
+   implicit none
+
+   character(len=32) :: empty_read
+   integer :: unit_num
+
+   call get_command_argument(1, empty_read)
+
+   if (trim(empty_read) == '--empty-read') then
+      print *, "Starting empty read. All input to stdin will be discarded."
+      read *
+      print *, "Empty read 1 completed successfully. Starting empty read 2 with unit=5 (stdin), fmt='(I10)'."
+      read (5, "(I10)")
+      print *, "Empty read 2 completed successfully. Starting empty read 3 with unit=*, fmt=*."
+      read (*, *)
+      print *, "Empty read 3 completed successfully. Starting empty read 4 with format label."
+      36  format(I10)
+      read 36
+      print *, "Empty read 4 completed successfully. Starting empty read 5 with unit passed through variable."
+      unit_num = 5
+      read (unit_num, "(I10)")
+      print *, "Empty read 5 completed successfully. All empty reads completed without error."
+   end if
+end program

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -1915,7 +1915,8 @@ read_statement
     | KW_READ "(" write_arg_list ")" "," expr_list { $$ = READ($3, $6, @$); }
     | KW_READ "(" write_arg_list ")" { $$ = READ0($3, @$); }
     | KW_READ TK_INTEGER "," expr_list { $$ = READ2($2, $4, @$); }
-    | KW_READ "*" "," expr_list { $$ = READ3($4, @$); }
+    | KW_READ "*" "," expr_list_opt { $$ = READ3($4, @$); }
+    | KW_READ "*" { $$ = READ6(@$); }
     | KW_READ TK_INTEGER { $$ = READ4($2, @$); }
     | KW_READ TK_STRING "," expr_list { $$ = READ5($2, $4, @$); }
     ;

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -1335,6 +1335,8 @@ ast_t* builtin3(Allocator &al,
         EXPR(INTEGER(arg, l)), nullptr, 0, nullptr, 0, nullptr, 0, nullptr)
 #define READ5(arg, args, l) make_Read_t(p.m_a, l, 0, \
         EXPR(STRING(arg, l)), nullptr, 0, nullptr, 0, EXPRS(args), args.size(), nullptr)
+#define READ6(l) make_Read_t(p.m_a, l, 0, \
+        nullptr, nullptr, 0, nullptr, 0, nullptr, 0, nullptr)
 
 #define OPEN(args0, l) builtin1(p.m_a, args0, l, make_Open_t)
 #define CLOSE(args0, l) builtin1(p.m_a, args0, l, make_Close_t)

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16710,7 +16710,11 @@ public:
         llvm::Value *iostat_user = nullptr; // User's iostat variable 
         int iostat_kind = 4; // kind of iostat variable (default INT32)
         bool is_string = false;
-        if (x.m_unit == nullptr) {
+        bool empty_read = (x.n_values == 0 && x.m_iostat == nullptr && x.m_iomsg == nullptr);
+        if (empty_read && x.m_unit == nullptr) {
+            unit_val = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
+                                              llvm::APInt(32, -2, true));
+        } else if (x.m_unit == nullptr) {
             // Read from stdin
             unit_val = llvm::ConstantInt::get(
                     llvm::Type::getInt32Ty(context), llvm::APInt(32, -1, true));
@@ -16721,6 +16725,19 @@ public:
             if(ASRUtils::is_integer(*ASRUtils::expr_type(x.m_unit))){
                 // Convert the unit to 32 bit integer (We only support unit number up to 1000).
                 unit_val = llvm_utils->convert_kind(tmp, llvm::Type::getInt32Ty(context));
+            }
+            if (empty_read && !is_string) {
+                // Unit is provided with no values, no iostat, no iomsg.
+                // If unit is 5 (stdin), set `unit_val` = -2.
+                // The unit need not be a compile-time constant.
+                llvm::Value* is_stdin = builder->CreateICmpEQ(unit_val,
+                    llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 5));
+                unit_val = builder->CreateSelect(is_stdin,
+                    llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
+                                            llvm::APInt(32, -2, true)),
+                    unit_val);
+            } else {
+                empty_read = false;
             }
         }
 
@@ -16832,7 +16849,7 @@ public:
             emit_seek_record_from_rec(x.m_rec, unit_val, iostat);
         }
 
-        if (x.m_fmt) {
+        if (x.m_fmt && !empty_read) {
             emit_formatted_read(x, unit_val, iostat, read_size, advance, advance_length, is_string);
         } else {
             llvm::Value* var_to_read_into = nullptr; // Var expression that we'll read into.
@@ -17334,7 +17351,7 @@ public:
             // Here, we can use `_lfortran_empty_read` function to move to the
             // pointer to the next line.
             // Skip for internal (string) reads — no file position to advance.
-            if (!is_string) {
+            if (!is_string || empty_read) {
             std::string runtime_func_name = "_lfortran_empty_read";
             llvm::Function *fn = module->getFunction(runtime_func_name);
             if (!fn) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -10043,7 +10043,13 @@ static void common_formatted_read(InputSource *inputSource,
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat) {
     if (iostat) *iostat = 0;
     if (unit_num == -1) {
+        return;
+    } else if (unit_num == -2) {
         // Read from stdin
+        int inp = 0;
+        do {
+            inp = fgetc(stdin);
+        } while (inp != '\n' && inp != EOF);
         return;
     }
 

--- a/tests/reference/llvm-read_83-d6544e3.json
+++ b/tests/reference/llvm-read_83-d6544e3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-read_83-d6544e3",
+    "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/read_83.f90",
+    "infile_hash": "617992e5d0104cdcfaa0fa8ecf772fc5b51badc6499cc8369e0c9654",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-read_83-d6544e3.stdout",
+    "stdout_hash": "84b4cc82535476635d62d87a51979a565c191cf99f897704a6dfbc5a",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-read_83-d6544e3.stdout
+++ b/tests/reference/llvm-read_83-d6544e3.stdout
@@ -1,0 +1,358 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+target datalayout = "..."
+
+%string_descriptor = type <{ i8*, i64 }>
+
+@__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
+@string_const_data = private constant [1 x i8] c" "
+@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data, i32 0, i32 0), i64 1 }>
+@string_const_data.1 = private constant [12 x i8] c"--empty-read"
+@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data.1, i32 0, i32 0), i64 12 }>
+@0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.3 = private constant [58 x i8] c"Starting empty read. All input to stdin will be discarded."
+@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([58 x i8], [58 x i8]* @string_const_data.3, i32 0, i32 0), i64 58 }>
+@1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@2 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
+@3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.5 = private constant [92 x i8] c"Empty read 1 completed successfully. Starting empty read 2 with unit=5 (stdin), fmt='(I10)'."
+@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([92 x i8], [92 x i8]* @string_const_data.5, i32 0, i32 0), i64 92 }>
+@4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@5 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
+@6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.7 = private constant [78 x i8] c"Empty read 2 completed successfully. Starting empty read 3 with unit=*, fmt=*."
+@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([78 x i8], [78 x i8]* @string_const_data.7, i32 0, i32 0), i64 78 }>
+@7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@8 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
+@9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.9 = private constant [77 x i8] c"Empty read 3 completed successfully. Starting empty read 4 with format label."
+@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([77 x i8], [77 x i8]* @string_const_data.9, i32 0, i32 0), i64 77 }>
+@10 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@11 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
+@12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.11 = private constant [93 x i8] c"Empty read 4 completed successfully. Starting empty read 5 with unit passed through variable."
+@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([93 x i8], [93 x i8]* @string_const_data.11, i32 0, i32 0), i64 93 }>
+@13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+@14 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
+@15 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@string_const_data.13 = private constant [77 x i8] c"Empty read 5 completed successfully. All empty reads completed without error."
+@string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([77 x i8], [77 x i8]* @string_const_data.13, i32 0, i32 0), i64 77 }>
+@16 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
+
+define void @_lcompilers_get_command_argument_(i32* %number, %string_descriptor* %value) {
+.entry:
+  %0 = call i8* @_lfortran_get_default_allocator()
+  %command_argument_holder = alloca %string_descriptor, align 8
+  store %string_descriptor zeroinitializer, %string_descriptor* %command_argument_holder, align 1
+  %length_to_allocate = alloca i32, align 4
+  store i32 0, i32* %length_to_allocate, align 4
+  %1 = load i32, i32* %number, align 4
+  %2 = call i32 @_lfortran_get_command_argument_length(i32 %1)
+  store i32 %2, i32* %length_to_allocate, align 4
+  %3 = load i32, i32* %length_to_allocate, align 4
+  %4 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %5 = load i8*, i8** %4, align 8
+  %6 = icmp ne i8* %5, null
+  br i1 %6, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %7 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %8 = sext i32 %3 to i64
+  %9 = call i8* @_lfortran_get_default_allocator()
+  %10 = call i8* @_lfortran_string_malloc_alloc(i8* %9, i64 %8)
+  store i8* %10, i8** %7, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 1
+  %12 = sext i32 %3 to i64
+  store i64 %12, i64* %11, align 8
+  %13 = load i32, i32* %number, align 4
+  %14 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %15 = load i8*, i8** %14, align 8
+  %16 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %17 = load i8*, i8** %16, align 8
+  call void @_lfortran_get_command_argument_value(i32 %13, i8* %17)
+  %18 = getelementptr %string_descriptor, %string_descriptor* %value, i32 0, i32 0
+  %19 = getelementptr %string_descriptor, %string_descriptor* %value, i32 0, i32 1
+  %20 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %21 = load i8*, i8** %20, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 1
+  %23 = load i64, i64* %22, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %18, i64* %19, i8 0, i8 0, i8* %21, i64 %23)
+  br label %return
+
+return:                                           ; preds = %ifcont
+  br label %FINALIZE_SYMTABLE__lcompilers_get_command_argument_
+
+FINALIZE_SYMTABLE__lcompilers_get_command_argument_: ; preds = %return
+  br label %Finalize_Variable_command_argument_holder
+
+Finalize_Variable_command_argument_holder:        ; preds = %FINALIZE_SYMTABLE__lcompilers_get_command_argument_
+  %24 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %25 = load i8*, i8** %24, align 8
+  call void @_lfortran_free_alloc(i8* %0, i8* %25)
+  ret void
+}
+
+declare i32 @_lfortran_get_command_argument_length(i32)
+
+declare void @_lfortran_get_command_argument_value(i32, i8*)
+
+define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
+.entry:
+  %StringItem = alloca %string_descriptor, align 8
+  %result = alloca i32, align 4
+  %0 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %1 = load i64, i64* %0, align 8
+  %2 = trunc i64 %1 to i32
+  store i32 %2, i32* %result, align 4
+  %3 = load i32, i32* %result, align 4
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %then, label %else2
+
+then:                                             ; preds = %.entry
+  br label %loop.head
+
+loop.head:                                        ; preds = %ifcont, %then
+  %5 = load i32, i32* %result, align 4
+  %6 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
+  %7 = load i8*, i8** %6, align 8
+  %8 = sext i32 %5 to i64
+  %9 = sub i64 %8, 1
+  %10 = getelementptr i8, i8* %7, i64 %9
+  %11 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
+  store i8* %10, i8** %11, align 8
+  %12 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
+  store i64 1, i64* %12, align 8
+  %13 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
+  %14 = load i8*, i8** %13, align 8
+  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %16 = load i8, i8* %14, align 1
+  %17 = load i8, i8* %15, align 1
+  %18 = icmp eq i8 %16, %17
+  br i1 %18, label %loop.body, label %loop.end
+
+loop.body:                                        ; preds = %loop.head
+  %19 = load i32, i32* %result, align 4
+  %20 = sub i32 %19, 1
+  store i32 %20, i32* %result, align 4
+  %21 = load i32, i32* %result, align 4
+  %22 = icmp eq i32 %21, 0
+  br i1 %22, label %then1, label %else
+
+then1:                                            ; preds = %loop.body
+  br label %loop.end
+
+unreachable_after_exit:                           ; No predecessors!
+  br label %ifcont
+
+else:                                             ; preds = %loop.body
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %unreachable_after_exit
+  br label %loop.head
+
+loop.end:                                         ; preds = %then1, %loop.head
+  br label %ifcont3
+
+else2:                                            ; preds = %.entry
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %loop.end
+  br label %return
+
+return:                                           ; preds = %ifcont3
+  br label %FINALIZE_SYMTABLE__lcompilers_len_trim_str
+
+FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
+  %23 = load i32, i32* %result, align 4
+  ret i32 %23
+}
+
+define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
+.entry:
+  %0 = call i8* @_lfortran_get_default_allocator()
+  %StrSlice_StrView = alloca %string_descriptor, align 8
+  %1 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %str)
+  %2 = sext i32 %1 to i64
+  %3 = sub i64 %2, 1
+  %4 = add i64 %3, 1
+  %5 = icmp slt i64 %4, 0
+  %6 = select i1 %5, i64 0, i64 %4
+  %7 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
+  %8 = load i8*, i8** %7, align 8
+  %StrSliceGEP = getelementptr i8, i8* %8, i64 0
+  %9 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  store i8* %StrSliceGEP, i8** %9, align 8
+  %10 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %6, i64* %10, align 8
+  %11 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 1
+  %13 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %14 = load i8*, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %16 = load i64, i64* %15, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %11, i64* %12, i8 0, i8 0, i8* %14, i64 %16)
+  br label %return
+
+return:                                           ; preds = %.entry
+  br label %FINALIZE_SYMTABLE__lcompilers_trim_str
+
+FINALIZE_SYMTABLE__lcompilers_trim_str:           ; preds = %return
+  ret void
+}
+
+declare void @_lcompilers_print_error(i8*, ...)
+
+declare void @exit(i32)
+
+declare i8* @_lfortran_string_malloc_alloc(i8*, i64)
+
+declare i8* @_lfortran_get_default_allocator()
+
+declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64)
+
+declare void @_lfortran_free_alloc(i8*, i8*)
+
+define i32 @main(i32 %0, i8** %1) {
+.entry:
+  %2 = call i8* @_lfortran_get_default_allocator()
+  %call_arg_value = alloca i32, align 4
+  %empty_read = alloca %string_descriptor, align 8
+  %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
+  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
+  store %string_descriptor zeroinitializer, %string_descriptor* %empty_read, align 1
+  %3 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 1
+  store i64 32, i64* %3, align 8
+  %4 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 0
+  %5 = call i8* @_lfortran_get_default_allocator()
+  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 32)
+  store i8* %6, i8** %4, align 8
+  %unit_num = alloca i32, align 4
+  store i32 1, i32* %call_arg_value, align 4
+  call void @_lcompilers_get_command_argument_(i32* %call_arg_value, %string_descriptor* %empty_read)
+  %7 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %8 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %9 = load i8*, i8** %7, align 8
+  call void @_lfortran_free_alloc(i8* %2, i8* %9)
+  store i8* null, i8** %7, align 8
+  store i64 0, i64* %8, align 8
+  %10 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %empty_read)
+  %11 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %12 = load i8*, i8** %11, align 8
+  %13 = icmp ne i8* %12, null
+  br i1 %13, label %then, label %else
+
+then:                                             ; preds = %.entry
+  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void @exit(i32 1)
+  br label %ifcont
+
+else:                                             ; preds = %.entry
+  br label %ifcont
+
+ifcont:                                           ; preds = %else, %then
+  %14 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %15 = sext i32 %10 to i64
+  %16 = call i8* @_lfortran_get_default_allocator()
+  %17 = call i8* @_lfortran_string_malloc_alloc(i8* %16, i64 %15)
+  store i8* %17, i8** %14, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %19 = sext i32 %10 to i64
+  store i64 %19, i64* %18, align 8
+  call void @_lcompilers_trim_str(%string_descriptor* %empty_read, %string_descriptor* %__libasr__created__var__0_return_slot)
+  %20 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %21 = load i8*, i8** %20, align 8
+  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %23 = load i64, i64* %22, align 8
+  %24 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  %25 = call i32 @str_compare(i8* %21, i64 %23, i8* %24, i64 12)
+  %26 = icmp eq i32 %25, 0
+  br i1 %26, label %then1, label %else2
+
+then1:                                            ; preds = %ifcont
+  %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %28 = alloca i32, align 4
+  store i32 0, i32* %28, align 4
+  %29 = alloca i32, align 4
+  call void @_lfortran_empty_read(i32 -2, i32* %28)
+  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %30, i32 92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
+  %31 = alloca i32, align 4
+  store i32 0, i32* %31, align 4
+  %32 = alloca i32, align 4
+  call void @_lfortran_empty_read(i32 -2, i32* %31)
+  %33 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %34 = alloca i32, align 4
+  store i32 0, i32* %34, align 4
+  %35 = alloca i32, align 4
+  call void @_lfortran_empty_read(i32 -2, i32* %34)
+  %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %36, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 1)
+  br label %goto_target
+
+goto_target:                                      ; preds = %then1
+  %37 = alloca i32, align 4
+  store i32 0, i32* %37, align 4
+  %38 = alloca i32, align 4
+  call void @_lfortran_empty_read(i32 -2, i32* %37)
+  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 93, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  store i32 5, i32* %unit_num, align 4
+  %40 = load i32, i32* %unit_num, align 4
+  %41 = icmp eq i32 %40, 5
+  %42 = select i1 %41, i32 -2, i32 %40
+  %43 = alloca i32, align 4
+  store i32 0, i32* %43, align 4
+  %44 = alloca i32, align 4
+  call void @_lfortran_empty_read(i32 %42, i32* %43)
+  %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i8* %45, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0), i32 1)
+  br label %ifcont3
+
+else2:                                            ; preds = %ifcont
+  br label %ifcont3
+
+ifcont3:                                          ; preds = %else2, %goto_target
+  br label %return
+
+return:                                           ; preds = %ifcont3
+  br label %FINALIZE_SYMTABLE_read_83
+
+FINALIZE_SYMTABLE_read_83:                        ; preds = %return
+  br label %Finalize_Variable___libasr__created__var__0_return_slot
+
+Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_read_83
+  %46 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %47 = load i8*, i8** %46, align 8
+  call void @_lfortran_free_alloc(i8* %2, i8* %47)
+  br label %Finalize_Variable_empty_read
+
+Finalize_Variable_empty_read:                     ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
+  %48 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 0
+  %49 = load i8*, i8** %48, align 8
+  call void @_lfortran_free_alloc(i8* %2, i8* %49)
+  call void @_lfortran_internal_alloc_finalize()
+  ret i32 0
+}
+
+declare void @_lpython_call_initial_functions(i32, i8**)
+
+declare i8* @_lfortran_malloc_alloc(i8*, i64)
+
+declare i32 @str_compare(i8*, i64, i8*, i64)
+
+declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+
+declare void @_lfortran_empty_read(i32, i32*)
+
+declare void @_lfortran_internal_alloc_finalize()

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5152,3 +5152,7 @@ asr = true
 [[test]]
 filename = "../integration_tests/arrays_107.f90"
 asr = true
+
+[[test]]
+filename = "../integration_tests/read_83.f90"
+llvm = true


### PR DESCRIPTION
Resolves #11097
Towards #11090 