### PR TITLE
Merge generic interfaces imported from multiple modules

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2047,6 +2047,7 @@ RUN(NAME generic_name_04 LABELS gfortran llvm)
 RUN(NAME generic_name_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_06 LABELS gfortran llvm)
 RUN(NAME generic_name_07 LABELS gfortran llvm)
+RUN(NAME generic_name_08 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2046,6 +2046,7 @@ RUN(NAME generic_name_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_04 LABELS gfortran llvm)
 RUN(NAME generic_name_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_06 LABELS gfortran llvm)
+RUN(NAME generic_name_07 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_name_07.f90
+++ b/integration_tests/generic_name_07.f90
@@ -1,0 +1,47 @@
+! Test: generic interfaces with the same name imported from multiple
+! modules via `use` are merged (F2018 C1515). Here `delete` is a generic
+! in both `a_m` and `b_m`; each specific dispatches on its own derived type.
+module generic_name_07_a_m
+  implicit none
+  type :: a_t
+    integer :: i = 0
+  end type
+  interface delete
+    module procedure del_a
+  end interface
+contains
+  subroutine del_a(x)
+    type(a_t), intent(out) :: x
+    x%i = -1
+  end subroutine
+end module
+
+module generic_name_07_b_m
+  implicit none
+  type :: b_t
+    integer :: j = 0
+  end type
+  interface delete
+    module procedure del_b
+  end interface
+contains
+  subroutine del_b(x)
+    type(b_t), intent(out) :: x
+    x%j = -2
+  end subroutine
+end module
+
+program generic_name_07
+  use generic_name_07_a_m
+  use generic_name_07_b_m
+  implicit none
+  type(a_t) :: a
+  type(b_t) :: b
+  a%i = 5
+  b%j = 7
+  call delete(a)
+  call delete(b)
+  if (a%i /= -1) error stop
+  if (b%j /= -2) error stop
+  print *, "PASS"
+end program

--- a/integration_tests/generic_name_08.f90
+++ b/integration_tests/generic_name_08.f90
@@ -1,0 +1,44 @@
+module generic_name_08_path_mod
+  implicit none
+  type :: toml_key
+    character(:), allocatable :: s
+  end type
+  type :: toml_path
+    type(toml_key), allocatable :: path(:)
+  end type
+  interface toml_path
+    module procedure new_path2
+  end interface
+contains
+  function new_path2(a, b) result(p)
+    character(*), intent(in) :: a, b
+    type(toml_path) :: p
+    allocate(p%path(2))
+    p%path(1)%s = a
+    p%path(2)%s = b
+  end function
+end module
+
+module generic_name_08_build_mod
+  use generic_name_08_path_mod, only : toml_path, toml_key
+  implicit none
+  public :: toml_path, toml_key
+end module
+
+module generic_name_08_top_mod
+  use generic_name_08_build_mod, only : toml_path, toml_key
+  implicit none
+  public :: toml_path, toml_key
+end module
+
+program generic_name_08
+  use generic_name_08_build_mod
+  use generic_name_08_top_mod
+  implicit none
+  type(toml_path) :: p
+  p = toml_path([toml_key("x"), toml_key("y")])
+  if (size(p%path) /= 2) error stop
+  if (p%path(1)%s /= "x") error stop
+  if (p%path(2)%s /= "y") error stop
+  print *, "PASS"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -19025,6 +19025,40 @@ public:
         }
     }
 
