### PR TITLE
fix: handle copy of arrays offsets inside deepcopy for structs

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4096,7 +4096,6 @@ RUN(NAME struct_type_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME struct_type_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME struct_type_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME struct_type_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
-
 RUN(NAME struct_type_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME func_call_in_decl_01 LABELS gfortran llvm)
@@ -4104,6 +4103,7 @@ RUN(NAME func_parameter_type_02 LABELS gfortran) # function passed in other argu
 RUN(NAME logical_not_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME assign_allocatable_array_of_struct_instances LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME allocatable_component_struct_array_01 LABELS gfortran llvm)
+RUN(NAME allocatable_component_struct_array_02 LABELS gfortran llvm)
 RUN(NAME derived_component_section_01 LABELS gfortran llvm)
 RUN(NAME derived_component_section_02 LABELS gfortran llvm)
 RUN(NAME generic_interface_function_call_of_function_call LABELS gfortran llvm

--- a/integration_tests/allocatable_component_struct_array_02.f90
+++ b/integration_tests/allocatable_component_struct_array_02.f90
@@ -1,0 +1,181 @@
+program allocatable_component_struct_array_02
+  implicit none
+  integer, parameter :: dp=kind(0.d0), nslots=100, s=200, n=80, m=1000
+  type :: var_t
+    character(len=n) :: var_name=""
+    character(len=s) :: description=""
+    integer :: var_type=0
+    character(len=m) :: stored_data=""
+    real(dp), allocatable :: real_data(:)
+    character(len=s), allocatable :: char_data(:)
+  end type
+  type :: cfg_t
+    integer :: num_vars=0
+    type(var_t), allocatable :: vars(:)
+  end type
+  type(cfg_t) :: cfg
+
+  call init(cfg)
+  call test_copies1(cfg)
+
+  deallocate(cfg%vars(1)%real_data)
+  allocate(cfg%vars(1)%real_data(2))
+  cfg%vars(1)%real_data = [1.0_dp, 2.0_dp]
+  cfg%vars(2)%char_data(1) = "J."
+  cfg%vars(3)%char_data = [character(len=s) :: "H.J.", "Teunissen"]
+  cfg%vars(4)%char_data(1) = "another_file"
+  call test_copies2(cfg)
+
+contains
+
+  subroutine init(cfg)
+    type(cfg_t), intent(out) :: cfg
+    allocate(cfg%vars(nslots))
+    cfg%num_vars = 4
+    cfg%vars(1)%var_name = "author%fav_reals"
+    cfg%vars(1)%var_type = 2
+    allocate(cfg%vars(1)%real_data(3))
+    cfg%vars(1)%real_data = [1.337_dp, 13.37_dp, 133.7_dp]
+    cfg%vars(2)%var_name = "author_name%first"
+    cfg%vars(2)%var_type = 3
+    allocate(cfg%vars(2)%char_data(1))
+    cfg%vars(2)%char_data(1) = "jannis"
+    cfg%vars(3)%var_name = "author_name%full"
+    cfg%vars(3)%var_type = 3
+    allocate(cfg%vars(3)%char_data(2))
+    cfg%vars(3)%char_data = [character(len=s) :: "Jannis", "Teunissen"]
+    cfg%vars(4)%var_name = "filename"
+    cfg%vars(4)%var_type = 3
+    allocate(cfg%vars(4)%char_data(1))
+    cfg%vars(4)%char_data(1) = "this/is/a/filename"
+  end subroutine
+
+  subroutine test_copies1(cfg)
+    type(cfg_t), intent(in) :: cfg
+    type(cfg_t) :: dst
+
+    print *, "---- Copy-1 PRE-COPY ----"
+    print *, "first    = '", trim(cfg%vars(2)%char_data(1)), "'"
+    print *, "filename = '", trim(cfg%vars(4)%char_data(1)), "'"
+
+    dst = cfg
+
+    print *, "---- Copy-1 POST-COPY ----"
+    print *, "first    = '", trim(dst%vars(2)%char_data(1)), "'"
+    print *, "filename = '", trim(dst%vars(4)%char_data(1)), "'"
+
+    
+
+    ! one scalar field to confirm basic copy works
+    if (trim(dst%vars(1)%var_name) /= "author%fav_reals") then
+      print *, "FAIL copy1: vars(1)%var_name: ", trim(dst%vars(1)%var_name), "'"
+      error stop
+    end if
+
+    ! real_data: the allocatable array under test
+    if (.not. allocated(dst%vars(1)%real_data)) then
+      print *, "FAIL copy1: vars(1)%real_data not allocated"
+      error stop
+    end if
+    if (size(dst%vars(1)%real_data) /= 3) then
+      print *, "FAIL copy1: vars(1)%real_data size: ", size(dst%vars(1)%real_data)
+      error stop
+    end if
+    if (dst%vars(1)%real_data(1) /= 1.337_dp) then
+      print *, "FAIL copy1: vars(1)%real_data(1): ", dst%vars(1)%real_data(1)
+      error stop
+    end if
+    if (dst%vars(1)%real_data(2) /= 13.37_dp) then
+      print *, "FAIL copy1: vars(1)%real_data(2): ", dst%vars(1)%real_data(2)
+      error stop
+    end if
+    if (dst%vars(1)%real_data(3) /= 133.7_dp) then
+      print *, "FAIL copy1: vars(1)%real_data(3): ", dst%vars(1)%real_data(3)
+      error stop
+    end if
+
+    ! char_data: the allocatable array under test
+    if (.not. allocated(dst%vars(2)%char_data)) then
+      print *, "FAIL copy1: vars(2)%char_data not allocated"
+      error stop
+    end if
+    if (trim(dst%vars(2)%char_data(1)) /= "jannis") then
+      print *, "FAIL copy1: vars(2)%char_data(1): ", trim(dst%vars(2)%char_data(1))
+      error stop
+    end if
+    if (trim(dst%vars(3)%char_data(1)) /= "Jannis") then
+      print *, "FAIL copy1: vars(3)%char_data(1): ", trim(dst%vars(3)%char_data(1))
+      error stop
+    end if
+    if (trim(dst%vars(3)%char_data(2)) /= "Teunissen") then
+      print *, "FAIL copy1: vars(3)%char_data(2): ", trim(dst%vars(3)%char_data(2))
+      error stop
+    end if
+    if (trim(dst%vars(4)%char_data(1)) /= "this/is/a/filename") then
+      print *, "FAIL copy1: vars(4)%char_data(1): '", trim(dst%vars(4)%char_data(1))
+      error stop
+    end if
+
+    print *, "All Copy 1 Tests Passed"
+  end subroutine
+
+  subroutine test_copies2(cfg)
+    type(cfg_t), intent(in) :: cfg
+    type(cfg_t) :: dst
+
+    print *, "---- Copy-1 PRE-COPY ----"
+    print *, "first    = '", trim(cfg%vars(2)%char_data(1)), "'"
+    print *, "filename = '", trim(cfg%vars(4)%char_data(1)), "'"
+
+    dst = cfg
+
+    print *, "---- Copy-2 POST-COPY ----"
+    print *, "first    = '", trim(dst%vars(2)%char_data(1)), "'"
+    print *, "filename = '", trim(dst%vars(4)%char_data(1)), "'"
+
+    ! one scalar field to confirm basic copy works
+    if (trim(dst%vars(1)%var_name) /= "author%fav_reals") then
+      print *, "FAIL copy2: vars(1)%var_name: '", trim(dst%vars(1)%var_name)
+      error stop
+    end if
+
+    ! real_data
+    if (.not. allocated(dst%vars(1)%real_data)) then
+      print *, "FAIL copy2: vars(1)%real_data not allocated"
+      error stop
+    end if
+    if (size(dst%vars(1)%real_data) /= 2) then
+      print *, "FAIL copy2: vars(1)%real_data size: ", size(dst%vars(1)%real_data)
+      error stop
+    end if
+    if (dst%vars(1)%real_data(1) /= 1.0_dp) then
+      print *, "FAIL copy2: vars(1)%real_data(1): ", dst%vars(1)%real_data(1)
+      error stop
+    end if
+    if (dst%vars(1)%real_data(2) /= 2.0_dp) then
+      print *, "FAIL copy2: vars(1)%real_data(2): ", dst%vars(1)%real_data(2)
+      error stop
+    end if
+
+    ! char_data
+    if (trim(dst%vars(2)%char_data(1)) /= "J.") then
+      print *, "FAIL copy2: vars(2)%char_data(1): ", trim(dst%vars(2)%char_data(1))
+      error stop
+    end if
+    if (trim(dst%vars(3)%char_data(1)) /= "H.J.") then
+      print *, "FAIL copy2: vars(3)%char_data(1): ", trim(dst%vars(3)%char_data(1))
+      error stop
+    end if
+    if (trim(dst%vars(3)%char_data(2)) /= "Teunissen") then
+      print *, "FAIL copy2: vars(3)%char_data(2): ", trim(dst%vars(3)%char_data(2))
+      error stop
+    end if
+    if (trim(dst%vars(4)%char_data(1)) /= "another_file") then
+      print *, "FAIL copy2: vars(4)%char_data(1): ", trim(dst%vars(4)%char_data(1))
+      error stop
+    end if
+
+    print *, "All Copy 2 Tests Passed"
+  end subroutine
+
+end program allocatable_component_struct_array_02

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3683,18 +3683,9 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                             create_gep2(llvm_str_desc_type, dest_str_desc, 0));
                         builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(64, str_len)),
                             create_gep2(llvm_str_desc_type, dest_str_desc, 1));
