### PR TITLE
fix: ExternalSymbol resolution for struct-scoped symbols in deserialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4239,6 +4239,8 @@ RUN(NAME separate_compilation_class_star_01 LABELS gfortran llvm
     EXTRAFILES separate_compilation_class_star_01a.f90)
 RUN(NAME separate_compilation_class_star_02 LABELS gfortran llvm
     EXTRAFILES separate_compilation_class_star_02a.f90)
+RUN(NAME separate_compilation_class_star_03 LABELS gfortran llvm
+    EXTRAFILES separate_compilation_class_star_03a.f90)
 RUN(NAME class_star_pointer_01 LABELS gfortran llvm)
 
 RUN(NAME separate_compilation_14 LABELS gfortran llvm EXTRAFILES separate_compilation_14a.f90)

--- a/integration_tests/separate_compilation_class_star_03.f90
+++ b/integration_tests/separate_compilation_class_star_03.f90
@@ -1,0 +1,6 @@
+program separate_compilation_class_star_03
+    use separate_compilation_class_star_03_method
+    implicit none
+    type(method) :: m
+    print *, "ok"
+end program

--- a/integration_tests/separate_compilation_class_star_03a.f90
+++ b/integration_tests/separate_compilation_class_star_03a.f90
@@ -1,0 +1,35 @@
+module separate_compilation_class_star_03_base
+    implicit none
+    private
+    type, public :: arg_base
+        class(*), allocatable :: value
+    end type
+end module
+
+module separate_compilation_class_star_03_arg
+    use separate_compilation_class_star_03_base
+    implicit none
+    private
+    type, extends(arg_base), public :: arg
+    end type
+end module
+
+module separate_compilation_class_star_03_method
+    use separate_compilation_class_star_03_arg
+    implicit none
+    private
+    type, public :: method
+        type(arg), allocatable, public :: args(:)
+    contains
+        procedure :: invoke => invoke_impl
+    end type
+contains
+    subroutine invoke_impl(this)
+        class(method), intent(inout) :: this
+        if (allocated(this%args)) then
+            associate(a => this%args(1)%value)
+                ! use a
+            end associate
+        end if
+    end subroutine
+end module

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9437,20 +9437,30 @@ public:
                         throw SemanticAbort();
                     }
                 } else {
-                    SymbolTable *parent_scope = current_scope;
-                    current_scope = al.make_new<SymbolTable>(parent_scope);
-                    ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, current_scope,
-                                                    s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
-                                                    nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
-                                                    nullptr, 0, nullptr, nullptr, nullptr, 0);
-                    ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
-                    ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
-                    ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
-                    struct_->m_struct_signature = struct_type;
-                    struct_symbol = ASR::down_cast<ASR::symbol_t>((ASR::asr_t*)struct_);
-                    v = ASR::down_cast<ASR::symbol_t>(dtype);
-                    parent_scope->add_symbol(derived_type_name, v);
-                    current_scope = parent_scope;
+                    // Place ~unlimited_polymorphic_type at the module or
+                    // program scope so it is shared across all class(*)
+                    // declarations and survives module serialisation.
+                    SymbolTable *target_scope = current_scope;
+                    while (target_scope->parent != nullptr
+                           && target_scope->parent->parent != nullptr) {
+                        target_scope = target_scope->parent;
+                    }
+                    if (target_scope->get_symbol(derived_type_name) != nullptr) {
+                        // Reuse the existing symbol
+                        v = target_scope->get_symbol(derived_type_name);
+                    } else {
+                        SymbolTable *struct_symtab = al.make_new<SymbolTable>(target_scope);
+                        ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
+                                                        s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
+                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
+                                                        nullptr, 0, nullptr, nullptr, nullptr, 0);
+                        ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
+                        ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
+                        ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
+                        struct_->m_struct_signature = struct_type;
+                        v = ASR::down_cast<ASR::symbol_t>(dtype);
+                        target_scope->add_symbol(derived_type_name, v);
+                    }
                     // this is class variable declaration
                     // set the variable's type declaration to the derived type
                     type_declaration = v;

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -382,6 +382,38 @@ public:
         }
         return result;
     }
