### PR TITLE
fix: remove files opened with `STATUS=scratch` on normal program termination

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2854,6 +2854,7 @@ RUN(NAME file_65 LABELS gfortran llvm)
 RUN(NAME file_66 LABELS gfortran llvm)
 RUN(NAME file_67 LABELS gfortran llvm)
 RUN(NAME file_68 LABELS gfortran llvm)
+RUN(NAME file_69 LABELS gfortran llvm)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_close_02 LABELS gfortran llvm)

--- a/integration_tests/file_69.f90
+++ b/integration_tests/file_69.f90
@@ -1,0 +1,12 @@
+program file_69
+   implicit none
+
+   character(128) :: scr_fn
+   integer, parameter :: lun_scr = 42
+
+   open (lun_scr, status='scratch', form='formatted')
+   inquire (lun_scr, name=scr_fn)
+   print *, 'scratch filename = ', trim (scr_fn)
+   write (lun_scr, *) 'hello world!'
+
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5748,8 +5748,15 @@ void remove_from_unit_to_file(int32_t unit_num) {
 }
 
 static void _lfortran_close_all_units(void) {
+    const char *scratch_prefix = "_lfortran_generated_file";
+    const size_t scratch_prefix_len = 24; // strlen("_lfortran_generated_file")
     for (int i = 0; i <= last_index_used; i++) {
         if (unit_to_file[i].filename != NULL) {
+            // Delete scratch files at normal program termination
+            if (strncmp(unit_to_file[i].filename, scratch_prefix,
+                        scratch_prefix_len) == 0) {
+                remove(unit_to_file[i].filename);
+            }
             internal_free(unit_to_file[i].filename);
             unit_to_file[i].filename = NULL;
         }


### PR DESCRIPTION
Fixes #11299 
