### PR TITLE
Fix tests to be conforming

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -279,7 +279,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             add_test(${name} ${CURRENT_BINARY_DIR}/${name})
         else ()
             add_executable(${name} ${file_name}.f90 ${extra_files})
-            target_compile_options(${name} PUBLIC ${gfortran_args})
+            target_compile_options(${name} PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${gfortran_args}>)
             target_link_options(${name} PUBLIC ${gfortran_args})
             if (ISO_FORTRAN_BINDING_INCLUDE_DIR)
                 target_include_directories(${name} PRIVATE ${ISO_FORTRAN_BINDING_INCLUDE_DIR})

--- a/integration_tests/bindc3.f90
+++ b/integration_tests/bindc3.f90
@@ -1,11 +1,11 @@
 program bindc3
-use iso_c_binding, only: c_loc, c_ptr, c_f_pointer
+use iso_c_binding, only: c_loc, c_ptr, c_f_pointer, c_intptr_t
 type(c_ptr) :: queries
 integer :: idx = 1
 integer(2), pointer :: x
 integer(2), target :: y
 call c_f_pointer(queries, x)
-print *, c_loc(x), queries
+print *, transfer(c_loc(x), 0_c_intptr_t), transfer(queries, 0_c_intptr_t)
 x => y
-print *, c_loc(x), c_loc(y)
+print *, transfer(c_loc(x), 0_c_intptr_t), transfer(c_loc(y), 0_c_intptr_t)
 end program

--- a/integration_tests/bindc4.f90
+++ b/integration_tests/bindc4.f90
@@ -1,5 +1,5 @@
 program bindc4
-use iso_c_binding, only: c_associated, c_loc, c_ptr, c_f_pointer, c_null_ptr
+use iso_c_binding, only: c_associated, c_loc, c_ptr, c_f_pointer, c_null_ptr, c_intptr_t
 type(c_ptr) :: queries
 type(c_ptr) :: queries2 = c_null_ptr
 integer :: i, j
@@ -15,27 +15,27 @@ y => yv
 
 do i = lbound(x, 1), ubound(x, 1)
     do j = lbound(x, 2), ubound(x, 2)
-        print *, i, j, c_loc(x(i, j))
+        print *, i, j, transfer(c_loc(x(i, j)), 0_c_intptr_t)
     end do
 end do
 
 call c_f_pointer(queries, x, newshape)
 
-print *, c_loc(x), queries
+print *, transfer(c_loc(x), 0_c_intptr_t), transfer(queries, 0_c_intptr_t)
 
 do i = lbound(x, 1), ubound(x, 1)
     do j = lbound(x, 2), ubound(x, 2)
-        print *, i, j, c_loc(x(i, j))
+        print *, i, j, transfer(c_loc(x(i, j)), 0_c_intptr_t)
     end do
 end do
 
 call c_f_pointer(queries, x, [3, 4])
 
-print *, c_loc(x), queries
+print *, transfer(c_loc(x), 0_c_intptr_t), transfer(queries, 0_c_intptr_t)
 
 do i = lbound(x, 1), ubound(x, 1)
     do j = lbound(x, 2), ubound(x, 2)
-        print *, i, j, c_loc(x(i, j))
+        print *, i, j, transfer(c_loc(x(i, j)), 0_c_intptr_t)
     end do
 end do
 

--- a/integration_tests/bindc_04.f90
+++ b/integration_tests/bindc_04.f90
@@ -16,8 +16,8 @@ real(c_float), pointer :: a(:)
 call c_f_pointer(data, tdata)
 
 call c_f_pointer(tdata%a, a, [5])
-print *, "Array address in fortran :", tdata%a
-print *, "c_loc(a) :", c_loc(a)
+print *, "Array address in fortran :", transfer(tdata%a, 0_c_intptr_t)
+print *, "c_loc(a) :", transfer(c_loc(a), 0_c_intptr_t)
 print *, sum(a)
 if (abs(sum(a) - 10.0) > 1.0e-8) error stop
 end subroutine
@@ -30,8 +30,8 @@ type(c_ptr), intent(in), value :: data
 real(c_float), pointer :: a(:)
 
 call c_f_pointer(data, a, [5])
