### PR TITLE
Fix pointer assoc to scalar component of allocatable struct array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2360,6 +2360,7 @@ RUN(NAME derived_types_134 LABELS gfortran llvm EXTRAFILES derived_types_134_mod
 RUN(NAME derived_types_135 LABELS gfortran llvm)
 RUN(NAME derived_types_136 LABELS gfortran llvm)
 RUN(NAME derived_types_137 LABELS gfortran llvm)
+RUN(NAME derived_types_138 LABELS gfortran llvm)
 RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 

--- a/integration_tests/derived_types_138.f90
+++ b/integration_tests/derived_types_138.f90
@@ -1,0 +1,31 @@
+program derived_types_138
+   implicit none
+   type :: element
+      integer :: data
+   end type
+   type :: variable
+      type(element), allocatable :: n(:)
+   end type
+   type(variable), target :: v
+   integer, pointer :: dd(:)
+   integer :: total
+
+   allocate(v%n(3))
+   v%n%data = [10, 20, 30]
+
+   dd => v%n%data
+   if (size(dd) /= 3) error stop "wrong size"
+   if (dd(1) /= 10) error stop "dd(1) wrong"
+   if (dd(2) /= 20) error stop "dd(2) wrong"
+   if (dd(3) /= 30) error stop "dd(3) wrong"
+
+   total = sum(dd)
+   if (total /= 60) error stop "wrong sum"
+
+   associate(aa => v%n%data)
+      if (size(aa) /= 3) error stop "associate size wrong"
+      if (sum(aa) /= 60) error stop "associate sum wrong"
+   end associate
+
+   print *, "OK"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8744,6 +8744,17 @@ public:
         llvm::Value* base_data_ptr = nullptr;
 
         if (base_ptype == ASR::array_physical_typeType::DescriptorArray) {
+            // If sim->m_v is itself a struct member access of an
+            // allocatable/pointer array (e.g. v%n where n is allocatable),
+            // the visited value is a pointer-to-pointer-to-descriptor
+            // because the array descriptor for an allocatable struct
+            // component is stored as a pointer inside the parent struct.
+            // Dereference once so base_array_desc is %descriptor*.
+            if (LLVM::is_llvm_pointer(*base_type) &&
+                ASR::is_a<ASR::StructInstanceMember_t>(*sim->m_v)) {
+                base_array_desc = llvm_utils->CreateLoad2(
+                    base_array_llvm_type->getPointerTo(), base_array_desc);
+            }
             base_data_ptr = arr_descr->get_pointer_to_data(
                 sim->m_v, base_struct_array_type, base_array_desc, module.get());
             base_data_ptr = llvm_utils->CreateLoad2(struct_llvm_type->getPointerTo(), base_data_ptr);


### PR DESCRIPTION
When a pointer is associated with the scalar component of an allocatable array of derived type held inside a struct (e.g. `dd => v%n%data` where `v%n` is an allocatable component), the LLVM codegen path in `handle_component_array_association` triggered an LCOMPILERS_ASSERT in `create_gep2` because the visited base value carried an extra level of indirection: the descriptor of an allocatable component is stored as a pointer inside the parent struct, so visiting it produced `%array**` rather than `%array*`.

Detect this case (sim->m_v is itself a StructInstanceMember of an allocatable/pointer array) and load the descriptor pointer once before calling `get_pointer_to_data` and `reset_array_details`.

Adds integration test `derived_types_138` covering pointer assignment and `associate` with a strided scalar component of an allocatable array of derived type.