+    /**
+     * Searches for a struct (derived type) containing a specific member
+     * across all loaded modules.  Mirrors enum_in_symtab exactly, but
+     * for Struct symbols rather than Enum symbols.
+     */
+    ASR::symbol_t* struct_in_symtab(SymbolTable *symtab,
+                                    const std::string &struct_name,
+                                    const std::string &member_name) {
+        for (auto &sym : symtab->get_scope()) {
+            if (ASR::is_a<ASR::Module_t>(*sym.second)) {
+                ASR::symbol_t* struct_sym = ASR::down_cast<ASR::Module_t>(
+                    sym.second)->m_symtab->get_symbol(struct_name);
+                if (struct_sym && ASR::is_a<ASR::Struct_t>(*struct_sym)) {
+                    ASR::Struct_t* s = ASR::down_cast<ASR::Struct_t>(struct_sym);
+                    if (s->m_symtab->get_symbol(member_name)) {
+                        return struct_sym;
+                    }
+                }
+            }
+        }
+        return nullptr;
+    }
+    ASR::symbol_t* struct_in_module(const std::string &struct_name,
+                                    const std::string &member_name) {
+        ASR::symbol_t* result = struct_in_symtab(global_symtab,
+            struct_name, member_name);
+        if (!result && external_symtab != global_symtab) {
+            result = struct_in_symtab(external_symtab,
+                struct_name, member_name);
+        }
+        return result;
+    }
     void visit_ExternalSymbol(const ExternalSymbol_t &x) {
         if (x.m_external != nullptr) {
             // Nothing to do, the external symbol is already resolved
@@ -471,6 +503,18 @@ public:
             xx.m_external = enum_->m_symtab->get_symbol(x.m_original_name);;
             if(!xx.m_external) { 
                 throw LCompilersException("Enumerator variable : '"+ original_name +"' not found, but enum symtab found.");
+            }
+        } else if (ASR::symbol_t* struct_sym = struct_in_module(module_name, original_name)) {
+            ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(struct_sym);
+            symbol_t *sym = st->m_symtab->find_scoped_symbol(
+                original_name, x.n_scope_names, x.m_scope_names);
+            if (sym) {
+                ExternalSymbol_t &xx = const_cast<ExternalSymbol_t&>(x);
+                xx.m_external = sym;
+            } else {
+                throw LCompilersException("ExternalSymbol cannot be resolved, the symbol '"
+                    + original_name + "' was not found in the struct '"
+                    + module_name + "' (but the struct was found)");
             }
         } else {
             if( attempt <= 1 ) {

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -382,38 +382,6 @@ public:
         }
         return result;
     }
-    /**
-     * Searches for a struct (derived type) containing a specific member
-     * across all loaded modules.  Mirrors enum_in_symtab exactly, but
-     * for Struct symbols rather than Enum symbols.
-     */
-    ASR::symbol_t* struct_in_symtab(SymbolTable *symtab,
-                                    const std::string &struct_name,
-                                    const std::string &member_name) {
-        for (auto &sym : symtab->get_scope()) {
-            if (ASR::is_a<ASR::Module_t>(*sym.second)) {
-                ASR::symbol_t* struct_sym = ASR::down_cast<ASR::Module_t>(
-                    sym.second)->m_symtab->get_symbol(struct_name);
-                if (struct_sym && ASR::is_a<ASR::Struct_t>(*struct_sym)) {
-                    ASR::Struct_t* s = ASR::down_cast<ASR::Struct_t>(struct_sym);
-                    if (s->m_symtab->get_symbol(member_name)) {
-                        return struct_sym;
-                    }
-                }
-            }
-        }
-        return nullptr;
-    }
-    ASR::symbol_t* struct_in_module(const std::string &struct_name,
-                                    const std::string &member_name) {
-        ASR::symbol_t* result = struct_in_symtab(global_symtab,
-            struct_name, member_name);
-        if (!result && external_symtab != global_symtab) {
-            result = struct_in_symtab(external_symtab,
-                struct_name, member_name);
-        }
-        return result;
-    }
     void visit_ExternalSymbol(const ExternalSymbol_t &x) {
         if (x.m_external != nullptr) {
             // Nothing to do, the external symbol is already resolved
@@ -503,18 +471,6 @@ public:
             xx.m_external = enum_->m_symtab->get_symbol(x.m_original_name);;
             if(!xx.m_external) { 
                 throw LCompilersException("Enumerator variable : '"+ original_name +"' not found, but enum symtab found.");
-            }
-        } else if (ASR::symbol_t* struct_sym = struct_in_module(module_name, original_name)) {
-            ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(struct_sym);
-            symbol_t *sym = st->m_symtab->find_scoped_symbol(
-                original_name, x.n_scope_names, x.m_scope_names);
-            if (sym) {
-                ExternalSymbol_t &xx = const_cast<ExternalSymbol_t&>(x);
-                xx.m_external = sym;
-            } else {
-                throw LCompilersException("ExternalSymbol cannot be resolved, the symbol '"
-                    + original_name + "' was not found in the struct '"
-                    + module_name + "' (but the struct was found)");
             }
         } else {
             if( attempt <= 1 ) {

--- a/tests/reference/asr-derived_types_06-5ae916e.json
+++ b/tests/reference/asr-derived_types_06-5ae916e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-5ae916e.stdout",
-    "stdout_hash": "fd0ced1d06c4202a8ddc75f74b4b6840cdaaa1545c6b78ba424466f4",
+    "stdout_hash": "daf0d2870c0c7cf4b4001c99537d090f309c746535969d3364069d82",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-5ae916e.stdout
+++ b/tests/reference/asr-derived_types_06-5ae916e.stdout
@@ -42,32 +42,6 @@
                                                     0
                                                     []
                                                     .false.
-                                                ),
-                                            ~unlimited_polymorphic_type:
-                                                (Struct
-                                                    (SymbolTable
-                                                        4
-                                                        {
-                                                            
-                                                        })
-                                                    ~unlimited_polymorphic_type
-                                                    (StructType
-                                                        []
-                                                        []
-                                                        .false.
-                                                        .true.
-                                                    )
-                                                    []
-                                                    []
-                                                    []
-                                                    Source
-                                                    Public
-                                                    .false.
-                                                    .true.
-                                                    []
-                                                    ()
-                                                    ()
-                                                    []
                                                 )
                                         })
                                     subrout

--- a/tests/reference/asr-derived_types_06-5ae916e.stdout
+++ b/tests/reference/asr-derived_types_06-5ae916e.stdout
@@ -27,7 +27,7 @@
                                                         .false.
                                                         .true.
                                                     )
