### PR TITLE
fix: eoshift on multi-dim arrays preserves shape

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1740,6 +1740,7 @@ RUN(NAME intrinsics_453 LABELS gfortran llvm) # Lgt intrinsic as while loop cond
 RUN(NAME intrinsics_454 LABELS gfortran llvm) # all/any with array section and whole array
 RUN(NAME intrinsics_455 LABELS gfortran llvm) # intrinsic declaration scope isolation
 RUN(NAME intrinsics_456 LABELS gfortran llvm) # move_alloc preserves lower bounds
+RUN(NAME intrinsics_457 LABELS gfortran llvm) # eoshift on 2D array with dim
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_457.f90
+++ b/integration_tests/intrinsics_457.f90
@@ -1,0 +1,34 @@
+program intrinsics_457
+implicit none
+integer, parameter :: nrow = 3, ncol = 4
+integer :: b(nrow, ncol), r2(nrow, ncol), r3(nrow, ncol)
+integer :: expected1(nrow, ncol), expected2(nrow, ncol)
+integer :: i, j
+
+do j = 1, ncol
+    do i = 1, nrow
+        b(i, j) = i * 10 + j
+    end do
+end do
+
+! eoshift along dim=1: each column is shifted by 1, last row filled with 0
+r2 = eoshift(b, shift=1, dim=1)
+do j = 1, ncol
+    expected1(1, j) = 20 + j
+    expected1(2, j) = 30 + j
+    expected1(3, j) = 0
+end do
+if (any(r2 /= expected1)) error stop
+
+! eoshift along dim=2 with negative shift and explicit boundary
+r3 = eoshift(b, shift=-1, boundary=99, dim=2)
+do i = 1, nrow
+    expected2(i, 1) = 99
+    expected2(i, 2) = i * 10 + 1
+    expected2(i, 3) = i * 10 + 2
+    expected2(i, 4) = i * 10 + 3
+end do
+if (any(r3 /= expected2)) error stop
+
+print *, "ok"
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2744,15 +2744,12 @@ namespace Eoshift {
         extract_value(array_dims[0].m_length, array_dim);
         ASRUtils::require_impl(array_rank > 0, "The argument `array` in `eoshift` must be of rank > 0", array->base.loc, diag);
         ASRBuilder b(al, loc);
-        Vec<ASR::dimension_t> result_dims; result_dims.reserve(al, 1);
+        Vec<ASR::dimension_t> result_dims; result_dims.reserve(al, array_rank);
         int overload_id = 2;
-        if (!is_dim_present) {
-            result_dims.push_back(al, b.set_dim(array_dims[0].m_start, array_dims[0].m_length));
-            ret_type = ASRUtils::duplicate_type(al, ret_type, &result_dims);
-        } else {
-            result_dims.push_back(al, b.set_dim(dim, dim));
-            ret_type = ASRUtils::duplicate_type(al, ret_type, &result_dims);
+        for (int i = 0; i < array_rank; i++) {
+            result_dims.push_back(al, b.set_dim(array_dims[i].m_start, array_dims[i].m_length));
         }
+        ret_type = ASRUtils::duplicate_type(al, ret_type, &result_dims);
         if (is_type_allocatable) {
             ret_type = TYPE(ASRUtils::make_Allocatable_t_util(al, loc, ret_type));
         }
@@ -2772,8 +2769,11 @@ namespace Eoshift {
                 final_boundary = b.StringConstant("  ", boundary_type);
             }
         }
-        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 3);
+        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 4);
         m_args.push_back(al, array); m_args.push_back(al, shift); m_args.push_back(al, final_boundary);
