### PR TITLE
Initialize rank in fill_malloc_array_details

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4157,6 +4157,7 @@ RUN(NAME separate_compilation_45 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_46 LABELS gfortran llvm EXTRAFILES separate_compilation_46a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compilation_47a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compilation_48a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_49.f90
+++ b/integration_tests/separate_compilation_49.f90
@@ -1,0 +1,16 @@
+program separate_compilation_49
+   implicit none
+   interface
+      subroutine separate_compilation_49_sub()
+      end subroutine
+   end interface
+   ! A format with an `Nx` descriptor (N >= 4) used to leave non-zero garbage
+   ! in the heap region that was later returned by malloc to back the data
+   ! pointer of the module-level allocatable array `d`. Combined with the
+   ! rank field of `d`'s descriptor never being initialized at allocation
+   ! time (it lives in .bss with separate compilation), only the first
+   ! element's allocatable component pointer was nullified, so `d(2)%a`
+   ! appeared "already allocated".
+   write(*,"(4x)")
+   call separate_compilation_49_sub()
+end program

--- a/integration_tests/separate_compilation_49a.f90
+++ b/integration_tests/separate_compilation_49a.f90
@@ -1,0 +1,22 @@
+module separate_compilation_49a_mod
+   implicit none
+   type :: t
+      integer :: i
+      integer, allocatable :: a(:)
+   end type
+   type(t), allocatable :: d(:)
+end module
+
+subroutine separate_compilation_49_sub()
+   use separate_compilation_49a_mod
+   implicit none
+   allocate(d(2))
+   if (allocated(d(1)%a)) error stop "d(1)%a unexpectedly allocated"
+   if (allocated(d(2)%a)) error stop "d(2)%a unexpectedly allocated"
+   allocate(d(1)%a(1))
+   allocate(d(2)%a(1))
+   d(1)%a(1) = 11
+   d(2)%a(1) = 22
+   if (d(1)%a(1) /= 11) error stop "wrong value in d(1)%a"
+   if (d(2)%a(1) /= 22) error stop "wrong value in d(2)%a"
+end subroutine

--- a/integration_tests/separate_compilation_49a.f90
+++ b/integration_tests/separate_compilation_49a.f90
@@ -19,4 +19,7 @@ subroutine separate_compilation_49_sub()
    d(2)%a(1) = 22
    if (d(1)%a(1) /= 11) error stop "wrong value in d(1)%a"
    if (d(2)%a(1) /= 22) error stop "wrong value in d(2)%a"
+   deallocate(d(1)%a)
+   deallocate(d(2)%a)
+   deallocate(d)
 end subroutine

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -477,6 +477,12 @@ namespace LCompilers {
             llvm::Value* offset_val = llvm_utils->create_gep2(arr_type, arr, FIELD_OFFSET);
             builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)),
                                     offset_val);
+            // Ensure the descriptor's rank field is initialized. For module-level
+            // allocatable variables under separate compilation, the descriptor lives
+            // in .bss (zero-initialized) and the rank may otherwise remain 0, which
+            // breaks subsequent walks over the array's elements (e.g. nullifying
+            // allocatable components of every element).
+            set_rank(arr_type, arr, llvm::ConstantInt::get(context, llvm::APInt(32, n_dims)));
             llvm::Value* dim_des_val = get_pointer_to_dimension_descriptor_array(arr_type, arr);
             llvm::Value* prod = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
             for( int r = 0; r < n_dims; r++ ) {

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "fd368afc409f3a67704e9b5b20b631829c48750e3fadb7f9d3483392",
+    "stdout_hash": "5237e69b171150d54680e0d2e73c7ec50480653604afaab7d40c2d58",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -86,126 +86,130 @@ ifcont:                                           ; preds = %merge_allocated
   %34 = load %array.1*, %array.1** %arr, align 8
   %35 = getelementptr %array.1, %array.1* %34, i32 0, i32 7
   store i64 0, i64* %35, align 8
-  %36 = getelementptr %array.1, %array.1* %34, i32 0, i32 8
-  %37 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %36, i32 0, i32 0
-  %38 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %37, i32 0
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 2
-  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 0
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %38, i32 0, i32 1
-  store i64 1, i64* %39, align 8
+  %36 = getelementptr %array.1, %array.1* %34, i32 0, i32 3
+  store i8 1, i8* %36, align 1
+  %37 = getelementptr %array.1, %array.1* %34, i32 0, i32 8
+  %38 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %37, i32 0, i32 0
+  %39 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %38, i32 0
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 2
+  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 0
+  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 1
   store i64 1, i64* %40, align 8
   store i64 1, i64* %41, align 8
-  %42 = getelementptr %array.1, %array.1* %34, i32 0, i32 0
-  %43 = call i8* @_lfortran_get_default_allocator()
-  %44 = call i8* @_lfortran_malloc_alloc(i8* %43, i64 4)
-  %45 = bitcast i8* %44 to i32*
-  store i32* %45, i32** %42, align 8
+  store i64 1, i64* %42, align 8
+  %43 = getelementptr %array.1, %array.1* %34, i32 0, i32 0
+  %44 = call i8* @_lfortran_get_default_allocator()
+  %45 = call i8* @_lfortran_malloc_alloc(i8* %44, i64 4)
+  %46 = bitcast i8* %45 to i32*
+  store i32* %46, i32** %43, align 8
   store i32 0, i32* %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont10, %ifcont
-  %46 = load i32, i32* %i, align 4
-  %47 = add i32 %46, 1
-  %48 = icmp sle i32 %47, 1000000
-  br i1 %48, label %loop.body, label %loop.end
+  %47 = load i32, i32* %i, align 4
+  %48 = add i32 %47, 1
+  %49 = icmp sle i32 %48, 1000000
+  br i1 %49, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %49 = load i32, i32* %i, align 4
-  %50 = add i32 %49, 1
-  store i32 %50, i32* %i, align 4
-  %51 = load %array.1*, %array.1** %arr, align 8
-  %52 = ptrtoint %array.1* %51 to i64
-  %53 = icmp eq i64 %52, 0
-  br i1 %53, label %merge_allocated2, label %check_data1
+  %50 = load i32, i32* %i, align 4
+  %51 = add i32 %50, 1
+  store i32 %51, i32* %i, align 4
+  %52 = load %array.1*, %array.1** %arr, align 8
+  %53 = ptrtoint %array.1* %52 to i64
+  %54 = icmp eq i64 %53, 0
+  br i1 %54, label %merge_allocated2, label %check_data1
 
 check_data1:                                      ; preds = %loop.body
-  %54 = getelementptr %array.1, %array.1* %51, i32 0, i32 0
-  %55 = load i32*, i32** %54, align 8
-  %56 = ptrtoint i32* %55 to i64
-  %57 = icmp ne i64 %56, 0
+  %55 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
+  %56 = load i32*, i32** %55, align 8
+  %57 = ptrtoint i32* %56 to i64
+  %58 = icmp ne i64 %57, 0
   br label %merge_allocated2
 
 merge_allocated2:                                 ; preds = %check_data1, %loop.body
-  %is_allocated3 = phi i1 [ false, %loop.body ], [ %57, %check_data1 ]
+  %is_allocated3 = phi i1 [ false, %loop.body ], [ %58, %check_data1 ]
   br i1 %is_allocated3, label %then4, label %else
 
 then4:                                            ; preds = %merge_allocated2
-  %58 = getelementptr %array.1, %array.1* %51, i32 0, i32 0
-  %59 = load i32*, i32** %58, align 8
-  %60 = bitcast i32* %59 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %60)
-  %61 = getelementptr %array.1, %array.1* %51, i32 0, i32 0
-  store i32* null, i32** %61, align 8
+  %59 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
+  %60 = load i32*, i32** %59, align 8
+  %61 = bitcast i32* %60 to i8*
+  call void @_lfortran_free_alloc(i8* %2, i8* %61)
+  %62 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
+  store i32* null, i32** %62, align 8
   br label %ifcont5
 
 else:                                             ; preds = %merge_allocated2
   br label %ifcont5
 
 ifcont5:                                          ; preds = %else, %then4
-  %62 = load %array.1*, %array.1** %arr, align 8
-  %63 = ptrtoint %array.1* %62 to i64
-  %64 = icmp eq i64 %63, 0
-  br i1 %64, label %merge_allocated7, label %check_data6
+  %63 = load %array.1*, %array.1** %arr, align 8
+  %64 = ptrtoint %array.1* %63 to i64
+  %65 = icmp eq i64 %64, 0
+  br i1 %65, label %merge_allocated7, label %check_data6
 
 check_data6:                                      ; preds = %ifcont5
-  %65 = getelementptr %array.1, %array.1* %62, i32 0, i32 0
-  %66 = load i32*, i32** %65, align 8
-  %67 = ptrtoint i32* %66 to i64
-  %68 = icmp ne i64 %67, 0
+  %66 = getelementptr %array.1, %array.1* %63, i32 0, i32 0
+  %67 = load i32*, i32** %66, align 8
+  %68 = ptrtoint i32* %67 to i64
+  %69 = icmp ne i64 %68, 0
   br label %merge_allocated7
 
 merge_allocated7:                                 ; preds = %check_data6, %ifcont5
-  %is_allocated8 = phi i1 [ false, %ifcont5 ], [ %68, %check_data6 ]
+  %is_allocated8 = phi i1 [ false, %ifcont5 ], [ %69, %check_data6 ]
   br i1 %is_allocated8, label %then9, label %ifcont10
 
 then9:                                            ; preds = %merge_allocated7
-  %69 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %70 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %71 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %70, i32 0, i32 0
-  %72 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 0
-  store i8* getelementptr inbounds ([22 x i8], [22 x i8]* @5, i32 0, i32 0), i8** %72, align 8
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 1
-  store i32 8, i32* %73, align 4
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 2
-  store i32 18, i32* %74, align 4
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 3
-  store i32 8, i32* %75, align 4
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %71, i32 0, i32 4
-  store i32 23, i32* %76, align 4
-  %77 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
-  %78 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %69, i32 0, i32 0
-  %79 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %70, i32 0, i32 0
-  %80 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 2
-  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 0
-  store i1 true, i1* %81, align 1
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 1
-  store i8* %77, i8** %82, align 8
-  store { i8*, i32, i32, i32, i32 }* %79, { i8*, i32, i32, i32, i32 }** %80, align 8
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 0, i32 3
-  store i32 1, i32* %83, align 4
-  %84 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %69, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %84, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
+  %70 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %71 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %72 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
+  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 0
+  store i8* getelementptr inbounds ([22 x i8], [22 x i8]* @5, i32 0, i32 0), i8** %73, align 8
+  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 1
+  store i32 8, i32* %74, align 4
+  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 2
+  store i32 18, i32* %75, align 4
+  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 3
+  store i32 8, i32* %76, align 4
+  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 4
+  store i32 23, i32* %77, align 4
+  %78 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
+  %79 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
+  %80 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
+  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 2
+  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 0
+  store i1 true, i1* %82, align 1
+  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 1
+  store i8* %78, i8** %83, align 8
+  store { i8*, i32, i32, i32, i32 }* %80, { i8*, i32, i32, i32, i32 }** %81, align 8
+  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 3
+  store i32 1, i32* %84, align 4
+  %85 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %85, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %merge_allocated7
-  %85 = load %array.1*, %array.1** %arr, align 8
-  %86 = getelementptr %array.1, %array.1* %85, i32 0, i32 7
-  store i64 0, i64* %86, align 8
-  %87 = getelementptr %array.1, %array.1* %85, i32 0, i32 8
-  %88 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %87, i32 0, i32 0
-  %89 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %88, i32 0
-  %90 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 2
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 0
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %89, i32 0, i32 1
-  store i64 1, i64* %90, align 8
-  store i64 1, i64* %91, align 8
+  %86 = load %array.1*, %array.1** %arr, align 8
+  %87 = getelementptr %array.1, %array.1* %86, i32 0, i32 7
+  store i64 0, i64* %87, align 8
+  %88 = getelementptr %array.1, %array.1* %86, i32 0, i32 3
+  store i8 1, i8* %88, align 1
+  %89 = getelementptr %array.1, %array.1* %86, i32 0, i32 8
+  %90 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %89, i32 0, i32 0
+  %91 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %90, i32 0
+  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 2
+  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 0
+  %94 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 1
   store i64 1, i64* %92, align 8
-  %93 = getelementptr %array.1, %array.1* %85, i32 0, i32 0
-  %94 = call i8* @_lfortran_get_default_allocator()
-  %95 = call i8* @_lfortran_malloc_alloc(i8* %94, i64 4)
-  %96 = bitcast i8* %95 to i32*
-  store i32* %96, i32** %93, align 8
+  store i64 1, i64* %93, align 8
+  store i64 1, i64* %94, align 8
+  %95 = getelementptr %array.1, %array.1* %86, i32 0, i32 0
+  %96 = call i8* @_lfortran_get_default_allocator()
+  %97 = call i8* @_lfortran_malloc_alloc(i8* %96, i64 4)
+  %98 = bitcast i8* %97 to i32*
+  store i32* %98, i32** %95, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
@@ -218,8 +222,8 @@ FINALIZE_SYMTABLE_allocate_02:                    ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_allocate_02
-  %97 = load %array.1*, %array.1** %arr, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %97)
+  %99 = load %array.1*, %array.1** %arr, align 8
+  call void @finalize_allocatable__Array_1_i32(%array.1* %99)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "e153dc87d818da9882c3a292a8eac0b48715a8054926f049ca017345",
+    "stdout_hash": "a960c261599897fb4c0d46b0026daf72c05c9f8cd01ca077c15e133f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -321,38 +321,40 @@ ifcont:                                           ; preds = %merge_allocated
   %42 = load %array.3*, %array.3** %c, align 8
   %43 = getelementptr %array.3, %array.3* %42, i32 0, i32 7
   store i64 0, i64* %43, align 8
-  %44 = getelementptr %array.3, %array.3* %42, i32 0, i32 8
-  %45 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %44, i32 0, i32 0
-  %46 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 0
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 2
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 0
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %46, i32 0, i32 1
-  store i64 1, i64* %47, align 8
+  %44 = getelementptr %array.3, %array.3* %42, i32 0, i32 3
+  store i8 3, i8* %44, align 1
+  %45 = getelementptr %array.3, %array.3* %42, i32 0, i32 8
+  %46 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %45, i32 0, i32 0
+  %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
+  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
+  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 0
+  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
   store i64 1, i64* %48, align 8
-  store i64 3, i64* %49, align 8
-  %50 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 1
-  %51 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 2
-  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 0
-  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %50, i32 0, i32 1
-  store i64 3, i64* %51, align 8
-  store i64 1, i64* %52, align 8
-  store i64 3, i64* %53, align 8
-  %54 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %45, i32 2
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 2
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 0
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %54, i32 0, i32 1
-  store i64 9, i64* %55, align 8
-  store i64 1, i64* %56, align 8
-  store i64 3, i64* %57, align 8
-  %58 = getelementptr %array.3, %array.3* %42, i32 0, i32 0
-  %59 = call i8* @_lfortran_get_default_allocator()
-  %60 = call i8* @_lfortran_malloc_alloc(i8* %59, i64 108)
-  %61 = bitcast i8* %60 to i32*
-  store i32* %61, i32** %58, align 8
+  store i64 1, i64* %49, align 8
+  store i64 3, i64* %50, align 8
+  %51 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 1
+  %52 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 2
+  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 0
+  %54 = getelementptr %dimension_descriptor, %dimension_descriptor* %51, i32 0, i32 1
+  store i64 3, i64* %52, align 8
+  store i64 1, i64* %53, align 8
+  store i64 3, i64* %54, align 8
+  %55 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 2
+  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
+  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
+  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
+  store i64 9, i64* %56, align 8
+  store i64 1, i64* %57, align 8
+  store i64 3, i64* %58, align 8
+  %59 = getelementptr %array.3, %array.3* %42, i32 0, i32 0
+  %60 = call i8* @_lfortran_get_default_allocator()
+  %61 = call i8* @_lfortran_malloc_alloc(i8* %60, i64 108)
+  %62 = bitcast i8* %61 to i32*
+  store i32* %62, i32** %59, align 8
   store i32 0, i32* %stat, align 4
-  %62 = load i32, i32* %stat, align 4
-  %63 = icmp ne i32 %62, 0
-  br i1 %63, label %then1, label %else
+  %63 = load i32, i32* %stat, align 4
+  %64 = icmp ne i32 %63, 0
+  br i1 %64, label %then1, label %else
 
 then1:                                            ; preds = %ifcont
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @166, i32 0, i32 0))
@@ -364,413 +366,413 @@ else:                                             ; preds = %ifcont
   br label %ifcont2
 
 ifcont2:                                          ; preds = %else, %then1