-                                                    3 ~unlimited_polymorphic_type
+                                                    2 ~unlimited_polymorphic_type
                                                     Source
                                                     Public
                                                     Required
@@ -98,6 +98,32 @@
                                     .true.
                                     .true.
                                     ()
+                                ),
+                            ~unlimited_polymorphic_type:
+                                (Struct
+                                    (SymbolTable
+                                        4
+                                        {
+                                            
+                                        })
+                                    ~unlimited_polymorphic_type
+                                    (StructType
+                                        []
+                                        []
+                                        .false.
+                                        .true.
+                                    )
+                                    []
+                                    []
+                                    []
+                                    Source
+                                    Public
+                                    .false.
+                                    .true.
+                                    []
+                                    ()
+                                    ()
+                                    []
                                 )
                         })
                     abstract_type

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_arguments_02-bb6f3e2.stdout",
-    "stdout_hash": "57aa93204270745ca54d8f6ee2e5fdce1cf8bfe312c15b7ce1e6d462",
+    "stdout_hash": "e712d54f44f491de2d1a9371dea5d6c36ec4d50d6fd92f5ecbba06b8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
@@ -203,32 +203,6 @@
                                                     0
                                                     []
                                                     .false.
-                                                ),
-                                            ~unlimited_polymorphic_type:
-                                                (Struct
-                                                    (SymbolTable
-                                                        4
-                                                        {
-                                                            
-                                                        })
-                                                    ~unlimited_polymorphic_type
-                                                    (StructType
-                                                        []
-                                                        []
-                                                        .false.
-                                                        .true.
-                                                    )
-                                                    []
-                                                    []
-                                                    []
-                                                    Source
-                                                    Public
-                                                    .false.
-                                                    .true.
-                                                    []
-                                                    ()
-                                                    ()
-                                                    []
                                                 )
                                         })
                                     str_scalar

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
@@ -162,7 +162,7 @@
                                                         .false.
                                                         .true.
                                                     )
