### PR TITLE
fix: add support for character reads into bool and complex arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3426,6 +3426,9 @@ RUN(NAME read_85 LABELS gfortran llvm)
 RUN(NAME read_86 LABELS gfortran llvm)
 RUN(NAME read_87 LABELS gfortran llvm)
 
+
+RUN(NAME read_90 LABELS gfortran llvm fortran)
+
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/read_90.f90
+++ b/integration_tests/read_90.f90
@@ -1,0 +1,34 @@
+! This MRE tests the following:
+! List-directed internal read from character into a whole logical array.
+! List-directed internal read from character into complex(kind=4 or kind=8) array.
+
+program read_90
+    implicit none
+    character(len=10) :: buf = ' T F T '
+    logical :: v(3)
+    character(len=30) :: buf1 = ' (1.0,2.0) (3.0,4.0) '
+    complex(kind=4) :: v1(2)
+
+    character(len=30) :: buf2 = ' (1.d0,2.d0) (3.d0,4.d0) '
+    complex(kind=8) :: v2(2)
+
+    ! Part-1: Logical array
+    read(buf, *) v
+    print *, v
+    if (v(1) .neqv. .true.) error stop
+    if (v(2) .neqv. .false.) error stop
+    if (v(3) .neqv. .true.) error stop
+
+    ! Part-2: Complex array
+    read(buf1, *) v1
+    read(buf2, *) v2
+    print *, v1
+    if (abs(v1(1) - (1.0,2.0)) > 1.0e-6) error stop
+    if (abs(v1(2) - (3.0,4.0)) > 1.0e-6) error stop
+    print *, v2
+    if (abs(v2(1) - (1.d0,2.d0)) > 1.0e-6) error stop
+    if (abs(v2(2) - (3.d0,4.d0)) > 1.0e-6) error stop
+
+    print *, "All tests passed"
+end program read_90
+  

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -12023,6 +12023,126 @@ LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *
     if (iostat) *iostat = (count < array_size) ? -1 : 0;
 }
 