-  %64 = load %array.3*, %array.3** %c, align 8
-  %65 = ptrtoint %array.3* %64 to i64
-  %66 = icmp eq i64 %65, 0
-  br i1 %66, label %merge_allocated4, label %check_data3
+  %65 = load %array.3*, %array.3** %c, align 8
+  %66 = ptrtoint %array.3* %65 to i64
+  %67 = icmp eq i64 %66, 0
+  br i1 %67, label %merge_allocated4, label %check_data3
 
 check_data3:                                      ; preds = %ifcont2
-  %67 = getelementptr %array.3, %array.3* %64, i32 0, i32 0
-  %68 = load i32*, i32** %67, align 8
-  %69 = ptrtoint i32* %68 to i64
-  %70 = icmp ne i64 %69, 0
+  %68 = getelementptr %array.3, %array.3* %65, i32 0, i32 0
+  %69 = load i32*, i32** %68, align 8
+  %70 = ptrtoint i32* %69 to i64
+  %71 = icmp ne i64 %70, 0
   br label %merge_allocated4
 
 merge_allocated4:                                 ; preds = %check_data3, %ifcont2
-  %is_allocated5 = phi i1 [ false, %ifcont2 ], [ %70, %check_data3 ]
-  %71 = xor i1 %is_allocated5, true
-  br i1 %71, label %then6, label %ifcont7
+  %is_allocated5 = phi i1 [ false, %ifcont2 ], [ %71, %check_data3 ]
+  %72 = xor i1 %is_allocated5, true
+  br i1 %72, label %then6, label %ifcont7
 
 then6:                                            ; preds = %merge_allocated4
-  %72 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %73 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %74 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %73, i32 0, i32 0
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @169, i32 0, i32 0), i8** %75, align 8
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 1
-  store i32 10, i32* %76, align 4
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 2
-  store i32 5, i32* %77, align 4
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 3
-  store i32 10, i32* %78, align 4
-  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %74, i32 0, i32 4
-  store i32 14, i32* %79, align 4
-  %80 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
-  %81 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %72, i32 0, i32 0
-  %82 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %73, i32 0, i32 0
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 2
-  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 0
-  store i1 true, i1* %84, align 1
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 1
-  store i8* %80, i8** %85, align 8
-  store { i8*, i32, i32, i32, i32 }* %82, { i8*, i32, i32, i32, i32 }** %83, align 8
-  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 0, i32 3
-  store i32 1, i32* %86, align 4
-  %87 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %72, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0))
+  %73 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %74 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %75 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %74, i32 0, i32 0
+  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @169, i32 0, i32 0), i8** %76, align 8
+  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 1
+  store i32 10, i32* %77, align 4
+  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 2
+  store i32 5, i32* %78, align 4
+  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 3
+  store i32 10, i32* %79, align 4
+  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 4
+  store i32 14, i32* %80, align 4
+  %81 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
+  %82 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %73, i32 0, i32 0
+  %83 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %74, i32 0, i32 0
+  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 2
+  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 0
+  store i1 true, i1* %85, align 1
+  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 1
+  store i8* %81, i8** %86, align 8
+  store { i8*, i32, i32, i32, i32 }* %83, { i8*, i32, i32, i32, i32 }** %84, align 8
+  %87 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 3
+  store i32 1, i32* %87, align 4
+  %88 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %73, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont7:                                          ; preds = %merge_allocated4
-  %88 = getelementptr %array.3, %array.3* %64, i32 0, i32 8
-  %89 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %88, i32 0, i32 0
-  %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 0
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
-  %92 = load i64, i64* %91, align 8
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
-  %94 = load i64, i64* %93, align 8
-  %95 = sub i64 1, %92
-  %96 = add i64 %92, %94
-  %97 = sub i64 %96, 1
-  %98 = icmp slt i64 1, %92
-  %99 = icmp sgt i64 1, %97
-  %100 = or i1 %98, %99
-  br i1 %100, label %then8, label %ifcont9
+  %89 = getelementptr %array.3, %array.3* %65, i32 0, i32 8
+  %90 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %89, i32 0, i32 0
+  %91 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %90, i32 0
+  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 0
+  %93 = load i64, i64* %92, align 8
+  %94 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 1
+  %95 = load i64, i64* %94, align 8
+  %96 = sub i64 1, %93
+  %97 = add i64 %93, %95
+  %98 = sub i64 %97, 1
+  %99 = icmp slt i64 1, %93
+  %100 = icmp sgt i64 1, %98
+  %101 = or i1 %99, %100
+  br i1 %101, label %then8, label %ifcont9
 
 then8:                                            ; preds = %ifcont7
-  %101 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %102 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %103 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @173, i32 0, i32 0), i8** %104, align 8
-  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 1
-  store i32 10, i32* %105, align 4
-  %106 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 2
-  store i32 5, i32* %106, align 4
-  %107 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 3
-  store i32 10, i32* %107, align 4
-  %108 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 4
-  store i32 14, i32* %108, align 4
-  %109 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
-  %110 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
-  %111 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
-  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 2
-  %113 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 0
-  store i1 true, i1* %113, align 1
-  %114 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 1
-  store i8* %109, i8** %114, align 8
-  store { i8*, i32, i32, i32, i32 }* %111, { i8*, i32, i32, i32, i32 }** %112, align 8
-  %115 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 3
-  store i32 1, i32* %115, align 4
-  %116 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i64 1, i32 1, i64 %92, i64 %97)
+  %102 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %103 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %104 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %103, i32 0, i32 0
+  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %104, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @173, i32 0, i32 0), i8** %105, align 8
+  %106 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %104, i32 0, i32 1
+  store i32 10, i32* %106, align 4
+  %107 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %104, i32 0, i32 2
+  store i32 5, i32* %107, align 4
+  %108 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %104, i32 0, i32 3
+  store i32 10, i32* %108, align 4
+  %109 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %104, i32 0, i32 4
+  store i32 14, i32* %109, align 4
+  %110 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
+  %111 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %102, i32 0, i32 0
+  %112 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %103, i32 0, i32 0
+  %113 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %111, i32 0, i32 2
+  %114 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %111, i32 0, i32 0
+  store i1 true, i1* %114, align 1
+  %115 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %111, i32 0, i32 1
+  store i8* %110, i8** %115, align 8
+  store { i8*, i32, i32, i32, i32 }* %112, { i8*, i32, i32, i32, i32 }** %113, align 8
+  %116 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %111, i32 0, i32 3
+  store i32 1, i32* %116, align 4
+  %117 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %102, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %117, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i64 1, i32 1, i64 %93, i64 %98)
   call void @exit(i32 1)
   unreachable
 
 ifcont9:                                          ; preds = %ifcont7
-  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
-  %118 = load i64, i64* %117, align 8
-  %119 = mul i64 %118, %95
-  %120 = add i64 0, %119
-  %121 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 1
-  %122 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 0
-  %123 = load i64, i64* %122, align 8
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 1
-  %125 = load i64, i64* %124, align 8
-  %126 = sub i64 1, %123
-  %127 = add i64 %123, %125
-  %128 = sub i64 %127, 1
-  %129 = icmp slt i64 1, %123
-  %130 = icmp sgt i64 1, %128
-  %131 = or i1 %129, %130
-  br i1 %131, label %then10, label %ifcont11
+  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 2
+  %119 = load i64, i64* %118, align 8
+  %120 = mul i64 %119, %96
+  %121 = add i64 0, %120
+  %122 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %90, i32 1
+  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 0
+  %124 = load i64, i64* %123, align 8
+  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 1
+  %126 = load i64, i64* %125, align 8
+  %127 = sub i64 1, %124
+  %128 = add i64 %124, %126
+  %129 = sub i64 %128, 1
+  %130 = icmp slt i64 1, %124
+  %131 = icmp sgt i64 1, %129
+  %132 = or i1 %130, %131
+  br i1 %132, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  %132 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %133 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %134 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %133, i32 0, i32 0
-  %135 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %134, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @177, i32 0, i32 0), i8** %135, align 8
-  %136 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %134, i32 0, i32 1
-  store i32 10, i32* %136, align 4
-  %137 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %134, i32 0, i32 2
-  store i32 5, i32* %137, align 4
-  %138 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %134, i32 0, i32 3
-  store i32 10, i32* %138, align 4
-  %139 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %134, i32 0, i32 4
-  store i32 14, i32* %139, align 4
-  %140 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @178, i32 0, i32 0))
-  %141 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %132, i32 0, i32 0
-  %142 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %133, i32 0, i32 0
-  %143 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %141, i32 0, i32 2
-  %144 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %141, i32 0, i32 0
-  store i1 true, i1* %144, align 1
-  %145 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %141, i32 0, i32 1
-  store i8* %140, i8** %145, align 8
-  store { i8*, i32, i32, i32, i32 }* %142, { i8*, i32, i32, i32, i32 }** %143, align 8
-  %146 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %141, i32 0, i32 3
-  store i32 1, i32* %146, align 4
-  %147 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %132, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %147, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @179, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0), i64 1, i32 2, i64 %123, i64 %128)
+  %133 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %134 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %135 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %134, i32 0, i32 0
+  %136 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @177, i32 0, i32 0), i8** %136, align 8
+  %137 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 1
+  store i32 10, i32* %137, align 4
+  %138 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 2
+  store i32 5, i32* %138, align 4
+  %139 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 3
+  store i32 10, i32* %139, align 4
+  %140 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 4
+  store i32 14, i32* %140, align 4
+  %141 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @178, i32 0, i32 0))
+  %142 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %133, i32 0, i32 0
+  %143 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %134, i32 0, i32 0
+  %144 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 2
+  %145 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 0
+  store i1 true, i1* %145, align 1
+  %146 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 1
+  store i8* %141, i8** %146, align 8
+  store { i8*, i32, i32, i32, i32 }* %143, { i8*, i32, i32, i32, i32 }** %144, align 8
+  %147 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 3
+  store i32 1, i32* %147, align 4
+  %148 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %133, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @179, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0), i64 1, i32 2, i64 %124, i64 %129)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %148 = getelementptr %dimension_descriptor, %dimension_descriptor* %121, i32 0, i32 2
-  %149 = load i64, i64* %148, align 8
-  %150 = mul i64 %149, %126
-  %151 = add i64 %120, %150
-  %152 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %89, i32 2
-  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 0
-  %154 = load i64, i64* %153, align 8
-  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 1
-  %156 = load i64, i64* %155, align 8
-  %157 = sub i64 1, %154
-  %158 = add i64 %154, %156
-  %159 = sub i64 %158, 1
-  %160 = icmp slt i64 1, %154
-  %161 = icmp sgt i64 1, %159
-  %162 = or i1 %160, %161
-  br i1 %162, label %then12, label %ifcont13
+  %149 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 2
+  %150 = load i64, i64* %149, align 8
+  %151 = mul i64 %150, %127
+  %152 = add i64 %121, %151
+  %153 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %90, i32 2
+  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %153, i32 0, i32 0
+  %155 = load i64, i64* %154, align 8
+  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %153, i32 0, i32 1
+  %157 = load i64, i64* %156, align 8
+  %158 = sub i64 1, %155
+  %159 = add i64 %155, %157
+  %160 = sub i64 %159, 1
+  %161 = icmp slt i64 1, %155
+  %162 = icmp sgt i64 1, %160
+  %163 = or i1 %161, %162
+  br i1 %163, label %then12, label %ifcont13
 
 then12:                                           ; preds = %ifcont11
-  %163 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %164 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %165 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %164, i32 0, i32 0
-  %166 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %165, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @181, i32 0, i32 0), i8** %166, align 8
-  %167 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %165, i32 0, i32 1
-  store i32 10, i32* %167, align 4
-  %168 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %165, i32 0, i32 2
-  store i32 5, i32* %168, align 4
-  %169 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %165, i32 0, i32 3
-  store i32 10, i32* %169, align 4
-  %170 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %165, i32 0, i32 4
-  store i32 14, i32* %170, align 4
-  %171 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @182, i32 0, i32 0))
-  %172 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %163, i32 0, i32 0
-  %173 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %164, i32 0, i32 0
-  %174 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %172, i32 0, i32 2
-  %175 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %172, i32 0, i32 0
-  store i1 true, i1* %175, align 1
-  %176 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %172, i32 0, i32 1
-  store i8* %171, i8** %176, align 8
-  store { i8*, i32, i32, i32, i32 }* %173, { i8*, i32, i32, i32, i32 }** %174, align 8
-  %177 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %172, i32 0, i32 3
-  store i32 1, i32* %177, align 4
-  %178 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %163, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %178, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @183, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @180, i32 0, i32 0), i64 1, i32 3, i64 %154, i64 %159)
+  %164 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %165 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %166 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %165, i32 0, i32 0
+  %167 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @181, i32 0, i32 0), i8** %167, align 8
+  %168 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 1
+  store i32 10, i32* %168, align 4
+  %169 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 2
+  store i32 5, i32* %169, align 4
+  %170 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 3
+  store i32 10, i32* %170, align 4
+  %171 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 4
+  store i32 14, i32* %171, align 4
+  %172 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @182, i32 0, i32 0))
+  %173 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %164, i32 0, i32 0
+  %174 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %165, i32 0, i32 0
+  %175 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 2
+  %176 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 0
+  store i1 true, i1* %176, align 1
+  %177 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 1
+  store i8* %172, i8** %177, align 8
+  store { i8*, i32, i32, i32, i32 }* %174, { i8*, i32, i32, i32, i32 }** %175, align 8
+  %178 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 3
+  store i32 1, i32* %178, align 4
+  %179 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %164, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @183, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @180, i32 0, i32 0), i64 1, i32 3, i64 %155, i64 %160)
   call void @exit(i32 1)
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %179 = getelementptr %dimension_descriptor, %dimension_descriptor* %152, i32 0, i32 2
-  %180 = load i64, i64* %179, align 8
-  %181 = mul i64 %180, %157
-  %182 = add i64 %151, %181
-  %183 = getelementptr %array.3, %array.3* %64, i32 0, i32 7
-  %184 = load i64, i64* %183, align 8
-  %185 = add i64 %182, %184
-  %186 = getelementptr %array.3, %array.3* %64, i32 0, i32 0
-  %187 = load i32*, i32** %186, align 8
-  %188 = getelementptr inbounds i32, i32* %187, i64 %185
-  store i32 3, i32* %188, align 4
+  %180 = getelementptr %dimension_descriptor, %dimension_descriptor* %153, i32 0, i32 2
+  %181 = load i64, i64* %180, align 8
+  %182 = mul i64 %181, %158
+  %183 = add i64 %152, %182
+  %184 = getelementptr %array.3, %array.3* %65, i32 0, i32 7
+  %185 = load i64, i64* %184, align 8
+  %186 = add i64 %183, %185
+  %187 = getelementptr %array.3, %array.3* %65, i32 0, i32 0
+  %188 = load i32*, i32** %187, align 8
+  %189 = getelementptr inbounds i32, i32* %188, i64 %186
+  store i32 3, i32* %189, align 4
   call void @h(%array.3** %c)
-  %189 = call i32 @g(%array.3** %c)
-  store i32 %189, i32* %r, align 4
-  %190 = load %array.3*, %array.3** %c, align 8
-  %191 = ptrtoint %array.3* %190 to i64
-  %192 = icmp eq i64 %191, 0
-  br i1 %192, label %merge_allocated15, label %check_data14
+  %190 = call i32 @g(%array.3** %c)
+  store i32 %190, i32* %r, align 4
+  %191 = load %array.3*, %array.3** %c, align 8
+  %192 = ptrtoint %array.3* %191 to i64
+  %193 = icmp eq i64 %192, 0
+  br i1 %193, label %merge_allocated15, label %check_data14
 
 check_data14:                                     ; preds = %ifcont13
-  %193 = getelementptr %array.3, %array.3* %190, i32 0, i32 0
-  %194 = load i32*, i32** %193, align 8
-  %195 = ptrtoint i32* %194 to i64
-  %196 = icmp ne i64 %195, 0
+  %194 = getelementptr %array.3, %array.3* %191, i32 0, i32 0
+  %195 = load i32*, i32** %194, align 8
+  %196 = ptrtoint i32* %195 to i64
+  %197 = icmp ne i64 %196, 0
   br label %merge_allocated15
 
 merge_allocated15:                                ; preds = %check_data14, %ifcont13
