### PR TITLE
Fix iostat for list-directed internal array read

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3417,7 +3417,7 @@ RUN(NAME read_82 LABELS gfortran llvm)
 RUN(NAME read_83 LABELS gfortran llvm)
 RUN(NAME read_84 LABELS gfortran llvm)
 RUN(NAME read_85 LABELS gfortran llvm)
-RUN(NAME read_86 LABELS gfortran llvm)
+RUN(NAME read_86 LABELS llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3417,6 +3417,7 @@ RUN(NAME read_82 LABELS gfortran llvm)
 RUN(NAME read_83 LABELS gfortran llvm)
 RUN(NAME read_84 LABELS gfortran llvm)
 RUN(NAME read_85 LABELS gfortran llvm)
+RUN(NAME read_86 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3417,7 +3417,7 @@ RUN(NAME read_82 LABELS gfortran llvm)
 RUN(NAME read_83 LABELS gfortran llvm)
 RUN(NAME read_84 LABELS gfortran llvm)
 RUN(NAME read_85 LABELS gfortran llvm)
-RUN(NAME read_86 LABELS llvm)
+RUN(NAME read_86 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_86.f90
+++ b/integration_tests/read_86.f90
@@ -1,0 +1,22 @@
+program read_86
+implicit none
+integer, parameter :: dp = kind(1.0d0)
+real(kind=dp) :: xread(4)
+integer :: i, ierr, nread_, max_read_
+character(len=*), parameter :: text = "1.5 2.5 3.5"
+
+max_read_ = 4
+nread_ = 0
+do i = max_read_, 1, -1
+    read(text, *, iostat=ierr) xread(:i)
+    if (ierr == 0) then
+        nread_ = i
+        exit
+    end if
+end do
+print *, "nread_ =", nread_
+if (nread_ /= 3) error stop
+if (abs(xread(1) - 1.5_dp) > 1.0e-12_dp) error stop
+if (abs(xread(2) - 2.5_dp) > 1.0e-12_dp) error stop
+if (abs(xread(3) - 3.5_dp) > 1.0e-12_dp) error stop
+end program

--- a/integration_tests/read_86.f90
+++ b/integration_tests/read_86.f90
@@ -3,7 +3,9 @@ implicit none
 integer, parameter :: dp = kind(1.0d0)
 real(kind=dp) :: xread(4)
 integer :: i, ierr, nread_, max_read_
-character(len=*), parameter :: text = "1.5 2.5 3.5"
+character(len=*), parameter :: text_param = "1.5 2.5 3.5"
+character(len=len(text_param)) :: text
+text = text_param
 
 max_read_ = 4
 nread_ = 0

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -17473,7 +17473,9 @@ public:
                                             x.m_values[i],
                                             ASRUtils::type_get_past_allocatable_pointer(type),
                                             module.get()
-                                        )->getPointerTo()
+                                        )->getPointerTo(),
+                                        llvm::Type::getInt64Ty(context) /*array_size*/,
+                                        llvm::Type::getInt32Ty(context)->getPointerTo() /*iostat*/
                                     },
                                     false);
                             }
@@ -17567,7 +17569,8 @@ public:
                                 }
                             }
                         }
