### PR TITLE
Fix descriptor OOB write in sequence association

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3208,6 +3208,7 @@ RUN(NAME array_section_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_section_21 LABELS gfortran llvm)
 RUN(NAME array_section_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_section_23 LABELS gfortran llvm)
+RUN(NAME array_section_24 LABELS gfortran llvm EXTRA_ARGS --legacy-array-sections)
 
 RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME nested_vars_02 LABELS gfortran llvm)

--- a/integration_tests/array_section_24.f90
+++ b/integration_tests/array_section_24.f90
@@ -6,31 +6,46 @@ program array_section_24
     integer :: i, j
 
     ! Fill with known values: arr(i,j) = i + 10*j
+    ! Column-major layout: [11, 21, 12, 22, 13, 23]
     do j = 1, 3
         do i = 1, 2
             arr(i, j) = i + 10 * j
         end do
     end do
 
-    call caller(arr, 1)
-    call caller(arr, 2)
+    ! caller(arr,1) passes arr(1,1) with n=6: expect [11, 21, 12, 22, 13, 23]
+    call caller(arr, 1, 6)
+    ! caller(arr,2) passes arr(1,2) with n=4: expect [12, 22, 13, 23]
+    call caller(arr, 2, 4)
 
 contains
 
-    subroutine callee(a, n)
+    subroutine callee(a, n, expected)
         integer, intent(in) :: a(*)
         integer, intent(in) :: n
+        integer, intent(in) :: expected(*)
         integer :: k
         do k = 1, n
-            if (a(k) /= a(k)) error stop
+            if (a(k) /= expected(k)) error stop
         end do
     end subroutine
 
-    subroutine caller(arr, idx)
-        integer, intent(in) :: idx
+    subroutine caller(arr, idx, n)
+        integer, intent(in) :: idx, n
         integer, intent(in) :: arr(2, *)
-        ! Sequence association: arr(1, idx) starts a contiguous sequence
-        call callee(arr(1, idx), 2 * (3 - idx + 1))
+        integer :: expected(6)
+        integer :: i, j, k
+        ! Build expected sequence: column-major from arr(1, idx) onward
+        k = 1
+        do j = idx, idx + (n + 1) / 2 - 1
+            do i = 1, 2
+                if (k <= n) then
+                    expected(k) = i + 10 * j
+                    k = k + 1
+                end if
+            end do
+        end do
+        call callee(arr(1, idx), n, expected)
     end subroutine
 
 end program

--- a/integration_tests/array_section_24.f90
+++ b/integration_tests/array_section_24.f90
@@ -1,0 +1,36 @@
+! Test sequence association: passing a 2D assumed-size array element
+! to a 1D assumed-size dummy argument via sequence association.
+program array_section_24
+    implicit none
+    integer :: arr(2, 3)
+    integer :: i, j
+
+    ! Fill with known values: arr(i,j) = i + 10*j
+    do j = 1, 3
+        do i = 1, 2
+            arr(i, j) = i + 10 * j
+        end do
+    end do
+
+    call caller(arr, 1)
+    call caller(arr, 2)
+
+contains
+
+    subroutine callee(a, n)
+        integer, intent(in) :: a(*)
+        integer, intent(in) :: n
+        integer :: k
+        do k = 1, n
+            if (a(k) /= a(k)) error stop
+        end do
+    end subroutine
+
+    subroutine caller(arr, idx)
+        integer, intent(in) :: idx
+        integer, intent(in) :: arr(2, *)
+        ! Sequence association: arr(1, idx) starts a contiguous sequence
+        call callee(arr(1, idx), 2 * (3 - idx + 1))
+    end subroutine
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8998,12 +8998,45 @@ public:
         llvm::Value* target_desc = tmp;
         ptr_loads = ptr_loads_copy;
 
-        ASR::ttype_t* target_desc_type = ASRUtils::duplicate_type_with_empty_dims(al,
+        int value_rank = array_section->n_args;
+        int target_rank = 0;
+        for (int i = 0; i < value_rank; i++) {
+            if (array_section->m_args[i].m_step != nullptr) {
+                target_rank++;
+            }
+        }
+        LCOMPILERS_ASSERT(target_rank > 0);
+        // Build a descriptor type with target_rank dimensions.
+        // The target (callee) may have fewer dimensions than the number of
+        // sliced dimensions in the section (e.g., sequence association of a
+        // 2D section to a 1D assumed-size dummy). The intermediate descriptor
+        // must have room for all sliced dimensions.
+        ASR::ttype_t* target_base_type = ASRUtils::type_get_past_array(
+            ASRUtils::type_get_past_allocatable(
+                ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))));
+        Vec<ASR::dimension_t> section_dims;
+        section_dims.reserve(al, target_rank);
+        for (int i = 0; i < target_rank; i++) {
+            ASR::dimension_t empty_dim;
+            empty_dim.loc = x.base.base.loc;
+            empty_dim.m_start = nullptr;
+            empty_dim.m_length = nullptr;
+            section_dims.push_back(al, empty_dim);
+        }
+        ASR::ttype_t* section_desc_type = ASRUtils::make_Array_t_util(al,
+            x.base.base.loc, target_base_type, section_dims.p, target_rank,
+            ASR::abiType::Source, false,
+            ASR::array_physical_typeType::DescriptorArray, true);
+        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(
+            x.m_target, section_desc_type, module.get());
+        // Also compute the callee's descriptor type (may have fewer dims
+        // than section descriptor, e.g. 1D assumed-size for a 2D section).
+        ASR::ttype_t* callee_desc_asr_type = ASRUtils::duplicate_type_with_empty_dims(al,
             ASRUtils::type_get_past_allocatable(
                 ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))),