+        if (is_dim_present) {
+            m_args.push_back(al, dim);
+        }
         ASR::expr_t *value = nullptr;
         if (all_args_evaluated(m_args)) {
             value = eval_Eoshift(al, loc, ret_type, m_args, diag);
@@ -2788,34 +2788,21 @@ namespace Eoshift {
             Vec<ASR::ttype_t*> &arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t> &m_args, int64_t /*overload_id*/,
             int index_kind) {
+        int shifting_dim = 1;
+        if (m_args.size() == 4) {
+            int64_t dim_val = -1;
+            if (ASRUtils::extract_value(m_args[3].m_value, dim_val)) {
+                shifting_dim = (int)dim_val;
+            }
+        }
         declare_basic_variables("_lcompilers_eoshift");
+        if (shifting_dim != 1) {
+            fn_name += "_dim" + std::to_string(shifting_dim);
+        }
         fill_func_arg("array", duplicate_type_with_empty_dims(al, arg_types[0]));
         fill_func_arg("shift", arg_types[1]);
         fill_func_arg("boundary", arg_types[2]);
         ASR::ttype_t* return_type_ = return_type;
-        /*
-            Eoshift(array, shift, boundary, dim)
-            int i = 0
-            do j = shift, size(array)
-                result[i] = array[j]
-                i = i + 1
-            end do
-            do j = 1, shift
-                result[i] = array[j]
-                i = i + 1
-            end do
-
-            if (shift >= 0) then
-                i = size(array) - shift + 1
-            else
-                i = 1
-            end if
-
-            do j = 1, shift
-                result(i) = boundary
-                i = i + 1
-            end do
-        */
         if( !ASRUtils::is_fixed_size_array(return_type) ) {
             bool is_allocatable = ASRUtils::is_allocatable(return_type);
             int n_dims = ASRUtils::extract_n_dims_from_ttype(return_type_);
@@ -2841,60 +2828,64 @@ namespace Eoshift {
         ASR::expr_t *j = declare("j", b.int_type(index_kind), Local);
         ASR::expr_t* abs_shift = declare("z", b.int_type(index_kind), Local);
         ASR::expr_t* abs_shift_val = declare("k", b.int_type(index_kind), Local);
-        ASR::expr_t* shift_val = declare("shift_val", b.int_type(index_kind), Local);;
-        ASR::expr_t* final_boundary = declare("final_boundary", character(2), Local);   //TODO: It does not handle character type
+        ASR::expr_t* shift_val = declare("shift_val", b.int_type(index_kind), Local);
         ASR::expr_t* boundary = args[2];
+
+        int n_dims = extract_n_dims_from_ttype(return_type);
+        std::vector<ASR::expr_t*> do_loop_variables;
+        for (int idx = 0; idx < n_dims - 1; idx++) {
+            ASR::expr_t* var = declare("i_" + std::to_string(idx), b.int_type(index_kind), Local);
+            do_loop_variables.push_back(var);
+        }
 
         body.push_back(al, b.Assignment(shift_val, args[1]));
         body.push_back(al, b.Assignment(abs_shift, shift_val));
         body.push_back(al, b.Assignment(abs_shift_val, shift_val));
 
         body.push_back(al, b.If(b.Lt(args[1], b.i_idx(0, index_kind)), {
-            b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], 1, index_kind))),
+            b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], shifting_dim, index_kind))),
             b.Assignment(abs_shift, b.Mul(abs_shift, b.i_idx(-1, index_kind)))
         }, {
             b.Assignment(shift_val, shift_val)
         }
         ));
-        body.push_back(al, b.Assignment(i, b.i_idx(1, index_kind)));
-        body.push_back(al, b.DoLoop(j, b.Add(shift_val, b.i_idx(1, index_kind)), b.GetUBound(args[0], 1, index_kind), {
-            b.Assignment(b.ArrayItem_01(result, {i}), b.ArrayItem_01(args[0], {j})),
-            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind))),
-        }, nullptr));
-        body.push_back(al, b.DoLoop(j, b.GetLBound(args[0], 1, index_kind), shift_val, {
-            b.Assignment(b.ArrayItem_01(result, {i}), b.ArrayItem_01(args[0], {j})),
-            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind))),
-        }, nullptr));
+        body.push_back(al, b.Assignment(i, b.GetLBound(args[0], shifting_dim, index_kind)));
+
+        ASR::stmt_t *do_loop_copy = PassUtils::create_do_loop_helper_cshift(al, loc,
+            do_loop_variables, j, i, args[0], result, 0, shifting_dim);
+
+        ASR::expr_t* lbound_s = b.GetLBound(args[0], shifting_dim, index_kind);
+        ASR::expr_t* shift_start = b.Add(lbound_s, shift_val);
+
+        body.push_back(al, b.DoLoop(j, shift_start, b.GetUBound(args[0], shifting_dim, index_kind),
+            {do_loop_copy, b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))}, nullptr));
+        body.push_back(al, b.DoLoop(j, lbound_s, b.Sub(shift_start, b.i_idx(1, index_kind)),
+            {do_loop_copy, b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))}, nullptr));
 
         body.push_back(al, b.If(b.GtE(abs_shift_val, b.i_idx(0, index_kind)), {
-            b.Assignment(i, b.GetUBound(args[0], 1, index_kind)),
+            b.Assignment(i, b.GetUBound(args[0], shifting_dim, index_kind)),
             b.Assignment(i, b.Sub(i, abs_shift)),
             b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
         }, {
-            b.Assignment(i, b.i_idx(1, index_kind))
+            b.Assignment(i, b.GetLBound(args[0], shifting_dim, index_kind))
         }
         ));
 
-        if(is_character(*expr_type(b.ArrayItem_01(args[0], {b.i_idx(1, index_kind)}))) && is_logical(*expr_type(args[2]))){
-            body.push_back(al, b.Assignment(final_boundary, b.StringConstant("  ", expr_type(b.ArrayItem_01(args[0], {b.i_idx(1, index_kind)})))));
-            body.push_back(al, b.DoLoop(j, b.i_idx(1, index_kind), abs_shift, {
-            b.Assignment(b.ArrayItem_01(result, {i}), final_boundary),
-            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind))),
-        }, nullptr));
+        ASR::stmt_t *do_loop_fill = PassUtils::create_do_loop_helper_eoshift_fill(al, loc,
+            do_loop_variables, i, boundary, args[0], result, 0, shifting_dim);
 
