### PR TITLE
fix: internal list-directed read for arrays 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3413,6 +3413,7 @@ RUN(NAME read_82 LABELS gfortran llvm)
 RUN(NAME read_83 LABELS gfortran llvm)
 RUN(NAME read_84 LABELS gfortran llvm)
 RUN(NAME read_85 LABELS gfortran llvm)
+RUN(NAME read_86 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_86.f90
+++ b/integration_tests/read_86.f90
@@ -1,0 +1,40 @@
+module read_86_mod
+implicit none
+integer, parameter :: dp = kind(1.0d0)
+contains
+
+subroutine read_vec_real(text, xx, nread)
+    character(len=*), intent(in) :: text
+    real(kind=dp), intent(out), allocatable :: xx(:)
+    integer, intent(out) :: nread
+    real(kind=dp), allocatable :: xread(:)
+    integer :: i, ierr, nread_, max_read_
+
+    max_read_ = 4
+    allocate(xread(max_read_))
+    nread_ = 0
+    do i = max_read_, 1, -1
+        read(text, *, iostat=ierr) xread(:i)
+        if (ierr == 0) then
+            nread_ = i
+            exit
+        end if
+    end do
+    nread = nread_
+    allocate(xx(nread_))
+    xx = xread(:nread_)
+    deallocate(xread)
+end subroutine read_vec_real
+
+end module read_86_mod
+
+program read_86
+use read_86_mod, only: read_vec_real, dp
+implicit none
+real(kind=dp), allocatable :: x(:)
+integer :: nread
+
+call read_vec_real("1.5 2.5 3.5", x, nread)
+if (nread /= 3) error stop
+if (any(abs(x - (/1.5_dp, 2.5_dp, 3.5_dp/)) > 1.0d-12)) error stop
+end program read_86

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -17630,7 +17630,8 @@ public:
                             }
                             llvm::Value* data_ptr = arr_data;
                             if (data_ptr->getType()->isPointerTy() &&
-                                data_ptr->getType()->getPointerElementType()->isStructTy()) {
+                                llvm::cast<llvm::PointerType>(data_ptr->getType())
+                                    ->getElementType()->isStructTy()) {
                                 llvm::Type* arr_type = llvm_utils->get_type_from_ttype_t_util(
                                     x.m_values[i],
                                     ASRUtils::type_get_past_allocatable_pointer(type),
@@ -17639,8 +17640,10 @@ public:
                                 data_ptr = llvm_utils->CreateLoad2(llvm_elem_type->getPointerTo(), data_ptr);
                             }
                             if (data_ptr->getType()->isPointerTy() &&
-                                data_ptr->getType()->getPointerElementType()->isArrayTy()) {
-                                llvm::Type* array_elem_type = data_ptr->getType()->getPointerElementType();
+                                llvm::cast<llvm::PointerType>(data_ptr->getType())
+                                    ->getElementType()->isArrayTy()) {
+                                llvm::Type* array_elem_type = llvm::cast<llvm::PointerType>(
+                                    data_ptr->getType())->getElementType();
                                 data_ptr = builder->CreateGEP(array_elem_type, data_ptr,
                                     { llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
                                       llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0) });

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -17629,22 +17629,21 @@ public:
                                     array_size, llvm::Type::getInt32Ty(context), true);
                             }
                             llvm::Value* data_ptr = arr_data;