-  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %196, %check_data14 ]
-  %197 = xor i1 %is_allocated16, true
-  br i1 %197, label %then17, label %ifcont18
+  %is_allocated16 = phi i1 [ false, %ifcont13 ], [ %197, %check_data14 ]
+  %198 = xor i1 %is_allocated16, true
+  br i1 %198, label %then17, label %ifcont18
 
 then17:                                           ; preds = %merge_allocated15
-  %198 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %199 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %200 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %199, i32 0, i32 0
-  %201 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %200, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @185, i32 0, i32 0), i8** %201, align 8
-  %202 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %200, i32 0, i32 1
-  store i32 13, i32* %202, align 4
-  %203 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %200, i32 0, i32 2
-  store i32 9, i32* %203, align 4
-  %204 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %200, i32 0, i32 3
-  store i32 13, i32* %204, align 4
-  %205 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %200, i32 0, i32 4
-  store i32 18, i32* %205, align 4
-  %206 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @186, i32 0, i32 0))
-  %207 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %198, i32 0, i32 0
-  %208 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %199, i32 0, i32 0
-  %209 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %207, i32 0, i32 2
-  %210 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %207, i32 0, i32 0
-  store i1 true, i1* %210, align 1
-  %211 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %207, i32 0, i32 1
-  store i8* %206, i8** %211, align 8
-  store { i8*, i32, i32, i32, i32 }* %208, { i8*, i32, i32, i32, i32 }** %209, align 8
-  %212 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %207, i32 0, i32 3
-  store i32 1, i32* %212, align 4
-  %213 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %198, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %213, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @184, i32 0, i32 0))
+  %199 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %200 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %201 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %200, i32 0, i32 0
+  %202 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %201, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @185, i32 0, i32 0), i8** %202, align 8
+  %203 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %201, i32 0, i32 1
+  store i32 13, i32* %203, align 4
+  %204 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %201, i32 0, i32 2
+  store i32 9, i32* %204, align 4
+  %205 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %201, i32 0, i32 3
+  store i32 13, i32* %205, align 4
+  %206 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %201, i32 0, i32 4
+  store i32 18, i32* %206, align 4
+  %207 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @186, i32 0, i32 0))
+  %208 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %199, i32 0, i32 0
+  %209 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %200, i32 0, i32 0
+  %210 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %208, i32 0, i32 2
+  %211 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %208, i32 0, i32 0
+  store i1 true, i1* %211, align 1
+  %212 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %208, i32 0, i32 1
+  store i8* %207, i8** %212, align 8
+  store { i8*, i32, i32, i32, i32 }* %209, { i8*, i32, i32, i32, i32 }** %210, align 8
+  %213 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %208, i32 0, i32 3
+  store i32 1, i32* %213, align 4
+  %214 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %199, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %214, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @184, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %merge_allocated15
-  %214 = getelementptr %array.3, %array.3* %190, i32 0, i32 8
-  %215 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %214, i32 0, i32 0
-  %216 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 0
-  %217 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 0
-  %218 = load i64, i64* %217, align 8
-  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 1
-  %220 = load i64, i64* %219, align 8
-  %221 = sub i64 1, %218
-  %222 = add i64 %218, %220
-  %223 = sub i64 %222, 1
-  %224 = icmp slt i64 1, %218
-  %225 = icmp sgt i64 1, %223
-  %226 = or i1 %224, %225
-  br i1 %226, label %then19, label %ifcont20
+  %215 = getelementptr %array.3, %array.3* %191, i32 0, i32 8
+  %216 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %215, i32 0, i32 0
+  %217 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %216, i32 0
+  %218 = getelementptr %dimension_descriptor, %dimension_descriptor* %217, i32 0, i32 0
+  %219 = load i64, i64* %218, align 8
+  %220 = getelementptr %dimension_descriptor, %dimension_descriptor* %217, i32 0, i32 1
+  %221 = load i64, i64* %220, align 8
+  %222 = sub i64 1, %219
+  %223 = add i64 %219, %221
+  %224 = sub i64 %223, 1
+  %225 = icmp slt i64 1, %219
+  %226 = icmp sgt i64 1, %224
+  %227 = or i1 %225, %226
+  br i1 %227, label %then19, label %ifcont20
 
 then19:                                           ; preds = %ifcont18
-  %227 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %228 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %229 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %228, i32 0, i32 0
-  %230 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %229, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @189, i32 0, i32 0), i8** %230, align 8
-  %231 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %229, i32 0, i32 1
-  store i32 13, i32* %231, align 4
-  %232 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %229, i32 0, i32 2
-  store i32 9, i32* %232, align 4
-  %233 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %229, i32 0, i32 3
-  store i32 13, i32* %233, align 4
-  %234 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %229, i32 0, i32 4
-  store i32 18, i32* %234, align 4
-  %235 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @190, i32 0, i32 0))
-  %236 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %227, i32 0, i32 0
-  %237 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %228, i32 0, i32 0
-  %238 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %236, i32 0, i32 2
-  %239 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %236, i32 0, i32 0
-  store i1 true, i1* %239, align 1
-  %240 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %236, i32 0, i32 1
-  store i8* %235, i8** %240, align 8
-  store { i8*, i32, i32, i32, i32 }* %237, { i8*, i32, i32, i32, i32 }** %238, align 8
-  %241 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %236, i32 0, i32 3
-  store i32 1, i32* %241, align 4
-  %242 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %227, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %242, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @191, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @188, i32 0, i32 0), i64 1, i32 1, i64 %218, i64 %223)
+  %228 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %229 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %230 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %229, i32 0, i32 0
+  %231 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %230, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @189, i32 0, i32 0), i8** %231, align 8
+  %232 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %230, i32 0, i32 1
+  store i32 13, i32* %232, align 4
+  %233 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %230, i32 0, i32 2
+  store i32 9, i32* %233, align 4
+  %234 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %230, i32 0, i32 3
+  store i32 13, i32* %234, align 4
+  %235 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %230, i32 0, i32 4
+  store i32 18, i32* %235, align 4
+  %236 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @190, i32 0, i32 0))
+  %237 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %228, i32 0, i32 0
+  %238 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %229, i32 0, i32 0
+  %239 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %237, i32 0, i32 2
+  %240 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %237, i32 0, i32 0
+  store i1 true, i1* %240, align 1
+  %241 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %237, i32 0, i32 1
+  store i8* %236, i8** %241, align 8
+  store { i8*, i32, i32, i32, i32 }* %238, { i8*, i32, i32, i32, i32 }** %239, align 8
+  %242 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %237, i32 0, i32 3
+  store i32 1, i32* %242, align 4
+  %243 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %228, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %243, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @191, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @188, i32 0, i32 0), i64 1, i32 1, i64 %219, i64 %224)
   call void @exit(i32 1)
   unreachable
 
 ifcont20:                                         ; preds = %ifcont18
-  %243 = getelementptr %dimension_descriptor, %dimension_descriptor* %216, i32 0, i32 2
-  %244 = load i64, i64* %243, align 8
-  %245 = mul i64 %244, %221
-  %246 = add i64 0, %245
-  %247 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 1
-  %248 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 0
-  %249 = load i64, i64* %248, align 8
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 1
-  %251 = load i64, i64* %250, align 8
-  %252 = sub i64 1, %249
-  %253 = add i64 %249, %251
-  %254 = sub i64 %253, 1
-  %255 = icmp slt i64 1, %249
-  %256 = icmp sgt i64 1, %254
-  %257 = or i1 %255, %256
-  br i1 %257, label %then21, label %ifcont22
+  %244 = getelementptr %dimension_descriptor, %dimension_descriptor* %217, i32 0, i32 2
+  %245 = load i64, i64* %244, align 8
+  %246 = mul i64 %245, %222
+  %247 = add i64 0, %246
+  %248 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %216, i32 1
+  %249 = getelementptr %dimension_descriptor, %dimension_descriptor* %248, i32 0, i32 0
+  %250 = load i64, i64* %249, align 8
+  %251 = getelementptr %dimension_descriptor, %dimension_descriptor* %248, i32 0, i32 1
+  %252 = load i64, i64* %251, align 8
+  %253 = sub i64 1, %250
+  %254 = add i64 %250, %252
+  %255 = sub i64 %254, 1
+  %256 = icmp slt i64 1, %250
+  %257 = icmp sgt i64 1, %255
+  %258 = or i1 %256, %257
+  br i1 %258, label %then21, label %ifcont22
 
 then21:                                           ; preds = %ifcont20
-  %258 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %259 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %260 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %259, i32 0, i32 0
-  %261 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %260, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @193, i32 0, i32 0), i8** %261, align 8
-  %262 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %260, i32 0, i32 1
-  store i32 13, i32* %262, align 4
-  %263 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %260, i32 0, i32 2
-  store i32 9, i32* %263, align 4
-  %264 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %260, i32 0, i32 3
-  store i32 13, i32* %264, align 4
-  %265 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %260, i32 0, i32 4
-  store i32 18, i32* %265, align 4
-  %266 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @194, i32 0, i32 0))
-  %267 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %258, i32 0, i32 0
-  %268 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %259, i32 0, i32 0
-  %269 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %267, i32 0, i32 2
-  %270 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %267, i32 0, i32 0
-  store i1 true, i1* %270, align 1
-  %271 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %267, i32 0, i32 1
-  store i8* %266, i8** %271, align 8
-  store { i8*, i32, i32, i32, i32 }* %268, { i8*, i32, i32, i32, i32 }** %269, align 8
-  %272 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %267, i32 0, i32 3
-  store i32 1, i32* %272, align 4
-  %273 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %258, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %273, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @195, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @192, i32 0, i32 0), i64 1, i32 2, i64 %249, i64 %254)
+  %259 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %260 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %261 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %260, i32 0, i32 0
+  %262 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @193, i32 0, i32 0), i8** %262, align 8
+  %263 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 1
+  store i32 13, i32* %263, align 4
+  %264 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 2
+  store i32 9, i32* %264, align 4
+  %265 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 3
+  store i32 13, i32* %265, align 4
+  %266 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 4
+  store i32 18, i32* %266, align 4
+  %267 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @194, i32 0, i32 0))
+  %268 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %259, i32 0, i32 0
+  %269 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %260, i32 0, i32 0
+  %270 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 2
+  %271 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 0
+  store i1 true, i1* %271, align 1
+  %272 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 1
+  store i8* %267, i8** %272, align 8
+  store { i8*, i32, i32, i32, i32 }* %269, { i8*, i32, i32, i32, i32 }** %270, align 8
+  %273 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 3
+  store i32 1, i32* %273, align 4
+  %274 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %259, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @195, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @192, i32 0, i32 0), i64 1, i32 2, i64 %250, i64 %255)
   call void @exit(i32 1)
   unreachable
 
 ifcont22:                                         ; preds = %ifcont20
-  %274 = getelementptr %dimension_descriptor, %dimension_descriptor* %247, i32 0, i32 2
-  %275 = load i64, i64* %274, align 8
-  %276 = mul i64 %275, %252
-  %277 = add i64 %246, %276
-  %278 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %215, i32 2
-  %279 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 0
-  %280 = load i64, i64* %279, align 8
-  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 1
-  %282 = load i64, i64* %281, align 8
-  %283 = sub i64 1, %280
-  %284 = add i64 %280, %282
-  %285 = sub i64 %284, 1
-  %286 = icmp slt i64 1, %280
-  %287 = icmp sgt i64 1, %285
-  %288 = or i1 %286, %287
-  br i1 %288, label %then23, label %ifcont24
+  %275 = getelementptr %dimension_descriptor, %dimension_descriptor* %248, i32 0, i32 2
+  %276 = load i64, i64* %275, align 8
+  %277 = mul i64 %276, %253
+  %278 = add i64 %247, %277
+  %279 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %216, i32 2
+  %280 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 0
+  %281 = load i64, i64* %280, align 8
+  %282 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 1
+  %283 = load i64, i64* %282, align 8
+  %284 = sub i64 1, %281
+  %285 = add i64 %281, %283
+  %286 = sub i64 %285, 1
+  %287 = icmp slt i64 1, %281
+  %288 = icmp sgt i64 1, %286
+  %289 = or i1 %287, %288
+  br i1 %289, label %then23, label %ifcont24
 
 then23:                                           ; preds = %ifcont22
-  %289 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %290 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %291 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %290, i32 0, i32 0
-  %292 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %291, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @197, i32 0, i32 0), i8** %292, align 8
-  %293 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %291, i32 0, i32 1
-  store i32 13, i32* %293, align 4
-  %294 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %291, i32 0, i32 2
-  store i32 9, i32* %294, align 4
-  %295 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %291, i32 0, i32 3
-  store i32 13, i32* %295, align 4
-  %296 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %291, i32 0, i32 4
-  store i32 18, i32* %296, align 4
-  %297 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @198, i32 0, i32 0))
-  %298 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %289, i32 0, i32 0
-  %299 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %290, i32 0, i32 0
-  %300 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %298, i32 0, i32 2
-  %301 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %298, i32 0, i32 0
-  store i1 true, i1* %301, align 1
-  %302 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %298, i32 0, i32 1
-  store i8* %297, i8** %302, align 8
-  store { i8*, i32, i32, i32, i32 }* %299, { i8*, i32, i32, i32, i32 }** %300, align 8
-  %303 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %298, i32 0, i32 3
-  store i32 1, i32* %303, align 4
-  %304 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %289, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %304, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @199, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @196, i32 0, i32 0), i64 1, i32 3, i64 %280, i64 %285)
+  %290 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %291 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %292 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %291, i32 0, i32 0
+  %293 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %292, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @197, i32 0, i32 0), i8** %293, align 8
+  %294 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %292, i32 0, i32 1
+  store i32 13, i32* %294, align 4
+  %295 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %292, i32 0, i32 2
+  store i32 9, i32* %295, align 4
+  %296 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %292, i32 0, i32 3
+  store i32 13, i32* %296, align 4
+  %297 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %292, i32 0, i32 4
+  store i32 18, i32* %297, align 4
+  %298 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @198, i32 0, i32 0))
+  %299 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %290, i32 0, i32 0
+  %300 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %291, i32 0, i32 0
+  %301 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %299, i32 0, i32 2
+  %302 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %299, i32 0, i32 0
+  store i1 true, i1* %302, align 1
+  %303 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %299, i32 0, i32 1
+  store i8* %298, i8** %303, align 8
+  store { i8*, i32, i32, i32, i32 }* %300, { i8*, i32, i32, i32, i32 }** %301, align 8
+  %304 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %299, i32 0, i32 3
+  store i32 1, i32* %304, align 4
+  %305 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %290, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %305, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @199, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @196, i32 0, i32 0), i64 1, i32 3, i64 %281, i64 %286)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %ifcont22
-  %305 = getelementptr %dimension_descriptor, %dimension_descriptor* %278, i32 0, i32 2
-  %306 = load i64, i64* %305, align 8
-  %307 = mul i64 %306, %283
-  %308 = add i64 %277, %307
-  %309 = getelementptr %array.3, %array.3* %190, i32 0, i32 7
-  %310 = load i64, i64* %309, align 8
-  %311 = add i64 %308, %310
-  %312 = getelementptr %array.3, %array.3* %190, i32 0, i32 0
-  %313 = load i32*, i32** %312, align 8
-  %314 = getelementptr inbounds i32, i32* %313, i64 %311
-  %315 = load i32, i32* %314, align 4
-  %316 = icmp ne i32 %315, 8
-  br i1 %316, label %then25, label %else26
+  %306 = getelementptr %dimension_descriptor, %dimension_descriptor* %279, i32 0, i32 2
+  %307 = load i64, i64* %306, align 8
+  %308 = mul i64 %307, %284
+  %309 = add i64 %278, %308
+  %310 = getelementptr %array.3, %array.3* %191, i32 0, i32 7
+  %311 = load i64, i64* %310, align 8
+  %312 = add i64 %309, %311
+  %313 = getelementptr %array.3, %array.3* %191, i32 0, i32 0
+  %314 = load i32*, i32** %313, align 8
+  %315 = getelementptr inbounds i32, i32* %314, i64 %312
+  %316 = load i32, i32* %315, align 4
+  %317 = icmp ne i32 %316, 8
+  br i1 %317, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @201, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @200, i32 0, i32 0))
@@ -782,227 +784,227 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %317 = alloca i64, align 8
-  %318 = load %array.3*, %array.3** %c, align 8
-  %319 = ptrtoint %array.3* %318 to i64
-  %320 = icmp eq i64 %319, 0
-  br i1 %320, label %merge_allocated29, label %check_data28
+  %318 = alloca i64, align 8
+  %319 = load %array.3*, %array.3** %c, align 8
+  %320 = ptrtoint %array.3* %319 to i64
+  %321 = icmp eq i64 %320, 0
+  br i1 %321, label %merge_allocated29, label %check_data28
 
 check_data28:                                     ; preds = %ifcont27