-        }
-        else{
-            body.push_back(al, b.DoLoop(j, b.i_idx(1, index_kind), abs_shift, {
-            b.Assignment(b.ArrayItem_01(result, {i}), boundary),
-            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind))),
-        }, nullptr));
-        }
+        body.push_back(al, b.DoLoop(j, b.i_idx(1, index_kind), abs_shift,
+            {do_loop_fill, b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))}, nullptr));
 
         body.push_back(al, b.Return());
         ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
                 body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, fn_sym);
-        return b.Call(fn_sym, m_args, return_type, nullptr);
+        Vec<ASR::call_arg_t> new_args; new_args.reserve(al, 3);
+        new_args.push_back(al, m_args[0]);
+        new_args.push_back(al, m_args[1]);
+        new_args.push_back(al, m_args[2]);
+        return b.Call(fn_sym, new_args, return_type, nullptr);
     }
 
 } // namespace Eoshift

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -827,6 +827,45 @@ namespace LCompilers {
             }, nullptr);
         }
 
+        ASR::stmt_t* create_do_loop_helper_eoshift_fill(Allocator &al, const Location &loc,
+                    std::vector<ASR::expr_t*> do_loop_variables, ASR::expr_t* res_var,
+                    ASR::expr_t* boundary, ASR::expr_t* array, ASR::expr_t* res,
+                    int curr_idx, int shifting_dim) {
+            ASRUtils::ASRBuilder b(al, loc);
+            if ( do_loop_variables.size() == 0 ) {
+                return b.Assignment(b.ArrayItem_01(res, {res_var}), boundary);
+            }
+            if (shifting_dim == 0) shifting_dim = 1;
+            int rank = (int)do_loop_variables.size() + 1;
+            int actual_dim = -1;
+            int count = 0;
+            for(int i=1; i<=rank; i++) {
+                if(i == shifting_dim) continue;
+                if(count == curr_idx) {
+                    actual_dim = i;
+                    break;
+                }
+                count++;
+            }
+
+            if (curr_idx == (int)do_loop_variables.size() - 1) {
+                std::vector<ASR::expr_t*> res_vars(rank);
+                res_vars[shifting_dim - 1] = res_var;
+                int k = 0;
+                for(int i=0; i<rank; i++) {
+                    if (i == shifting_dim - 1) continue;
+                    res_vars[i] = do_loop_variables[k];
+                    k++;
+                }
+                return b.DoLoop(do_loop_variables[curr_idx], b.GetLBound(array, actual_dim), b.GetUBound(array, actual_dim), {
+                    b.Assignment(b.ArrayItem_01(res, res_vars), boundary),
+                }, nullptr);
+            }
+            return b.DoLoop(do_loop_variables[curr_idx], b.GetLBound(array, actual_dim), b.GetUBound(array, actual_dim), {
+                create_do_loop_helper_eoshift_fill(al, loc, do_loop_variables, res_var, boundary, array, res, curr_idx + 1, shifting_dim)
+            }, nullptr);
+        }
+
         ASR::stmt_t* create_do_loop_helper_random_number(Allocator &al, const Location &loc, std::vector<ASR::expr_t*> do_loop_variables,
                     ASR::symbol_t* s, ASR::expr_t* arr, ASR::ttype_t* return_type, ASR::expr_t* arr_item, ASR::stmt_t* stmt, int curr_idx) {
             ASRUtils::ASRBuilder b(al, loc);

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -127,6 +127,11 @@ namespace LCompilers {
             ASR::expr_t* res_var, ASR::expr_t* array, ASR::expr_t* res, int curr_idx,
             int shifting_dim = 0);
 
+        ASR::stmt_t* create_do_loop_helper_eoshift_fill(Allocator &al, const Location &loc,
+            std::vector<ASR::expr_t*> do_loop_variables, ASR::expr_t* res_var,
+            ASR::expr_t* boundary, ASR::expr_t* array, ASR::expr_t* res, int curr_idx,
+            int shifting_dim = 0);
+
         ASR::stmt_t* create_do_loop_helper_count(Allocator &al, const Location &loc,
             std::vector<ASR::expr_t*> do_loop_variables, ASR::expr_t* mask, ASR::expr_t* res,
             int curr_idx);


### PR DESCRIPTION
eoshift returns an array of the same shape as the input array. Previously create_Eoshift always built a 1-D result type and instantiate_Eoshift only emitted a single-dimensional shift loop, so calls like 'eoshift(b, shift=1, dim=1)' on a 2-D array failed with 'Incompatible ranks' or produced wrong results.

Build the result type from all of the input array dimensions, pass the optional 'dim' argument through to instantiate_Eoshift, and generate nested loops over the non-shifting dimensions for both the cyclic copy phase and the boundary fill phase, mirroring the existing cshift implementation.

Fixes #11288.