-                        if (x.m_iostat) {
+                        if (x.m_iostat && ASRUtils::is_array_of_strings(type)) {
+                            // String array runtime does not return iostat; assume success.
                             int ptr_copy = ptr_loads;
                             ptr_loads = 0;
 
@@ -17603,7 +17606,19 @@ public:
                             }
                             builder->CreateCall(fn, { str_src_data, str_src_len, fmt, arr_data, elem_len_llvm });
                         } else {
-                            builder->CreateCall(fn, { str_src_data, str_src_len, fmt, arr_data });
+                            // Compute array size to detect EOF (fewer values than requested).
+                            ASR::ttype_t *type32_local = ASRUtils::TYPE(
+                                ASR::make_Integer_t(al, x.base.base.loc, 4));
+                            ASR::ArraySize_t* array_size_node =
+                                ASR::down_cast2<ASR::ArraySize_t>(ASR::make_ArraySize_t(
+                                    al, x.base.base.loc, x.m_values[i],
+                                    nullptr, type32_local, nullptr));
+                            visit_ArraySize(*array_size_node);
+                            llvm::Value* arr_size_i64 = builder->CreateIntCast(
+                                tmp, llvm::Type::getInt64Ty(context), true);
+                            tmp = nullptr;
+                            builder->CreateCall(fn, { str_src_data, str_src_len, fmt,
+                                arr_data, arr_size_i64, iostat });
                         }
                     } else {
                         if (ASR::is_a<ASR::Allocatable_t>(*type) ||

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -11930,13 +11930,13 @@ void lfortran_error(const char *message) {
 
 // TODO: add support for reading comma separated string, into `_arr` functions
 // by accepting array size as an argument as well
-LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *format, int32_t *arr) {
+LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *format, int32_t *arr, int64_t array_size, int32_t *iostat) {
     (void)format; // currently unused
     const char *pos = str;
     const char *end = str + len;
     char *next = NULL;
     int64_t count = 0;
-    while (pos < end) {
+    while (pos < end && count < array_size) {
         // Skip whitespace and common separators
         while (pos < end && (isspace((unsigned char)*pos) || *pos == ',')) {
             pos++;
@@ -11949,15 +11949,16 @@ LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *
         arr[count++] = (int32_t)value;
         pos = next;
     }
+    if (iostat) *iostat = (count < array_size) ? -1 : 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *format, int64_t *arr) {
-    (void)format; 
+LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *format, int64_t *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
     const char *pos = str;
     const char *end = str + len;
     char *next = NULL;
     int64_t count = 0;
-    while (pos < end) {
+    while (pos < end && count < array_size) {
         while (pos < end && (isspace((unsigned char)*pos) || *pos == ',')) {
             pos++;
         }
@@ -11969,17 +11970,18 @@ LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *
         arr[count++] = (int64_t)value;
         pos = next;
     }
+    if (iostat) *iostat = (count < array_size) ? -1 : 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *format, float *arr) {
-    (void)format; 
+LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *format, float *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
     char *buf = to_c_string((const fchar*)str, len);
     convert_fortran_d_exponent(buf);
     const char *pos = buf;
     const char *end = buf + len;
     char *next = NULL;
     int64_t count = 0;
-    while (pos < end) {
+    while (pos < end && count < array_size) {
         while (pos < end && (isspace((unsigned char)*pos) || *pos == ',')) {
             pos++;
         }
@@ -11992,17 +11994,18 @@ LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *
         pos = next;
     }
     internal_free(buf);
+    if (iostat) *iostat = (count < array_size) ? -1 : 0;
 }
 
-LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *format, double *arr) {
-    (void)format; 
+LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *format, double *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
     char *buf = to_c_string((const fchar*)str, len);
     convert_fortran_d_exponent(buf);
     const char *pos = buf;
     const char *end = buf + len;
     char *next = NULL;
     int64_t count = 0;
-    while (pos < end) {
+    while (pos < end && count < array_size) {
         while (pos < end && (isspace((unsigned char)*pos) || *pos == ',')) {
             pos++;
         }
@@ -12015,6 +12018,7 @@ LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *
         pos = next;
     }
     internal_free(buf);
+    if (iostat) *iostat = (count < array_size) ? -1 : 0;
 }
 
 LFORTRAN_API void _lfortran_string_read_str_array(char *str, int64_t len, char *format, char *arr, int64_t elem_len) {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -355,13 +355,13 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 LFORTRAN_API void _lfortran_string_read_i8(char *str, int64_t len, char *format, int8_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i16(char *str, int64_t len, char *format, int16_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);
-LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *format, int32_t *arr);
+LFORTRAN_API void _lfortran_string_read_i32_array(char *str, int64_t len, char *format, int32_t *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_i64(char *str, int64_t len, char *format, int64_t *i, int32_t *iostat, int64_t *offset);
-LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *format, int64_t *arr);
+LFORTRAN_API void _lfortran_string_read_i64_array(char *str, int64_t len, char *format, int64_t *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_f32(char *str, int64_t len, char *format, float *f, int32_t *iostat, int64_t *offset);
-LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *format, float *arr);
+LFORTRAN_API void _lfortran_string_read_f32_array(char *str, int64_t len, char *format, float *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_f64(char *str, int64_t len, char *format, double *f, int32_t *iostat, int64_t *offset);
-LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *format, double *arr);
+LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *format, double *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_str_array(char *str, int64_t len, char *format, char *arr, int64_t elem_len);
 LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);


### PR DESCRIPTION
When list-directed reading an array (or array section) from an internal character variable with fewer values than requested, lfortran erroneously returned iostat=0 and left trailing array elements zero-initialized. Fortran requires iostat to be non-zero (EOF) in this case so callers can detect the short input.

The numeric array runtime helpers (_lfortran_string_read_{i32,i64,f32,f64}_array) now take the array size and an iostat pointer, set iostat=-1 when the input string yields fewer values than the requested array size, and stop once the array is filled. The LLVM codegen passes the array size and iostat pointer, and no longer unconditionally stores 0 to iostat for numeric array internal reads (the unconditional zero-store is kept only for character-array internal reads, whose runtime helper does not yet return iostat).

Adds integration test integration_tests/read_86.f90 that exercises the shrinking array section pattern (read into xread(:i)) used by typical 'read as many values as possible' loops.

Fixes #11261.