-  %321 = getelementptr %array.3, %array.3* %318, i32 0, i32 0
-  %322 = load i32*, i32** %321, align 8
-  %323 = ptrtoint i32* %322 to i64
-  %324 = icmp ne i64 %323, 0
+  %322 = getelementptr %array.3, %array.3* %319, i32 0, i32 0
+  %323 = load i32*, i32** %322, align 8
+  %324 = ptrtoint i32* %323 to i64
+  %325 = icmp ne i64 %324, 0
   br label %merge_allocated29
 
 merge_allocated29:                                ; preds = %check_data28, %ifcont27
-  %is_allocated30 = phi i1 [ false, %ifcont27 ], [ %324, %check_data28 ]
-  %325 = xor i1 %is_allocated30, true
-  br i1 %325, label %then31, label %ifcont32
+  %is_allocated30 = phi i1 [ false, %ifcont27 ], [ %325, %check_data28 ]
+  %326 = xor i1 %is_allocated30, true
+  br i1 %326, label %then31, label %ifcont32
 
 then31:                                           ; preds = %merge_allocated29
-  %326 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %327 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %328 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %327, i32 0, i32 0
-  %329 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %328, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @204, i32 0, i32 0), i8** %329, align 8
-  %330 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %328, i32 0, i32 1
-  store i32 14, i32* %330, align 4
-  %331 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %328, i32 0, i32 2
+  %327 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %328 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %329 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %328, i32 0, i32 0
+  %330 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %329, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @204, i32 0, i32 0), i8** %330, align 8
+  %331 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %329, i32 0, i32 1
   store i32 14, i32* %331, align 4
-  %332 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %328, i32 0, i32 3
+  %332 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %329, i32 0, i32 2
   store i32 14, i32* %332, align 4
-  %333 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %328, i32 0, i32 4
-  store i32 23, i32* %333, align 4
-  %334 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @205, i32 0, i32 0))
-  %335 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %326, i32 0, i32 0
-  %336 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %327, i32 0, i32 0
-  %337 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %335, i32 0, i32 2
-  %338 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %335, i32 0, i32 0
-  store i1 true, i1* %338, align 1
-  %339 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %335, i32 0, i32 1
-  store i8* %334, i8** %339, align 8
-  store { i8*, i32, i32, i32, i32 }* %336, { i8*, i32, i32, i32, i32 }** %337, align 8
-  %340 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %335, i32 0, i32 3
-  store i32 1, i32* %340, align 4
-  %341 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %326, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %341, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @206, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @203, i32 0, i32 0))
+  %333 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %329, i32 0, i32 3
+  store i32 14, i32* %333, align 4
+  %334 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %329, i32 0, i32 4
+  store i32 23, i32* %334, align 4
+  %335 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @205, i32 0, i32 0))
+  %336 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %327, i32 0, i32 0
+  %337 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %328, i32 0, i32 0
+  %338 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %336, i32 0, i32 2
+  %339 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %336, i32 0, i32 0
+  store i1 true, i1* %339, align 1
+  %340 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %336, i32 0, i32 1
+  store i8* %335, i8** %340, align 8
+  store { i8*, i32, i32, i32, i32 }* %337, { i8*, i32, i32, i32, i32 }** %338, align 8
+  %341 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %336, i32 0, i32 3
+  store i32 1, i32* %341, align 4
+  %342 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %327, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %342, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @206, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @203, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %merge_allocated29
-  %342 = getelementptr %array.3, %array.3* %318, i32 0, i32 8
-  %343 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %342, i32 0, i32 0
-  %344 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 0
-  %345 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 0
-  %346 = load i64, i64* %345, align 8
-  %347 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 1
-  %348 = load i64, i64* %347, align 8
-  %349 = sub i64 1, %346
-  %350 = add i64 %346, %348
-  %351 = sub i64 %350, 1
-  %352 = icmp slt i64 1, %346
-  %353 = icmp sgt i64 1, %351
-  %354 = or i1 %352, %353
-  br i1 %354, label %then33, label %ifcont34
+  %343 = getelementptr %array.3, %array.3* %319, i32 0, i32 8
+  %344 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %343, i32 0, i32 0
+  %345 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %344, i32 0
+  %346 = getelementptr %dimension_descriptor, %dimension_descriptor* %345, i32 0, i32 0
+  %347 = load i64, i64* %346, align 8
+  %348 = getelementptr %dimension_descriptor, %dimension_descriptor* %345, i32 0, i32 1
+  %349 = load i64, i64* %348, align 8
+  %350 = sub i64 1, %347
+  %351 = add i64 %347, %349
+  %352 = sub i64 %351, 1
+  %353 = icmp slt i64 1, %347
+  %354 = icmp sgt i64 1, %352
+  %355 = or i1 %353, %354
+  br i1 %355, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  %355 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %356 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %357 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %356, i32 0, i32 0
-  %358 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %357, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @208, i32 0, i32 0), i8** %358, align 8
-  %359 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %357, i32 0, i32 1
-  store i32 14, i32* %359, align 4
-  %360 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %357, i32 0, i32 2
+  %356 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %357 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %358 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %357, i32 0, i32 0
+  %359 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %358, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @208, i32 0, i32 0), i8** %359, align 8
+  %360 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %358, i32 0, i32 1
   store i32 14, i32* %360, align 4
-  %361 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %357, i32 0, i32 3
+  %361 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %358, i32 0, i32 2
   store i32 14, i32* %361, align 4
-  %362 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %357, i32 0, i32 4
-  store i32 23, i32* %362, align 4
-  %363 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @209, i32 0, i32 0))
-  %364 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %355, i32 0, i32 0
-  %365 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %356, i32 0, i32 0
-  %366 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 0, i32 2
-  %367 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 0, i32 0
-  store i1 true, i1* %367, align 1
-  %368 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 0, i32 1
-  store i8* %363, i8** %368, align 8
-  store { i8*, i32, i32, i32, i32 }* %365, { i8*, i32, i32, i32, i32 }** %366, align 8
-  %369 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 0, i32 3
-  store i32 1, i32* %369, align 4
-  %370 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %355, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %370, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @210, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @207, i32 0, i32 0), i64 1, i32 1, i64 %346, i64 %351)
+  %362 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %358, i32 0, i32 3
+  store i32 14, i32* %362, align 4
+  %363 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %358, i32 0, i32 4
+  store i32 23, i32* %363, align 4
+  %364 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @209, i32 0, i32 0))
+  %365 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %356, i32 0, i32 0
+  %366 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %357, i32 0, i32 0
+  %367 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %365, i32 0, i32 2
+  %368 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %365, i32 0, i32 0
+  store i1 true, i1* %368, align 1
+  %369 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %365, i32 0, i32 1
+  store i8* %364, i8** %369, align 8
+  store { i8*, i32, i32, i32, i32 }* %366, { i8*, i32, i32, i32, i32 }** %367, align 8
+  %370 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %365, i32 0, i32 3
+  store i32 1, i32* %370, align 4
+  %371 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %356, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %371, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @210, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @207, i32 0, i32 0), i64 1, i32 1, i64 %347, i64 %352)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %371 = getelementptr %dimension_descriptor, %dimension_descriptor* %344, i32 0, i32 2
-  %372 = load i64, i64* %371, align 8
-  %373 = mul i64 %372, %349
-  %374 = add i64 0, %373
-  %375 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 1
-  %376 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 0
-  %377 = load i64, i64* %376, align 8
-  %378 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 1
-  %379 = load i64, i64* %378, align 8
-  %380 = sub i64 1, %377
-  %381 = add i64 %377, %379
-  %382 = sub i64 %381, 1
-  %383 = icmp slt i64 1, %377
-  %384 = icmp sgt i64 1, %382
-  %385 = or i1 %383, %384
-  br i1 %385, label %then35, label %ifcont36
+  %372 = getelementptr %dimension_descriptor, %dimension_descriptor* %345, i32 0, i32 2
+  %373 = load i64, i64* %372, align 8
+  %374 = mul i64 %373, %350
+  %375 = add i64 0, %374
+  %376 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %344, i32 1
+  %377 = getelementptr %dimension_descriptor, %dimension_descriptor* %376, i32 0, i32 0
+  %378 = load i64, i64* %377, align 8
+  %379 = getelementptr %dimension_descriptor, %dimension_descriptor* %376, i32 0, i32 1
+  %380 = load i64, i64* %379, align 8
+  %381 = sub i64 1, %378
+  %382 = add i64 %378, %380
+  %383 = sub i64 %382, 1
+  %384 = icmp slt i64 1, %378
+  %385 = icmp sgt i64 1, %383
+  %386 = or i1 %384, %385
+  br i1 %386, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  %386 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %387 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %388 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %387, i32 0, i32 0
-  %389 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %388, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @212, i32 0, i32 0), i8** %389, align 8
-  %390 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %388, i32 0, i32 1
-  store i32 14, i32* %390, align 4
-  %391 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %388, i32 0, i32 2
+  %387 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %388 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %389 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
+  %390 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @212, i32 0, i32 0), i8** %390, align 8
+  %391 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 1
   store i32 14, i32* %391, align 4
-  %392 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %388, i32 0, i32 3
+  %392 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 2
   store i32 14, i32* %392, align 4
-  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %388, i32 0, i32 4
-  store i32 23, i32* %393, align 4
-  %394 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @213, i32 0, i32 0))
-  %395 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %386, i32 0, i32 0
-  %396 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %387, i32 0, i32 0
-  %397 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %395, i32 0, i32 2
-  %398 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %395, i32 0, i32 0
-  store i1 true, i1* %398, align 1
-  %399 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %395, i32 0, i32 1
-  store i8* %394, i8** %399, align 8
-  store { i8*, i32, i32, i32, i32 }* %396, { i8*, i32, i32, i32, i32 }** %397, align 8
-  %400 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %395, i32 0, i32 3
-  store i32 1, i32* %400, align 4
-  %401 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %386, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %401, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @214, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @211, i32 0, i32 0), i64 1, i32 2, i64 %377, i64 %382)
+  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 3
+  store i32 14, i32* %393, align 4
+  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 4
+  store i32 23, i32* %394, align 4
+  %395 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @213, i32 0, i32 0))
+  %396 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
+  %397 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
+  %398 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 2
+  %399 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 0
+  store i1 true, i1* %399, align 1
+  %400 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 1
+  store i8* %395, i8** %400, align 8
+  store { i8*, i32, i32, i32, i32 }* %397, { i8*, i32, i32, i32, i32 }** %398, align 8
+  %401 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 3
+  store i32 1, i32* %401, align 4
+  %402 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %402, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @214, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @211, i32 0, i32 0), i64 1, i32 2, i64 %378, i64 %383)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %402 = getelementptr %dimension_descriptor, %dimension_descriptor* %375, i32 0, i32 2
-  %403 = load i64, i64* %402, align 8
-  %404 = mul i64 %403, %380
-  %405 = add i64 %374, %404
-  %406 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %343, i32 2
-  %407 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 0
-  %408 = load i64, i64* %407, align 8
-  %409 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 1
-  %410 = load i64, i64* %409, align 8
-  %411 = sub i64 1, %408
-  %412 = add i64 %408, %410
-  %413 = sub i64 %412, 1
-  %414 = icmp slt i64 1, %408
-  %415 = icmp sgt i64 1, %413
-  %416 = or i1 %414, %415
-  br i1 %416, label %then37, label %ifcont38
+  %403 = getelementptr %dimension_descriptor, %dimension_descriptor* %376, i32 0, i32 2
+  %404 = load i64, i64* %403, align 8
+  %405 = mul i64 %404, %381
+  %406 = add i64 %375, %405
+  %407 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %344, i32 2
+  %408 = getelementptr %dimension_descriptor, %dimension_descriptor* %407, i32 0, i32 0
+  %409 = load i64, i64* %408, align 8
+  %410 = getelementptr %dimension_descriptor, %dimension_descriptor* %407, i32 0, i32 1
+  %411 = load i64, i64* %410, align 8
+  %412 = sub i64 1, %409
+  %413 = add i64 %409, %411
+  %414 = sub i64 %413, 1
+  %415 = icmp slt i64 1, %409
+  %416 = icmp sgt i64 1, %414
+  %417 = or i1 %415, %416
+  br i1 %417, label %then37, label %ifcont38
 
 then37:                                           ; preds = %ifcont36
-  %417 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %418 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %419 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %418, i32 0, i32 0
-  %420 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @216, i32 0, i32 0), i8** %420, align 8
-  %421 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 1
-  store i32 14, i32* %421, align 4
-  %422 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 2
+  %418 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %419 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %420 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %419, i32 0, i32 0
+  %421 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %420, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @216, i32 0, i32 0), i8** %421, align 8
+  %422 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %420, i32 0, i32 1
   store i32 14, i32* %422, align 4
-  %423 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 3
+  %423 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %420, i32 0, i32 2
   store i32 14, i32* %423, align 4
-  %424 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 4
-  store i32 23, i32* %424, align 4
-  %425 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @217, i32 0, i32 0))
-  %426 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %417, i32 0, i32 0
-  %427 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %418, i32 0, i32 0
-  %428 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 2
-  %429 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 0
-  store i1 true, i1* %429, align 1
-  %430 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 1
-  store i8* %425, i8** %430, align 8
-  store { i8*, i32, i32, i32, i32 }* %427, { i8*, i32, i32, i32, i32 }** %428, align 8
-  %431 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 3
-  store i32 1, i32* %431, align 4
-  %432 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %417, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @218, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @215, i32 0, i32 0), i64 1, i32 3, i64 %408, i64 %413)
+  %424 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %420, i32 0, i32 3
+  store i32 14, i32* %424, align 4
+  %425 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %420, i32 0, i32 4
+  store i32 23, i32* %425, align 4
+  %426 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @217, i32 0, i32 0))
+  %427 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %418, i32 0, i32 0
+  %428 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %419, i32 0, i32 0
+  %429 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %427, i32 0, i32 2
+  %430 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %427, i32 0, i32 0
+  store i1 true, i1* %430, align 1
+  %431 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %427, i32 0, i32 1
+  store i8* %426, i8** %431, align 8
+  store { i8*, i32, i32, i32, i32 }* %428, { i8*, i32, i32, i32, i32 }** %429, align 8
+  %432 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %427, i32 0, i32 3
+  store i32 1, i32* %432, align 4
+  %433 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %418, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %433, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @218, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @215, i32 0, i32 0), i64 1, i32 3, i64 %409, i64 %414)
   call void @exit(i32 1)
   unreachable
 
 ifcont38:                                         ; preds = %ifcont36
-  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %406, i32 0, i32 2
-  %434 = load i64, i64* %433, align 8
-  %435 = mul i64 %434, %411
-  %436 = add i64 %405, %435
-  %437 = getelementptr %array.3, %array.3* %318, i32 0, i32 7
-  %438 = load i64, i64* %437, align 8
-  %439 = add i64 %436, %438
-  %440 = getelementptr %array.3, %array.3* %318, i32 0, i32 0
-  %441 = load i32*, i32** %440, align 8
-  %442 = getelementptr inbounds i32, i32* %441, i64 %439
-  %443 = load i32, i32* %442, align 4
-  %444 = alloca i32, align 4
-  store i32 %443, i32* %444, align 4
-  %445 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %317, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %444)
-  %446 = load i64, i64* %317, align 8
-  %447 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %445, i8** %447, align 8
-  %448 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %446, i64* %448, align 8
-  %449 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %450 = load i8*, i8** %449, align 8
-  %451 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %452 = load i64, i64* %451, align 8
-  %453 = trunc i64 %452 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @219, i32 0, i32 0), i8* %450, i32 %453, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @202, i32 0, i32 0), i32 1)
-  %454 = icmp eq i8* %445, null
-  br i1 %454, label %free_done, label %free_nonnull
+  %434 = getelementptr %dimension_descriptor, %dimension_descriptor* %407, i32 0, i32 2
+  %435 = load i64, i64* %434, align 8
+  %436 = mul i64 %435, %412
+  %437 = add i64 %406, %436
+  %438 = getelementptr %array.3, %array.3* %319, i32 0, i32 7
+  %439 = load i64, i64* %438, align 8
+  %440 = add i64 %437, %439
+  %441 = getelementptr %array.3, %array.3* %319, i32 0, i32 0
+  %442 = load i32*, i32** %441, align 8
+  %443 = getelementptr inbounds i32, i32* %442, i64 %440
+  %444 = load i32, i32* %443, align 4
+  %445 = alloca i32, align 4
+  store i32 %444, i32* %445, align 4
+  %446 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %318, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %445)
+  %447 = load i64, i64* %318, align 8
+  %448 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  store i8* %446, i8** %448, align 8
+  %449 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  store i64 %447, i64* %449, align 8
+  %450 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
+  %451 = load i8*, i8** %450, align 8
+  %452 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
+  %453 = load i64, i64* %452, align 8
+  %454 = trunc i64 %453 to i32
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @219, i32 0, i32 0), i8* %451, i32 %454, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @202, i32 0, i32 0), i32 1)
+  %455 = icmp eq i8* %446, null
+  br i1 %455, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont38
-  call void @_lfortran_free_alloc(i8* %2, i8* %445)
+  call void @_lfortran_free_alloc(i8* %2, i8* %446)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont38
@@ -1015,8 +1017,8 @@ FINALIZE_SYMTABLE_allocate_03:                    ; preds = %return
   br label %Finalize_Variable_c
 
 Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_allocate_03