-                            if (data_ptr->getType()->isPointerTy() &&
-                                llvm::cast<llvm::PointerType>(data_ptr->getType())
-                                    ->getElementType()->isStructTy()) {
+                            ASR::Array_t* arr_tp = ASR::down_cast<ASR::Array_t>(
+                                ASRUtils::type_get_past_allocatable_pointer(type));
+                            if (arr_tp->m_physical_type == ASR::array_physical_typeType::DescriptorArray) {
                                 llvm::Type* arr_type = llvm_utils->get_type_from_ttype_t_util(
                                     x.m_values[i],
                                     ASRUtils::type_get_past_allocatable_pointer(type),
                                     module.get());
                                 data_ptr = arr_descr->get_pointer_to_data(arr_type, arr_desc);
                                 data_ptr = llvm_utils->CreateLoad2(llvm_elem_type->getPointerTo(), data_ptr);
-                            }
-                            if (data_ptr->getType()->isPointerTy() &&
-                                llvm::cast<llvm::PointerType>(data_ptr->getType())
-                                    ->getElementType()->isArrayTy()) {
-                                llvm::Type* array_elem_type = llvm::cast<llvm::PointerType>(
-                                    data_ptr->getType())->getElementType();
-                                data_ptr = builder->CreateGEP(array_elem_type, data_ptr,
+                            } else if (arr_tp->m_physical_type == ASR::array_physical_typeType::FixedSizeArray) {
+                                llvm::Type* arr_type = llvm_utils->get_type_from_ttype_t_util(
+                                    x.m_values[i],
+                                    ASRUtils::type_get_past_allocatable_pointer(type),
+                                    module.get());
+                                data_ptr = builder->CreateGEP(arr_type, data_ptr,
                                     { llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
                                       llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0) });
                             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -17610,7 +17610,44 @@ public:
                             }
                             builder->CreateCall(fn, { str_src_data, str_src_len, fmt, arr_data, elem_len_llvm });
                         } else {
-                            builder->CreateCall(fn, { str_src_data, str_src_len, fmt, arr_data });
+                            ASR::ttype_t* elem_type = ASRUtils::type_get_past_array(
+                                ASRUtils::type_get_past_allocatable_pointer(type));
+                            llvm::Type* llvm_elem_type = llvm_utils->get_type_from_ttype_t_util(
+                                x.m_values[i], elem_type, module.get());
+                            llvm::Value* array_size = nullptr;
+                            if (ASRUtils::is_fixed_size_array(type)) {
+                                int64_t fixed_size = ASRUtils::get_fixed_size_of_array(type);
+                                array_size = llvm::ConstantInt::get(
+                                    llvm::Type::getInt32Ty(context), fixed_size);
+                            } else {
+                                llvm::Type* arr_type = llvm_utils->get_type_from_ttype_t_util(
+                                    x.m_values[i],
+                                    ASRUtils::type_get_past_allocatable_pointer(type),
+                                    module.get());
+                                array_size = arr_descr->get_array_size(arr_type, arr_desc, nullptr, 4);
+                                array_size = builder->CreateIntCast(
+                                    array_size, llvm::Type::getInt32Ty(context), true);
+                            }
+                            llvm::Value* data_ptr = arr_data;
+                            if (data_ptr->getType()->isPointerTy() &&
+                                data_ptr->getType()->getPointerElementType()->isStructTy()) {
+                                llvm::Type* arr_type = llvm_utils->get_type_from_ttype_t_util(
+                                    x.m_values[i],
+                                    ASRUtils::type_get_past_allocatable_pointer(type),
+                                    module.get());
+                                data_ptr = arr_descr->get_pointer_to_data(arr_type, arr_desc);
+                                data_ptr = llvm_utils->CreateLoad2(llvm_elem_type->getPointerTo(), data_ptr);
+                            }
+                            if (data_ptr->getType()->isPointerTy() &&
+                                data_ptr->getType()->getPointerElementType()->isArrayTy()) {
+                                llvm::Type* array_elem_type = data_ptr->getType()->getPointerElementType();
+                                data_ptr = builder->CreateGEP(array_elem_type, data_ptr,
+                                    { llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
+                                      llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0) });
+                            }
+                            emit_string_read_loop(elem_type, llvm_elem_type,
+                                data_ptr, array_size, str_src_data, str_src_len,
+                                iostat, str_offset, x.m_values[i]);
                         }
                     } else {
                         if (ASR::is_a<ASR::Allocatable_t>(*type) ||


### PR DESCRIPTION
Bug: internal list-directed reads into numeric arrays consumed the entire input string at once, so reads past the available values did not set iostat and left extra elements (e.g., a trailing zero), unlike GFortran.
Fix: route numeric array internal reads through the element-wise string reader with proper descriptor-to-data handling so [iostat] is raised at end-of-record and the read count is correct.
fixes #11261