### PR TITLE
Fix shape() on pointer array inside derived type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3025,6 +3025,7 @@ RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 
 RUN(NAME derived_type_member_procedure_call_01 LABELS gfortran llvm)
 RUN(NAME derived_type_member_procedure_call_02 LABELS gfortran llvm)
+RUN(NAME derived_type_shape_pointer_01 LABELS gfortran llvm)
 
 RUN(NAME class_allocate_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME class_allocate_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_type_shape_pointer_01.f90
+++ b/integration_tests/derived_type_shape_pointer_01.f90
@@ -1,0 +1,17 @@
+program derived_type_shape_pointer_01
+    implicit none
+    type t
+        real, pointer :: a(:)
+    end type t
+    type(t) :: x
+    integer :: s(1)
+
+    allocate(x%a(3))
+    x%a = [1.0, 2.0, 3.0]
+
+    s = shape(x%a)
+    if (s(1) /= 3) error stop
+    print *, s(1)
+
+    deallocate(x%a)
+end program derived_type_shape_pointer_01

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1979,8 +1979,7 @@ namespace Shape {
                 new_args[0].m_value);
         } else {
             fill_func_arg("source", ASRUtils::duplicate_type_with_empty_dims(al,
-                ASRUtils::type_get_past_allocatable(
-                    ASRUtils::type_get_past_pointer(arg_types[0]))));
+                ASRUtils::type_get_past_pointer(arg_types[0])));
         }
         ASR::expr_t* result = nullptr;
         result = declare(fn_name, return_type, Out);

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -1979,7 +1979,8 @@ namespace Shape {
                 new_args[0].m_value);
         } else {
             fill_func_arg("source", ASRUtils::duplicate_type_with_empty_dims(al,
-                arg_types[0]));
+                ASRUtils::type_get_past_allocatable(
+                    ASRUtils::type_get_past_pointer(arg_types[0]))));
         }
         ASR::expr_t* result = nullptr;
         result = declare(fn_name, return_type, Out);


### PR DESCRIPTION
The shape() intrinsic failed with an LLVM verification error when called on a pointer array member of a derived type (e.g., shape(x%a) where a is declared as 'real, pointer :: a(:)'). The generated _lcompilers_shape function's formal parameter retained the Pointer type wrapper, causing a type mismatch at the call site.

Strip Pointer and Allocatable wrappers from the argument type in instantiate_Shape, consistent with how other intrinsics handle this.

An integration test is added.

Fixes #https://github.com/lfortran/lfortran/issues/11264.