-print *, "Array address in fortran b_func_fortran:", data
-print *, "c_loc(a) b_func_fortran:", c_loc(a)
+print *, "Array address in fortran b_func_fortran:", transfer(data, 0_c_intptr_t)
+print *, "c_loc(a) b_func_fortran:", transfer(c_loc(a), 0_c_intptr_t)
 print *, sum(a)
 if (abs(sum(a) - 10.0) > 1.0e-8) error stop
 end subroutine

--- a/integration_tests/c_ptr_04.f90
+++ b/integration_tests/c_ptr_04.f90
@@ -1,13 +1,13 @@
 module mod_uop
     contains
     subroutine uop( sendbuf)
-        use iso_c_binding, only: c_loc, c_ptr, c_null_ptr, c_associated
+        use iso_c_binding, only: c_loc, c_ptr, c_null_ptr, c_associated, c_intptr_t
         real(8), dimension(:), intent(in), target :: sendbuf
         type(c_ptr) :: c_send
         c_send = c_null_ptr
         c_send = c_loc(sendbuf)
         
-        print *, 'C pointer: ', c_send
+        print *, 'C pointer: ', transfer(c_send, 0_c_intptr_t)
 
         if (.not. c_associated(c_send)) then
             error stop 'Error: c_send is null'

--- a/integration_tests/fortuno_01.f90
+++ b/integration_tests/fortuno_01.f90
@@ -24,11 +24,14 @@ module fortuno_basetypes
   
     subroutine test_list_free(this)
       class(test_list), intent(inout) :: this                                     
-  
-      select type (item => this%storage_(1)%item)                                 
-      class default
-      end select
-  
+
+      if (associated(this%storage_)) then
+        select type (item => this%storage_(1)%item)
+        class default
+        end select
+        deallocate(this%storage_)
+      end if
+
     end subroutine test_list_free
   
   end module fortuno_basetypes

--- a/tests/reference/asr-bindc3-91bce68.json
+++ b/tests/reference/asr-bindc3-91bce68.json
@@ -2,11 +2,11 @@
     "basename": "asr-bindc3-91bce68",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/bindc3.f90",
-    "infile_hash": "d2305932b687641416dda5e45cb66123d72a7d2ca5449952e2379d3b",
+    "infile_hash": "5641a25203f2b4025ab042a931b5f7f5978dd812c10833abf34bfd73",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc3-91bce68.stdout",
-    "stdout_hash": "817b72a0d1e804be871591860660a92bbe969d3887622882bcb258b8",
+    "stdout_hash": "4acdcdbb123c1a515184e2eca81003edfc388d4c7a9bd65317b42680",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc3-91bce68.stdout
+++ b/tests/reference/asr-bindc3-91bce68.stdout
@@ -17,6 +17,16 @@
                                     c_f_pointer
                                     Public
                                 ),
