### PR TITLE
fix: throw error when non-character arguments are passed to `Len` Intrinsic

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -12393,20 +12393,32 @@ public:
 
     ASR::asr_t* create_StringLen_from_expr(ASR::expr_t* v, ASR::ttype_t* type, const Location& loc) {
         ASR::expr_t* len_compiletime = nullptr;
-        if( !ASRUtils::is_character(*ASRUtils::expr_type(v)) ) {
-            diag.add(Diagnostic(
-                "Unexpected args, Len expects (char) as arguments",
-                Level::Error, Stage::Semantic, {Label("", {loc})}));
-            throw SemanticAbort();
+        ASR::ttype_t* v_type = ASRUtils::expr_type(v);
+        if( !ASRUtils::is_character(*v_type) ) {
+            if (ASRUtils::is_unlimited_polymorphic_type(v_type)) {
+                diag.add(Diagnostic(
+                    "Character intrinsic 'len' with class(*) argument must be inside " 
+                    "'type is (character(len=*))' guard", Level::Error, Stage::Semantic, {
+                        Label("invalid use of character intrinsic with polymorphic argument",
+                        {v->base.loc})
+                    }));
+                throw SemanticAbort();
+            } else {
+                diag.add(Diagnostic(
+                    "Argument of 'len' intrinsic must be CHARACTER, found " + 
+                    ASRUtils::type_to_str_fortran_expr(v_type, v) + " instead.", 
+                    Level::Error, Stage::Semantic, {Label("", {v->base.loc})}));
+                throw SemanticAbort();
+            }
         }
-        if( ASRUtils::is_array(ASRUtils::expr_type(v)) ) {
+        if( ASRUtils::is_array(v_type) ) {
             ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(v)));
             ASR::String_t* str = ASR::down_cast<ASR::String_t>(arr->m_type);
             int64_t length;
             len_compiletime = ASRUtils::extract_value(str->m_len, length) ? 
             make_ConstantWithType(make_IntegerConstant_t, length, type, loc) : nullptr;
             // TODO: If possible try to use m_len of `character(len=m_len)`
-            int n_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(v));
+            int n_dims = ASRUtils::extract_n_dims_from_ttype(v_type);
             Vec<ASR::array_index_t> lbs; lbs.reserve(al, n_dims);
             for( int i = 0; i < n_dims; i++ ) {
                 ASR::array_index_t index;
@@ -12417,7 +12429,7 @@ public:
                 lbs.push_back(al, index);
             }
             v = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc, v, lbs.p, lbs.size(),
-                    ASRUtils::extract_type(ASRUtils::expr_type(v)),
+                    ASRUtils::extract_type(v_type),
                         ASR::arraystorageType::ColMajor, nullptr));
         } else if(ASR::is_a<ASR::ArrayItem_t>(*v)) {
             ASR::ArrayItem_t* arr_item = ASR::down_cast<ASR::ArrayItem_t>(v);
@@ -12445,7 +12457,7 @@ public:
         }
 
         { // Try to get expression's string length (if exist)
-            ASR::ttype_t* base_t = ASRUtils::type_get_past_allocatable_pointer( ASRUtils::expr_type(v));
+            ASR::ttype_t* base_t = ASRUtils::type_get_past_allocatable_pointer( v_type );
             base_t = ASRUtils::type_get_past_array(base_t);
             if (ASR::is_a<ASR::String_t>(*base_t)) {
                 ASR::String_t* string_t = ASR::down_cast<ASR::String_t>(base_t);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -12393,6 +12393,12 @@ public:
 
     ASR::asr_t* create_StringLen_from_expr(ASR::expr_t* v, ASR::ttype_t* type, const Location& loc) {
         ASR::expr_t* len_compiletime = nullptr;
+        if( !ASRUtils::is_character(*ASRUtils::expr_type(v)) ) {
+            diag.add(Diagnostic(
+                "Unexpected args, Len expects (char) as arguments",
+                Level::Error, Stage::Semantic, {Label("", {loc})}));
+            throw SemanticAbort();
+        }
         if( ASRUtils::is_array(ASRUtils::expr_type(v)) ) {
             ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(v)));
             ASR::String_t* str = ASR::down_cast<ASR::String_t>(arr->m_type);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -647,7 +647,7 @@ program continue_compilation_1
     type(MyClass), pointer :: ptr_type_mismatch => ptr_tgt_base
     a(1) = .true.
     derived_cls = base_var
-
+    call print_len_non_char("  Hello World  ")
 
 
 
@@ -688,4 +688,13 @@ program continue_compilation_1
         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
         if (abs(arr1)(1) /= 2471095) error stop
     end subroutine
+
+    subroutine print_len_non_char(generic)
+        implicit none
+        class(*), intent(in) :: generic
+        integer :: a
+        a = 5
+        print *, len(generic)
+        print *, len(a)
+    end subroutine print_len_non_char
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "112cd8bc2c463bf9679f92f039c52db9d626278461d3998736433346",
+    "infile_hash": "91c89318250d31eafa009e01265522fb7be06c85db508c46411722c3",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "f97c16a9fbce83ed245dbdc275233d6f213ccef310de7d3265cd6c58",
+    "stderr_hash": "929102518c148bbc520665df8439eb512a2d0255447921557bc7d0bc",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "929102518c148bbc520665df8439eb512a2d0255447921557bc7d0bc",
+    "stderr_hash": "8bbd3bb592019cf45b13ecb509e67b76b76a81010ce38bd92dabe11b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1460,3 +1460,15 @@ semantic error: Expected logical expression in if statement, but recieved logica
     |
 689 |         if (abs(arr1)(1) /= 2471095) error stop
     |             ^^^^^^^^^^^^^^^^^^^^^^^ logical[:] expression, expected logical
+
+semantic error: Unexpected args, Len expects (char) as arguments
+   --> tests/errors/continue_compilation_1.f90:697:18
+    |
+697 |         print *, len(generic)
+    |                  ^^^^^^^^^^^^ 
+
+semantic error: Unexpected args, Len expects (char) as arguments
+   --> tests/errors/continue_compilation_1.f90:698:18
+    |
+698 |         print *, len(a)
+    |                  ^^^^^^ 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1461,14 +1461,14 @@ semantic error: Expected logical expression in if statement, but recieved logica
 689 |         if (abs(arr1)(1) /= 2471095) error stop
     |             ^^^^^^^^^^^^^^^^^^^^^^^ logical[:] expression, expected logical
 
-semantic error: Unexpected args, Len expects (char) as arguments
-   --> tests/errors/continue_compilation_1.f90:697:18
+semantic error: Character intrinsic 'len' with class(*) argument must be inside 'type is (character(len=*))' guard
+   --> tests/errors/continue_compilation_1.f90:697:22
     |
 697 |         print *, len(generic)
-    |                  ^^^^^^^^^^^^ 
+    |                      ^^^^^^^ invalid use of character intrinsic with polymorphic argument
 
-semantic error: Unexpected args, Len expects (char) as arguments
-   --> tests/errors/continue_compilation_1.f90:698:18
+semantic error: Argument of 'len' intrinsic must be CHARACTER, found integer instead.
+   --> tests/errors/continue_compilation_1.f90:698:22
     |
 698 |         print *, len(a)
-    |                  ^^^^^^ 
+    |                      ^ 


### PR DESCRIPTION
Fixes #9490 