### PR TITLE
fix: read of strings into character-array through an implied do loop inside subroutines

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3358,6 +3358,8 @@ RUN(NAME read_78 LABELS gfortran llvm)
 
 RUN(NAME read_79 LABELS gfortran llvm)
 
+RUN(NAME read_81 LABELS gfortran llvm)
+
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/read_81.f90
+++ b/integration_tests/read_81.f90
@@ -1,0 +1,39 @@
+! Tests for read(text, *) (arr(i), i=1,n) with character arrays inside do-loops
+! Case 1: FixedSizeArray
+! Case 2: PointerArray - Subroutine arguments
+
+program read_81
+  implicit none
+
+  integer, parameter :: SLEN = 20
+  character(len=SLEN) :: fixed_arr(2)
+  character(len=SLEN), allocatable :: alloc_arr(:)
+  character(len=SLEN) :: text
+  integer :: i
+  text = "'hello' 'world'"
+
+  ! Case 1: FixedSizeArray — arr is local fixed-size
+  read(text, *) (fixed_arr(i), i = 1, 2)
+  print *, fixed_arr(1), fixed_arr(2)
+  if (trim(fixed_arr(1)) /= 'hello') error stop
+  if (trim(fixed_arr(2)) /= 'world') error stop
+
+  ! Case 2: PointerArray — pass fixed array to assumed-shape dummy
+  allocate(alloc_arr(2))
+  call read_into_dummy(text, alloc_arr, 2)
+  print *, alloc_arr(1), alloc_arr(2)
+  if (trim(alloc_arr(1)) /= 'hello') error stop
+  if (trim(alloc_arr(2)) /= 'world') error stop
+
+contains
+
+  subroutine read_into_dummy(text, arr, n)
+    character(len=*), intent(in)  :: text
+    character(len=SLEN), intent(out) :: arr(:)
+    integer, intent(in) :: n
+    integer :: i
+
+    read(text, *) (arr(i), i = 1, n)
+  end subroutine read_into_dummy
+
+end program read_81

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16971,16 +16971,33 @@ public:
                                 // Convert size to i32
                                 size = builder->CreateIntCast(size, llvm::Type::getInt32Ty(context), true);
 
-                                // Call array read function
-                                llvm::Function* fn = get_read_function(arr_type);
-                                llvm::Value* stride_val = llvm::ConstantInt::get(
-                                    llvm::Type::getInt32Ty(context), 1);
-                                if (ASR::is_a<ASR::Logical_t>(*elem_type)) {
-                                    int a_kind = ASRUtils::extract_kind_from_ttype_t(elem_type);
-                                    llvm::Value* kind_val = llvm::ConstantInt::get(context, llvm::APInt(32, a_kind));
-                                    builder->CreateCall(fn, {section_ptr, size, kind_val, stride_val, unit_val, iostat});
+                                // Pointer-array string reads call the special API 
+                                // _lfortran_string_read_str_array so that passed input 
+                                // strings are copied into the target character array.
+                                if (is_string && ASR::is_a<ASR::String_t>(*elem_type)) {
+                                    llvm::Type* char_ptr_type = llvm::Type::getInt8Ty(context)->getPointerTo();
+                                    llvm::FunctionType* str_arr_ft = llvm::FunctionType::get(
+                                        llvm::Type::getVoidTy(context),
+                                        { char_ptr_type, llvm::Type::getInt64Ty(context),
+                                          char_ptr_type, char_ptr_type, llvm::Type::getInt64Ty(context) }, false);
+                                    auto [arr_data, elem_len_llvm] = llvm_utils->get_string_length_data(
+                                        ASR::down_cast<ASR::String_t>(elem_type), section_ptr);
+                                    llvm::Value* fmt_val = LCompilers::create_global_string_ptr(
+                                        context, *module, *builder, "%s");
+                                    std::vector<llvm::Value*> args = {str_src_data, str_src_len, fmt_val, arr_data, elem_len_llvm};
+                                    builder->CreateCall(module->getOrInsertFunction(
+                                            "_lfortran_string_read_str_array", str_arr_ft), args);
                                 } else {
-                                    builder->CreateCall(fn, {section_ptr, size, stride_val, unit_val, iostat});
+                                    llvm::Function* fn = get_read_function(arr_type);
+                                    llvm::Value* stride_val = llvm::ConstantInt::get(
+                                        llvm::Type::getInt32Ty(context), 1);
+                                    if (ASR::is_a<ASR::Logical_t>(*elem_type)) {
+                                        int a_kind = ASRUtils::extract_kind_from_ttype_t(elem_type);
+                                        llvm::Value* kind_val = llvm::ConstantInt::get(context, llvm::APInt(32, a_kind));
+                                        builder->CreateCall(fn, {section_ptr, size, kind_val, stride_val, unit_val, iostat});
+                                    } else {
+                                        builder->CreateCall(fn, {section_ptr, size, stride_val, unit_val, iostat});
+                                    }
                                 }
                                 continue;
                             }


### PR DESCRIPTION
Fixes #11208 
MRE created while working on compilation of #11144 

Changes made:
- Handle the read from character variable to arrays inside implied-do-loops
- Currently, we handle PointerArrays and FixedSizedArrays
- Add support for fixed-sized arrays using `_lfortran_string_read_str_array` runtime API to parse the input string section and copy the resulting strings into the destination array section.