### PR TITLE
fix: leave function-like macro name unexpanded when not followed by (

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3681,6 +3681,10 @@ RUN(NAME cpp_pre_13 LABELS gfortran llvm
     EXTRA_ARGS --cpp
     GFORTRAN_ARGS -cpp)
 
+RUN(NAME cpp_pre_14 LABELS gfortran llvm
+    EXTRA_ARGS --cpp
+    GFORTRAN_ARGS -cpp)
+
 RUN(NAME dabs_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME minpack_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/cpp_pre_14.f90
+++ b/integration_tests/cpp_pre_14.f90
@@ -1,0 +1,11 @@
+#define FOO(x,y) x + y
+
+program cpp_pre_14
+  implicit none
+  integer, parameter :: FOO = 1
+  integer :: r
+
+  r = FOO(1,2) + FOO
+  if (r /= 4) error stop
+  print *, r
+end program

--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -674,12 +674,18 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                     // Expand the macro once
                     std::string expansion;
                     if (macro_definitions[t].function_like) {
+                        unsigned char *before_skip = cur;
                         while (*cur == ' ' || *cur == '\t') cur++;
                         if (*cur != '(') {
-                            Location loc;
-                            loc.first = cur - string_start;
-                            loc.last = loc.first;
-                            throw PreprocessorError("function-like macro invocation must have argument list", loc);
+                            // Per C standard and J3/25-176r3 (2.1.1 ag01):
+                            // if a function-like macro name is not followed
+                            // by '(' it is not a macro invocation; leave it
+                            // unchanged.
+                            cur = before_skip;
+                            output.append(t);
+                            interval_end(lm, output.size(), cur-string_start,
+                                token(tok, cur).size()-1, 1);
+                            continue;
                         }
                         std::vector<std::string> args;
                         args = parse_arguments(string_start, cur, false);
@@ -1198,12 +1204,12 @@ int parse_factor(unsigned char *string_start, unsigned char *&cur, const cpp_sym
         if (macro_definitions.find(str) != macro_definitions.end()) {
             std::string v;
             if (macro_definitions.at(str).function_like) {
+                unsigned char *before_skip = cur;
                 while (*cur == ' ' || *cur == '\t') cur++;
                 if (*cur != '(') {
-                    Location loc;
-                    loc.first = cur - string_start;
-                    loc.last = loc.first;
-                    throw PreprocessorError("function-like macro invocation must have argument list", loc);
+                    // Not a macro invocation; treat as plain name
+                    cur = before_skip;
+                    return 0;
                 }
                 std::vector<std::string> args;
                 args = parse_arguments(string_start, cur, false);


### PR DESCRIPTION
Per the C standard and Fortran preprocessor spec J3/25-176r3 (2.1.1 ag01), a function-like macro name that is not followed by ( as the next preprocessing token is not a macro invocation and must be left unchanged. Previously LFortran threw "function-like macro invocation must have argument list" in this case.

Fixed in both the main preprocessor run() loop and parse_factor().

Fixes #11175.