### PR TITLE
Fix ICE in bounds_check_call with external procedure args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2010,6 +2010,7 @@ RUN(NAME implicit_interface_33 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_34 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_35 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 RUN(NAME implicit_interface_36 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_37 LABELS gfortran llvm EXTRA_ARGS --implicit-interface --legacy-array-sections)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_37.f90
+++ b/integration_tests/implicit_interface_37.f90
@@ -1,0 +1,33 @@
+subroutine compute(a, b, proc)
+integer :: a(2), b(1)
+external proc
+call sub1(b, proc)
+call sub1(a(2), proc)
+end subroutine
+
+subroutine sub1(x, proc)
+integer :: x(*)
+external proc
+call proc(x(1))
+end subroutine
+
+subroutine add_one(val)
+integer :: val
+val = val + 1
+end subroutine
+
+program implicit_interface_37
+implicit none
+integer :: a(2), b(1)
+external add_one
+
+a = [10, 20]
+b = [5]
+
+call compute(a, b, add_one)
+
+if (b(1) /= 6) error stop
+if (a(2) /= 21) error stop
+
+print *, "ok"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -23628,7 +23628,9 @@ public:
                 llvm::BasicBlock *optional_check_mergeBB = nullptr;
                 if (i + 1 < x.n_args && x.m_args[i + 1].m_value != nullptr) {
                     ASR::expr_t* next_arg = x.m_args[i + 1].m_value;
-                    if (ASR::is_a<ASR::Var_t>(*next_arg)) {
+                    if (ASR::is_a<ASR::Var_t>(*next_arg) &&
+                        ASR::is_a<ASR::Variable_t>(*ASRUtils::symbol_get_past_external(
+                            ASR::down_cast<ASR::Var_t>(next_arg)->m_v))) {
                         ASR::Variable_t* next_var = ASRUtils::EXPR2VAR(next_arg);
                         std::string var_name = std::string(next_var->m_name);
                         ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(next_var->m_type);


### PR DESCRIPTION
The bounds_check_call function in LLVM codegen crashed when checking array arguments of an implicitly-interfaced subroutine that also receives an external procedure as an argument. When looking ahead at the next argument to check for an optional-present flag, the code assumed the Var node always wraps a Variable_t symbol. However, an external procedure argument is a Function_t, causing the down_cast<Variable_t> assertion to fail.

Add a check that the Var's underlying symbol is a Variable_t before calling EXPR2VAR. An integration test is added.

Fixes #11150.