### PR TITLE
fix: fix incorrect formatted write calculations

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1159,6 +1159,7 @@ RUN(NAME format_84 LABELS gfortran llvm)
 RUN(NAME format_85 LABELS gfortran llvm)
 RUN(NAME format_86 LABELS gfortran llvm)
 RUN(NAME format_87 LABELS gfortran llvm)
+RUN(NAME format_88 LABELS gfortran llvm fortran)
 
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)

--- a/integration_tests/format_88.f90
+++ b/integration_tests/format_88.f90
@@ -1,0 +1,19 @@
+program format_88
+    implicit none
+    character(len=30) :: wr
+    character(len=18) :: poison
+    character(len=10) :: hello_god
+    character(len=*), parameter :: expected = "                    Hello God!"
+
+    hello_god = "Hello God!"
+
+    write(poison, "(A)") "12345678901234567" // new_line("a")
+    print *, poison
+    write(wr, "(TR23, TL3, A)") hello_god
+    print *, wr, hello_god
+    if (wr /= expected) then
+        print *, "actual  = '", wr, "'"
+        print *, "expected = '", expected, "'"
+        error stop
+    end if
+end program format_88

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -2795,10 +2795,6 @@ static inline int64_t get_current_record_start(int64_t result_len, const char* r
     return i + 1;
 }
 
-static inline int64_t get_current_record_column(int64_t result_len, const char* result) {
-    return result_len - get_current_record_start(result_len, result) + 1;
-}
-
 static inline char* write_to_result_at_pos(lfortran_allocator_t* al,
         char* dest, int64_t* used_len, int64_t pos,
         const char* src, int64_t src_len) {
@@ -2994,8 +2990,13 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
                     // handle "TL" format specifier - move position left
                     int tab_left_pos = atoi(value + 2);
                     if (tab_left_pos > 0) {
-                        int64_t record_start = get_current_record_start(result_extent, result);
-                        int64_t current_col = get_current_record_column(result_len, result);
+                        // For cases with both TR and TL, for example, (TR5, TL3, A)
+                        // The issue is TR moves the cursor right, but it doesn't write spaces 
+                        // into buffer yet. Buffer is empty or has garbage values. 
+                        // So, instead of buffer, use current cursor value to know current column value
+                        int64_t search_pos = result_len > result_extent ? result_extent : result_len;
+                        int64_t record_start = get_current_record_start(search_pos, result);
+                        int64_t current_col = result_len - record_start + 1;
                         int64_t target_col = current_col - tab_left_pos;
                         if (target_col < 1) target_col = 1;
                         result_len = record_start + (target_col - 1);


### PR DESCRIPTION
fix for flaky `format_14` failure

Previous behavior: This solution is for cases with both TR(Row) and TL(Column) in write statements,
for example, (TR5, TL3, A).
The issue is TR moves the cursor right, but it doesn't write spaces into buffer yet.
So buffer might be empty. Previous logic used buffer contents to find the column value,
which can lead to reading incorrect/ garbage values, and wrong calculations of TL.
This made the formatting incorrect in the target variable.

So, instead of buffer, use current cursor value & use only the part
of the buffer which is already written to calculate the starting value for TL.
So, adding a guardrail check for the calculation of
starting position for TL parameter correctly.
