### PR TITLE
fix: do not update variable dependencies for implicitly declared variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2088,6 +2088,7 @@ RUN(NAME implicit_typing_07 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_08 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME implicit_typing_10 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
+RUN(NAME implicit_typing_11 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_11.f90
+++ b/integration_tests/implicit_typing_11.f90
@@ -1,0 +1,47 @@
+subroutine c1 (IDIMY, Y)
+   integer idimy
+   DIMENSION       Y(IDIMY,*)
+   COMPLEX         Y
+
+   print *, Y(1:IDIMY, 1)
+   ! check that the values are correct
+   if (Y(1,1) /= (1.0, 1.0)) then
+      error stop "Error: Y(1,1) is not correct"
+   else if (Y(2,1) /= (2.0, 2.0)) then
+      error stop "Error: Y(2,1) is not correct"
+   else if (Y(3,1) /= (3.0, 3.0)) then
+      error stop "Error: Y(3,1) is not correct"
+   else
+      print *, "All values are correct"
+   end if
+
+END
+
+subroutine test()
+   implicit real(kind=8) (a-h,o-z), integer(kind=4) (i-n)
+   parameter ( a = 5.d0  )
+   parameter ( b = 2.d0  )
+   parameter ( c = a / b )
+
+   print *, "Value of c is:", c
+   if (abs(c - 2.5d0) > 1d-10) then
+      error stop "Error: c is not correct"
+   else
+      print *, "Value of c is correct"
+   end if
+end subroutine test
+
+
+
+program implicit_typing_10
+   integer idimy
+   parameter (idimy=3)
+   complex y(idimy,1)
+
+   y(1:IDIMY,1) = [(cmplx(i,i), i=1,idimy)]
+
+   call c1(idimy,y)
+   call test()
+
+end program
+

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8259,11 +8259,17 @@ public:
                             variable_added_to_symtab->m_type = type;
                         }
                     }
-                    SetChar variable_dependencies_vec;
-                    variable_dependencies_vec.reserve(al, 1);
-                    ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type, init_expr, value, sym);
-                    variable_added_to_symtab->m_dependencies = variable_dependencies_vec.p;
-                    variable_added_to_symtab->n_dependencies = variable_dependencies_vec.n;
+
+                    if (!is_implicitly_declared) {
+                        // An implicit dimension statement can declare array dimensions containing
+                        // variables, which are added to the dependencies. 
+                        // Collecting variable dependencies again overwrites them, so skip them.
+                        SetChar variable_dependencies_vec;
+                        variable_dependencies_vec.reserve(al, 1);
+                        ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type, init_expr, value, sym);
+                        variable_added_to_symtab->m_dependencies = variable_dependencies_vec.p;
+                        variable_added_to_symtab->n_dependencies = variable_dependencies_vec.n;
+                    }
 
                     if (ASR::is_a<ASR::StructType_t>(
                             *ASRUtils::extract_type(variable_added_to_symtab->m_type))

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2154,7 +2154,7 @@ public:
         }
         SetChar variable_dependencies_vec;
         variable_dependencies_vec.reserve(al, 1);
-        ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
+        ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type, nullptr, value);
         ASR::symbol_t *v = ASR::down_cast<ASR::symbol_t>(ASRUtils::make_Variable_t_util(al, loc,
             current_scope, s2c(al, var_name), variable_dependencies_vec.p,
             variable_dependencies_vec.size(), intent, value, value != nullptr ? ASRUtils::expr_value(value) : value,


### PR DESCRIPTION
Fixes #11318 Fixes #11426

* An implicit `dimension` statement can declare array dimensions containing variables, which are added to the dependencies already. Collecting variable dependencies again overwrites them.
* With `parameter` statement, we pass the value to collect the dependencies.