### PR TITLE
fix: use source expr type for assumed-rank array descriptor in visit_Assign

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -964,6 +964,7 @@ RUN(NAME select_rank_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_27 LABELS gfortran llvm)
 RUN(NAME select_rank_28 LABELS gfortran llvm)
 RUN(NAME select_rank_29 LABELS gfortran llvm)
+RUN(NAME select_rank_30 LABELS gfortran llvm)
 
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_rank_30.f90
+++ b/integration_tests/select_rank_30.f90
@@ -1,0 +1,28 @@
+program select_rank_30
+    implicit none
+    real, allocatable :: arr(:,:)
+    allocate(arr(3,4))
+    arr = 1.0
+    call assign_by_rank(arr)
+    if (abs(arr(1,1) - 2.0) > 1.0e-6) error stop
+    if (abs(arr(3,4) - 2.0) > 1.0e-6) error stop
+    print *, "PASS"
+contains
+    subroutine assign_by_rank(x)
+        real, intent(inout) :: x(..)
+        real, allocatable :: r(:)
+        integer :: n
+        n = size(x)
+        allocate(r(n))
+        r = 2.0
+        select rank(x)
+        rank(1)
+            x = r
+        rank(2)
+            x = reshape(r, shape(x))
+        rank default
+            error stop "unsupported rank"
+        end select
+        deallocate(r)
+    end subroutine
+end program select_rank_30

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11309,6 +11309,7 @@ public:
 
         llvm::Value *target, *value;
         uint32_t h;
+        ASR::expr_t* target_expr_for_type = x.m_target;
         if( x.m_target->type == ASR::exprType::ArrayPhysicalCast ) {
             ASR::ArrayPhysicalCast_t* apc = ASR::down_cast<ASR::ArrayPhysicalCast_t>(x.m_target);
             ASR::ttype_t* src_asr_type = ASRUtils::expr_type(apc->m_arg);
@@ -11332,6 +11333,9 @@ public:
                 this->visit_expr(*apc->m_arg);
                 is_assignment_target = false;
                 target = tmp;
+                if (apc->m_old == ASR::array_physical_typeType::AssumedRankArray) {
+                    target_expr_for_type = apc->m_arg;
+                }
             }
         } else if( x.m_target->type == ASR::exprType::ArrayItem ||
             x.m_target->type == ASR::exprType::StringItem ||
@@ -11751,8 +11755,9 @@ public:
                     llvm::Type* ptr_load_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, ASRUtils::type_get_past_allocatable_pointer(target_type), module.get());
                     target = llvm_utils->CreateLoad2(ptr_load_type->getPointerTo(), target);
                 }
-                llvm::Type* target_array_type = llvm_utils->get_type_from_ttype_t_util(x.m_target,
-                        ASRUtils::type_get_past_allocatable_pointer(target_type), module.get());
+                ASR::ttype_t* target_llvm_type_asr = ASRUtils::expr_type(target_expr_for_type);
+                llvm::Type* target_array_type = llvm_utils->get_type_from_ttype_t_util(target_expr_for_type,
+                        ASRUtils::type_get_past_allocatable_pointer(target_llvm_type_asr), module.get());
                 llvm::Type* source_array_type = llvm_utils->get_type_from_ttype_t_util(x.m_value,
                         ASRUtils::type_get_past_allocatable_pointer(value_type), module.get());
                 if (x.m_move_allocation) {


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/11266