### PR TITLE
fix: return negative unit numbers from open(newunit=...)

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2821,6 +2821,7 @@ RUN(NAME file_open_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME file_open_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME file_open_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_open_08 LABELS gfortran llvm)
+RUN(NAME file_open_09 LABELS gfortran llvm)
 
 RUN(NAME file_overwrite LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_open_09.f90
+++ b/integration_tests/file_open_09.f90
@@ -1,0 +1,23 @@
+program file_open_09
+! Test that open(newunit=...) returns a valid F2023 12.5.6.13 unit number:
+! must be negative, must not be -1, and must not equal INPUT_UNIT,
+! OUTPUT_UNIT, or ERROR_UNIT.
+use iso_fortran_env
+implicit none
+integer :: u1, u2
+
+open(newunit=u1, file="file_open_09.tmp", status="replace", form="formatted")
+if (u1 >= -1) error stop "newunit >= -1"
+if (u1 == ERROR_UNIT) error stop "newunit == ERROR_UNIT"
+if (u1 == INPUT_UNIT) error stop "newunit == INPUT_UNIT"
+if (u1 == OUTPUT_UNIT) error stop "newunit == OUTPUT_UNIT"
+
+! A second concurrent open must produce a different unit number.
+open(newunit=u2, status="scratch", form="formatted")
+if (u2 >= -1) error stop "second newunit >= -1"
+if (u2 == u1) error stop "second newunit collides with first"
+
+close(u2)
+close(u1, status="delete")
+print *, "PASS"
+end program

--- a/src/runtime/custom/lfortran_intrinsic_custom.f90
+++ b/src/runtime/custom/lfortran_intrinsic_custom.f90
@@ -10,11 +10,13 @@ end interface
 
 contains
     function get_valid_newunit() result(unit)
-        integer, parameter :: LUN_MIN=0, LUN_MAX=1000
+        ! F2023 12.5.6.13: NEWUNIT= must return a negative unit number
+        ! that is not -1 and is not currently associated with any unit.
+        integer, parameter :: LUN_START=-10, LUN_MIN=-1000
         logical :: opened
-        integer(4) :: lun 
-        integer(4) :: unit ! no need for kind 8, we have limit of 1000 for now.
-        do lun=LUN_MIN,LUN_MAX
+        integer(4) :: lun
+        integer(4) :: unit
+        do lun=LUN_START,LUN_MIN,-1
             inquire(unit=lun,opened=opened)
             if (.not. opened) then
                 unit = lun
@@ -28,12 +30,14 @@ contains
     subroutine newunit_int_1(unit)
         implicit none
         integer(1), intent(out) :: unit
-        if(get_valid_newunit() >= 2**8) then
-            print *, "integer(KIND=1) & 
-            &is has small limit. Use larger kind for the unit number"
+        integer(4) :: u
+        u = get_valid_newunit()
+        if (u < -2**7) then
+            print *, "integer(KIND=1) &
+            &has small range. Use larger kind for the unit number"
             error stop
         end if
-        unit =  INT(get_valid_newunit(),1)
+        unit =  INT(u,1)
     end subroutine newunit_int_1
 
     subroutine newunit_int_2(unit)


### PR DESCRIPTION
Fixes #11228
- `open(newunit=u, ...)` now returns a negative unit number (starts at -10), per F2023 12.5.6.13.
- Previously returned positive units (starting at 1), which collides with `OUTPUT_UNIT`/`ERROR_UNIT` and violates the standard.
- Added `integration_tests/file_open_09.f90` (labels: `gfortran llvm`).
- Test fails on `main`, passes on this branch; also passes with gfortran.