+                            c_intptr_t:
+                                (ExternalSymbol
+                                    2
+                                    c_intptr_t
+                                    4 c_intptr_t
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_intptr_t
+                                    Public
+                                ),
                             c_loc:
                                 (ExternalSymbol
                                     2
@@ -147,12 +157,24 @@
                     (Print
                         (StringFormat
                             ()
-                            [(PointerToCPtr
-                                (Var 2 x)
-                                (CPtr)
+                            [(BitCast
+                                (PointerToCPtr
+                                    (Var 2 x)
+                                    (CPtr)
+                                    ()
+                                )
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
                                 ()
                             )
-                            (Var 2 queries)]
+                            (BitCast
+                                (Var 2 queries)
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
+                                ()
+                            )]
                             FormatFortran
                             (Allocatable
                                 (String 1 () DeferredLength DescriptorString)
@@ -167,20 +189,32 @@
                     (Print
                         (StringFormat
                             ()
-                            [(PointerToCPtr
-                                (Var 2 x)
-                                (CPtr)
-                                ()
-                            )
-                            (PointerToCPtr
-                                (GetPointer
-                                    (Var 2 y)
-                                    (Pointer
-                                        (Integer 2)
-                                    )
+                            [(BitCast
+                                (PointerToCPtr
+                                    (Var 2 x)
+                                    (CPtr)
                                     ()
                                 )
-                                (CPtr)
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
+                                ()
+                            )
+                            (BitCast
+                                (PointerToCPtr
+                                    (GetPointer
+                                        (Var 2 y)
+                                        (Pointer
+                                            (Integer 2)
+                                        )
+                                        ()
+                                    )
+                                    (CPtr)
+                                    ()
+                                )
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
                                 ()
                             )]
                             FormatFortran

--- a/tests/reference/asr-bindc4-22df995.json
+++ b/tests/reference/asr-bindc4-22df995.json
@@ -2,11 +2,11 @@
     "basename": "asr-bindc4-22df995",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/bindc4.f90",
-    "infile_hash": "82f6261052d996468e9b5ef860d730cf31765f67f4eec663e5c4af11",
+    "infile_hash": "421dc94d9239b11a66352b4cd31b78bb82ad39b738ca161fe2192d35",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc4-22df995.stdout",
-    "stdout_hash": "fbe9d32de30d6b8534ec170df30105e537f740238e911e65cecb2db9",
+    "stdout_hash": "23ca41f513e309dfbb63c01daae77ecf93b211fc25b1660d5442950f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc4-22df995.stdout
+++ b/tests/reference/asr-bindc4-22df995.stdout
@@ -27,6 +27,16 @@
                                     c_f_pointer
                                     Public
                                 ),
+                            c_intptr_t:
+                                (ExternalSymbol
+                                    2
+                                    c_intptr_t
+                                    4 c_intptr_t
+                                    lfortran_intrinsic_iso_c_binding
+                                    []
+                                    c_intptr_t
+                                    Public
+                                ),
                             c_loc:
                                 (ExternalSymbol
                                     2
@@ -424,26 +434,32 @@
                                     ()
                                     [(Var 2 i)
                                     (Var 2 j)
-                                    (PointerToCPtr
-                                        (GetPointer
-                                            (ArrayItem
-                                                (Var 2 x)
-                                                [(()
-                                                (Var 2 i)
-                                                ())
-                                                (()
-                                                (Var 2 j)
-                                                ())]
-                                                (Integer 2)
-                                                ColMajor
+                                    (BitCast
+                                        (PointerToCPtr
+                                            (GetPointer
+                                                (ArrayItem
+                                                    (Var 2 x)
+                                                    [(()
+                                                    (Var 2 i)
+                                                    ())
+                                                    (()
+                                                    (Var 2 j)
+                                                    ())]
+                                                    (Integer 2)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (Pointer
+                                                    (Integer 2)
+                                                )
                                                 ()
                                             )
-                                            (Pointer
-                                                (Integer 2)
-                                            )
+                                            (CPtr)
                                             ()
                                         )
-                                        (CPtr)
+                                        (IntegerConstant 0 (Integer 8) Decimal)
+                                        ()
+                                        (Integer 8)
                                         ()
                                     )]
                                     FormatFortran
@@ -466,12 +482,24 @@
                     (Print
                         (StringFormat
                             ()
-                            [(PointerToCPtr
-                                (Var 2 x)
-                                (CPtr)
+                            [(BitCast
+                                (PointerToCPtr
+                                    (Var 2 x)
+                                    (CPtr)
+                                    ()
+                                )
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
                                 ()
                             )
-                            (Var 2 queries)]
+                            (BitCast
+                                (Var 2 queries)
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
+                                ()
+                            )]
                             FormatFortran
                             (Allocatable
                                 (String 1 () DeferredLength DescriptorString)
@@ -520,26 +548,32 @@
                                     ()
                                     [(Var 2 i)
                                     (Var 2 j)
-                                    (PointerToCPtr
-                                        (GetPointer
-                                            (ArrayItem
-                                                (Var 2 x)
-                                                [(()
-                                                (Var 2 i)
-                                                ())
-                                                (()
-                                                (Var 2 j)
-                                                ())]
-                                                (Integer 2)
-                                                ColMajor
+                                    (BitCast
+                                        (PointerToCPtr
+                                            (GetPointer
+                                                (ArrayItem
+                                                    (Var 2 x)
+                                                    [(()
+                                                    (Var 2 i)
+                                                    ())
+                                                    (()
+                                                    (Var 2 j)
+                                                    ())]
+                                                    (Integer 2)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (Pointer
+                                                    (Integer 2)
+                                                )
                                                 ()
                                             )
-                                            (Pointer
-                                                (Integer 2)
-                                            )
+                                            (CPtr)
                                             ()
                                         )
-                                        (CPtr)
+                                        (IntegerConstant 0 (Integer 8) Decimal)
+                                        ()
+                                        (Integer 8)
                                         ()
                                     )]
                                     FormatFortran
@@ -572,12 +606,24 @@
                     (Print
                         (StringFormat
                             ()
-                            [(PointerToCPtr
-                                (Var 2 x)
-                                (CPtr)
+                            [(BitCast
+                                (PointerToCPtr
+                                    (Var 2 x)
+                                    (CPtr)
+                                    ()
+                                )
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
                                 ()
                             )
-                            (Var 2 queries)]
+                            (BitCast
+                                (Var 2 queries)
+                                (IntegerConstant 0 (Integer 8) Decimal)
+                                ()
+                                (Integer 8)
+                                ()
+                            )]
                             FormatFortran
                             (Allocatable
                                 (String 1 () DeferredLength DescriptorString)
@@ -626,26 +672,32 @@
                                     ()
                                     [(Var 2 i)
                                     (Var 2 j)
-                                    (PointerToCPtr
-                                        (GetPointer
-                                            (ArrayItem
-                                                (Var 2 x)
-                                                [(()
-                                                (Var 2 i)
-                                                ())
-                                                (()
-                                                (Var 2 j)
-                                                ())]
-                                                (Integer 2)
-                                                ColMajor
+                                    (BitCast
+                                        (PointerToCPtr
+                                            (GetPointer
+                                                (ArrayItem
+                                                    (Var 2 x)
+                                                    [(()
+                                                    (Var 2 i)
+                                                    ())
+                                                    (()
+                                                    (Var 2 j)
+                                                    ())]
+                                                    (Integer 2)
+                                                    ColMajor
+                                                    ()
+                                                )
+                                                (Pointer
+                                                    (Integer 2)
+                                                )
                                                 ()
                                             )
-                                            (Pointer
-                                                (Integer 2)
-                                            )
+                                            (CPtr)
                                             ()
                                         )
-                                        (CPtr)
+                                        (IntegerConstant 0 (Integer 8) Decimal)
+                                        ()
+                                        (Integer 8)
                                         ()
                                     )]
                                     FormatFortran

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -2,11 +2,11 @@
     "basename": "llvm-bindc3-d064ff7",
     "cmd": "lfortran --no-color --show-llvm {infile} -o {outfile}",
     "infile": "tests/../integration_tests/bindc3.f90",
-    "infile_hash": "d2305932b687641416dda5e45cb66123d72a7d2ca5449952e2379d3b",
+    "infile_hash": "5641a25203f2b4025ab042a931b5f7f5978dd812c10833abf34bfd73",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "aa546a3d77a820823b5e1be19f20660b87141666eec7834232af13dc",
+    "stdout_hash": "b1921503d30e4aa1baee1b5c9136ac723db34167790af4b84fccd2ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -6,17 +6,21 @@ target datalayout = "..."
 
 @bindc3.idx = internal global i32 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [10 x i8] c"CPtr,CPtr\00", align 1
+@serialization_info = private unnamed_addr constant [6 x i8] c"I8,I8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [10 x i8] c"CPtr,CPtr\00", align 1
+@serialization_info.1 = private unnamed_addr constant [6 x i8] c"I8,I8\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %stringFormat_desc1 = alloca %string_descriptor, align 8
+  %stringFormat_desc4 = alloca %string_descriptor, align 8
+  %bitcast_cptr_source3 = alloca void*, align 8
+  %bitcast_cptr_source2 = alloca void*, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = call i8* @_lfortran_get_default_allocator()
+  %bitcast_cptr_source1 = alloca void*, align 8
+  %bitcast_cptr_source = alloca void*, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %queries = alloca void*, align 8
   %x = alloca i16*, align 8
@@ -28,60 +32,75 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = alloca i64, align 8
   %6 = load i16*, i16** %x, align 8
   %7 = bitcast i16* %6 to void*
-  %8 = alloca void*, align 8
-  store void* %7, void** %8, align 8
-  %9 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32 0, i32 0, i32 0, void** %8, void** %queries)
-  %10 = load i64, i64* %5, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %9, i8** %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %10, i64* %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %16 = load i64, i64* %15, align 8
-  %17 = trunc i64 %16 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %14, i32 %17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %18 = icmp eq i8* %9, null
-  br i1 %18, label %free_done, label %free_nonnull
+  store void* %7, void** %bitcast_cptr_source, align 8
+  %8 = bitcast void** %bitcast_cptr_source to i64*
+  %9 = load i64, i64* %8, align 8
+  %10 = alloca i64, align 8
+  store i64 %9, i64* %10, align 8
+  %11 = load void*, void** %queries, align 8
+  store void* %11, void** %bitcast_cptr_source1, align 8
+  %12 = bitcast void** %bitcast_cptr_source1 to i64*
+  %13 = load i64, i64* %12, align 8
+  %14 = alloca i64, align 8
+  store i64 %13, i64* %14, align 8
+  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %10, i64* %14)
+  %16 = load i64, i64* %5, align 8
+  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %15, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %16, i64* %18, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %20 = load i8*, i8** %19, align 8
+  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
+  %23 = trunc i64 %22 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %24 = icmp eq i8* %15, null
+  br i1 %24, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %9)
+  call void @_lfortran_free_alloc(i8* %2, i8* %15)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   store i16* %y, i16** %x, align 8
-  %19 = alloca i64, align 8
-  %20 = load i16*, i16** %x, align 8
-  %21 = bitcast i16* %20 to void*
-  %22 = alloca void*, align 8
-  store void* %21, void** %22, align 8
-  %23 = bitcast i16* %y to void*
-  %24 = alloca void*, align 8
-  store void* %23, void** %24, align 8
-  %25 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.1, i32 0, i32 0), i64* %19, i32 0, i32 0, i32 0, i32 0, i32 0, void** %22, void** %24)
-  %26 = load i64, i64* %19, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %25, i8** %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %26, i64* %28, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %30 = load i8*, i8** %29, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %32 = load i64, i64* %31, align 8
-  %33 = trunc i64 %32 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %30, i32 %33, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %34 = icmp eq i8* %25, null
-  br i1 %34, label %free_done3, label %free_nonnull2
+  %25 = alloca i64, align 8
+  %26 = load i16*, i16** %x, align 8
+  %27 = bitcast i16* %26 to void*
+  store void* %27, void** %bitcast_cptr_source2, align 8
+  %28 = bitcast void** %bitcast_cptr_source2 to i64*
+  %29 = load i64, i64* %28, align 8
+  %30 = alloca i64, align 8
+  store i64 %29, i64* %30, align 8
+  %31 = bitcast i16* %y to void*
+  store void* %31, void** %bitcast_cptr_source3, align 8
+  %32 = bitcast void** %bitcast_cptr_source3 to i64*
+  %33 = load i64, i64* %32, align 8
+  %34 = alloca i64, align 8
+  store i64 %33, i64* %34, align 8
+  %35 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %25, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %30, i64* %34)
+  %36 = load i64, i64* %25, align 8
+  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  store i8* %35, i8** %37, align 8
+  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  store i64 %36, i64* %38, align 8
+  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
+  %40 = load i8*, i8** %39, align 8
+  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
+  %42 = load i64, i64* %41, align 8
+  %43 = trunc i64 %42 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %44 = icmp eq i8* %35, null
+  br i1 %44, label %free_done6, label %free_nonnull5
 
-free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %25)
-  br label %free_done3
+free_nonnull5:                                    ; preds = %free_done
+  call void @_lfortran_free_alloc(i8* %2, i8* %35)
+  br label %free_done6
 
-free_done3:                                       ; preds = %free_nonnull2, %free_done
+free_done6:                                       ; preds = %free_nonnull5, %free_done
   br label %return
 
-return:                                           ; preds = %free_done3
+return:                                           ; preds = %free_done6
   br label %FINALIZE_SYMTABLE_bindc3
 
 FINALIZE_SYMTABLE_bindc3:                         ; preds = %return


### PR DESCRIPTION
The previous tests were not valid Fortran and GFortran 15 failed to compile them. They are now fixed, everything works.

Updated reference tests.