### PR TITLE
fix: replace only symbolic logical intrinsic functions in the `replace_symbolic` pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1692,6 +1692,7 @@ RUN(NAME intrinsics_449 LABELS gfortran llvm) # storage_size with c_ptr
 RUN(NAME intrinsics_450 LABELS llvm) # storage_size struct alignment
 RUN(NAME intrinsics_451 LABELS gfortran llvm) # findloc with character ExpressionLength
 RUN(NAME intrinsics_452 LABELS gfortran llvm) # findloc with Pointer-wrapped ExpressionLength
+RUN(NAME intrinsics_453 LABELS gfortran llvm) # Lgt intrinsic as while loop condition
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_453.f90
+++ b/integration_tests/intrinsics_453.f90
@@ -1,0 +1,37 @@
+program intrinsics_453
+    implicit none
+
+    type CFG_var_t
+        character(len=100) :: var_name
+    end type CFG_var_t
+
+    type(CFG_var_t) :: list(2)
+    integer :: marker
+
+    list(1)%var_name = "zeta"
+    list(2)%var_name = "alpha"
+
+    call partition_var_list(list, marker)
+
+    if (marker /= 2) error stop
+
+contains
+
+    subroutine partition_var_list(list, marker)
+        type(CFG_var_t), intent(inout) :: list(:)
+        integer, intent(out)           :: marker
+        integer                        :: right
+        character(len=100)             :: pivot_value
+
+        right = size(list)
+        pivot_value = list(1)%var_name
+
+        do while (lgt(list(right)%var_name, pivot_value))
+            right = right - 1
+            if (right < 1) error stop
+        end do
+
+        marker = right
+    end subroutine partition_var_list
+
+end program intrinsics_453

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -1185,8 +1185,10 @@ public:
         if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*xx.m_test)) {
             ASR::IntrinsicElementalFunction_t* intrinsic_func = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(xx.m_test);
             if (ASR::is_a<ASR::Logical_t>(*intrinsic_func->m_type)) {
-                ASR::expr_t* function_call = process_attributes(xx.base.base.loc, xx.m_test);
-                xx.m_test = function_call;
+                if (is_logical_intrinsic_symbolic(xx.m_test)) {
+                    ASR::expr_t* function_call = process_attributes(xx.base.base.loc, xx.m_test);
+                    xx.m_test = function_call;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #11164
Towards #11144 