### PR TITLE
Allow character variable as unit= keyword in write/read

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3384,6 +3384,7 @@ RUN(NAME write_23 LABELS gfortran llvm)
 RUN(NAME write_24 LABELS gfortran llvm)
 RUN(NAME write_25 LABELS gfortran llvm)
 RUN(NAME write_26 LABELS gfortran llvm)
+RUN(NAME write_27 LABELS gfortran llvm)
 
 RUN(NAME write_fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME write_fortran_02 LABELS gfortran llvm fortran)

--- a/integration_tests/write_27.f90
+++ b/integration_tests/write_27.f90
@@ -1,0 +1,18 @@
+program write_27
+implicit none
+character(len=10) :: s
+character(len=3) :: t
+integer :: val
+
+! Test write with unit= keyword pointing to a character variable (internal file)
+val = 42
+write(unit=s, fmt="(i10)") val
+if (trim(adjustl(s)) /= "42") error stop
+
+! Test with a shorter string
+write(unit=t, fmt="(i3)") 7
+if (trim(adjustl(t)) /= "7") error stop
+
+print *, trim(adjustl(s))
+print *, trim(adjustl(t))
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1652,9 +1652,10 @@ public:
                     this->visit_expr(*kwarg.m_value);
                     a_unit = ASRUtils::EXPR(tmp);
                     ASR::ttype_t* a_unit_type = ASRUtils::expr_type(a_unit);
-                    if  (!ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(a_unit_type))) {
+                    if  (!ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(a_unit_type))
+                         && !ASRUtils::is_character(*a_unit_type)) {
                             diag.add(Diagnostic(
-                                "`unit` must be of type, Integer",
+                                "`unit` must be of type Integer or Character",
                                 Level::Error, Stage::Semantic, {
                                     Label("",{loc})
                                 }));

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -697,4 +697,10 @@ program continue_compilation_1
         print *, len(generic)
         print *, len(a)
     end subroutine print_len_non_char
+
+    subroutine sub_write_unit_bad_type()
+        implicit none
+        real :: r
+        write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
+    end subroutine sub_write_unit_bad_type
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "91c89318250d31eafa009e01265522fb7be06c85db508c46411722c3",
+    "infile_hash": "a6b034b194206b7f5391f8f382be0189dfd41f56ea01969e416fd1a7",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "8bbd3bb592019cf45b13ecb509e67b76b76a81010ce38bd92dabe11b",
+    "stderr_hash": "e228e35ad2741d19de27c4995a359649fea9fb1b4f07b64e2164d86e",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1472,3 +1472,9 @@ semantic error: Argument of 'len' intrinsic must be CHARACTER, found integer ins
     |
 698 |         print *, len(a)
     |                      ^ 
+
+semantic error: `unit` must be of type Integer or Character
+   --> tests/errors/continue_compilation_1.f90:704:9
+    |
+704 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
When using write(unit=s, fmt=...) where s is a character variable, the compiler incorrectly rejected it with 'unit must be of type, Integer'. This is valid Fortran for internal file I/O. The positional argument path already accepted character units, but the keyword argument path only checked for Integer type.

The fix adds a check for Character type alongside Integer in the keyword unit= validation for write/read statements.

An integration test (write_27) is added to verify this works.

Fixes #https://github.com/lfortran/lfortran/issues/11224.