### PR TITLE
cpp: support comments in #if expressions, implement #warning and #error

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3792,6 +3792,10 @@ RUN(NAME cpp_pre_15 LABELS gfortran llvm
     EXTRA_ARGS --cpp
     GFORTRAN_ARGS -cpp)
 
+RUN(NAME cpp_pre_16 LABELS gfortran llvm
+    EXTRA_ARGS --cpp
+    GFORTRAN_ARGS -cpp)
+
 RUN(NAME dabs_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME minpack_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/cpp_pre_16.f90
+++ b/integration_tests/cpp_pre_16.f90
@@ -1,0 +1,20 @@
+program cpp_pre_16
+    implicit none
+    integer :: x
+
+#if 1 /* taken */ || defined(__NOTDEFINED_MACRO__) /* not defined */
+    x = 42
+#else
+#error This branch must not be selected
+#endif
+
+#if 0 /* not taken */
+#error This #error must be ignored because branch is not taken
+#warning This #warning must be ignored because branch is not taken
+#endif
+
+# /* a CPP null directive with a C-style comment */
+
+    if (x /= 42) error stop
+    print *, x
+end program

--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -612,6 +612,30 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                 interval_end_type_0(lm, output.size(), cur-string_start);
                 continue;
             }
+            "#" whitespace? "warning" [ \t\v\r]* @t1 [^\n\x00]* @t2 newline {
+                if (!branch_enabled) continue;
+                std::string msg = token(t1, t2);
+                Location loc;
+                loc.first = tok - string_start;
+                loc.last = (cur > string_start ? cur - 1 : cur) - string_start;
+                diagnostics.add(diag::Diagnostic(
+                    "#warning " + msg, diag::Level::Warning,
+                    diag::Stage::CPreprocessor,
+                    { diag::Label("", {loc}) }));
+                interval_end_type_0(lm, output.size(), cur-string_start);
+                continue;
+            }
+            "#" whitespace? "error" [ \t\v\r]* @t1 [^\n\x00]* @t2 newline {
+                if (!branch_enabled) continue;
+                std::string msg = token(t1, t2);
+                Location loc;
+                loc.first = tok - string_start;
+                loc.last = (cur > string_start ? cur - 1 : cur) - string_start;
+                throw PreprocessorError(diag::Diagnostic(
+                    "#error " + msg, diag::Level::Error,
+                    diag::Stage::CPreprocessor,
+                    { diag::Label("", {loc}) }));
+            }
             "#" whitespace? "include" whitespace ["<] @t1 [^">\x00]* @t2 [">] [^\n\x00]* newline {
                 if (!branch_enabled) continue;
                 std::string filename = token(t1, t2);
@@ -996,6 +1020,8 @@ void get_next_token(unsigned char *string_start, unsigned char *&cur, CPPTokenTy
             end { type = CPPTokenType::TK_EOF; return; }
             newline { type = CPPTokenType::TK_EOF; return; }
             whitespace { continue; }
+            "//" [^\n\x00]* { continue; }
+            "/*" ([^*\x00] | "*"[^/\x00])* "*/" { continue; }
             "\\" whitespace? newline { continue; }
             "+" { type = CPPTokenType::TK_PLUS; return; }
             "-" { type = CPPTokenType::TK_MINUS; return; }


### PR DESCRIPTION
The C preprocessor expression tokenizer used by #if directives now skips C-style /* ... */ and C++ // ... comments so they can appear between operands, e.g.:

    #if FOO /* desc */ || defined(BAR) /* desc */

In addition, #warning and #error directives are now recognized and handled by the preprocessor:

  - #warning emits a Warning diagnostic with the user-provided message
  - #error emits an Error diagnostic with the user-provided message and aborts compilation

Both directives respect conditional compilation: they are ignored inside branches that are not taken.

Closes #11260