### PR TITLE
fix: load pointer value passed to `sign` intrinsic before use 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1741,6 +1741,7 @@ RUN(NAME intrinsics_454 LABELS gfortran llvm) # all/any with array section and w
 RUN(NAME intrinsics_455 LABELS gfortran llvm) # intrinsic declaration scope isolation
 RUN(NAME intrinsics_456 LABELS gfortran llvm) # move_alloc preserves lower bounds
 RUN(NAME intrinsics_457 LABELS gfortran llvm) # eoshift on 2D array with dim
+RUN(NAME intrinsics_458 LABELS gfortran llvm) # sign with common block variables
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_458.f90
+++ b/integration_tests/intrinsics_458.f90
@@ -1,0 +1,53 @@
+program intrinsics_458
+    implicit none
+    
+    real :: h, ha, res
+    double precision :: dh, dha, dres
+
+    COMMON /c1/  h, ha, res
+    COMMON /c2/  dh, dha, dres
+    
+    h = -3.0
+    ha = 5.0
+    res = sign(ha, h)
+    print *, "res: ", res
+    if (abs(res - (-5.0)) > 1e-6) error stop
+
+    h = 7.0
+    ha = 5.0
+    res = sign(ha, h)
+    print *, "res: ", res
+    if (abs(res - 5.0) > 1e-6) error stop
+
+    h = 4.0
+    ha = -2.0
+    res = sign(h, ha)
+    print *, "res: ", res
+    if (abs(res - (-4.0)) > 1e-6) error stop
+
+    h = -9.0
+    res = sign(h, h)
+    print *, "res: ", res
+    if (abs(res - (-9.0)) > 1e-6) error stop
+
+    h = 6.0
+    ha = -1.0
+    h = sign(ha, h)
+    print *, "h: ", h
+    if (abs(h - 1.0) > 1e-6) error stop
+
+    dh = -3.0d0
+    dha = 5.0d0
+    dres = sign(dha, dh)
+    print *, "dres: ", dres
+    if (abs(dres - (-5.0d0)) > 1d-12) error stop
+
+    dh = 7.0d0
+    dha = 5.0d0
+    dres = sign(dha, dh)
+    print *, "dres: ", dres
+    if (abs(dres - 5.0d0) > 1d-12) error stop
+
+    print *, "All tests passed."
+
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -14295,22 +14295,20 @@ public:
             this->visit_expr_wrapper(x.m_value, true);
             return;
         }
-        this->visit_expr(*x.m_target);
+        this->visit_expr_load_wrapper(x.m_target,
+            LLVM::is_llvm_pointer(*expr_type(x.m_target)) ? 2 : 1,
+            true);
         llvm::Value* target = tmp;
 
-        this->visit_expr(*x.m_source);
+        this->visit_expr_load_wrapper(x.m_source,
+            LLVM::is_llvm_pointer(*expr_type(x.m_source)) ? 2 : 1,
+            true);
         llvm::Value* source = tmp;
 
         llvm::Type *type;
         int a_kind;
         a_kind = down_cast<ASR::Real_t>(ASRUtils::type_get_past_pointer(x.m_type))->m_kind;
         type = llvm_utils->getFPType(a_kind);
-        if (ASR::is_a<ASR::ArrayItem_t>(*(x.m_target))) {
-            target = llvm_utils->CreateLoad2(type, target);
-        }
-        if (ASR::is_a<ASR::ArrayItem_t>(*(x.m_source))) {
-            source = llvm_utils->CreateLoad2(type, source);
-        }
         llvm::Value *ftarget = target;
         llvm::Value *fsource = source;
         if (ftarget->getType() != type) {


### PR DESCRIPTION
Fixes #11321

Previously, common block variables were passed as pointers causing error.