### PR TITLE
Fix: null field handling in list-directed logical READ

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3422,6 +3422,7 @@ RUN(NAME read_83 LABELS gfortran llvm)
 RUN(NAME read_84 LABELS gfortran llvm)
 RUN(NAME read_85 LABELS gfortran llvm)
 RUN(NAME read_86 LABELS gfortran llvm)
+RUN(NAME read_87 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_87.f90
+++ b/integration_tests/read_87.f90
@@ -1,0 +1,32 @@
+program read_87
+    implicit none
+
+    character(4) :: s1
+    integer :: i1
+    logical :: l1
+    real :: r1
+    integer :: unit_no
+    character(20), parameter :: instring = "'TWO ', 2, , 2.0"
+
+    open (newunit=unit_no, status='scratch', form='formatted')
+    write (unit_no, '(a)') instring
+    rewind (unit_no)
+
+    s1 = 'nono'
+    i1 = -42
+    l1 = .false.
+    r1 = -42.42
+
+    read (unit_no, *) s1, i1, l1, r1
+    if (s1 /= 'TWO') error stop 1
+    if (i1 /= 2) error stop 2
+    if (l1) error stop 3
+    if (r1 /= 2.0) error stop 4
+
+    l1 = .true.
+    rewind (unit_no)
+    read (unit_no, *) s1, i1, l1, r1
+    if (.not. l1) error stop 5
+
+    close (unit_no)
+end program read_87

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -17725,11 +17725,18 @@ public:
                             // but the Fortran logical variable is wider (i8/i16/i32/i64).
                             // Use a temporary i1 alloca, call the function,
                             // then widen and store back.
-                            llvm::Value* tmp_bool = llvm_utils->CreateAlloca(*builder,
-                                llvm::Type::getInt1Ty(context));
-                            builder->CreateCall(fn, {tmp_bool, unit_val, iostat});
+                            // Initialize tmp_bool with the current value so that null
+                            // fields in list-directed I/O preserve the existing value.
                             int kind = ASRUtils::extract_kind_from_ttype_t(
                                 ASRUtils::type_get_past_allocatable_pointer(val_type));
+                            llvm::Value* tmp_bool = llvm_utils->CreateAlloca(*builder,
+                                llvm::Type::getInt1Ty(context));
+                            llvm::Value* cur_val = llvm_utils->CreateLoad2(
+                                llvm_utils->getIntType(kind), var_to_read_into);
+                            llvm::Value* cur_bool = builder->CreateTrunc(cur_val,
+                                llvm::Type::getInt1Ty(context));
+                            builder->CreateStore(cur_bool, tmp_bool);
+                            builder->CreateCall(fn, {tmp_bool, unit_val, iostat});
                             llvm::Value* loaded = llvm_utils->CreateLoad2(
                                 llvm::Type::getInt1Ty(context), tmp_bool);
                             llvm::Value* widened = builder->CreateZExt(loaded,

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -7706,16 +7706,11 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
         }
         
         if (c == ',') {
-            while ((c = fgetc(filep)) != EOF && isspace(c)) {
-            }
-            if (c == EOF) {
-                if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
-                fprintf(stderr, "Error: Invalid logical input from file (EOF).\n");
-                exit(1);
-            }
+            // Null field: two consecutive separators mean "keep current value"
+            return;
         }
         
-        if (c == ',' || c == '/') {
+        if (c == '/') {
             ungetc(c, filep);
             return;
         }


### PR DESCRIPTION
Fix null field handling in list-directed logical READ

In Fortran list-directed I/O, consecutive commas (e.g., ", ,") denote
a null field, meaning the variable should retain its current value.

Bug: _lfortran_read_logical incorrectly read past the null-field comma
and tried to parse the next field's value (e.g., "2.0") as a logical,
causing "Error: Invalid logical input '2.0'".

Fix (runtime): When the first non-whitespace character is a comma,
return immediately without modifying *p, matching the behavior of
_lfortran_read_float.

Fix (codegen): Initialize the temporary i1 alloca with the current
value of the logical variable before calling _lfortran_read_logical,
so null fields preserve the existing value instead of storing garbage
from an uninitialized alloca.


fixes #11298