### PR TITLE
enh: support additional IO keywords in fixed-form tokenizer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -453,6 +453,7 @@ RUN(NAME fixed_form_select_case_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form 
 RUN(NAME fixed_form_select_rank_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_io_keyword_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_io_keyword_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_io_keyword_02.f90
+++ b/integration_tests/fixed_form_io_keyword_02.f90
@@ -1,0 +1,13 @@
+      program fixed_form_io_keyword_02
+         implicit none
+         character(len=1) :: seq
+         character(len=5) :: str
+         open(10, file='file_01_data.txt')
+         read(10, *) str
+         print *, 'str =', str
+         if (str /= "10130") error stop 1
+         INQUIRE(UNIT=10,SEQUENTIAL=seq)
+         print *, 'seq =', seq
+         REWIND(UNIT=10)
+         FLUSH(UNIT=10)
+      end program fixed_form_io_keyword_02

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -297,7 +297,8 @@ const std::vector<std::string> declarators{
 
 std::vector<std::string> lines{};
 
-std::vector<std::string> io_names{"open", "read", "write", "format", "close", "print"};
+std::vector<std::string> io_names{ "open",  "read",    "write",  "format", "close",
+                                   "print", "inquire", "rewind", "flush" };
 
 void FixedFormTokenizer::set_string(const std::string &str)
 {
@@ -1124,7 +1125,6 @@ struct FixedFormRecursiveDescent {
         }
 
         // assignment
-        // TODO: this is fragile
         if (is_possible_assignment(cur, cur)) {
             tokenize_line(cur);
             return true;


### PR DESCRIPTION
Resolves #11142 

These keywords were previoulsy being tokenized correctly due to a weak assignment check. The assignment check was fixed recently causing the bug to show up.