-  %455 = load %array.3*, %array.3** %c, align 8
-  call void @finalize_allocatable__Array_3_i32(%array.3* %455)
+  %456 = load %array.3*, %array.3** %c, align 8
+  call void @finalize_allocatable__Array_3_i32(%array.3* %456)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
@@ -1147,235 +1149,237 @@ ifcont14:                                         ; preds = %else13, %then12
   %51 = load %array.3*, %array.3** %c, align 8
   %52 = getelementptr %array.3, %array.3* %51, i32 0, i32 7
   store i64 0, i64* %52, align 8
-  %53 = getelementptr %array.3, %array.3* %51, i32 0, i32 8
-  %54 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %53, i32 0, i32 0
-  %55 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 0
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
-  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
-  store i64 1, i64* %56, align 8
+  %53 = getelementptr %array.3, %array.3* %51, i32 0, i32 3
+  store i8 3, i8* %53, align 1
+  %54 = getelementptr %array.3, %array.3* %51, i32 0, i32 8
+  %55 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %54, i32 0, i32 0
+  %56 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 0
+  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 2
+  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 0
+  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 1
   store i64 1, i64* %57, align 8
-  store i64 3, i64* %58, align 8
-  %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 1
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 2
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
-  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
-  store i64 3, i64* %60, align 8
-  store i64 1, i64* %61, align 8
-  store i64 3, i64* %62, align 8
-  %63 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 2
-  %64 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 2
-  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 0
-  %66 = getelementptr %dimension_descriptor, %dimension_descriptor* %63, i32 0, i32 1
-  store i64 9, i64* %64, align 8
-  store i64 1, i64* %65, align 8
-  store i64 3, i64* %66, align 8
-  %67 = getelementptr %array.3, %array.3* %51, i32 0, i32 0
-  %68 = call i8* @_lfortran_get_default_allocator()
-  %69 = call i8* @_lfortran_malloc_alloc(i8* %68, i64 108)
-  %70 = bitcast i8* %69 to i32*
-  store i32* %70, i32** %67, align 8
-  %71 = load %array.3*, %array.3** %c, align 8
-  %72 = ptrtoint %array.3* %71 to i64
-  %73 = icmp eq i64 %72, 0
-  br i1 %73, label %merge_allocated16, label %check_data15
+  store i64 1, i64* %58, align 8
+  store i64 3, i64* %59, align 8
+  %60 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 1
+  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 2
+  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 0
+  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 1
+  store i64 3, i64* %61, align 8
+  store i64 1, i64* %62, align 8
+  store i64 3, i64* %63, align 8
+  %64 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 2
+  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 2
+  %66 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 0
+  %67 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 1
+  store i64 9, i64* %65, align 8
+  store i64 1, i64* %66, align 8
+  store i64 3, i64* %67, align 8
+  %68 = getelementptr %array.3, %array.3* %51, i32 0, i32 0
+  %69 = call i8* @_lfortran_get_default_allocator()
+  %70 = call i8* @_lfortran_malloc_alloc(i8* %69, i64 108)
+  %71 = bitcast i8* %70 to i32*
+  store i32* %71, i32** %68, align 8
+  %72 = load %array.3*, %array.3** %c, align 8
+  %73 = ptrtoint %array.3* %72 to i64
+  %74 = icmp eq i64 %73, 0
+  br i1 %74, label %merge_allocated16, label %check_data15
 
 check_data15:                                     ; preds = %ifcont14
-  %74 = getelementptr %array.3, %array.3* %71, i32 0, i32 0
-  %75 = load i32*, i32** %74, align 8
-  %76 = ptrtoint i32* %75 to i64
-  %77 = icmp ne i64 %76, 0
+  %75 = getelementptr %array.3, %array.3* %72, i32 0, i32 0
+  %76 = load i32*, i32** %75, align 8
+  %77 = ptrtoint i32* %76 to i64
+  %78 = icmp ne i64 %77, 0
   br label %merge_allocated16
 
 merge_allocated16:                                ; preds = %check_data15, %ifcont14
-  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %77, %check_data15 ]
-  %78 = xor i1 %is_allocated17, true
-  br i1 %78, label %then18, label %ifcont19
+  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %78, %check_data15 ]
+  %79 = xor i1 %is_allocated17, true
+  br i1 %79, label %then18, label %ifcont19
 
 then18:                                           ; preds = %merge_allocated16
-  %79 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %80 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %81 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %80, i32 0, i32 0
-  %82 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @5, i32 0, i32 0), i8** %82, align 8
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 1
-  store i32 21, i32* %83, align 4
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 2
-  store i32 5, i32* %84, align 4
-  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 3
-  store i32 21, i32* %85, align 4
-  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 4
-  store i32 14, i32* %86, align 4
-  %87 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %88 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %79, i32 0, i32 0
-  %89 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %80, i32 0, i32 0
-  %90 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 2
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 0
-  store i1 true, i1* %91, align 1
-  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 1
-  store i8* %87, i8** %92, align 8
-  store { i8*, i32, i32, i32, i32 }* %89, { i8*, i32, i32, i32, i32 }** %90, align 8
-  %93 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 3
-  store i32 1, i32* %93, align 4
-  %94 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %79, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %94, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %80 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %81 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %82 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
+  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @5, i32 0, i32 0), i8** %83, align 8
+  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 1
+  store i32 21, i32* %84, align 4
+  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 2
+  store i32 5, i32* %85, align 4
+  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 3
+  store i32 21, i32* %86, align 4
+  %87 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 4
+  store i32 14, i32* %87, align 4
+  %88 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
+  %89 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
+  %90 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
+  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 2
+  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 0
+  store i1 true, i1* %92, align 1
+  %93 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 1
+  store i8* %88, i8** %93, align 8
+  store { i8*, i32, i32, i32, i32 }* %90, { i8*, i32, i32, i32, i32 }** %91, align 8
+  %94 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 3
+  store i32 1, i32* %94, align 4
+  %95 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %95, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %merge_allocated16
-  %95 = getelementptr %array.3, %array.3* %71, i32 0, i32 8
-  %96 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %95, i32 0, i32 0
-  %97 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %96, i32 0
-  %98 = getelementptr %dimension_descriptor, %dimension_descriptor* %97, i32 0, i32 0
-  %99 = load i64, i64* %98, align 8
-  %100 = getelementptr %dimension_descriptor, %dimension_descriptor* %97, i32 0, i32 1
-  %101 = load i64, i64* %100, align 8
-  %102 = sub i64 1, %99
-  %103 = add i64 %99, %101
-  %104 = sub i64 %103, 1
-  %105 = icmp slt i64 1, %99
-  %106 = icmp sgt i64 1, %104
-  %107 = or i1 %105, %106
-  br i1 %107, label %then20, label %ifcont21
+  %96 = getelementptr %array.3, %array.3* %72, i32 0, i32 8
+  %97 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %96, i32 0, i32 0
+  %98 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 0
+  %99 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 0
+  %100 = load i64, i64* %99, align 8
+  %101 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 1
+  %102 = load i64, i64* %101, align 8
+  %103 = sub i64 1, %100
+  %104 = add i64 %100, %102
+  %105 = sub i64 %104, 1
+  %106 = icmp slt i64 1, %100
+  %107 = icmp sgt i64 1, %105
+  %108 = or i1 %106, %107
+  br i1 %108, label %then20, label %ifcont21
 
 then20:                                           ; preds = %ifcont19
-  %108 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %109 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %110 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %109, i32 0, i32 0
-  %111 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %110, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @9, i32 0, i32 0), i8** %111, align 8
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %110, i32 0, i32 1
-  store i32 21, i32* %112, align 4
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %110, i32 0, i32 2
-  store i32 5, i32* %113, align 4
-  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %110, i32 0, i32 3
-  store i32 21, i32* %114, align 4
-  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %110, i32 0, i32 4
-  store i32 14, i32* %115, align 4
-  %116 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %117 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %108, i32 0, i32 0
-  %118 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %109, i32 0, i32 0
-  %119 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %117, i32 0, i32 2
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %117, i32 0, i32 0
-  store i1 true, i1* %120, align 1
-  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %117, i32 0, i32 1
-  store i8* %116, i8** %121, align 8
-  store { i8*, i32, i32, i32, i32 }* %118, { i8*, i32, i32, i32, i32 }** %119, align 8
-  %122 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %117, i32 0, i32 3
-  store i32 1, i32* %122, align 4
-  %123 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %108, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i64 1, i32 1, i64 %99, i64 %104)
+  %109 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %110 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %111 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
+  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @9, i32 0, i32 0), i8** %112, align 8
+  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 1
+  store i32 21, i32* %113, align 4
+  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 2
+  store i32 5, i32* %114, align 4
+  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 3
+  store i32 21, i32* %115, align 4
+  %116 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 4
+  store i32 14, i32* %116, align 4
+  %117 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
+  %118 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
+  %119 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
+  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 2
+  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 0
+  store i1 true, i1* %121, align 1
+  %122 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 1
+  store i8* %117, i8** %122, align 8
+  store { i8*, i32, i32, i32, i32 }* %119, { i8*, i32, i32, i32, i32 }** %120, align 8
+  %123 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 3
+  store i32 1, i32* %123, align 4
+  %124 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i64 1, i32 1, i64 %100, i64 %105)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %124 = getelementptr %dimension_descriptor, %dimension_descriptor* %97, i32 0, i32 2
-  %125 = load i64, i64* %124, align 8
-  %126 = mul i64 %125, %102
-  %127 = add i64 0, %126
-  %128 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %96, i32 1
-  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 0
-  %130 = load i64, i64* %129, align 8
-  %131 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 1
-  %132 = load i64, i64* %131, align 8
-  %133 = sub i64 1, %130
-  %134 = add i64 %130, %132
-  %135 = sub i64 %134, 1
-  %136 = icmp slt i64 1, %130
-  %137 = icmp sgt i64 1, %135
-  %138 = or i1 %136, %137
-  br i1 %138, label %then22, label %ifcont23
+  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 2
+  %126 = load i64, i64* %125, align 8
+  %127 = mul i64 %126, %103
+  %128 = add i64 0, %127
+  %129 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 1
+  %130 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 0
+  %131 = load i64, i64* %130, align 8
+  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 1
+  %133 = load i64, i64* %132, align 8
+  %134 = sub i64 1, %131
+  %135 = add i64 %131, %133
+  %136 = sub i64 %135, 1
+  %137 = icmp slt i64 1, %131
+  %138 = icmp sgt i64 1, %136
+  %139 = or i1 %137, %138
+  br i1 %139, label %then22, label %ifcont23
 
 then22:                                           ; preds = %ifcont21
-  %139 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %140 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %141 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %140, i32 0, i32 0
-  %142 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %141, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @13, i32 0, i32 0), i8** %142, align 8
-  %143 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %141, i32 0, i32 1
-  store i32 21, i32* %143, align 4
-  %144 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %141, i32 0, i32 2
-  store i32 5, i32* %144, align 4
-  %145 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %141, i32 0, i32 3
-  store i32 21, i32* %145, align 4
-  %146 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %141, i32 0, i32 4
-  store i32 14, i32* %146, align 4
-  %147 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
-  %148 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %139, i32 0, i32 0
-  %149 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %140, i32 0, i32 0
-  %150 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 0, i32 2
-  %151 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 0, i32 0
-  store i1 true, i1* %151, align 1
-  %152 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 0, i32 1
-  store i8* %147, i8** %152, align 8
-  store { i8*, i32, i32, i32, i32 }* %149, { i8*, i32, i32, i32, i32 }** %150, align 8
-  %153 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 0, i32 3
-  store i32 1, i32* %153, align 4
-  %154 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %139, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %154, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i64 1, i32 2, i64 %130, i64 %135)
+  %140 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %141 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %142 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %141, i32 0, i32 0
+  %143 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @13, i32 0, i32 0), i8** %143, align 8
+  %144 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 1
+  store i32 21, i32* %144, align 4
+  %145 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 2
+  store i32 5, i32* %145, align 4
+  %146 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 3
+  store i32 21, i32* %146, align 4
+  %147 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 4
+  store i32 14, i32* %147, align 4
+  %148 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
+  %149 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %140, i32 0, i32 0
+  %150 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %141, i32 0, i32 0
+  %151 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 2
+  %152 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 0
+  store i1 true, i1* %152, align 1
+  %153 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 1
+  store i8* %148, i8** %153, align 8
+  store { i8*, i32, i32, i32, i32 }* %150, { i8*, i32, i32, i32, i32 }** %151, align 8
+  %154 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 3
+  store i32 1, i32* %154, align 4
+  %155 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %140, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i64 1, i32 2, i64 %131, i64 %136)
   call void @exit(i32 1)
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %128, i32 0, i32 2
-  %156 = load i64, i64* %155, align 8
-  %157 = mul i64 %156, %133
-  %158 = add i64 %127, %157
-  %159 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %96, i32 2
-  %160 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 0
-  %161 = load i64, i64* %160, align 8
-  %162 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 1
-  %163 = load i64, i64* %162, align 8
-  %164 = sub i64 1, %161
-  %165 = add i64 %161, %163
-  %166 = sub i64 %165, 1
-  %167 = icmp slt i64 1, %161
-  %168 = icmp sgt i64 1, %166
-  %169 = or i1 %167, %168
-  br i1 %169, label %then24, label %ifcont25
+  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 2
+  %157 = load i64, i64* %156, align 8
+  %158 = mul i64 %157, %134
+  %159 = add i64 %128, %158
+  %160 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 2
+  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 0
+  %162 = load i64, i64* %161, align 8
+  %163 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 1
+  %164 = load i64, i64* %163, align 8
+  %165 = sub i64 1, %162
+  %166 = add i64 %162, %164
+  %167 = sub i64 %166, 1
+  %168 = icmp slt i64 1, %162
+  %169 = icmp sgt i64 1, %167
+  %170 = or i1 %168, %169
+  br i1 %170, label %then24, label %ifcont25
 
 then24:                                           ; preds = %ifcont23
-  %170 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %171 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %172 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %171, i32 0, i32 0
-  %173 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %172, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @17, i32 0, i32 0), i8** %173, align 8
-  %174 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %172, i32 0, i32 1
-  store i32 21, i32* %174, align 4
-  %175 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %172, i32 0, i32 2
-  store i32 5, i32* %175, align 4
-  %176 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %172, i32 0, i32 3
-  store i32 21, i32* %176, align 4
-  %177 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %172, i32 0, i32 4
-  store i32 14, i32* %177, align 4
-  %178 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %179 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %170, i32 0, i32 0
-  %180 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %171, i32 0, i32 0
-  %181 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 0, i32 2
-  %182 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 0, i32 0
-  store i1 true, i1* %182, align 1
-  %183 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 0, i32 1
-  store i8* %178, i8** %183, align 8
-  store { i8*, i32, i32, i32, i32 }* %180, { i8*, i32, i32, i32, i32 }** %181, align 8
-  %184 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 0, i32 3
-  store i32 1, i32* %184, align 4
-  %185 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %170, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 1, i32 3, i64 %161, i64 %166)
+  %171 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %172 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %173 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
+  %174 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 0
+  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @17, i32 0, i32 0), i8** %174, align 8
+  %175 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 1
+  store i32 21, i32* %175, align 4
+  %176 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 2
+  store i32 5, i32* %176, align 4
+  %177 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 3
+  store i32 21, i32* %177, align 4
+  %178 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 4
+  store i32 14, i32* %178, align 4
+  %179 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
+  %180 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
+  %181 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
+  %182 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 2
+  %183 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 0
+  store i1 true, i1* %183, align 1
+  %184 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 1
+  store i8* %179, i8** %184, align 8
+  store { i8*, i32, i32, i32, i32 }* %181, { i8*, i32, i32, i32, i32 }** %182, align 8
+  %185 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 3
+  store i32 1, i32* %185, align 4
+  %186 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %186, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 1, i32 3, i64 %162, i64 %167)
   call void @exit(i32 1)
   unreachable
 
 ifcont25:                                         ; preds = %ifcont23