-                                                    3 ~unlimited_polymorphic_type
+                                                    2 ~unlimited_polymorphic_type
                                                     Source
                                                     Public
                                                     Required
@@ -265,6 +265,32 @@
                                     .true.
                                     .true.
                                     ()
+                                ),
+                            ~unlimited_polymorphic_type:
+                                (Struct
+                                    (SymbolTable
+                                        4
+                                        {
+                                            
+                                        })
+                                    ~unlimited_polymorphic_type
+                                    (StructType
+                                        []
+                                        []
+                                        .false.
+                                        .true.
+                                    )
+                                    []
+                                    []
+                                    []
+                                    Source
+                                    Public
+                                    .false.
+                                    .true.
+                                    []
+                                    ()
+                                    ()
+                                    []
                                 )
                         })
                     polymorphic_argument_02

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_in_derived_type-15eb7b6.stdout",
-    "stdout_hash": "6c66928c6f9b9a580b402232509ce3c0bf14818a78369175b24e8bef",
+    "stdout_hash": "0f675a6c2bdc77a7e8a1b05236c0e8da7068cef0ba267d6dc2f64ecc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
@@ -29,7 +29,7 @@
                                                             .true.
                                                         )
                                                     )
-                                                    3 ~unlimited_polymorphic_type
+                                                    2 ~unlimited_polymorphic_type
                                                     Source
                                                     Public
                                                     Required
@@ -62,7 +62,7 @@
                                                             .true.
                                                         )
                                                     )
-                                                    3 ~unlimited_polymorphic_type
+                                                    2 ~unlimited_polymorphic_type
                                                     Source
                                                     Public
                                                     Required
@@ -135,6 +135,32 @@
                                     Public
                                     .false.
                                     .false.
+                                    []
+                                    ()
+                                    ()
+                                    []
+                                ),
+                            ~unlimited_polymorphic_type:
+                                (Struct
+                                    (SymbolTable
+                                        4
+                                        {
+                                            
+                                        })
+                                    ~unlimited_polymorphic_type
+                                    (StructType
+                                        []
+                                        []
+                                        .false.
+                                        .true.
+                                    )
+                                    []
+                                    []
+                                    []
+                                    Source
+                                    Public
+                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
@@ -77,32 +77,6 @@
                                                     0
                                                     []
                                                     .false.
-                                                ),
-                                            ~unlimited_polymorphic_type:
-                                                (Struct
-                                                    (SymbolTable
-                                                        4
-                                                        {
-                                                            
-                                                        })
-                                                    ~unlimited_polymorphic_type
-                                                    (StructType
-                                                        []
-                                                        []
-                                                        .false.
-                                                        .true.
-                                                    )
-                                                    []
-                                                    []
-                                                    []
-                                                    Source
-                                                    Public
-                                                    .false.
-                                                    .true.
-                                                    []
-                                                    ()
-                                                    ()
-                                                    []
                                                 )
                                         })
                                     dict_item


### PR DESCRIPTION
fixes #11332
fix: create unlimited polymorphic type in global module/program scope

Previously, the `~unlimited_polymorphic_type` struct for `class(*)`
was always created in the current scope, which could incorrectly place
it inside nested scopes such as `arg_base`.

This change updates `ast_common_visitor.h` to:
- Walk up the scope chain to locate the top-level Module or Program scope
- Reuse an existing `~unlimited_polymorphic_type` if already present
- Create the struct only once in the global scope otherwise

This ensures unlimited polymorphic type symbols are stored consistently
and are accessible across nested scopes.
