### PR TITLE
Fix DATA stmt with multiple implied-do on same array in module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3548,6 +3548,7 @@ RUN(NAME data_implied_do_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortra
 RUN(NAME data_implied_do_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_07 LABELS gfortran llvm)
+RUN(NAME data_implied_do_08 LABELS gfortran llvm)
 
 RUN(NAME save_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME save_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/data_implied_do_08.f90
+++ b/integration_tests/data_implied_do_08.f90
@@ -1,0 +1,17 @@
+module data_implied_do_08_mod
+    implicit none
+    integer :: i
+    integer(4) :: kr(2,2)
+    data ( kr(i,1), i=1,2 ) / 1, 0 /
+    data ( kr(i,2), i=1,2 ) / 0, 1 /
+end module data_implied_do_08_mod
+
+program data_implied_do_08
+    use data_implied_do_08_mod
+    implicit none
+    print *, kr(1,1), kr(2,1), kr(1,2), kr(2,2)
+    if (kr(1,1) /= 1) error stop
+    if (kr(2,1) /= 0) error stop
+    if (kr(1,2) /= 0) error stop
+    if (kr(2,2) /= 1) error stop
+end program data_implied_do_08

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -3445,7 +3445,9 @@ public:
                                           AST::DataStmtSet_t *data_stmt_set,
                                           ASR::expr_t* implied_do_loop_expr,
                                           size_t &value_index,
-                                          Vec<ASR::expr_t*>* collected_values = nullptr) {
+                                          Vec<ASR::expr_t*>* collected_values = nullptr,
+                                          Vec<int64_t>* collected_indices = nullptr,
+                                          ASR::Variable_t* target_variable = nullptr) {
         ASR::ImpliedDoLoop_t *implied_do_loop = ASR::down_cast<ASR::ImpliedDoLoop_t>(implied_do_loop_expr);
         ASR::expr_t* loop_start_expr = implied_do_loop->m_start;
         ASR::expr_t* loop_end_expr = implied_do_loop->m_end;
@@ -3497,9 +3499,28 @@ public:
         //collect values when in top level module scope instead of runtime assignments for data stmts
         bool top_level_module_scope = (current_module != nullptr && collected_values == nullptr);
         Vec<ASR::expr_t*> local_collected_values;
+        Vec<int64_t> local_collected_indices;
         if (top_level_module_scope) {
             local_collected_values.reserve(al, data_stmt_set->n_value);
+            local_collected_indices.reserve(al, data_stmt_set->n_value);
             collected_values = &local_collected_values;
+            collected_indices = &local_collected_indices;
+            // Determine the target Variable from the first ArrayItem so we can
+            // compute flat (ColMajor) indices and preserve the full array shape.
+            ASR::expr_t* first_val = implied_do_loop->m_values[0];
+            while (ASR::is_a<ASR::ImpliedDoLoop_t>(*first_val)) {
+                first_val = ASR::down_cast<ASR::ImpliedDoLoop_t>(first_val)->m_values[0];
+            }
+            if (ASR::is_a<ASR::ArrayItem_t>(*first_val)) {
+                ASR::ArrayItem_t* arr_item = ASR::down_cast<ASR::ArrayItem_t>(first_val);
+                if (ASR::is_a<ASR::Var_t>(*arr_item->m_v)) {
+                    ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
+                        ASR::down_cast<ASR::Var_t>(arr_item->m_v)->m_v);
+                    if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                        target_variable = ASR::down_cast<ASR::Variable_t>(sym);
+                    }
+                }
+            }
         }
 
         ASRUtils::ExprStmtDuplicator exprDuplicator(al);
@@ -3511,7 +3532,7 @@ public:
                     // Substitute the current loop variable in nested loop before recursing
                     ASR::ImpliedDoLoop_t* nested_idl = ASR::down_cast<ASR::ImpliedDoLoop_t>(duplicatedExpr);
                     substitute_var_in_implied_do_loop(nested_idl, loop_var_sym, loop_var, integer_type);