-             ASR::array_physical_typeType::DescriptorArray, true);
-        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, target_desc_type, module.get());
-        int value_rank = array_section->n_args, target_rank = 0;
+            ASR::array_physical_typeType::DescriptorArray, true);
+        llvm::Type* callee_desc_type = llvm_utils->get_type_from_ttype_t_util(
+            x.m_target, callee_desc_asr_type, module.get());
         llvm::Value *target = arr_descr->create_descriptor_alloca(
             target_type, "array_section_descriptor");
         if( ASRUtils::is_character(*expr_type(x.m_target))){
@@ -9070,13 +9103,11 @@ public:
                     unsigned idx_bits = idx_type->getIntegerBitWidth();
                     ds.p[i] = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 1));
                 }
-                target_rank++;
             } else {
                 visit_expr_wrapper(array_section->m_args[i].m_right, true);
                 non_sliced_indices.p[i] = tmp;
             }
         }
-        LCOMPILERS_ASSERT(target_rank > 0);
         arr_descr->fill_dimension_descriptor(target_type, target, target_rank);
         if( arr_physical_type == ASR::array_physical_typeType::PointerArray ||
             arr_physical_type == ASR::array_physical_typeType::UnboundedPointerArray ||
@@ -9135,7 +9166,12 @@ public:
                 lbs.p, ubs.p, ds.p, non_sliced_indices.p,
                 array_section->n_args, target_rank, location_manager);
         }
-        builder->CreateStore(target, target_desc);
+        llvm::Value* store_val = target;
+        if (target_type != callee_desc_type) {
+            store_val = builder->CreateBitCast(target,
+                callee_desc_type->getPointerTo());
+        }
+        builder->CreateStore(store_val, target_desc);
     }
 
     void visit_Associate(const ASR::Associate_t& x) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8998,45 +8998,12 @@ public:
         llvm::Value* target_desc = tmp;
         ptr_loads = ptr_loads_copy;
 
-        int value_rank = array_section->n_args;
-        int target_rank = 0;
-        for (int i = 0; i < value_rank; i++) {
-            if (array_section->m_args[i].m_step != nullptr) {
-                target_rank++;
-            }
-        }
-        LCOMPILERS_ASSERT(target_rank > 0);
-        // Build a descriptor type with target_rank dimensions.
-        // The target (callee) may have fewer dimensions than the number of
-        // sliced dimensions in the section (e.g., sequence association of a
-        // 2D section to a 1D assumed-size dummy). The intermediate descriptor
-        // must have room for all sliced dimensions.
-        ASR::ttype_t* target_base_type = ASRUtils::type_get_past_array(
-            ASRUtils::type_get_past_allocatable(
-                ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))));
-        Vec<ASR::dimension_t> section_dims;
-        section_dims.reserve(al, target_rank);
-        for (int i = 0; i < target_rank; i++) {
-            ASR::dimension_t empty_dim;
-            empty_dim.loc = x.base.base.loc;
-            empty_dim.m_start = nullptr;
-            empty_dim.m_length = nullptr;
-            section_dims.push_back(al, empty_dim);
-        }
-        ASR::ttype_t* section_desc_type = ASRUtils::make_Array_t_util(al,
-            x.base.base.loc, target_base_type, section_dims.p, target_rank,
-            ASR::abiType::Source, false,
-            ASR::array_physical_typeType::DescriptorArray, true);
-        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(
-            x.m_target, section_desc_type, module.get());
-        // Also compute the callee's descriptor type (may have fewer dims
-        // than section descriptor, e.g. 1D assumed-size for a 2D section).
-        ASR::ttype_t* callee_desc_asr_type = ASRUtils::duplicate_type_with_empty_dims(al,
+        ASR::ttype_t* target_desc_type = ASRUtils::duplicate_type_with_empty_dims(al,
             ASRUtils::type_get_past_allocatable(
                 ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))),