+    // Return true if every specific procedure of `incoming` resolves (past
+    // ExternalSymbol) to a specific already referenced by `existing`. Used to
+    // avoid re-merging a GenericProcedure/CustomOperator that reaches the
+    // current scope through multiple re-export chains with identical content.
+    bool generic_specifics_subset(ASR::symbol_t* existing,
+            ASR::symbol_t* incoming, bool is_gp) {
+        size_t e_n, i_n;
+        ASR::symbol_t** e_procs;
+        ASR::symbol_t** i_procs;
+        if (is_gp) {
+            ASR::GenericProcedure_t* e = ASR::down_cast<ASR::GenericProcedure_t>(existing);
+            ASR::GenericProcedure_t* i = ASR::down_cast<ASR::GenericProcedure_t>(incoming);
+            e_n = e->n_procs; i_n = i->n_procs;
+            e_procs = e->m_procs; i_procs = i->m_procs;
+        } else {
+            ASR::CustomOperator_t* e = ASR::down_cast<ASR::CustomOperator_t>(existing);
+            ASR::CustomOperator_t* i = ASR::down_cast<ASR::CustomOperator_t>(incoming);
+            e_n = e->n_procs; i_n = i->n_procs;
+            e_procs = e->m_procs; i_procs = i->m_procs;
+        }
+        for (size_t ii = 0; ii < i_n; ii++) {
+            ASR::symbol_t* ip = ASRUtils::symbol_get_past_external(i_procs[ii]);
+            bool found = false;
+            for (size_t ee = 0; ee < e_n; ee++) {
+                if (ASRUtils::symbol_get_past_external(e_procs[ee]) == ip) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return false;
+        }
+        return true;
+    }
+
     // Import a GenericProcedure/CustomOperator from module `m` into the
     // current scope, merging with an existing same-named generic in the
     // current scope if one is present. Used by `import_all` so that `use a;
@@ -19083,13 +19117,29 @@ public:
                 // are merged at the use-point (F2018 C1515).
                 ASR::symbol_t* existing = current_scope->get_symbol(item.first);
                 ASR::symbol_t* existing_past = ASRUtils::symbol_get_past_external(existing);
-                bool is_gp_merge = existing_past != nullptr &&
-                    ASR::is_a<ASR::GenericProcedure_t>(*item.second) &&
+                ASR::symbol_t* incoming_past = ASRUtils::symbol_get_past_external(item.second);
+                // Skip if the incoming symbol already resolves to the same
+                // underlying symbol as the existing one (re-import of the same
+                // generic via a different re-export chain).
+                if (existing_past == incoming_past) {
+                    continue;
+                }
+                bool is_gp_merge = existing_past != nullptr && incoming_past != nullptr &&
+                    ASR::is_a<ASR::GenericProcedure_t>(*incoming_past) &&
                     ASR::is_a<ASR::GenericProcedure_t>(*existing_past);
-                bool is_co_merge = existing_past != nullptr &&
-                    ASR::is_a<ASR::CustomOperator_t>(*item.second) &&
+                bool is_co_merge = existing_past != nullptr && incoming_past != nullptr &&
+                    ASR::is_a<ASR::CustomOperator_t>(*incoming_past) &&
                     ASR::is_a<ASR::CustomOperator_t>(*existing_past);
                 if (!is_gp_merge && !is_co_merge) {
+                    continue;
+                }
+                // Skip the merge if the incoming generic's specific procedures
+                // (compared by their past-external target) are all already
+                // referenced by the existing generic. This is the common case
+                // when the same underlying generic reaches the current scope
+                // through two re-export chains (each module constructs its own
+                // GenericProcedure node but the specifics are the same).
+                if (generic_specifics_subset(existing_past, incoming_past, is_gp_merge)) {
                     continue;
                 }
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -19025,6 +19025,41 @@ public:
         }
     }
 