-                    handle_implied_do_loop_data_stmt(data_stmt, data_stmt_set, duplicatedExpr, value_index, collected_values);
+                    handle_implied_do_loop_data_stmt(data_stmt, data_stmt_set, duplicatedExpr, value_index, collected_values, collected_indices, target_variable);
                 } else if (ASR::is_a<ASR::ArrayItem_t>(*duplicatedExpr)) {
                     ASR::ArrayItem_t* array_item_expr = ASR::down_cast<ASR::ArrayItem_t>(duplicatedExpr);
                     for (size_t arg_index = 0; arg_index < array_item_expr->n_args; arg_index++) {
@@ -3535,6 +3556,49 @@ public:
                         ASR::expr_t* expression_value = ASRUtils::expr_value(value);
                         if (!expression_value) expression_value = value;
                         collected_values->push_back(al, expression_value);
+                        if (collected_indices && target_variable) {
+                            // Compute flat (ColMajor) index from the substituted
+                            // subscripts, using the target variable's dimensions
+                            // (including declared lower bounds).
+                            ASR::ttype_t* tv_arr_ttype = ASRUtils::type_get_past_allocatable(
+                                ASRUtils::type_get_past_pointer(target_variable->m_type));
+                            ASR::dimension_t* tv_dims = nullptr;
+                            size_t tv_n_dims = 0;
+                            if (ASR::is_a<ASR::Array_t>(*tv_arr_ttype)) {
+                                ASR::Array_t* tv_arr_t = ASR::down_cast<ASR::Array_t>(tv_arr_ttype);
+                                tv_dims = tv_arr_t->m_dims;
+                                tv_n_dims = tv_arr_t->n_dims;
+                            }
+                            int64_t flat = 0;
+                            int64_t stride = 1;
+                            bool indices_valid = (tv_n_dims == array_item_expr->n_args);
+                            for (size_t d = 0; d < tv_n_dims && d < array_item_expr->n_args; d++) {
+                                int64_t idx_val = 0;
+                                int64_t start_val = 1;
+                                int64_t dim_size = 1;
+                                bool ok = true;
+                                ASR::expr_t* idx_expr = array_item_expr->m_args[d].m_right;
+                                if (idx_expr) {
+                                    ASR::expr_t* iv = ASRUtils::expr_value(idx_expr);
+                                    if (!iv) iv = idx_expr;
+                                    if (!ASRUtils::extract_value(iv, idx_val)) ok = false;
+                                } else {
+                                    ok = false;
+                                }
+                                if (tv_dims[d].m_start) {
+                                    ASR::expr_t* sv = ASRUtils::expr_value(tv_dims[d].m_start);
+                                    if (sv) ASRUtils::extract_value(sv, start_val);
+                                }
+                                if (tv_dims[d].m_length) {
+                                    ASR::expr_t* lv = ASRUtils::expr_value(tv_dims[d].m_length);
+                                    if (lv) ASRUtils::extract_value(lv, dim_size);
+                                }
+                                if (!ok) { indices_valid = false; break; }
+                                flat += (idx_val - start_val) * stride;
+                                stride *= dim_size;
+                            }
+                            collected_indices->push_back(al, indices_valid ? flat : (int64_t)-1);
+                        }
                     } else {
                         ASR::expr_t* target = ASRUtils::EXPR((ASR::asr_t*) array_item_expr);
                         ASRUtils::make_ArrayBroadcast_t_util(al, data_stmt.base.base.loc, target, value);
@@ -3555,46 +3619,93 @@ public:
             }
         }
 