-                        // Copy dimension descriptors
-                        llvm::DataLayout data_layout(module->getDataLayout());
-                        llvm::Value* src_dim_ptr = arr_api->get_pointer_to_dimension_descriptor_array(llvm_array_type, src, true);
-                        llvm::Value* dest_dim_ptr = arr_api->get_pointer_to_dimension_descriptor_array(llvm_array_type, dest, true);
-                        llvm::Value* n_dims = arr_api->get_rank(llvm_array_type, src, false);
-                        llvm::Type* dim_des = arr_api->get_dimension_descriptor_type(false);
-                        llvm::Value* total_dim_bytes = builder->CreateMul(
-                            builder->CreateSExtOrBitCast(n_dims, llvm::Type::getInt64Ty(context)),
-                            llvm::ConstantInt::get(context, llvm::APInt(64, data_layout.getTypeAllocSize(dim_des))));
-                        builder->CreateMemCpy(dest_dim_ptr, llvm::MaybeAlign(), src_dim_ptr, llvm::MaybeAlign(), total_dim_bytes);
-                        // Copy rank
-                        arr_api->set_rank(llvm_array_type, dest, n_dims);
+                        // Fill the array details for offset, rank, dim using existing function
+                        arr_api->fill_array_details(src_expr, src_expr, src, dest,
+                            alloc_type->m_type, alloc_type->m_type, module, true);
                     } else {
                         ensure_dest_array_descriptor();
                         deepcopy(src_expr, src, dest,


### PR DESCRIPTION
Towards #11144 
Fixes #11244

Issue: Current design didn't copy the array offset inside deepcopies of structs.
This caused arrays to have garbage-values.

fix: Instead of manually copying all the metadata, reuse the backend array api `fill_array_details`,
to handle the copy operation correctly, which handles offsets as well.