+    // Import a GenericProcedure/CustomOperator from module `m` into the
+    // current scope, merging with an existing same-named generic in the
+    // current scope if one is present. Used by `import_all` so that `use a;
+    // use b` merges generics defined in both modules (F2018 C1515), matching
+    // the behaviour of the `use, only:` path.
+    template <typename T>
+    void import_or_merge_generic(const ASR::Module_t* m, T* gp,
+            std::string& sym,
+            ASR::asr_t* (*constructor)(Allocator&, const Location&,
+                SymbolTable*, char*, ASR::symbol_t**, size_t,
+                ASR::accessType)) {
+        ASR::Module_t* m_nc = const_cast<ASR::Module_t*>(m);
+        if (current_scope->get_symbol(sym) != nullptr) {
+            std::queue<std::pair<std::string, std::string>> tbi;
+            process_generic_proc_custom_op<T>(sym, (ASR::symbol_t*)gp, tbi,
+                gp->base.base.loc, m_nc, constructor, nullptr);
+            while (!tbi.empty()) {
+                std::string rs = tbi.front().first;
+                std::string ls = tbi.front().second;
+                tbi.pop();
+                if (current_scope->resolve_symbol(ls) == nullptr) {
+                    std::string msym_ = std::string(m->m_name);
+                    import_symbols_util(m_nc, msym_, rs, ls, tbi,
+                                        gp->base.base.loc);
+                }
+            }
+            return;
+        }
+        ASR::asr_t *ep = ASR::make_ExternalSymbol_t(
+            al, gp->base.base.loc, current_scope,
+            /* a_name */ gp->m_name, (ASR::symbol_t*)gp,
+            m->m_name, nullptr, 0, gp->m_name, dflt_access);
+        current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(ep));
+    }
+
     std::string import_all(const ASR::Module_t* m, bool to_submodule=false,
                            std::vector<std::string> symbols_already_imported_with_renaming = {},
                            std::set<std::string> submodule_proc_names = {}) {
@@ -19040,7 +19075,23 @@ public:
                 continue;
             }
             if( current_scope->get_symbol(item.first) != nullptr) {
-                continue;
+                // If the existing symbol and the incoming symbol are both
+                // generic interfaces (GenericProcedure) or user-defined
+                // operators (CustomOperator), merge their specific procedures
+                // instead of skipping. This is required by Fortran semantics:
+                // generics with the same name imported from multiple modules
+                // are merged at the use-point (F2018 C1515).
+                ASR::symbol_t* existing = current_scope->get_symbol(item.first);
+                ASR::symbol_t* existing_past = ASRUtils::symbol_get_past_external(existing);
+                bool is_gp_merge = existing_past != nullptr &&
+                    ASR::is_a<ASR::GenericProcedure_t>(*item.second) &&
+                    ASR::is_a<ASR::GenericProcedure_t>(*existing_past);
+                bool is_co_merge = existing_past != nullptr &&
+                    ASR::is_a<ASR::CustomOperator_t>(*item.second) &&
+                    ASR::is_a<ASR::CustomOperator_t>(*existing_past);
+                if (!is_gp_merge && !is_co_merge) {
+                    continue;
+                }
             }
             // TODO: only import "public" symbols from the module
             if (ASR::is_a<ASR::Function_t>(*item.second)) {
@@ -19069,29 +19120,15 @@ public:
             } else if (ASR::is_a<ASR::GenericProcedure_t>(*item.second)) {
                 ASR::GenericProcedure_t *gp = ASR::down_cast<
                     ASR::GenericProcedure_t>(item.second);
-                ASR::asr_t *ep = ASR::make_ExternalSymbol_t(
-                    al, gp->base.base.loc,
-                    current_scope,
-                    /* a_name */ gp->m_name,
-                    (ASR::symbol_t*)gp,
-                    m->m_name, nullptr, 0, gp->m_name,
-                    dflt_access
-                    );
                 std::string sym = to_lower(gp->m_name);
-                current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(ep));
+                import_or_merge_generic<ASR::GenericProcedure_t>(
+                    m, gp, sym, &ASR::make_GenericProcedure_t);
             }  else if (ASR::is_a<ASR::CustomOperator_t>(*item.second)) {
                 ASR::CustomOperator_t *gp = ASR::down_cast<
                     ASR::CustomOperator_t>(item.second);
-                ASR::asr_t *ep = ASR::make_ExternalSymbol_t(
-                    al, gp->base.base.loc,
-                    current_scope,
-                    /* a_name */ gp->m_name,
-                    (ASR::symbol_t*)gp,
-                    m->m_name, nullptr, 0, gp->m_name,
-                    dflt_access
-                    );
                 std::string sym = gp->m_name;
-                current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(ep));
+                import_or_merge_generic<ASR::CustomOperator_t>(
+                    m, gp, sym, &ASR::make_CustomOperator_t);
             } else if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *mvar = ASR::down_cast<ASR::Variable_t>(item.second);
                 // check if m_access of mvar is public


### PR DESCRIPTION
When two modules define a generic interface (or user-defined operator) with the same name and both are brought into scope via `use`, the Fortran standard requires the specific procedures to be merged into a single generic at the use-point (F2018 C1515). Previously `import_all` skipped the second import whenever a symbol with that name already existed, so only the specifics from the first module were visible; calling the generic with an argument matching a specific from the second module produced 'Arguments do not match for any generic procedure'.

This change detects the GenericProcedure/CustomOperator-with-same-name case in `import_all` and delegates merging to the existing `process_generic_proc_custom_op` helper already used by the `use, only:` path, so both `use` forms behave the same.

Adds integration_tests/generic_name_07.f90.

Fixes #11160.