-  %186 = getelementptr %dimension_descriptor, %dimension_descriptor* %159, i32 0, i32 2
-  %187 = load i64, i64* %186, align 8
-  %188 = mul i64 %187, %164
-  %189 = add i64 %158, %188
-  %190 = getelementptr %array.3, %array.3* %71, i32 0, i32 7
-  %191 = load i64, i64* %190, align 8
-  %192 = add i64 %189, %191
-  %193 = getelementptr %array.3, %array.3* %71, i32 0, i32 0
-  %194 = load i32*, i32** %193, align 8
-  %195 = getelementptr inbounds i32, i32* %194, i64 %192
-  store i32 99, i32* %195, align 4
+  %187 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 2
+  %188 = load i64, i64* %187, align 8
+  %189 = mul i64 %188, %165
+  %190 = add i64 %159, %189
+  %191 = getelementptr %array.3, %array.3* %72, i32 0, i32 7
+  %192 = load i64, i64* %191, align 8
+  %193 = add i64 %190, %192
+  %194 = getelementptr %array.3, %array.3* %72, i32 0, i32 0
+  %195 = load i32*, i32** %194, align 8
+  %196 = getelementptr inbounds i32, i32* %195, i64 %193
+  store i32 99, i32* %196, align 4
   br label %return
 
 return:                                           ; preds = %ifcont25

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "1f645146a21faf540ce42ff4bc12269ff682646b5139811e8e980697",
+    "stdout_hash": "57f68ae3bfc9fe2a95fcb8cb6e9e69427487b36fcff902e5a50a7bee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -83,20 +83,22 @@ ifcont:                                           ; preds = %merge_allocated
   %32 = load %array.1*, %array.1** %arr, align 8
   %33 = getelementptr %array.1, %array.1* %32, i32 0, i32 7
   store i64 0, i64* %33, align 8
-  %34 = getelementptr %array.1, %array.1* %32, i32 0, i32 8
-  %35 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %34, i32 0, i32 0
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  store i64 1, i64* %37, align 8
+  %34 = getelementptr %array.1, %array.1* %32, i32 0, i32 3
+  store i8 1, i8* %34, align 1
+  %35 = getelementptr %array.1, %array.1* %32, i32 0, i32 8
+  %36 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %35, i32 0, i32 0
+  %37 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %36, i32 0
+  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 2
+  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 0
+  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 1
   store i64 1, i64* %38, align 8
-  store i64 10, i64* %39, align 8
-  %40 = getelementptr %array.1, %array.1* %32, i32 0, i32 0
-  %41 = call i8* @_lfortran_get_default_allocator()
-  %42 = call i8* @_lfortran_malloc_alloc(i8* %41, i64 40)
-  %43 = bitcast i8* %42 to i32*
-  store i32* %43, i32** %40, align 8
+  store i64 1, i64* %39, align 8
+  store i64 10, i64* %40, align 8
+  %41 = getelementptr %array.1, %array.1* %32, i32 0, i32 0
+  %42 = call i8* @_lfortran_get_default_allocator()
+  %43 = call i8* @_lfortran_malloc_alloc(i8* %42, i64 40)
+  %44 = bitcast i8* %43 to i32*
+  store i32* %44, i32** %41, align 8
   br i1 true, label %then1, label %else
 
 then1:                                            ; preds = %ifcont
@@ -121,8 +123,8 @@ FINALIZE_SYMTABLE_ss:                             ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_ss
-  %44 = load %array.1*, %array.1** %arr, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %44)
+  %45 = load %array.1*, %array.1** %arr, align 8
+  call void @finalize_allocatable__Array_1_i32(%array.1* %45)
   ret void
 }
 

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "b35b436633eb95c1d17ef95c309515a138887ff348f5f4c7bfdd39ca",
+    "stdout_hash": "c5f5f1073e67d1ad30706694e2992ec6b2f310480a488d34ea388476",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -266,199 +266,201 @@ ifcont10:                                         ; preds = %merge_allocated7
   %122 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
   %123 = getelementptr %array.1, %array.1* %122, i32 0, i32 7
   store i64 0, i64* %123, align 8
-  %124 = getelementptr %array.1, %array.1* %122, i32 0, i32 8
-  %125 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %124, i32 0, i32 0
-  %126 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %125, i32 0
-  %127 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 2
-  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 0
-  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %126, i32 0, i32 1
-  %130 = sext i32 %121 to i64
-  %131 = icmp slt i64 %130, 0
-  %132 = select i1 %131, i64 0, i64 %130
-  store i64 1, i64* %127, align 8
+  %124 = getelementptr %array.1, %array.1* %122, i32 0, i32 3
+  store i8 1, i8* %124, align 1
+  %125 = getelementptr %array.1, %array.1* %122, i32 0, i32 8
+  %126 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %125, i32 0, i32 0
+  %127 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %126, i32 0
+  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 2
+  %129 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 0
+  %130 = getelementptr %dimension_descriptor, %dimension_descriptor* %127, i32 0, i32 1
+  %131 = sext i32 %121 to i64
+  %132 = icmp slt i64 %131, 0
+  %133 = select i1 %132, i64 0, i64 %131
   store i64 1, i64* %128, align 8
-  store i64 %132, i64* %129, align 8
-  %133 = mul i64 1, %132
-  %134 = getelementptr %array.1, %array.1* %122, i32 0, i32 0
-  %135 = mul i64 %133, 8
-  %136 = call i8* @_lfortran_get_default_allocator()
-  %137 = call i8* @_lfortran_malloc_alloc(i8* %136, i64 %135)
-  %138 = bitcast i8* %137 to double*
-  store double* %138, double** %134, align 8
-  %139 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %140 = getelementptr %array.1, %array.1* %139, i32 0, i32 8
-  %141 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %140, i32 0, i32 0
-  %142 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %141, i32 0
-  %143 = getelementptr %dimension_descriptor, %dimension_descriptor* %142, i32 0, i32 0
-  %144 = load i64, i64* %143, align 8
-  %145 = getelementptr %dimension_descriptor, %dimension_descriptor* %142, i32 0, i32 1
-  %146 = load i64, i64* %145, align 8
-  %147 = add i64 %146, %144
-  %148 = sub i64 %147, 1
-  %149 = trunc i64 %148 to i32
-  store i32 %149, i32* %__do_loop_end, align 4
-  %150 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %151 = getelementptr %array.1, %array.1* %150, i32 0, i32 8
-  %152 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %151, i32 0, i32 0
-  %153 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %152, i32 0
-  %154 = getelementptr %dimension_descriptor, %dimension_descriptor* %153, i32 0, i32 0
-  %155 = load i64, i64* %154, align 8
-  %156 = trunc i64 %155 to i32
-  %157 = sub i32 %156, 1
-  store i32 %157, i32* %__lcompilers_i_0, align 4
+  store i64 1, i64* %129, align 8
+  store i64 %133, i64* %130, align 8
+  %134 = mul i64 1, %133
+  %135 = getelementptr %array.1, %array.1* %122, i32 0, i32 0
+  %136 = mul i64 %134, 8
+  %137 = call i8* @_lfortran_get_default_allocator()
+  %138 = call i8* @_lfortran_malloc_alloc(i8* %137, i64 %136)
+  %139 = bitcast i8* %138 to double*
+  store double* %139, double** %135, align 8
+  %140 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %141 = getelementptr %array.1, %array.1* %140, i32 0, i32 8
+  %142 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %141, i32 0, i32 0
+  %143 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %142, i32 0
+  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %143, i32 0, i32 0
+  %145 = load i64, i64* %144, align 8
+  %146 = getelementptr %dimension_descriptor, %dimension_descriptor* %143, i32 0, i32 1
+  %147 = load i64, i64* %146, align 8
+  %148 = add i64 %147, %145
+  %149 = sub i64 %148, 1
+  %150 = trunc i64 %149 to i32
+  store i32 %150, i32* %__do_loop_end, align 4
+  %151 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %152 = getelementptr %array.1, %array.1* %151, i32 0, i32 8
+  %153 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %152, i32 0, i32 0
+  %154 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %153, i32 0
+  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %154, i32 0, i32 0
+  %156 = load i64, i64* %155, align 8
+  %157 = trunc i64 %156 to i32
+  %158 = sub i32 %157, 1
+  store i32 %158, i32* %__lcompilers_i_0, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont14, %ifcont10
-  %158 = load i32, i32* %__lcompilers_i_0, align 4
-  %159 = add i32 %158, 1
-  %160 = load i32, i32* %__do_loop_end, align 4
-  %161 = icmp sle i32 %159, %160
-  br i1 %161, label %loop.body, label %loop.end
+  %159 = load i32, i32* %__lcompilers_i_0, align 4
+  %160 = add i32 %159, 1
+  %161 = load i32, i32* %__do_loop_end, align 4
+  %162 = icmp sle i32 %160, %161
+  br i1 %162, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %162 = load i32, i32* %__lcompilers_i_0, align 4
-  %163 = add i32 %162, 1
-  store i32 %163, i32* %__lcompilers_i_0, align 4
-  %164 = load i32, i32* %__lcompilers_i_0, align 4
-  %165 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %166 = getelementptr %array.1, %array.1* %165, i32 0, i32 8
-  %167 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %166, i32 0, i32 0
-  %168 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %167, i32 0
-  %169 = getelementptr %dimension_descriptor, %dimension_descriptor* %168, i32 0, i32 0
-  %170 = load i64, i64* %169, align 8
-  %171 = getelementptr %dimension_descriptor, %dimension_descriptor* %168, i32 0, i32 1
-  %172 = load i64, i64* %171, align 8
-  %173 = sext i32 %164 to i64
-  %174 = sub i64 %173, %170
-  %175 = add i64 %170, %172
-  %176 = sub i64 %175, 1
-  %177 = icmp slt i64 %173, %170
-  %178 = icmp sgt i64 %173, %176
-  %179 = or i1 %177, %178
-  br i1 %179, label %then11, label %ifcont12
+  %163 = load i32, i32* %__lcompilers_i_0, align 4
+  %164 = add i32 %163, 1
+  store i32 %164, i32* %__lcompilers_i_0, align 4
+  %165 = load i32, i32* %__lcompilers_i_0, align 4
+  %166 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %167 = getelementptr %array.1, %array.1* %166, i32 0, i32 8
+  %168 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %167, i32 0, i32 0
+  %169 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %168, i32 0
+  %170 = getelementptr %dimension_descriptor, %dimension_descriptor* %169, i32 0, i32 0
+  %171 = load i64, i64* %170, align 8
+  %172 = getelementptr %dimension_descriptor, %dimension_descriptor* %169, i32 0, i32 1
+  %173 = load i64, i64* %172, align 8
+  %174 = sext i32 %165 to i64
+  %175 = sub i64 %174, %171
+  %176 = add i64 %171, %173
+  %177 = sub i64 %176, 1
+  %178 = icmp slt i64 %174, %171
+  %179 = icmp sgt i64 %174, %177
+  %180 = or i1 %178, %179
+  br i1 %180, label %then11, label %ifcont12
 
 then11:                                           ; preds = %loop.body
-  %180 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %181 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %182 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %181, i32 0, i32 0
-  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @5, i32 0, i32 0), i8** %183, align 8
-  %184 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 1
-  store i32 5, i32* %184, align 4
-  %185 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 2
-  store i32 8, i32* %185, align 4
-  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 3
-  store i32 5, i32* %186, align 4
-  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %182, i32 0, i32 4
-  store i32 14, i32* %187, align 4
-  %188 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %189 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %180, i32 0, i32 0
-  %190 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %181, i32 0, i32 0
-  %191 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 2
-  %192 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 0
-  store i1 true, i1* %192, align 1
-  %193 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 1
-  store i8* %188, i8** %193, align 8
-  store { i8*, i32, i32, i32, i32 }* %190, { i8*, i32, i32, i32, i32 }** %191, align 8
-  %194 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 0, i32 3
-  store i32 1, i32* %194, align 4
-  %195 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %180, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %195, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @4, i32 0, i32 0), i64 %173, i32 1, i64 %170, i64 %176)
+  %181 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %182 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %183 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %182, i32 0, i32 0
+  %184 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @5, i32 0, i32 0), i8** %184, align 8
+  %185 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 1
+  store i32 5, i32* %185, align 4
+  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 2
+  store i32 8, i32* %186, align 4
+  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 3
+  store i32 5, i32* %187, align 4
+  %188 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 4
+  store i32 14, i32* %188, align 4
+  %189 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
+  %190 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %181, i32 0, i32 0
+  %191 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %182, i32 0, i32 0
+  %192 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 2
+  %193 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 0
+  store i1 true, i1* %193, align 1
+  %194 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 1
+  store i8* %189, i8** %194, align 8
+  store { i8*, i32, i32, i32, i32 }* %191, { i8*, i32, i32, i32, i32 }** %192, align 8
+  %195 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 3
+  store i32 1, i32* %195, align 4
+  %196 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %181, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %196, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @4, i32 0, i32 0), i64 %174, i32 1, i64 %171, i64 %177)
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %loop.body
-  %196 = getelementptr %dimension_descriptor, %dimension_descriptor* %168, i32 0, i32 2
-  %197 = load i64, i64* %196, align 8
-  %198 = mul i64 %197, %174
-  %199 = add i64 0, %198
-  %200 = getelementptr %array.1, %array.1* %165, i32 0, i32 7
-  %201 = load i64, i64* %200, align 8
-  %202 = add i64 %199, %201
-  %203 = getelementptr %array.1, %array.1* %165, i32 0, i32 0
-  %204 = load double*, double** %203, align 8
-  %205 = getelementptr inbounds double, double* %204, i64 %202
-  %206 = load i32, i32* %__lcompilers_i_0, align 4
-  %207 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %208 = getelementptr %array.1, %array.1* %207, i32 0, i32 8
-  %209 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %208, i32 0, i32 0
-  %210 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %209, i32 0
-  %211 = getelementptr %dimension_descriptor, %dimension_descriptor* %210, i32 0, i32 0
-  %212 = load i64, i64* %211, align 8
-  %213 = getelementptr %dimension_descriptor, %dimension_descriptor* %210, i32 0, i32 1
-  %214 = load i64, i64* %213, align 8
-  %215 = sext i32 %206 to i64
-  %216 = sub i64 %215, %212
-  %217 = add i64 %212, %214
-  %218 = sub i64 %217, 1
-  %219 = icmp slt i64 %215, %212
-  %220 = icmp sgt i64 %215, %218
-  %221 = or i1 %219, %220
-  br i1 %221, label %then13, label %ifcont14
+  %197 = getelementptr %dimension_descriptor, %dimension_descriptor* %169, i32 0, i32 2
+  %198 = load i64, i64* %197, align 8
+  %199 = mul i64 %198, %175
+  %200 = add i64 0, %199
+  %201 = getelementptr %array.1, %array.1* %166, i32 0, i32 7
+  %202 = load i64, i64* %201, align 8
+  %203 = add i64 %200, %202
+  %204 = getelementptr %array.1, %array.1* %166, i32 0, i32 0
+  %205 = load double*, double** %204, align 8
+  %206 = getelementptr inbounds double, double* %205, i64 %203
+  %207 = load i32, i32* %__lcompilers_i_0, align 4
+  %208 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %209 = getelementptr %array.1, %array.1* %208, i32 0, i32 8
+  %210 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %209, i32 0, i32 0
+  %211 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %210, i32 0
+  %212 = getelementptr %dimension_descriptor, %dimension_descriptor* %211, i32 0, i32 0
+  %213 = load i64, i64* %212, align 8
+  %214 = getelementptr %dimension_descriptor, %dimension_descriptor* %211, i32 0, i32 1
+  %215 = load i64, i64* %214, align 8
+  %216 = sext i32 %207 to i64
+  %217 = sub i64 %216, %213
+  %218 = add i64 %213, %215
+  %219 = sub i64 %218, 1
+  %220 = icmp slt i64 %216, %213
+  %221 = icmp sgt i64 %216, %219
+  %222 = or i1 %220, %221
+  br i1 %222, label %then13, label %ifcont14
 
 then13:                                           ; preds = %ifcont12
