### PR TITLE
fix(runtime): handle list-directed slash in complex reads

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3313,6 +3313,7 @@ RUN(NAME read_72 LABELS gfortran llvm)
 RUN(NAME read_73 LABELS gfortran llvm)
 RUN(NAME read_74 LABELS gfortran llvm)
 RUN(NAME read_75 LABELS gfortran llvm)
+RUN(NAME read_76 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_76.f90
+++ b/integration_tests/read_76.f90
@@ -1,0 +1,35 @@
+program read_76
+  implicit none
+
+  double precision :: d1, d2, d3
+  complex :: c1, c2
+
+  open (42, file='read_76.dat', status='replace', form='formatted')
+  write (42,'(a)') '1.0D0  (2.0, 2.0)  3.0D0  (4.0, 4.0)  5.0D0'
+  write (42,'(a)') '6.0D0  (7.0, 7.0) / 8.0D0  (9.0, 9.0) 10.0D0'
+  rewind (42)
+
+  d1 = -1.0d0
+  c1 = (-2.0, -3.0)
+  d2 = -3.0d0
+  c2 = (-4.0, -5.0)
+  d3 = -5.0d0
+  read (42, *) d1, c1, d2, c2, d3
+
+  ! Slash should terminate assignment for the remaining items in this READ.
+  d1 = -1.0d0
+  c1 = (-2.0, -3.0)
+  d2 = -3.0d0
+  c2 = (-4.0, -5.0)
+  d3 = -5.0d0
+  read (42, *) d1, c1, d2, c2, d3
+
+  if (abs(d1 - 6.0d0) > 0.0001d0) error stop 'd1 failed'
+  if (abs(real(c1) - 7.0) > 0.0001 .or. abs(aimag(c1) - 7.0) > 0.0001) error stop 'c1 failed'
+  if (abs(d2 + 3.0d0) > 0.0001d0) error stop 'd2 failed'
+  if (abs(real(c2) + 4.0) > 0.0001 .or. abs(aimag(c2) + 5.0) > 0.0001) error stop 'c2 failed'
+  if (abs(d3 + 5.0d0) > 0.0001d0) error stop 'd3 failed'
+
+  close (42, status='delete')
+  print *, 'ok'
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -8002,6 +8002,13 @@ static int read_complex_expr(FILE *filep, char *buffer, size_t bufsize) {
     if (ch == ',') {
         return -1;
     }
+    // Slash terminates list-directed input for the current READ statement.
+    // Keep it in the stream so subsequent items in the same statement also
+    // remain unchanged.
+    if (ch == '/') {
+        ungetc(ch, filep);
+        return -1;
+    }
     if (ch == '(') {
         buffer[i++] = (char)ch;
         while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF) {
@@ -8012,7 +8019,7 @@ static int read_complex_expr(FILE *filep, char *buffer, size_t bufsize) {
         return (ch == ')') ? 1 : 0;
     } else {
         buffer[i++] = (char)ch;
-        while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF && !isspace(ch) && ch != ',') {
+        while (i < bufsize - 1 && (ch = fgetc(filep)) != EOF && !isspace(ch) && ch != ',' && ch != '/') {
             buffer[i++] = (char)ch;
         }
         buffer[i] = '\0';


### PR DESCRIPTION
Bug:
List-directed reads with complex items did not handle / as an input terminator in the complex token scanner. For input like 6.0D0 (7.0,7.0) / ..., LFortran tried to parse / as a complex value and aborted with "Invalid input from file."

Fix:
Teach the complex list-directed reader to recognize / as a terminator, push it back to the stream, and treat remaining items in the same READ statement as unchanged (Fortran semantics).


fixes #11146