### PR TITLE
Fixed visit_Array to reset _inside_array_physical_cast_type before visiting the element type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3260,6 +3260,7 @@ RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackA
 RUN(NAME nested_vars_02 LABELS gfortran llvm)
 RUN(NAME nested_vars_03 LABELS gfortran llvm)
 RUN(NAME nested_vars_04 LABELS gfortran llvm)
+RUN(NAME nested_vars_05 LABELS gfortran llvm)
 
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/nested_vars_05.f90
+++ b/integration_tests/nested_vars_05.f90
@@ -1,0 +1,27 @@
+module nested_vars_05_m
+  implicit none
+  type :: data_type
+    real, allocatable :: val(:,:)
+  end type
+contains
+  subroutine use_data(d, n)
+    type(data_type), dimension(:,:), intent(in) :: d
+    integer, intent(out) :: n
+    n = size(d, 1) + size(d, 2)
+  end subroutine
+end module
+
+program nested_vars_05
+  use nested_vars_05_m
+  implicit none
+  type(data_type), dimension(1,1) :: output
+  integer :: res
+  allocate(output(1,1)%val(1, 10))
+  call inner()
+  if (res /= 2) error stop
+  print *, "PASSED"
+contains
+  subroutine inner()
+    call use_data(output, res)
+  end subroutine
+end program

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1598,7 +1598,10 @@ public:
     void visit_Array(const Array_t& x) {
         require(!ASR::is_a<ASR::Allocatable_t>(*x.m_type),
             "Allocatable cannot be inside array");
+        bool _inside_array_physical_cast_type_copy = _inside_array_physical_cast_type;
+        _inside_array_physical_cast_type = false;
         visit_ttype(*x.m_type);
+        _inside_array_physical_cast_type = _inside_array_physical_cast_type_copy;
         if (x.m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
             require(x.n_dims == 0, "Assumed-rank arrays must have 0 dimensions");
             return ;


### PR DESCRIPTION
towards: https://github.com/lfortran/lfortran/issues/11248