### PR TITLE
Fix infinite loop on unsupported statement inside fixed-form IF

### DIFF
--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1672,7 +1672,14 @@ struct FixedFormRecursiveDescent {
             tokenize_line(cur);
             return true;
         }
-        lex_body_statement(cur);
+        unsigned char *prev = cur;
+        bool result = lex_body_statement(cur);
+        if (!result && cur == prev) {
+            // No progress was made (e.g. an unsupported statement like PAUSE).
+            // Abort the loop to avoid an infinite loop; the outer parser will
+            // emit an appropriate error.
+            return false;
+        }
         return true;
     }
 

--- a/tests/errors/fixed_form_6.f
+++ b/tests/errors/fixed_form_6.f
@@ -1,0 +1,5 @@
+      PROGRAM PAUSE0
+      IF (.TRUE.) THEN
+          PAUSE
+      ENDIF
+      END

--- a/tests/reference/ast-fixed_form_6-1dd815c.json
+++ b/tests/reference/ast-fixed_form_6-1dd815c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-fixed_form_6-1dd815c",
+    "cmd": "lfortran --fixed-form --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/fixed_form_6.f",
+    "infile_hash": "c7e7d1963ba30d8ee2d41bd639a12ccfb98171b95f9a3bf2676d4ea9",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-fixed_form_6-1dd815c.stderr",
+    "stderr_hash": "562372aa0381df517336ca356566a0438d1f73e91a411dcc681d9d92",
+    "returncode": 2
+}

--- a/tests/reference/ast-fixed_form_6-1dd815c.stderr
+++ b/tests/reference/ast-fixed_form_6-1dd815c.stderr
@@ -1,0 +1,5 @@
+tokenizer error: Expecting terminating symbol for program
+ --> tests/errors/fixed_form_6.f:3:11
+  |
+3 |           PAUSE
+  |           ^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3513,6 +3513,10 @@ filename = "errors/fixed_form_5.f"
 ast = true
 
 [[test]]
+filename = "errors/fixed_form_6.f"
+ast = true
+
+[[test]]
 filename = "errors/arithmetic_if1.f90"
 asr = true
 


### PR DESCRIPTION
When a fixed-form program contained an unsupported statement (e.g. PAUSE) inside an IF ... THEN ... ENDIF block, the tokenizer's if_advance_or_terminate would unconditionally return true after calling lex_body_statement, without checking whether the cursor had advanced. If lex_body_statement failed to make progress (as with PAUSE, which is not handled in lex_body_statement), the enclosing 'while (if_advance_or_terminate(cur))' in lex_cond would spin forever.

Detect the no-progress case and return false so the outer parser emits a normal tokenizer error instead of hanging.

Adds tests/errors/fixed_form_6.f to lock in the new behavior.

Fixes #11222