### PR TITLE
fix: print array-item lhs names in runtime errors

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -214,6 +214,37 @@ private:
             return ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(v->m_v));
         }
 
+        if (ASR::is_a<ASR::IntegerConstant_t>(*expr)) {
+            ASR::IntegerConstant_t* i = ASR::down_cast<ASR::IntegerConstant_t>(expr);
+            return std::to_string(i->m_n);
+        }
+
+        if (ASR::is_a<ASR::ArrayItem_t>(*expr)) {
+            ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(expr);
+            std::string base_name = get_expr_name_for_runtime_message(array_item->m_v);
+            if (base_name.empty()) {
+                return "";
+            }
+
+            std::string result = base_name + "(";
+            for (size_t i = 0; i < array_item->n_args; i++) {
+                ASR::array_index_t& idx = array_item->m_args[i];
+                if (idx.m_left != nullptr || idx.m_right == nullptr || idx.m_step != nullptr) {
+                    return "";
+                }
+                std::string index_name = get_expr_name_for_runtime_message(idx.m_right);
+                if (index_name.empty()) {
+                    return "";
+                }
+                if (i > 0) {
+                    result += ", ";
+                }
+                result += index_name;
+            }
+            result += ")";
+            return result;
+        }
+
         if (ASR::is_a<ASR::StructInstanceMember_t>(*expr)) {
             ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(expr);
             std::string base_name = get_expr_name_for_runtime_message(sim->m_v);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -229,9 +229,6 @@ private:
             std::string result = base_name + "(";
             for (size_t i = 0; i < array_item->n_args; i++) {
                 ASR::expr_t* idx_expr = array_item->m_args[i].m_right;
-                if (idx_expr == nullptr) {
-                    return "";
-                }
                 std::string index_name = get_expr_name_for_runtime_message(idx_expr);
                 if (index_name.empty()) {
                     return "";

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -228,11 +228,11 @@ private:
 
             std::string result = base_name + "(";
             for (size_t i = 0; i < array_item->n_args; i++) {
-                ASR::array_index_t& idx = array_item->m_args[i];
-                if (idx.m_left != nullptr || idx.m_right == nullptr || idx.m_step != nullptr) {
+                ASR::expr_t* idx_expr = array_item->m_args[i].m_right;
+                if (idx_expr == nullptr) {
                     return "";
                 }
-                std::string index_name = get_expr_name_for_runtime_message(idx.m_right);
+                std::string index_name = get_expr_name_for_runtime_message(idx_expr);
                 if (index_name.empty()) {
                     return "";
                 }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -261,18 +261,24 @@ private:
     void generate_unallocated_array_runtime_error(llvm::Value* is_not_allocated,
                                                   ASR::expr_t* target_expr) {
         std::string target_expr_name = get_expr_name_for_runtime_message(target_expr);
-        if (target_expr_name.empty()) {
-            target_expr_name = "LHS";
+        if (!target_expr_name.empty()) {
+            llvm::Value* target_expr_name_llvm = LCompilers::create_global_string_ptr(
+                context, *module, *builder, target_expr_name);
+            llvm_utils->generate_runtime_error(
+                is_not_allocated,
+                "Array '%s' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
+                {LLVMUtils::RuntimeLabel("not allocated here", {target_expr->base.loc}, {})},
+                infile,
+                location_manager,
+                target_expr_name_llvm);
+        } else {
+            llvm_utils->generate_runtime_error(
+                is_not_allocated,
+                "Array is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
+                {LLVMUtils::RuntimeLabel("not allocated here", {target_expr->base.loc}, {})},
+                infile,
+                location_manager);
         }
-        llvm::Value* target_expr_name_llvm = LCompilers::create_global_string_ptr(
-            context, *module, *builder, target_expr_name);
-        llvm_utils->generate_runtime_error(
-            is_not_allocated,
-            "Array '%s' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
-            {LLVMUtils::RuntimeLabel("not allocated here", {target_expr->base.loc}, {})},
-            infile,
-            location_manager,
-            target_expr_name_llvm);
     }
 
     llvm::Value* allocate_class_wrapper_storage(ASR::expr_t* target_expr,

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -258,6 +258,23 @@ private:
         return "";
     }
 
+    void generate_unallocated_array_runtime_error(llvm::Value* is_not_allocated,
+                                                  ASR::expr_t* target_expr) {
+        std::string target_expr_name = get_expr_name_for_runtime_message(target_expr);
+        if (target_expr_name.empty()) {
+            target_expr_name = "LHS";
+        }
+        llvm::Value* target_expr_name_llvm = LCompilers::create_global_string_ptr(
+            context, *module, *builder, target_expr_name);
+        llvm_utils->generate_runtime_error(
+            is_not_allocated,
+            "Array '%s' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
+            {LLVMUtils::RuntimeLabel("not allocated here", {target_expr->base.loc}, {})},
+            infile,
+            location_manager,
+            target_expr_name_llvm);
+    }
+
     llvm::Value* allocate_class_wrapper_storage(ASR::expr_t* target_expr,
                                                 llvm::Type* target_llvm_type,
                                                 llvm::Value* wrapper_size) {
@@ -11370,25 +11387,7 @@ public:
             bool is_allocatable_descriptor_target = (ASRUtils::is_allocatable(target_type) && target_ptype == ASR::array_physical_typeType::DescriptorArray);
             if( is_allocatable_descriptor_target && !x.m_realloc_lhs && !x.m_move_allocation ) {
                 llvm::Value* is_not_allocated = expr_is_unallocated(x.m_target);
-                std::string target_expr_name = get_expr_name_for_runtime_message(x.m_target);
-                if( !target_expr_name.empty() ) {
-                    llvm::Value* target_name_llvm = LCompilers::create_global_string_ptr(
-                        context, *module, *builder, target_expr_name);
-                    llvm_utils->generate_runtime_error(
-                        is_not_allocated,
-                        "Array '%s' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
-                        {LLVMUtils::RuntimeLabel("'%s' not allocated here", {x.m_target->base.loc}, {target_name_llvm})},
-                        infile,
-                        location_manager,
-                        target_name_llvm);
-                } else {
-                    llvm_utils->generate_runtime_error(
-                        is_not_allocated,
-                        "Array is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
-                        {LLVMUtils::RuntimeLabel("LHS not allocated here", {x.m_target->base.loc}, {})},
-                        infile,
-                        location_manager);
-                }
+                generate_unallocated_array_runtime_error(is_not_allocated, x.m_target);
             }
             if( is_value_fixed_sized_array && is_target_fixed_sized_array ) {
                 ASR::dimension_t* asr_dims = nullptr;
@@ -11714,25 +11713,7 @@ public:
                 ASRUtils::extract_physical_type(target_type) == ASR::array_physical_typeType::DescriptorArray;
             if (is_allocatable_descriptor_target && !x.m_move_allocation) {
                 llvm::Value* is_not_allocated = expr_is_unallocated(x.m_target);
-                std::string target_expr_name = get_expr_name_for_runtime_message(x.m_target);
-                if (!target_expr_name.empty()) {
-                    llvm::Value* target_expr_name_llvm = LCompilers::create_global_string_ptr(
-                        context, *module, *builder, target_expr_name);
-                    llvm_utils->generate_runtime_error(is_not_allocated,
-                        "Array '%s' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
-                        {LLVMUtils::RuntimeLabel("'%s' not allocated here",
-                            {x.m_target->base.loc}, {target_expr_name_llvm})},
-                        infile,
-                        location_manager,
-                        target_expr_name_llvm);
-                } else {
-                    llvm_utils->generate_runtime_error(is_not_allocated,
-                        "Array is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.",
-                        {LLVMUtils::RuntimeLabel("LHS not allocated here",
-                            {x.m_target->base.loc}, {})},
-                        infile,
-                        location_manager);
-                }
+                generate_unallocated_array_runtime_error(is_not_allocated, x.m_target);
             }
             ASR::dimension_t* m_dims = nullptr;
             size_t rank = ASRUtils::extract_dimensions_from_ttype(target_type, m_dims);

--- a/tests/reference/run-allocatable_component_reshape_unallocated_01-15046b1.json
+++ b/tests/reference/run-allocatable_component_reshape_unallocated_01-15046b1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-allocatable_component_reshape_unallocated_01-15046b1.stderr",
-    "stderr_hash": "f189ede90d14e98aef9467208e1527a7e6af77b41a51a16c2f9cf387",
+    "stderr_hash": "06b8410e31bd6348aa69cfc51a96e571324930fb15bf4e43fda9febd",
     "returncode": 1
 }

--- a/tests/reference/run-allocatable_component_reshape_unallocated_01-15046b1.stderr
+++ b/tests/reference/run-allocatable_component_reshape_unallocated_01-15046b1.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'x%arr' is not allocated. Allocate it manually or use the '
   --> tests/../integration_tests/allocatable_component_reshape_unallocated_01.f90:15:5
    |
 15 |     x%arr = reshape(gradient, shape(input))
-   |     ^^^^^ 'x%arr' not allocated here
+   |     ^^^^^ not allocated here

--- a/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.json
+++ b/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-allocatable_component_unnamed_unallocated_01-9346375.stderr",
-    "stderr_hash": "679704f58a59bf3bf873a19bfc3266310630f2e52caf8c3bf7885935",
+    "stderr_hash": "44ae4a40b709ca0af20d5a0f8b2c82f018e76c98e6ad9442311f6a4d",
     "returncode": 1
 }

--- a/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.json
+++ b/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-allocatable_component_unnamed_unallocated_01-9346375.stderr",
-    "stderr_hash": "44ae4a40b709ca0af20d5a0f8b2c82f018e76c98e6ad9442311f6a4d",
+    "stderr_hash": "36bd43e5a0903e0af06a5b9e945f999db819710a97ea2d48c8b51bce",
     "returncode": 1
 }

--- a/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.stderr
+++ b/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.stderr
@@ -1,5 +1,5 @@
-runtime error: Array is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.
+runtime error: Array 'x(1)%arr' is not allocated. Allocate it manually or use the '--realloc-lhs-arrays' option to allocate it automatically.
   --> tests/../integration_tests/allocatable_component_unnamed_unallocated_01.f90:10:5
    |
 10 |     x(1)%arr = [1, 2, 3]
-   |     ^^^^^^^^ LHS not allocated here
+   |     ^^^^^^^^ 'x(1)%arr' not allocated here

--- a/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.stderr
+++ b/tests/reference/run-allocatable_component_unnamed_unallocated_01-9346375.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'x(1)%arr' is not allocated. Allocate it manually or use th
   --> tests/../integration_tests/allocatable_component_unnamed_unallocated_01.f90:10:5
    |
 10 |     x(1)%arr = [1, 2, 3]
-   |     ^^^^^^^^ 'x(1)%arr' not allocated here
+   |     ^^^^^^^^ not allocated here

--- a/tests/reference/run-array_bounds_check_03-15fcd63.json
+++ b/tests/reference/run-array_bounds_check_03-15fcd63.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-array_bounds_check_03-15fcd63.stderr",
-    "stderr_hash": "66732e418b0d72dc75e6d3c3b3b00748da2ac7ddf57a937b922e8375",
+    "stderr_hash": "3bc517ec65cf0118aa7568908bf4989b69490fb7855c4aa5106da913",
     "returncode": 1
 }

--- a/tests/reference/run-array_bounds_check_03-15fcd63.stderr
+++ b/tests/reference/run-array_bounds_check_03-15fcd63.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'x' is not allocated. Allocate it manually or use the '--re
  --> tests/errors/array_bounds_check_03.f90:4:5
   |
 4 |     x = [1, 2, 3]
-  |     ^ 'x' not allocated here
+  |     ^ not allocated here

--- a/tests/reference/run-infer_realloc_disabled_01-25a8068.json
+++ b/tests/reference/run-infer_realloc_disabled_01-25a8068.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-infer_realloc_disabled_01-25a8068.stderr",
-    "stderr_hash": "cb8946869603ac1adefbf48a223c25305c3921c58de9c776de3ae908",
+    "stderr_hash": "218abe6c2d1c1090ef272a3724ef1d2f75c484896cd0ba0cc9959a62",
     "returncode": 1
 }

--- a/tests/reference/run-infer_realloc_disabled_01-25a8068.stderr
+++ b/tests/reference/run-infer_realloc_disabled_01-25a8068.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'x' is not allocated. Allocate it manually or use the '--re
  --> tests/errors/infer_realloc_disabled_01.f90:3:5
   |
 3 |     x = [1, 2, 3]
-  |     ^ 'x' not allocated here
+  |     ^ not allocated here

--- a/tests/reference/run-realloc_lhs_20-ef3baef.json
+++ b/tests/reference/run-realloc_lhs_20-ef3baef.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-realloc_lhs_20-ef3baef.stderr",
-    "stderr_hash": "cd90e7a73795c4d91de7ad88218f33a80869be40bb49c6d545c246f9",
+    "stderr_hash": "5e8972aeb81378bdc67d11f19e00e6c0cb1f647b8247cb4aa9518c3e",
     "returncode": 1
 }

--- a/tests/reference/run-realloc_lhs_20-ef3baef.stderr
+++ b/tests/reference/run-realloc_lhs_20-ef3baef.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'b%arr' is not allocated. Allocate it manually or use the '
   --> tests/../integration_tests/realloc_lhs_20.f90:12:5
    |
 12 |     b%arr = a%arr
-   |     ^^^^^ 'b%arr' not allocated here
+   |     ^^^^^ not allocated here

--- a/tests/reference/run-realloc_lhs_22-3d95c80.json
+++ b/tests/reference/run-realloc_lhs_22-3d95c80.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-realloc_lhs_22-3d95c80.stderr",
-    "stderr_hash": "223c59c67b6ca97dd0e9af2c43aa7461a78e7d5c92541106ad287846",
+    "stderr_hash": "2c415651b9a78448917d7b87678340521178f88293db0029919d9423",
     "returncode": 1
 }

--- a/tests/reference/run-realloc_lhs_22-3d95c80.stderr
+++ b/tests/reference/run-realloc_lhs_22-3d95c80.stderr
@@ -2,4 +2,4 @@ runtime error: Array 'x' is not allocated. Allocate it manually or use the '--re
  --> tests/../integration_tests/realloc_lhs_22.f90:5:5
   |
 5 |     x = [1, 2, 3]
-  |     ^ 'x' not allocated here
+  |     ^ not allocated here


### PR DESCRIPTION
Follow-up to #11031: this makes the runtime error print `x(1)%arr` instead of falling back to the generic message.