-        //In module scope, set the collected values directly on the array variable as an ArrayConstructor
-        if (top_level_module_scope && local_collected_values.size() > 0) {
-            ASR::expr_t* first_val = implied_do_loop->m_values[0];
-            while (ASR::is_a<ASR::ImpliedDoLoop_t>(*first_val)) {
-                first_val = ASR::down_cast<ASR::ImpliedDoLoop_t>(first_val)->m_values[0];
+        //In module scope, set the collected values on the array variable as a
+        //full-size ArrayConstructor, preserving any values from prior DATA
+        //statements and placing new values at their correct flat (ColMajor)
+        //positions.
+        if (top_level_module_scope && local_collected_values.size() > 0
+                && target_variable != nullptr) {
+            ASR::Variable_t* v2 = target_variable;
+            ASR::ttype_t *int_type = ASRUtils::TYPE(
+                ASR::make_Integer_t(al, data_stmt.base.base.loc,
+                                    compiler_options.po.default_integer_kind));
+            ASR::ttype_t* tv_arr_ttype = ASRUtils::type_get_past_allocatable(
+                ASRUtils::type_get_past_pointer(v2->m_type));
+            int64_t total_size = ASRUtils::get_fixed_size_of_array(tv_arr_ttype);
+            bool have_indices = (local_collected_indices.size()
+                                    == local_collected_values.size());
+            bool indices_ok = (total_size > 0) && have_indices;
+            if (indices_ok) {
+                for (size_t k = 0; k < local_collected_indices.size(); k++) {
+                    if (local_collected_indices[k] < 0
+                        || local_collected_indices[k] >= total_size) {
+                        indices_ok = false;
+                        break;
+                    }
+                }
             }
-            if (ASR::is_a<ASR::ArrayItem_t>(*first_val)) {
-                ASR::ArrayItem_t* arr_item = ASR::down_cast<ASR::ArrayItem_t>(first_val);
-                ASR::Variable_t* v2 = nullptr;
-                if (ASR::is_a<ASR::Var_t>(*arr_item->m_v)) {
-                    v2 = ASR::down_cast<ASR::Variable_t>(
-                        ASR::down_cast<ASR::Var_t>(arr_item->m_v)->m_v);
+
+            if (indices_ok) {
+                ASR::ttype_t* elem_type = ASR::down_cast<ASR::Array_t>(tv_arr_ttype)->m_type;
+                std::vector<ASR::expr_t*> slots(total_size, nullptr);
+
+                // Preserve values from a prior DATA statement if any.
+                if (v2->m_value && ASR::is_a<ASR::ArrayConstant_t>(*v2->m_value)) {
+                    ASR::ArrayConstant_t* prev = ASR::down_cast<ASR::ArrayConstant_t>(v2->m_value);
+                    int64_t prev_size = ASRUtils::get_fixed_size_of_array(prev->m_type);
+                    for (int64_t k = 0; k < prev_size && k < total_size; k++) {
+                        slots[k] = ASRUtils::fetch_ArrayConstant_value(al, prev, (int)k);
+                    }
                 }
-                if (v2) {
-                    ASR::ttype_t *int_type = ASRUtils::TYPE(
-                        ASR::make_Integer_t(al, data_stmt.base.base.loc,
-                                            compiler_options.po.default_integer_kind));
-                    Vec<ASR::dimension_t> dims;
-                    dims.reserve(al, 1);
-                    ASR::dimension_t dim;
-                    dim.loc = data_stmt.base.base.loc;
-                    dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, data_stmt.base.base.loc, 1, int_type));
-                    dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, data_stmt.base.base.loc, (int64_t)local_collected_values.size(), int_type));
-                    dims.push_back(al, dim);
-                    ASR::ttype_t* arr_type = ASRUtils::duplicate_type(al, v2->m_type, &dims);
-                    ASR::asr_t* arr_constructor = ASRUtils::make_ArrayConstructor_t_util(
-                        al, data_stmt.base.base.loc, local_collected_values.p,
-                        local_collected_values.size(), arr_type,
-                        ASR::arraystorageType::ColMajor);
-                    v2->m_value = ASRUtils::EXPR(arr_constructor);
-                    v2->m_symbolic_value = ASRUtils::EXPR(arr_constructor);
-                    SetChar var_deps_vec;
-                    var_deps_vec.reserve(al, 1);
-                    ASRUtils::collect_variable_dependencies(al, var_deps_vec, v2->m_type,
-                        v2->m_symbolic_value, v2->m_value);
-                    v2->m_dependencies = var_deps_vec.p;
-                    v2->n_dependencies = var_deps_vec.size();
+                for (size_t k = 0; k < local_collected_values.size(); k++) {
+                    slots[local_collected_indices[k]] = local_collected_values[k];
                 }
+                Vec<ASR::expr_t*> full_values;
+                full_values.reserve(al, (size_t)total_size);
+                for (int64_t k = 0; k < total_size; k++) {
+                    if (slots[k] == nullptr) {
+                        slots[k] = ASRUtils::get_constant_zero_with_given_type(al, elem_type);
+                    }
+                    full_values.push_back(al, slots[k]);
+                }
+                ASR::asr_t* arr_constructor = ASRUtils::make_ArrayConstructor_t_util(
+                    al, data_stmt.base.base.loc, full_values.p,
+                    full_values.size(), v2->m_type,
+                    ASR::arraystorageType::ColMajor);
+                v2->m_value = ASRUtils::EXPR(arr_constructor);
+                v2->m_symbolic_value = ASRUtils::EXPR(arr_constructor);
+                SetChar var_deps_vec;
+                var_deps_vec.reserve(al, 1);
+                ASRUtils::collect_variable_dependencies(al, var_deps_vec, v2->m_type,
+                    v2->m_symbolic_value, v2->m_value);
+                v2->m_dependencies = var_deps_vec.p;
+                v2->n_dependencies = var_deps_vec.size();
+            } else {
+                // Fallback: old behavior (1D ArrayConstructor sized to
+                // collected values). Used when we can't compute flat indices
+                // or array bounds aren't known at compile time.
+                Vec<ASR::dimension_t> dims;
+                dims.reserve(al, 1);
+                ASR::dimension_t dim;
+                dim.loc = data_stmt.base.base.loc;
+                dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                    al, data_stmt.base.base.loc, 1, int_type));
+                dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                    al, data_stmt.base.base.loc, (int64_t)local_collected_values.size(), int_type));
+                dims.push_back(al, dim);
+                ASR::ttype_t* arr_type = ASRUtils::duplicate_type(al, v2->m_type, &dims);
+                ASR::asr_t* arr_constructor = ASRUtils::make_ArrayConstructor_t_util(
+                    al, data_stmt.base.base.loc, local_collected_values.p,
+                    local_collected_values.size(), arr_type,
+                    ASR::arraystorageType::ColMajor);
+                v2->m_value = ASRUtils::EXPR(arr_constructor);
+                v2->m_symbolic_value = ASRUtils::EXPR(arr_constructor);
+                SetChar var_deps_vec;
+                var_deps_vec.reserve(al, 1);
+                ASRUtils::collect_variable_dependencies(al, var_deps_vec, v2->m_type,
+                    v2->m_symbolic_value, v2->m_value);
+                v2->m_dependencies = var_deps_vec.p;
+                v2->n_dependencies = var_deps_vec.size();
             }
         }
     }


### PR DESCRIPTION
When a module-scope array was initialized by multiple DATA statements using implied-do loops that each filled a disjoint slice of the array (e.g. different columns of a 2D array), the semantic pass overwrote the variable's initializer with just the last DATA statement's values and produced a partial 1D ArrayConstant whose flat size did not match the variable's declared type. LLVM then rejected the module with:

  Global variable initializer type does not match global variable type

Fix handle_implied_do_loop_data_stmt in ast_common_visitor.h to:
  * Compute the flat (ColMajor) index for each collected value using the declared dimensions (including lower bounds) of the target variable.
  * At the top-level module scope finalization, build a full-size ArrayConstructor: seed it with any values from a previous DATA statement on the same variable, overlay the newly collected values at their flat indices, and pad the untouched slots with type- appropriate zero constants so the initializer matches the declared type.

A fallback to the previous 1D-sized ArrayConstructor is retained for cases where the array size or indices cannot be determined at compile time.

Adds integration test data_implied_do_08 reproducing the MRE.