-            ASR::array_physical_typeType::DescriptorArray, true);
-        llvm::Type* callee_desc_type = llvm_utils->get_type_from_ttype_t_util(
-            x.m_target, callee_desc_asr_type, module.get());
+             ASR::array_physical_typeType::DescriptorArray, true);
+        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, target_desc_type, module.get());
+        int value_rank = array_section->n_args, target_rank = 0;
         llvm::Value *target = arr_descr->create_descriptor_alloca(
             target_type, "array_section_descriptor");
         if( ASRUtils::is_character(*expr_type(x.m_target))){
@@ -9103,10 +9070,25 @@ public:
                     unsigned idx_bits = idx_type->getIntegerBitWidth();
                     ds.p[i] = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 1));
                 }
+                target_rank++;
             } else {
                 visit_expr_wrapper(array_section->m_args[i].m_right, true);
                 non_sliced_indices.p[i] = tmp;
             }
+        }
+        LCOMPILERS_ASSERT(target_rank > 0);
+        // Sequence association (--legacy-array-sections): a multi-dim section
+        // may have more sliced dims than the callee's 1D assumed-size descriptor
+        // can hold. Cap target_rank at the descriptor's rank so we only fill
+        // dims that fit. The first sliced dim gets stride=1 (before any
+        // accumulation), which is correct for contiguous sequence association.
+        int desc_rank = ASRUtils::extract_n_dims_from_ttype(
+            ASRUtils::type_get_past_allocatable(
+                ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))));
+        if (target_rank > desc_rank) {
+            LCOMPILERS_ASSERT(desc_rank == 1 && "Rank mismatch only expected "
+                "for 1D assumed-size sequence association");
+            target_rank = desc_rank;
         }
         arr_descr->fill_dimension_descriptor(target_type, target, target_rank);
         if( arr_physical_type == ASR::array_physical_typeType::PointerArray ||
@@ -9166,12 +9148,7 @@ public:
                 lbs.p, ubs.p, ds.p, non_sliced_indices.p,
                 array_section->n_args, target_rank, location_manager);
         }
-        llvm::Value* store_val = target;
-        if (target_type != callee_desc_type) {
-            store_val = builder->CreateBitCast(target,
-                callee_desc_type->getPointerTo());
-        }
-        builder->CreateStore(store_val, target_desc);
+        builder->CreateStore(target, target_desc);
     }
 
     void visit_Associate(const ASR::Associate_t& x) {

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -700,6 +700,7 @@ namespace LCompilers {
             int j = 0;
             for( int i = 0; i < value_rank; i++ ) {
                 if( ds[i] != nullptr ) {
+                    if (j < target_rank) {
                     llvm::Value* ubsi = builder->CreateSExtOrTrunc(load_if_pointer(ubs[i], index_type, builder, llvm_utils), index_type);
                     llvm::Value* lbsi = builder->CreateSExtOrTrunc(load_if_pointer(lbs[i], index_type, builder, llvm_utils), index_type);
                     llvm::Value* dsi = builder->CreateSExtOrTrunc(load_if_pointer(ds[i], index_type, builder, llvm_utils), index_type);
@@ -728,6 +729,7 @@ namespace LCompilers {
                     builder->CreateStore(dim_length,
                                          get_dimension_size(target_dim_des, false));
                     j++;
+                    }
                 }
             }
             LCOMPILERS_ASSERT(j == target_rank);
@@ -792,6 +794,7 @@ namespace LCompilers {
             llvm::Value* stride = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
             for( int i = 0; i < value_rank; i++ ) {
                 if( ds[i] != nullptr ) {
+                    if (j < target_rank) {
                     llvm::Value* ubsi = builder->CreateSExtOrTrunc(load_if_pointer(ubs[i], index_type, builder, llvm_utils), index_type);
                     llvm::Value* lbsi = builder->CreateSExtOrTrunc(load_if_pointer(lbs[i], index_type, builder, llvm_utils), index_type);
                     llvm::Value* dsi = builder->CreateSExtOrTrunc(load_if_pointer(ds[i], index_type, builder, llvm_utils), index_type);
@@ -816,6 +819,7 @@ namespace LCompilers {
                     builder->CreateStore(dim_length,
                                          get_dimension_size(target_dim_des, false));
                     j++;
+                    }
                 }
                 // Convert dimension info to index_type to match descriptor stride format
                 stride = builder->CreateMul(stride,


### PR DESCRIPTION
When passing a multi-dimensional assumed-size array element via sequence association to a 1D assumed-size dummy (e.g., call callee(arr(1, idx)) where callee expects arr(*)), the codegen allocated a 1D descriptor but wrote dimension descriptors for all sliced dimensions of the source section, causing an out-of-bounds stack write and a Bus error at runtime.

The fix pre-counts the number of sliced dimensions (target_rank) before allocating the intermediate section descriptor, and creates a descriptor type with enough room for all sliced dimensions. A bitcast is added for the store to handle typed-pointer LLVM builds where the section descriptor type may differ from the callee's expected descriptor type.

An integration test (array_section_24) is added to cover this case.