### PR TITLE
Fix type-bound operator resolution with shared interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2131,6 +2131,7 @@ RUN(NAME operator_overloading_35 LABELS gfortran llvm EXTRAFILES
     operator_overloading_35_mod.f90)
 RUN(NAME operator_overloading_36 LABELS gfortran llvm_submodule EXTRAFILES
     operator_overloading_36_mod_base.f90 operator_overloading_36_mod_base_sub.f90)
+RUN(NAME operator_overloading_37 LABELS gfortran llvm)
 
 RUN(NAME custom_unary_operator_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_unary_operator_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/operator_overloading_37.f90
+++ b/integration_tests/operator_overloading_37.f90
@@ -1,0 +1,94 @@
+module operator_overloading_37_mod
+   implicit none
+   type, abstract :: base
+   contains
+      procedure(binop), deferred :: add
+      procedure(binop), deferred :: sub
+      generic :: operator(+) => add
+      generic :: operator(-) => sub
+   end type base
+
+   type, extends(base) :: mytype
+      real :: val
+   contains
+      procedure :: add => my_add
+      procedure :: sub => my_sub
+   end type mytype
+
+   abstract interface
+      function binop(a, b) result(r)
+         import :: base
+         class(base), intent(in) :: a, b
+         class(base), allocatable :: r
+      end function binop
+   end interface
+
+contains
+
+   function my_add(a, b) result(r)
+      class(mytype), intent(in) :: a
+      class(base), intent(in) :: b
+      class(base), allocatable :: r
+      select type (b)
+      type is (mytype)
+         allocate(mytype :: r)
+         select type (r)
+         type is (mytype)
+            r%val = a%val + b%val
+         end select
+      end select
+   end function my_add
+
+   function my_sub(a, b) result(r)
+      class(mytype), intent(in) :: a
+      class(base), intent(in) :: b
+      class(base), allocatable :: r
+      select type (b)
+      type is (mytype)
+         allocate(mytype :: r)
+         select type (r)
+         type is (mytype)
+            r%val = a%val - b%val
+         end select
+      end select
+   end function my_sub
+
+end module operator_overloading_37_mod
+
+program operator_overloading_37
+   use operator_overloading_37_mod
+   implicit none
+   class(base), allocatable :: a, b, tmp, res
+
+   allocate(mytype :: a)
+   select type (a)
+   type is (mytype)
+      a%val = 0.0
+   end select
+
+   allocate(tmp, source = (a - a))
+
+   select type (tmp)
+   type is (mytype)
+      allocate(b, source = tmp)
+      tmp%val = 1.0
+   end select
+
+   allocate(res, source = (b + tmp))
+
+   select type (res)
+   type is (mytype)
+      print *, "res =", res%val
+      if (abs(res%val - 1.0) > 1.0e-6) error stop "FAIL: expected 1.0"
+   end select
+
+   ! Also verify subtraction still works
+   deallocate(res)
+   allocate(res, source = (tmp - b))
+
+   select type (res)
+   type is (mytype)
+      print *, "res =", res%val
+      if (abs(res%val - 1.0) > 1.0e-6) error stop "FAIL: expected 1.0 from sub"
+   end select
+end program operator_overloading_37

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3169,9 +3169,8 @@ ASR::symbol_t* import_class_procedure(Allocator &al, const Location& loc,
         (ASR::is_a<ASR::Variable_t>(*original_sym) &&
          ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_pointer(ASRUtils::symbol_type(original_sym))))) ) {
         std::string class_proc_name;
-        // StructMethodDeclaration name might be same if the procedure is overridden, use proc_name instead
         if (ASR::is_a<ASR::StructMethodDeclaration_t>(*original_sym)) {
-            class_proc_name = std::string(ASR::down_cast<ASR::StructMethodDeclaration_t>(original_sym)->m_proc_name);
+            class_proc_name = std::string(ASR::down_cast<ASR::StructMethodDeclaration_t>(original_sym)->m_name);
         } else {
             class_proc_name = ASRUtils::symbol_name(original_sym);
         }

--- a/tests/reference/asr-class_01-704dee8.json
+++ b/tests/reference/asr-class_01-704dee8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_01-704dee8.stdout",
-    "stdout_hash": "a5c09625ebd707882a15352ff9a813e79115e97fc93b7f6894c015f4",
+    "stdout_hash": "75ed68b98ce3f2c5f097e5eb955fa7df54507ebf06567ea501ffe540",
     "stderr": "asr-class_01-704dee8.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/asr-class_01-704dee8.stdout
+++ b/tests/reference/asr-class_01-704dee8.stdout
@@ -7,10 +7,10 @@
                     (SymbolTable
                         6
                         {
-                            1_circle_circle_print:
+                            1_circle_print:
                                 (ExternalSymbol
                                     6
-                                    1_circle_circle_print
+                                    1_circle_print
                                     3 print
                                     circle
                                     []
@@ -90,7 +90,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        6 1_circle_circle_print
+                        6 1_circle_print
                         ()
                         [((Var 6 c))]
                         (Var 6 c)
@@ -112,7 +112,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        6 1_circle_circle_print
+                        6 1_circle_print
                         ()
                         [((Var 6 c))]
                         (Var 6 c)
@@ -321,10 +321,10 @@
                                     (SymbolTable
                                         5
                                         {
-                                            1_circle_circle_area:
+                                            1_circle_area:
                                                 (ExternalSymbol
                                                     5
-                                                    1_circle_circle_area
+                                                    1_circle_area
                                                     3 area
                                                     circle
                                                     []
@@ -420,7 +420,7 @@
                                     [(Assignment
                                         (Var 5 area)
                                         (FunctionCall
-                                            5 1_circle_circle_area
+                                            5 1_circle_area
                                             ()
                                             [((Var 5 this))]
                                             (Real 4)

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "4cc72a1553bda5416695d5885d17d1751d79f0b07c80f238469c44b1",
+    "stdout_hash": "34e10ca98ed5547e71d6f7d12b798002c5f3ab2933c90eaf237323e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -216,10 +216,10 @@
                                     (SymbolTable
                                         8
                                         {
-                                            1_toml_date_date_to_string:
+                                            1_toml_date_to_string:
                                                 (ExternalSymbol
                                                     8
-                                                    1_toml_date_date_to_string
+                                                    1_toml_date_to_string
                                                     4 to_string
                                                     toml_date
                                                     []
@@ -246,10 +246,10 @@
                                                     time
                                                     Public
                                                 ),
-                                            1_toml_time_time_to_string:
+                                            1_toml_time_to_string:
                                                 (ExternalSymbol
                                                     8
-                                                    1_toml_time_time_to_string
+                                                    1_toml_time_to_string
                                                     3 to_string
                                                     toml_time
                                                     []
@@ -448,7 +448,7 @@
                                             ()
                                         )
                                         [(SubroutineCall
-                                            8 1_toml_date_date_to_string
+                                            8 1_toml_date_to_string
                                             ()
                                             [((Var 8 lhs))
                                             ((StructInstanceMember
@@ -513,7 +513,7 @@
                                                 ()
                                             )
                                             [(SubroutineCall
-                                                8 1_toml_time_time_to_string
+                                                8 1_toml_time_to_string
                                                 ()
                                                 [((Var 8 temporary))
                                                 ((StructInstanceMember

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "a3d22d03c1748f0e36a093fdafae20e08ce513af0be7f5db343b1890",
+    "stdout_hash": "59bfecbb09e36ea19e8740574918cb97cf5971d1d4084642885c795a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -216,10 +216,10 @@
                                     (SymbolTable
                                         12
                                         {
-                                            1_toml_date_date_to_string:
+                                            1_toml_date_to_string:
                                                 (ExternalSymbol
                                                     12
-                                                    1_toml_date_date_to_string
+                                                    1_toml_date_to_string
                                                     8 to_string
                                                     toml_date
                                                     []
@@ -246,10 +246,10 @@
                                                     time
                                                     Public
                                                 ),
-                                            1_toml_time_time_to_string:
+                                            1_toml_time_to_string:
                                                 (ExternalSymbol
                                                     12
-                                                    1_toml_time_time_to_string
+                                                    1_toml_time_to_string
                                                     10 to_string
                                                     toml_time
                                                     []
@@ -448,7 +448,7 @@
                                             ()
                                         )
                                         [(SubroutineCall
-                                            12 1_toml_date_date_to_string
+                                            12 1_toml_date_to_string
                                             ()
                                             [((Var 12 lhs))
                                             ((StructInstanceMember
@@ -513,7 +513,7 @@
                                                 ()
                                             )
                                             [(SubroutineCall
-                                                12 1_toml_time_time_to_string
+                                                12 1_toml_time_to_string
                                                 ()
                                                 [((Var 12 temporary))
                                                 ((StructInstanceMember

--- a/tests/reference/asr-derived_types_08-3680946.json
+++ b/tests/reference/asr-derived_types_08-3680946.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_08-3680946.stdout",
-    "stdout_hash": "145a852647c0262f19a1db516aa3bc87abb16440b15ed1ea1bafe9db",
+    "stdout_hash": "af064333675c5a244973f6d1ce81d6a43eaf6e1170d411605b88eb3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_08-3680946.stdout
+++ b/tests/reference/asr-derived_types_08-3680946.stdout
@@ -47,10 +47,10 @@
                                     filled
                                     Public
                                 ),
-                            1_shape_initialize_subrout:
+                            1_shape_initialize:
                                 (ExternalSymbol
                                     6
-                                    1_shape_initialize_subrout
+                                    1_shape_initialize
                                     3 initialize
                                     shape
                                     []
@@ -173,7 +173,7 @@
                     derived_types_08
                     [shape_mod]
                     [(SubroutineCall
-                        6 1_shape_initialize_subrout
+                        6 1_shape_initialize
                         ()
                         [((Var 6 shp))
                         ((IntegerConstant 1 (Integer 4) Decimal))
@@ -187,7 +187,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        6 1_shape_initialize_subrout
+                        6 1_shape_initialize
                         ()
                         [((Var 6 rect))
                         ((IntegerConstant 2 (Integer 4) Decimal))

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.json
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nested_struct_proc_01-3b9017b.stdout",
-    "stdout_hash": "f5909962d95f4d4f22a096c737b90e1e2ced7f811cf525d291c262d7",
+    "stdout_hash": "14f2322064a085af43a01045184874862e7562c6fd6525d499f7d025",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
@@ -592,10 +592,10 @@
                                                     map
                                                     Public
                                                 ),
-                                            1_omap_map_omap_i_at_rc:
+                                            1_omap_map_at_rc:
                                                 (ExternalSymbol
                                                     11
-                                                    1_omap_map_omap_i_at_rc
+                                                    1_omap_map_at_rc
                                                     8 at_rc
                                                     omap_map
                                                     []
@@ -849,7 +849,7 @@
                                     (Associate
                                         (Var 11 tmp)
                                         (FunctionCall
-                                            11 1_omap_map_omap_i_at_rc
+                                            11 1_omap_map_at_rc
                                             ()
                                             [((StructInstanceMember
                                                 (Var 11 this)
@@ -1262,10 +1262,10 @@
                                     insert
                                     Private
                                 ),
-                            1_integer32complex32orderedmap_omap_insert_key_value:
+                            1_integer32complex32orderedmap_insert_key_value:
                                 (ExternalSymbol
                                     12
-                                    1_integer32complex32orderedmap_omap_insert_key_value
+                                    1_integer32complex32orderedmap_insert_key_value
                                     9 insert_key_value
                                     integer32complex32orderedmap
                                     []
@@ -1843,7 +1843,7 @@
                         .false.
                     )
                     (SubroutineCall
-                        12 1_integer32complex32orderedmap_omap_insert_key_value
+                        12 1_integer32complex32orderedmap_insert_key_value
                         12 1_insert
                         [((Var 12 my_map))
                         ((Var 12 key))

--- a/tests/reference/asr-submodule_04-987b68b.json
+++ b/tests/reference/asr-submodule_04-987b68b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_04-987b68b.stdout",
-    "stdout_hash": "15c0c8d1004504189678ff3db1a29823447f6ec8e6f06ae90fc48261",
+    "stdout_hash": "0167e46bdc539ac45e496cbee751b7dd5e5e3eb55bf28c5435ca317b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_04-987b68b.stdout
+++ b/tests/reference/asr-submodule_04-987b68b.stdout
@@ -289,10 +289,10 @@
                     (SymbolTable
                         7
                         {
-                            1_open_hashmap_type_map_open_entry:
+                            1_open_hashmap_type_map_entry:
                                 (ExternalSymbol
                                     7
-                                    1_open_hashmap_type_map_open_entry
+                                    1_open_hashmap_type_map_entry
                                     3 map_entry
                                     open_hashmap_type
                                     []
@@ -366,7 +366,7 @@
                     submodule_04
                     [mod_submodule_04]
                     [(SubroutineCall
-                        7 1_open_hashmap_type_map_open_entry
+                        7 1_open_hashmap_type_map_entry
                         ()
                         [((Var 7 map))
                         ((Var 7 key))]

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "ee27b08c5561e1f5161d7c69a136018b434b9605429c3a63c8da8da5",
+    "stdout_hash": "a8a61335ec83538a50e71726f1a36175c40f101fd3e49db00990e205",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -48,16 +48,6 @@
                                     (SymbolTable
                                         7
                                         {
-                                            1_intvector___asr_push_back:
-                                                (ExternalSymbol
-                                                    7
-                                                    1_intvector___asr_push_back
-                                                    8 push_back
-                                                    intvector
-                                                    []
-                                                    push_back
-                                                    Public
-                                                ),
                                             1_intvector_elements:
                                                 (ExternalSymbol
                                                     7
@@ -66,6 +56,16 @@
                                                     intvector
                                                     []
                                                     elements
+                                                    Public
+                                                ),
+                                            1_intvector_push_back:
+                                                (ExternalSymbol
+                                                    7
+                                                    1_intvector_push_back
+                                                    8 push_back
+                                                    intvector
+                                                    []
+                                                    push_back
                                                     Public
                                                 ),
                                             __asr_push_back:
@@ -782,7 +782,7 @@
                                     []
                                     []
                                     [(SubroutineCall
-                                        7 1_intvector___asr_push_back
+                                        7 1_intvector_push_back
                                         ()
                                         [((Var 7 v))
                                         ((IntegerConstant 10 (Integer 4) Decimal))]


### PR DESCRIPTION
When multiple type-bound operators (e.g., operator(+) and operator(-)) shared the same abstract interface name (e.g., 'binop'), the import_class_procedure function generated the same ExternalSymbol name for both (e.g., '1_base_binop'). This caused the second operator to reuse the first's symbol, calling the wrong procedure at runtime.

Fix: use the StructMethodDeclaration's m_name (the unique binding name, e.g., 'add' or 'sub') instead of m_proc_name (the interface name) when constructing the imported symbol name.

An integration test is added to verify both operator(+) and operator(-) produce correct results on polymorphic variables.

Fixes #11334.