### PR TITLE
fix: add support for complex return types for runtime polymorphic function calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -689,6 +689,7 @@ RUN(NAME functions_57 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME functions_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME functions_61 LABELS gfortran llvm fortran)
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_61.f90
+++ b/integration_tests/functions_61.f90
@@ -1,0 +1,39 @@
+module functions_61_mod
+    implicit none
+
+    type :: t
+        contains
+            procedure :: get_c_impl
+    end type t
+
+    contains
+    
+    function get_c_impl(this) result(v)
+        class(t), intent(in) :: this
+        complex :: v
+
+        v = cmplx(1.0, 2.0)
+    end function get_c_impl
+
+    subroutine get_c(this, val)
+        class(t), intent(in) :: this
+        complex, intent(out) :: val
+
+        val = this%get_c_impl()
+    end subroutine get_c
+
+end module functions_61_mod
+
+
+program functions_61
+    use functions_61_mod
+    implicit none
+
+    type(t) :: x
+    complex :: v
+
+    call get_c(x, v)
+
+    if (abs(real(v) - 1.0) > 1e-6 .or. abs(aimag(v) - 2.0) > 1e-6) error stop
+
+end program functions_61

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -25165,6 +25165,12 @@ public:
             vtable_ptr, struct_api->struct_vtab_function_offset[struct_sym][proc_sym_name]));
         fn = llvm_utils->CreateLoad2(fnPtrTy, fn);
         tmp = builder->CreateCall(fnTy, fn, args);
+        if (func->m_return_var) {
+            ASR::ttype_t* ret_ty = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
+            if (ASR::is_a<ASR::Complex_t>(*ret_ty)) {
+                tmp = llvm_utils->complex_function_return_abi_to_internal(tmp, ret_ty);
+            }
+        }
         return;
     }
 
@@ -25373,38 +25379,11 @@ public:
             }
         }
         // Convert complex return value from platform ABI to internal representation
-        {
+        if (s->m_return_var) {
             ASR::ttype_t *return_var_type0 = EXPR2VAR(s->m_return_var)->m_type;
             if (is_a<ASR::Complex_t>(*return_var_type0)) {
-                int a_kind = down_cast<ASR::Complex_t>(return_var_type0)->m_kind;
-                if (a_kind == 4) {
-                    if (compiler_options.platform == Platform::Windows) {
-                        // tmp is i64, have to convert to {float, float}
-
-                        // i64
-                        llvm::Type* type_fx2 = llvm::Type::getInt64Ty(context);
-                        // Convert i64 to i64*
-                        llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
-                        builder->CreateStore(tmp, p_fx2);
-                        // Convert i64* to {float,float}* using bitcast
-                        tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());
-                        // Convert {float,float}* to {float,float}
-                        tmp = llvm_utils->CreateLoad2(complex_type_4, tmp);
-                    } else if (compiler_options.platform == Platform::macOS_ARM) {
-                        // pass - already {float, float}
-                    } else {
-                        // tmp is <2 x float>, convert to {float, float}
-                        // <2 x float>
-                        llvm::Type* type_fx2 = FIXED_VECTOR_TYPE::get(llvm::Type::getFloatTy(context), 2);
-                        // Convert <2 x float> to <2 x float>*
-                        llvm::AllocaInst *p_fx2 = llvm_utils->CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
-                        builder->CreateStore(tmp, p_fx2);
-                        // Convert <2 x float>* to {float,float}* using bitcast
-                        tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());
-                        // Convert {float,float}* to {float,float}
-                        tmp = llvm_utils->CreateLoad2(complex_type_4, tmp);
-                    }
-                }
+                tmp = llvm_utils->complex_function_return_abi_to_internal(tmp,
+                    return_var_type0);
             }
         }
         if (ASRUtils::is_character(*x.m_type)) {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1432,6 +1432,41 @@ namespace LCompilers {
         return function_type;
     }
 
+    llvm::Value* LLVMUtils::complex_function_return_abi_to_internal(llvm::Value* tmp,
+            ASR::ttype_t* return_var_type0) {
+        LCOMPILERS_ASSERT(ASR::is_a<ASR::Complex_t>(*return_var_type0));
+        int a_kind = ASR::down_cast<ASR::Complex_t>(return_var_type0)->m_kind;
+        if (a_kind != 4) {
+            return tmp;
+        }
+        if (compiler_options.platform == Platform::Windows) {
+            // tmp is i64, have to convert to {float, float}
+            // i64
+            llvm::Type* type_fx2 = llvm::Type::getInt64Ty(context);
+            // Convert i64 to i64*
+            llvm::AllocaInst *p_fx2 = CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
+            builder->CreateStore(tmp, p_fx2);
+            // Convert i64* to {float,float}* using bitcast
+            tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());
+            // Convert {float,float}* to {float,float}
+            tmp = CreateLoad2(complex_type_4, tmp);
+        } else if (compiler_options.platform == Platform::macOS_ARM) {
+            // pass - already {float, float}
+        } else {
+            // tmp is <2 x float>, convert to {float, float}
+            // <2 x float>
+            llvm::Type* type_fx2 = FIXED_VECTOR_TYPE::get(llvm::Type::getFloatTy(context), 2);
+            // Convert <2 x float> to <2 x float>*
+            llvm::AllocaInst *p_fx2 = CreateAlloca(type_fx2, nullptr, "complex_ret_tmp");
+            builder->CreateStore(tmp, p_fx2);
+            // Convert <2 x float>* to {float,float}* using bitcast
+            tmp = builder->CreateBitCast(p_fx2, complex_type_4->getPointerTo());
+            // Convert {float,float}* to {float,float}
+            tmp = CreateLoad2(complex_type_4, tmp);
+        }
+        return tmp;
+    }
+
     std::vector<llvm::Type*> LLVMUtils::convert_args(ASR::Function_t* fn, ASR::FunctionType_t* x) {
         std::vector<llvm::Type*> args;
         for (size_t i=0; i < x->n_arg_types; i++) {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -779,6 +779,11 @@ class ASRToLLVMVisitor;
 
             llvm::FunctionType* get_function_type(const ASR::Function_t &x, llvm::Module* module);
 
+            // Convert complex return value from platform ABI to internal representation
+            // (\<2 x float\>, i64 on Windows, etc.) to the internal complex_4 struct.
+            llvm::Value* complex_function_return_abi_to_internal(llvm::Value* abi_val,
+                ASR::ttype_t* return_var_type0);
+
             std::vector<llvm::Type*> convert_args(const ASR::Function_t &x, llvm::Module* module);
 
             std::vector<llvm::Type*> convert_args(ASR::Function_t* fn, ASR::FunctionType_t* x);


### PR DESCRIPTION
Fixes #11193
Towards #11143
Alternate to #11194

Complex return types are represented using different formats in windows, linux, macos etc.
Previously, we had support for complex return types in normal functions, now this PR tries to extend the same for runtime function calls as well.

Changes made:
- implement a llvm util function `complex_function_return_abi_to_internal` which handles various ABI for complex types in different platforms, from existing logic inside visit_FunctionCall.