-  %222 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %223 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %224 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %223, i32 0, i32 0
-  %225 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %224, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @9, i32 0, i32 0), i8** %225, align 8
-  %226 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %224, i32 0, i32 1
-  store i32 5, i32* %226, align 4
-  %227 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %224, i32 0, i32 2
-  store i32 8, i32* %227, align 4
-  %228 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %224, i32 0, i32 3
-  store i32 5, i32* %228, align 4
-  %229 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %224, i32 0, i32 4
-  store i32 14, i32* %229, align 4
-  %230 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %231 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %222, i32 0, i32 0
-  %232 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %223, i32 0, i32 0
-  %233 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %231, i32 0, i32 2
-  %234 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %231, i32 0, i32 0
-  store i1 true, i1* %234, align 1
-  %235 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %231, i32 0, i32 1
-  store i8* %230, i8** %235, align 8
-  store { i8*, i32, i32, i32, i32 }* %232, { i8*, i32, i32, i32, i32 }** %233, align 8
-  %236 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %231, i32 0, i32 3
-  store i32 1, i32* %236, align 4
-  %237 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %222, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %237, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @8, i32 0, i32 0), i64 %215, i32 1, i64 %212, i64 %218)
+  %223 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %224 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %225 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %224, i32 0, i32 0
+  %226 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %225, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @9, i32 0, i32 0), i8** %226, align 8
+  %227 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %225, i32 0, i32 1
+  store i32 5, i32* %227, align 4
+  %228 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %225, i32 0, i32 2
+  store i32 8, i32* %228, align 4
+  %229 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %225, i32 0, i32 3
+  store i32 5, i32* %229, align 4
+  %230 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %225, i32 0, i32 4
+  store i32 14, i32* %230, align 4
+  %231 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
+  %232 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %223, i32 0, i32 0
+  %233 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %224, i32 0, i32 0
+  %234 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %232, i32 0, i32 2
+  %235 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %232, i32 0, i32 0
+  store i1 true, i1* %235, align 1
+  %236 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %232, i32 0, i32 1
+  store i8* %231, i8** %236, align 8
+  store { i8*, i32, i32, i32, i32 }* %233, { i8*, i32, i32, i32, i32 }** %234, align 8
+  %237 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %232, i32 0, i32 3
+  store i32 1, i32* %237, align 4
+  %238 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %223, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %238, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @8, i32 0, i32 0), i64 %216, i32 1, i64 %213, i64 %219)
   call void @exit(i32 1)
   unreachable
 
 ifcont14:                                         ; preds = %ifcont12
-  %238 = getelementptr %dimension_descriptor, %dimension_descriptor* %210, i32 0, i32 2
-  %239 = load i64, i64* %238, align 8
-  %240 = mul i64 %239, %216
-  %241 = add i64 0, %240
-  %242 = getelementptr %array.1, %array.1* %207, i32 0, i32 7
-  %243 = load i64, i64* %242, align 8
-  %244 = add i64 %241, %243
-  %245 = getelementptr %array.1, %array.1* %207, i32 0, i32 0
-  %246 = load double*, double** %245, align 8
-  %247 = getelementptr inbounds double, double* %246, i64 %244
-  %248 = load double, double* %247, align 8
-  store double %248, double* %205, align 8
+  %239 = getelementptr %dimension_descriptor, %dimension_descriptor* %211, i32 0, i32 2
+  %240 = load i64, i64* %239, align 8
+  %241 = mul i64 %240, %217
+  %242 = add i64 0, %241
+  %243 = getelementptr %array.1, %array.1* %208, i32 0, i32 7
+  %244 = load i64, i64* %243, align 8
+  %245 = add i64 %242, %244
+  %246 = getelementptr %array.1, %array.1* %208, i32 0, i32 0
+  %247 = load double*, double** %246, align 8
+  %248 = getelementptr inbounds double, double* %247, i64 %245
+  %249 = load double, double* %248, align 8
+  store double %249, double* %206, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br label %ifcont20
 
 else15:                                           ; preds = %merge_allocated
-  %249 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %250 = getelementptr %array.1, %array.1* %249, i32 0, i32 3
-  %251 = load i8, i8* %250, align 1
-  %252 = zext i8 %251 to i32
-  %253 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %254 = icmp eq %array.1* %253, null
-  br i1 %254, label %then16, label %else18
+  %250 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %251 = getelementptr %array.1, %array.1* %250, i32 0, i32 3
+  %252 = load i8, i8* %251, align 1
+  %253 = zext i8 %252 to i32
+  %254 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %255 = icmp eq %array.1* %254, null
+  br i1 %255, label %then16, label %else18
 
 then16:                                           ; preds = %else15
-  %255 = bitcast %array.1* %arr_desc17 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %255, i8 0, i64 8, i1 false)
-  %256 = getelementptr %array.1, %array.1* %arr_desc17, i32 0, i32 3
-  %257 = trunc i32 %252 to i8
-  store i8 %257, i8* %256, align 1
+  %256 = bitcast %array.1* %arr_desc17 to i8*
+  call void @llvm.memset.p0i8.i64(i8* %256, i8 0, i64 8, i1 false)
+  %257 = getelementptr %array.1, %array.1* %arr_desc17, i32 0, i32 3
+  %258 = trunc i32 %253 to i8
+  store i8 %258, i8* %257, align 1
   store %array.1* %arr_desc17, %array.1** %__libasr_created__subroutine_call_b1, align 8
   br label %ifcont19
 
@@ -466,227 +468,227 @@ else18:                                           ; preds = %else15
   br label %ifcont19
 
 ifcont19:                                         ; preds = %else18, %then16
-  %258 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %259 = getelementptr %array.1, %array.1* %249, i32 0, i32 0
-  %260 = getelementptr %array.1, %array.1* %258, i32 0, i32 0
-  %261 = load double*, double** %259, align 8
-  store double* %261, double** %260, align 8
-  %262 = getelementptr %array.1, %array.1* %249, i32 0, i32 8
-  %263 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %262, i32 0, i32 0
-  %264 = getelementptr %array.1, %array.1* %258, i32 0, i32 8
-  %265 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %264, i32 0, i32 0
-  %266 = bitcast %dimension_descriptor* %265 to i8*
-  %267 = bitcast %dimension_descriptor* %263 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %266, i8* align 8 %267, i64 24, i1 false)
-  %268 = getelementptr %array.1, %array.1* %258, i32 0, i32 3
-  %269 = trunc i32 %252 to i8
-  store i8 %269, i8* %268, align 1
-  %270 = getelementptr %array.1, %array.1* %249, i32 0, i32 7
-  %271 = load i64, i64* %270, align 8
-  %272 = getelementptr %array.1, %array.1* %258, i32 0, i32 7
-  store i64 %271, i64* %272, align 8
+  %259 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %260 = getelementptr %array.1, %array.1* %250, i32 0, i32 0
+  %261 = getelementptr %array.1, %array.1* %259, i32 0, i32 0
+  %262 = load double*, double** %260, align 8
+  store double* %262, double** %261, align 8
+  %263 = getelementptr %array.1, %array.1* %250, i32 0, i32 8
+  %264 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %263, i32 0, i32 0
+  %265 = getelementptr %array.1, %array.1* %259, i32 0, i32 8
+  %266 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %265, i32 0, i32 0
+  %267 = bitcast %dimension_descriptor* %266 to i8*
+  %268 = bitcast %dimension_descriptor* %264 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %267, i8* align 8 %268, i64 24, i1 false)
+  %269 = getelementptr %array.1, %array.1* %259, i32 0, i32 3
+  %270 = trunc i32 %253 to i8
+  store i8 %270, i8* %269, align 1
+  %271 = getelementptr %array.1, %array.1* %250, i32 0, i32 7
+  %272 = load i64, i64* %271, align 8
+  %273 = getelementptr %array.1, %array.1* %259, i32 0, i32 7
+  store i64 %272, i64* %273, align 8
   br label %ifcont20
 
 ifcont20:                                         ; preds = %ifcont19, %loop.end
-  %273 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %274 = getelementptr %array.1, %array.1* %273, i32 0, i32 0
-  %275 = load double*, double** %274, align 8
-  %276 = getelementptr %array.1, %array.1* %273, i32 0, i32 7
-  %277 = load i64, i64* %276, align 8
-  %278 = getelementptr inbounds double, double* %275, i64 %277
-  call void @b(double* %278)
-  %279 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %280 = getelementptr %array.1, %array.1* %279, i32 0, i32 8
-  %281 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %280, i32 0, i32 0
-  %282 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %281, i32 0
-  %283 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 0
-  %284 = load i64, i64* %283, align 8
-  %285 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 2
-  %286 = load i64, i64* %285, align 8
-  %287 = icmp eq i64 %286, 1
-  %288 = and i1 true, %287
-  %289 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 0
-  %290 = load i64, i64* %289, align 8
-  %291 = getelementptr %dimension_descriptor, %dimension_descriptor* %282, i32 0, i32 1
-  %292 = load i64, i64* %291, align 8
-  %293 = add i64 %292, %290
-  %294 = sub i64 %293, 1
-  %295 = sub i64 %294, %284
-  %296 = add i64 %295, 1
-  %297 = mul i64 1, %296
-  %298 = ptrtoint %array.1* %279 to i64
-  %299 = icmp eq i64 %298, 0
-  br i1 %299, label %merge_allocated22, label %check_data21
+  %274 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %275 = getelementptr %array.1, %array.1* %274, i32 0, i32 0
+  %276 = load double*, double** %275, align 8
+  %277 = getelementptr %array.1, %array.1* %274, i32 0, i32 7
+  %278 = load i64, i64* %277, align 8
+  %279 = getelementptr inbounds double, double* %276, i64 %278
+  call void @b(double* %279)
+  %280 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %281 = getelementptr %array.1, %array.1* %280, i32 0, i32 8
+  %282 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %281, i32 0, i32 0
+  %283 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %282, i32 0
+  %284 = getelementptr %dimension_descriptor, %dimension_descriptor* %283, i32 0, i32 0
+  %285 = load i64, i64* %284, align 8
+  %286 = getelementptr %dimension_descriptor, %dimension_descriptor* %283, i32 0, i32 2
+  %287 = load i64, i64* %286, align 8
+  %288 = icmp eq i64 %287, 1
+  %289 = and i1 true, %288
+  %290 = getelementptr %dimension_descriptor, %dimension_descriptor* %283, i32 0, i32 0
+  %291 = load i64, i64* %290, align 8
+  %292 = getelementptr %dimension_descriptor, %dimension_descriptor* %283, i32 0, i32 1
+  %293 = load i64, i64* %292, align 8
+  %294 = add i64 %293, %291
+  %295 = sub i64 %294, 1
+  %296 = sub i64 %295, %285
+  %297 = add i64 %296, 1
+  %298 = mul i64 1, %297
+  %299 = ptrtoint %array.1* %280 to i64
+  %300 = icmp eq i64 %299, 0
+  br i1 %300, label %merge_allocated22, label %check_data21
 
 check_data21:                                     ; preds = %ifcont20
-  %300 = getelementptr %array.1, %array.1* %279, i32 0, i32 0
-  %301 = load double*, double** %300, align 8
-  %302 = ptrtoint double* %301 to i64
-  %303 = icmp ne i64 %302, 0
+  %301 = getelementptr %array.1, %array.1* %280, i32 0, i32 0
+  %302 = load double*, double** %301, align 8
+  %303 = ptrtoint double* %302 to i64
+  %304 = icmp ne i64 %303, 0
   br label %merge_allocated22
 
 merge_allocated22:                                ; preds = %check_data21, %ifcont20
-  %is_allocated23 = phi i1 [ false, %ifcont20 ], [ %303, %check_data21 ]
-  %304 = xor i1 %is_allocated23, true
-  %305 = or i1 %288, %304
-  %306 = xor i1 %305, true
-  br i1 %306, label %then24, label %else32
+  %is_allocated23 = phi i1 [ false, %ifcont20 ], [ %304, %check_data21 ]
+  %305 = xor i1 %is_allocated23, true
+  %306 = or i1 %289, %305
+  %307 = xor i1 %306, true
+  br i1 %307, label %then24, label %else32
 
 then24:                                           ; preds = %merge_allocated22
-  %307 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %308 = getelementptr %array.1, %array.1* %307, i32 0, i32 8
-  %309 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %308, i32 0, i32 0
-  %310 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %309, i32 0
-  %311 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 0
-  %312 = load i64, i64* %311, align 8
-  %313 = getelementptr %dimension_descriptor, %dimension_descriptor* %310, i32 0, i32 1
-  %314 = load i64, i64* %313, align 8
-  %315 = add i64 %314, %312
-  %316 = sub i64 %315, 1
-  %317 = trunc i64 %316 to i32
-  store i32 %317, i32* %__do_loop_end1, align 4
-  %318 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %319 = getelementptr %array.1, %array.1* %318, i32 0, i32 8
-  %320 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %319, i32 0, i32 0
-  %321 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %320, i32 0
-  %322 = getelementptr %dimension_descriptor, %dimension_descriptor* %321, i32 0, i32 0
-  %323 = load i64, i64* %322, align 8
-  %324 = trunc i64 %323 to i32
-  %325 = sub i32 %324, 1
-  store i32 %325, i32* %__lcompilers_i_0, align 4
+  %308 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %309 = getelementptr %array.1, %array.1* %308, i32 0, i32 8
+  %310 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %309, i32 0, i32 0
+  %311 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %310, i32 0
+  %312 = getelementptr %dimension_descriptor, %dimension_descriptor* %311, i32 0, i32 0
+  %313 = load i64, i64* %312, align 8
+  %314 = getelementptr %dimension_descriptor, %dimension_descriptor* %311, i32 0, i32 1
+  %315 = load i64, i64* %314, align 8
+  %316 = add i64 %315, %313
+  %317 = sub i64 %316, 1
+  %318 = trunc i64 %317 to i32
+  store i32 %318, i32* %__do_loop_end1, align 4
+  %319 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %320 = getelementptr %array.1, %array.1* %319, i32 0, i32 8
+  %321 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %320, i32 0, i32 0
+  %322 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %321, i32 0
+  %323 = getelementptr %dimension_descriptor, %dimension_descriptor* %322, i32 0, i32 0
+  %324 = load i64, i64* %323, align 8
+  %325 = trunc i64 %324 to i32
+  %326 = sub i32 %325, 1
+  store i32 %326, i32* %__lcompilers_i_0, align 4
   br label %loop.head25
 
 loop.head25:                                      ; preds = %ifcont30, %then24
-  %326 = load i32, i32* %__lcompilers_i_0, align 4
-  %327 = add i32 %326, 1
-  %328 = load i32, i32* %__do_loop_end1, align 4
-  %329 = icmp sle i32 %327, %328
-  br i1 %329, label %loop.body26, label %loop.end31
+  %327 = load i32, i32* %__lcompilers_i_0, align 4
+  %328 = add i32 %327, 1
+  %329 = load i32, i32* %__do_loop_end1, align 4
+  %330 = icmp sle i32 %328, %329
+  br i1 %330, label %loop.body26, label %loop.end31
 
 loop.body26:                                      ; preds = %loop.head25
-  %330 = load i32, i32* %__lcompilers_i_0, align 4
-  %331 = add i32 %330, 1
-  store i32 %331, i32* %__lcompilers_i_0, align 4
-  %332 = load i32, i32* %__lcompilers_i_0, align 4
-  %333 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %334 = getelementptr %array.1, %array.1* %333, i32 0, i32 8
-  %335 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %334, i32 0, i32 0
-  %336 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %335, i32 0
-  %337 = getelementptr %dimension_descriptor, %dimension_descriptor* %336, i32 0, i32 0
-  %338 = load i64, i64* %337, align 8
-  %339 = getelementptr %dimension_descriptor, %dimension_descriptor* %336, i32 0, i32 1
-  %340 = load i64, i64* %339, align 8
-  %341 = sext i32 %332 to i64
-  %342 = sub i64 %341, %338
-  %343 = add i64 %338, %340
-  %344 = sub i64 %343, 1
-  %345 = icmp slt i64 %341, %338
-  %346 = icmp sgt i64 %341, %344
-  %347 = or i1 %345, %346
-  br i1 %347, label %then27, label %ifcont28
+  %331 = load i32, i32* %__lcompilers_i_0, align 4
+  %332 = add i32 %331, 1
+  store i32 %332, i32* %__lcompilers_i_0, align 4
+  %333 = load i32, i32* %__lcompilers_i_0, align 4
+  %334 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %335 = getelementptr %array.1, %array.1* %334, i32 0, i32 8
+  %336 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %335, i32 0, i32 0
+  %337 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %336, i32 0
+  %338 = getelementptr %dimension_descriptor, %dimension_descriptor* %337, i32 0, i32 0
+  %339 = load i64, i64* %338, align 8
+  %340 = getelementptr %dimension_descriptor, %dimension_descriptor* %337, i32 0, i32 1
+  %341 = load i64, i64* %340, align 8
+  %342 = sext i32 %333 to i64
+  %343 = sub i64 %342, %339
+  %344 = add i64 %339, %341
+  %345 = sub i64 %344, 1
+  %346 = icmp slt i64 %342, %339
+  %347 = icmp sgt i64 %342, %345
+  %348 = or i1 %346, %347
+  br i1 %348, label %then27, label %ifcont28
 
 then27:                                           ; preds = %loop.body26