+LFORTRAN_API void _lfortran_string_read_bool_array(char *str, int64_t len, char *format, int32_t *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
+    const char *pos = str;
+    const char *end = str + len;
+    int64_t count = 0;
+    while (pos < end && count < array_size) {
+        while (pos < end && (isspace((unsigned char)*pos) || *pos == ',')) {
+            pos++;
+        }
+        if ((pos >= end) || (*pos == '/')) {
+            break;
+        }
+        const char *tok_start = pos;
+        while (pos < end && *pos != ' ' && *pos != '\t' && *pos != '\n' &&
+                *pos != ',' && *pos != '/') {
+            pos++;
+        }
+        int token_len = (int)(pos - tok_start);
+        int32_t value = 0;
+        int ok = 0;
+        if (token_len > 0 && token_len < 16) {
+            char tok[16];
+            for (int j = 0; j < token_len; j++) {
+                tok[j] = (char)tolower((unsigned char)tok_start[j]);
+            }
+            tok[token_len] = '\0';
+            if (strcmp(tok, "t") == 0 || strcmp(tok, "true") == 0 ||
+                    strcmp(tok, ".t.") == 0 || strcmp(tok, ".true.") == 0 ||
+                    strcmp(tok, ".true") == 0) {
+                value = 1;
+                ok = 1;
+            } else if (strcmp(tok, "f") == 0 || strcmp(tok, "false") == 0 ||
+                    strcmp(tok, ".f.") == 0 || strcmp(tok, ".false.") == 0 ||
+                    strcmp(tok, ".false") == 0) {
+                value = 0;
+                ok = 1;
+            }
+        }
+        if (!ok) {
+            break;
+        }
+        arr[count++] = value;
+    }
+    if (iostat) {
+        *iostat = (count < array_size) ? -1 : 0;
+    }
+}
+
+LFORTRAN_API void _lfortran_string_read_c32_array(char *str, int64_t len, char *format,
+        struct _lfortran_complex_32 *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
+    int64_t off = 0;
+    int64_t count = 0;
+    const char *end = str + len;
+    while (count < array_size && off < len) {
+        const char *peek = str + off;
+        while (peek < end && (isspace((unsigned char)*peek) || *peek == ',')) {
+            peek++;
+        }
+        if ((peek >= end) || (*peek == '/')) {
+            break;
+        }
+        char *buf = to_c_string((const fchar*)(str + off), len - off);
+        _lfortran_replace_d_exponent(buf);
+        int skip = 0;
+        while (buf[skip]
+                && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) {
+            skip++;
+        }
+        int n = 0;
+        int rc = sscanf(buf + skip, " (%f,%f)%n",
+                &arr[count].re, &arr[count].im, &n);
+        internal_free(buf);
+        if (rc != 2) {
+            break;
+        }
+        off += skip + n;
+        count++;
+    }
+    if (iostat) {
+        *iostat = (count < array_size) ? -1 : 0;
+    }
+}
+
+LFORTRAN_API void _lfortran_string_read_c64_array(char *str, int64_t len, char *format,
+        struct _lfortran_complex_64 *arr, int64_t array_size, int32_t *iostat) {
+    (void)format;
+    int64_t off = 0;
+    int64_t count = 0;
+    const char *end = str + len;
+    while (count < array_size && off < len) {
+        const char *peek = str + off;
+        while (peek < end && (isspace((unsigned char)*peek) || *peek == ',')) {
+            peek++;
+        }
+        if ((peek >= end) || (*peek == '/')) {
+            break;
+        }
+        char *buf = to_c_string((const fchar*)(str + off), len - off);
+        _lfortran_replace_d_exponent(buf);
+        int skip = 0;
+        while (buf[skip]
+                && (buf[skip] == ' ' || buf[skip] == '\t' || buf[skip] == ',')) {
+            skip++;
+        }
+        int n = 0;
+        int rc = sscanf(buf + skip, " (%lf,%lf)%n",
+                &arr[count].re, &arr[count].im, &n);
+        internal_free(buf);
+        if (rc != 2) {
+            break;
+        }
+        off += skip + n;
+        count++;
+    }
+    if (iostat) {
+        *iostat = (count < array_size) ? -1 : 0;
+    }
+}
+
 LFORTRAN_API void _lfortran_string_read_str_array(char *str, int64_t len, char *format, char *arr, int64_t elem_len) {
     (void)format;
     const char *pos = str;

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -365,8 +365,11 @@ LFORTRAN_API void _lfortran_string_read_f64_array(char *str, int64_t len, char *
 LFORTRAN_API void _lfortran_string_read_str(char *src_data, int64_t src_len, char *dest_data, int64_t dest_len, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_str_array(char *str, int64_t len, char *format, char *arr, int64_t elem_len);
 LFORTRAN_API void _lfortran_string_read_bool(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);
+LFORTRAN_API void _lfortran_string_read_bool_array(char *str, int64_t len, char *format, int32_t *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_c32(char *str, int64_t len, char *format, struct _lfortran_complex_32 *c, int32_t *iostat, int64_t *offset);
+LFORTRAN_API void _lfortran_string_read_c32_array(char *str, int64_t len, char *format, struct _lfortran_complex_32 *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_read_c64(char *str, int64_t len, char *format, struct _lfortran_complex_64 *c, int32_t *iostat, int64_t *offset);
+LFORTRAN_API void _lfortran_string_read_c64_array(char *str, int64_t len, char *format, struct _lfortran_complex_64 *arr, int64_t array_size, int32_t *iostat);
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_t no_values);
 LFORTRAN_API void _lfortran_set_read_iomsg(int32_t iostat, char* iomsg, int64_t iomsg_len);
 LFORTRAN_API void _lfortran_file_seek(int32_t unit_num, int64_t pos, int32_t* iostat);


### PR DESCRIPTION
Fixes #11308
Towards #11143 

Changes made:
- add intrinsic functions `_lfortran_string_read_bool_array`, `_lfortran_string_read_c32_array`, `_lfortran_string_read_c64_array` which handle reads from strings into bool, complex-32 and complex-64 arrays, respectively.
- These follow the same pattern as we do handle for integer and float reads into arrays, for various dtypes.