-  %348 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %349 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %350 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %349, i32 0, i32 0
-  %351 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %350, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @13, i32 0, i32 0), i8** %351, align 8
-  %352 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %350, i32 0, i32 1
-  store i32 5, i32* %352, align 4
-  %353 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %350, i32 0, i32 2
-  store i32 8, i32* %353, align 4
-  %354 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %350, i32 0, i32 3
-  store i32 5, i32* %354, align 4
-  %355 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %350, i32 0, i32 4
-  store i32 14, i32* %355, align 4
-  %356 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
-  %357 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %348, i32 0, i32 0
-  %358 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %349, i32 0, i32 0
-  %359 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 0, i32 2
-  %360 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 0, i32 0
-  store i1 true, i1* %360, align 1
-  %361 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 0, i32 1
-  store i8* %356, i8** %361, align 8
-  store { i8*, i32, i32, i32, i32 }* %358, { i8*, i32, i32, i32, i32 }** %359, align 8
-  %362 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 0, i32 3
-  store i32 1, i32* %362, align 4
-  %363 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %348, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %363, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @12, i32 0, i32 0), i64 %341, i32 1, i64 %338, i64 %344)
+  %349 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %350 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %351 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
+  %352 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @13, i32 0, i32 0), i8** %352, align 8
+  %353 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 1
+  store i32 5, i32* %353, align 4
+  %354 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 2
+  store i32 8, i32* %354, align 4
+  %355 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 3
+  store i32 5, i32* %355, align 4
+  %356 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 4
+  store i32 14, i32* %356, align 4
+  %357 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
+  %358 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
+  %359 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
+  %360 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 2
+  %361 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 0
+  store i1 true, i1* %361, align 1
+  %362 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 1
+  store i8* %357, i8** %362, align 8
+  store { i8*, i32, i32, i32, i32 }* %359, { i8*, i32, i32, i32, i32 }** %360, align 8
+  %363 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 3
+  store i32 1, i32* %363, align 4
+  %364 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @12, i32 0, i32 0), i64 %342, i32 1, i64 %339, i64 %345)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %loop.body26
-  %364 = getelementptr %dimension_descriptor, %dimension_descriptor* %336, i32 0, i32 2
-  %365 = load i64, i64* %364, align 8
-  %366 = mul i64 %365, %342
-  %367 = add i64 0, %366
-  %368 = getelementptr %array.1, %array.1* %333, i32 0, i32 7
-  %369 = load i64, i64* %368, align 8
-  %370 = add i64 %367, %369
-  %371 = getelementptr %array.1, %array.1* %333, i32 0, i32 0
-  %372 = load double*, double** %371, align 8
-  %373 = getelementptr inbounds double, double* %372, i64 %370
-  %374 = load i32, i32* %__lcompilers_i_0, align 4
-  %375 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %376 = getelementptr %array.1, %array.1* %375, i32 0, i32 8
-  %377 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %376, i32 0, i32 0
-  %378 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %377, i32 0
-  %379 = getelementptr %dimension_descriptor, %dimension_descriptor* %378, i32 0, i32 0
-  %380 = load i64, i64* %379, align 8
-  %381 = getelementptr %dimension_descriptor, %dimension_descriptor* %378, i32 0, i32 1
-  %382 = load i64, i64* %381, align 8
-  %383 = sext i32 %374 to i64
-  %384 = sub i64 %383, %380
-  %385 = add i64 %380, %382
-  %386 = sub i64 %385, 1
-  %387 = icmp slt i64 %383, %380
-  %388 = icmp sgt i64 %383, %386
-  %389 = or i1 %387, %388
-  br i1 %389, label %then29, label %ifcont30
+  %365 = getelementptr %dimension_descriptor, %dimension_descriptor* %337, i32 0, i32 2
+  %366 = load i64, i64* %365, align 8
+  %367 = mul i64 %366, %343
+  %368 = add i64 0, %367
+  %369 = getelementptr %array.1, %array.1* %334, i32 0, i32 7
+  %370 = load i64, i64* %369, align 8
+  %371 = add i64 %368, %370
+  %372 = getelementptr %array.1, %array.1* %334, i32 0, i32 0
+  %373 = load double*, double** %372, align 8
+  %374 = getelementptr inbounds double, double* %373, i64 %371
+  %375 = load i32, i32* %__lcompilers_i_0, align 4
+  %376 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %377 = getelementptr %array.1, %array.1* %376, i32 0, i32 8
+  %378 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %377, i32 0, i32 0
+  %379 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %378, i32 0
+  %380 = getelementptr %dimension_descriptor, %dimension_descriptor* %379, i32 0, i32 0
+  %381 = load i64, i64* %380, align 8
+  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %379, i32 0, i32 1
+  %383 = load i64, i64* %382, align 8
+  %384 = sext i32 %375 to i64
+  %385 = sub i64 %384, %381
+  %386 = add i64 %381, %383
+  %387 = sub i64 %386, 1
+  %388 = icmp slt i64 %384, %381
+  %389 = icmp sgt i64 %384, %387
+  %390 = or i1 %388, %389
+  br i1 %390, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %390 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %391 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %392 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %391, i32 0, i32 0
-  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %392, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @17, i32 0, i32 0), i8** %393, align 8
-  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %392, i32 0, i32 1
-  store i32 5, i32* %394, align 4
-  %395 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %392, i32 0, i32 2
-  store i32 8, i32* %395, align 4
-  %396 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %392, i32 0, i32 3
-  store i32 5, i32* %396, align 4
-  %397 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %392, i32 0, i32 4
-  store i32 14, i32* %397, align 4
-  %398 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %399 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %390, i32 0, i32 0
-  %400 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %391, i32 0, i32 0
-  %401 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %399, i32 0, i32 2
-  %402 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %399, i32 0, i32 0
-  store i1 true, i1* %402, align 1
-  %403 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %399, i32 0, i32 1
-  store i8* %398, i8** %403, align 8
-  store { i8*, i32, i32, i32, i32 }* %400, { i8*, i32, i32, i32, i32 }** %401, align 8
-  %404 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %399, i32 0, i32 3
-  store i32 1, i32* %404, align 4
-  %405 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %390, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %405, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @16, i32 0, i32 0), i64 %383, i32 1, i64 %380, i64 %386)
+  %391 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
+  %392 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
+  %393 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %392, i32 0, i32 0
+  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %393, i32 0, i32 0
+  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @17, i32 0, i32 0), i8** %394, align 8
+  %395 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %393, i32 0, i32 1
+  store i32 5, i32* %395, align 4
+  %396 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %393, i32 0, i32 2
+  store i32 8, i32* %396, align 4
+  %397 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %393, i32 0, i32 3
+  store i32 5, i32* %397, align 4
+  %398 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %393, i32 0, i32 4
+  store i32 14, i32* %398, align 4
+  %399 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
+  %400 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %391, i32 0, i32 0
+  %401 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %392, i32 0, i32 0
+  %402 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %400, i32 0, i32 2
+  %403 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %400, i32 0, i32 0
+  store i1 true, i1* %403, align 1
+  %404 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %400, i32 0, i32 1
+  store i8* %399, i8** %404, align 8
+  store { i8*, i32, i32, i32, i32 }* %401, { i8*, i32, i32, i32, i32 }** %402, align 8
+  %405 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %400, i32 0, i32 3
+  store i32 1, i32* %405, align 4
+  %406 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %391, i32 0, i32 0
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %406, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @16, i32 0, i32 0), i64 %384, i32 1, i64 %381, i64 %387)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %406 = getelementptr %dimension_descriptor, %dimension_descriptor* %378, i32 0, i32 2
-  %407 = load i64, i64* %406, align 8
-  %408 = mul i64 %407, %384
-  %409 = add i64 0, %408
-  %410 = getelementptr %array.1, %array.1* %375, i32 0, i32 7
-  %411 = load i64, i64* %410, align 8
-  %412 = add i64 %409, %411
-  %413 = getelementptr %array.1, %array.1* %375, i32 0, i32 0
-  %414 = load double*, double** %413, align 8
-  %415 = getelementptr inbounds double, double* %414, i64 %412
-  %416 = load double, double* %415, align 8
-  store double %416, double* %373, align 8
+  %407 = getelementptr %dimension_descriptor, %dimension_descriptor* %379, i32 0, i32 2
+  %408 = load i64, i64* %407, align 8
+  %409 = mul i64 %408, %385
+  %410 = add i64 0, %409
+  %411 = getelementptr %array.1, %array.1* %376, i32 0, i32 7
+  %412 = load i64, i64* %411, align 8
+  %413 = add i64 %410, %412
+  %414 = getelementptr %array.1, %array.1* %376, i32 0, i32 0
+  %415 = load double*, double** %414, align 8
+  %416 = getelementptr inbounds double, double* %415, i64 %413
+  %417 = load double, double* %416, align 8
+  store double %417, double* %374, align 8
   br label %loop.head25
 
 loop.end31:                                       ; preds = %loop.head25
@@ -696,72 +698,72 @@ else32:                                           ; preds = %merge_allocated22
   br label %ifcont33
 
 ifcont33:                                         ; preds = %else32, %loop.end31
-  %417 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %418 = getelementptr %array.1, %array.1* %417, i32 0, i32 8
-  %419 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %418, i32 0, i32 0
-  %420 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %419, i32 0
-  %421 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 0
-  %422 = load i64, i64* %421, align 8
-  %423 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 2
-  %424 = load i64, i64* %423, align 8
-  %425 = icmp eq i64 %424, 1
-  %426 = and i1 true, %425
-  %427 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 0
-  %428 = load i64, i64* %427, align 8
-  %429 = getelementptr %dimension_descriptor, %dimension_descriptor* %420, i32 0, i32 1
-  %430 = load i64, i64* %429, align 8
-  %431 = add i64 %430, %428
-  %432 = sub i64 %431, 1
-  %433 = sub i64 %432, %422
-  %434 = add i64 %433, 1
-  %435 = mul i64 1, %434
-  %436 = ptrtoint %array.1* %417 to i64
-  %437 = icmp eq i64 %436, 0
-  br i1 %437, label %merge_allocated35, label %check_data34
+  %418 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
+  %419 = getelementptr %array.1, %array.1* %418, i32 0, i32 8
+  %420 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %419, i32 0, i32 0
+  %421 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %420, i32 0
+  %422 = getelementptr %dimension_descriptor, %dimension_descriptor* %421, i32 0, i32 0
+  %423 = load i64, i64* %422, align 8
+  %424 = getelementptr %dimension_descriptor, %dimension_descriptor* %421, i32 0, i32 2
+  %425 = load i64, i64* %424, align 8
+  %426 = icmp eq i64 %425, 1
+  %427 = and i1 true, %426
+  %428 = getelementptr %dimension_descriptor, %dimension_descriptor* %421, i32 0, i32 0
+  %429 = load i64, i64* %428, align 8
+  %430 = getelementptr %dimension_descriptor, %dimension_descriptor* %421, i32 0, i32 1
+  %431 = load i64, i64* %430, align 8
+  %432 = add i64 %431, %429
+  %433 = sub i64 %432, 1
+  %434 = sub i64 %433, %423
+  %435 = add i64 %434, 1
+  %436 = mul i64 1, %435
+  %437 = ptrtoint %array.1* %418 to i64
+  %438 = icmp eq i64 %437, 0
+  br i1 %438, label %merge_allocated35, label %check_data34
 
 check_data34:                                     ; preds = %ifcont33
-  %438 = getelementptr %array.1, %array.1* %417, i32 0, i32 0
-  %439 = load double*, double** %438, align 8
-  %440 = ptrtoint double* %439 to i64
-  %441 = icmp ne i64 %440, 0
+  %439 = getelementptr %array.1, %array.1* %418, i32 0, i32 0
+  %440 = load double*, double** %439, align 8
+  %441 = ptrtoint double* %440 to i64
+  %442 = icmp ne i64 %441, 0
   br label %merge_allocated35
 
 merge_allocated35:                                ; preds = %check_data34, %ifcont33
-  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %441, %check_data34 ]
-  %442 = xor i1 %is_allocated36, true
-  %443 = or i1 %426, %442
-  br i1 %443, label %then37, label %else38
+  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %442, %check_data34 ]
+  %443 = xor i1 %is_allocated36, true
+  %444 = or i1 %427, %443
+  br i1 %444, label %then37, label %else38
 
 then37:                                           ; preds = %merge_allocated35
-  %444 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %445 = getelementptr %array.1, %array.1* %444, i32 0, i32 0
-  store double* null, double** %445, align 8
+  %445 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %446 = getelementptr %array.1, %array.1* %445, i32 0, i32 0
+  store double* null, double** %446, align 8
   br label %ifcont45
 
 else38:                                           ; preds = %merge_allocated35
-  %446 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %447 = ptrtoint %array.1* %446 to i64
-  %448 = icmp eq i64 %447, 0
-  br i1 %448, label %merge_allocated40, label %check_data39
+  %447 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %448 = ptrtoint %array.1* %447 to i64
+  %449 = icmp eq i64 %448, 0
+  br i1 %449, label %merge_allocated40, label %check_data39
 
 check_data39:                                     ; preds = %else38
-  %449 = getelementptr %array.1, %array.1* %446, i32 0, i32 0
-  %450 = load double*, double** %449, align 8
-  %451 = ptrtoint double* %450 to i64
-  %452 = icmp ne i64 %451, 0
+  %450 = getelementptr %array.1, %array.1* %447, i32 0, i32 0
+  %451 = load double*, double** %450, align 8
+  %452 = ptrtoint double* %451 to i64
+  %453 = icmp ne i64 %452, 0
   br label %merge_allocated40
 
 merge_allocated40:                                ; preds = %check_data39, %else38
-  %is_allocated41 = phi i1 [ false, %else38 ], [ %452, %check_data39 ]
+  %is_allocated41 = phi i1 [ false, %else38 ], [ %453, %check_data39 ]
   br i1 %is_allocated41, label %then42, label %else43
 
 then42:                                           ; preds = %merge_allocated40
-  %453 = getelementptr %array.1, %array.1* %446, i32 0, i32 0
-  %454 = load double*, double** %453, align 8
-  %455 = bitcast double* %454 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %455)
-  %456 = getelementptr %array.1, %array.1* %446, i32 0, i32 0
-  store double* null, double** %456, align 8
+  %454 = getelementptr %array.1, %array.1* %447, i32 0, i32 0
+  %455 = load double*, double** %454, align 8
+  %456 = bitcast double* %455 to i8*
+  call void @_lfortran_free_alloc(i8* %0, i8* %456)
+  %457 = getelementptr %array.1, %array.1* %447, i32 0, i32 0
+  store double* null, double** %457, align 8
   br label %ifcont44
 
 else43:                                           ; preds = %merge_allocated40


### PR DESCRIPTION
When allocating an array via the simple CMO descriptor's malloc path, the dim 0..n-1 fields and offset were set, but the rank field was never written. For module-level allocatable arrays compiled with --separate-compilation, the descriptor lives in .bss (zero-initialized) and the rank therefore remained 0. Subsequent passes that walk over the array's elements (e.g. nullifying allocatable components of every element of a derived-type array) would then see size 1 instead of the real size, leaving later elements with garbage allocatable-component pointers. This manifested, for instance, as a runtime 'already allocated' error on the second allocate(d(2)%a(1)) when format processing left non-zero bytes in the heap region returned by malloc.

Set the rank explicitly in fill_malloc_array_details, mirroring what fill_array_details and fill_dimension_descriptor already do.

Adds integration test separate_compilation_49 that triggers the scenario via a write(*,'(4x)') format followed by allocation of a module-level allocatable array of derived type with allocatable components, called from a program that does not 'use' the module.