### PR TITLE
fix: ICE on alternate-return args with --implicit-interface

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2071,6 +2071,7 @@ RUN(NAME implicit_interface_34 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_35 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 RUN(NAME implicit_interface_36 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_37 LABELS gfortran llvm EXTRA_ARGS --implicit-interface --legacy-array-sections)
+RUN(NAME implicit_interface_38 LABELS gfortran llvm EXTRA_ARGS --implicit-interface EXTRAFILES implicit_interface_38b.f90)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_38.f90
+++ b/integration_tests/implicit_interface_38.f90
@@ -1,0 +1,13 @@
+program implicit_interface_38
+  implicit none
+
+  call sub(*10, *20)
+  error stop "alternate return did not jump"
+
+10 continue
+  stop 0
+
+20 continue
+  error stop "unexpected alternate return"
+
+end program

--- a/integration_tests/implicit_interface_38b.f90
+++ b/integration_tests/implicit_interface_38b.f90
@@ -1,0 +1,3 @@
+subroutine sub(*, *)
+  return 1
+end subroutine

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -15396,10 +15396,27 @@ public:
         current_scope = al.make_new<SymbolTable>(sym_scope);
 
         Vec<ASR::call_arg_t> c_args;
-        visit_expr_list(x.m_args, x.n_args, c_args);
+        c_args.reserve(al, x.n_args + 1);
+        bool has_alt_returns = false;
+        for (size_t i = 0; i < x.n_args; i++) {
+            if (x.m_args[i].m_end == nullptr && x.m_args[i].m_label != 0) {
+                has_alt_returns = true;
+                continue;
+            }
+            this->visit_expr(*x.m_args[i].m_end);
+            ASR::expr_t *expr = ASRUtils::EXPR(tmp);
+            c_args.push_back(al, {expr->base.loc, expr});
+        }
+        if (has_alt_returns) {
+            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc,
+                compiler_options.po.default_integer_kind));
+            ASR::expr_t* alt_ret_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                al, x.base.base.loc, 0, int_type));
+            c_args.push_back(al, {x.base.base.loc, alt_ret_expr});
+        }
 
         Vec<ASR::expr_t*> args;
-        args.reserve(al, x.n_args);
+        args.reserve(al, c_args.size());
         std::string sym_name = to_lower(func_name);
 
         // For implicit argument casting, look up the Implementation to get correct param types
@@ -15419,7 +15436,7 @@ public:
             }
         }
 
-        for (size_t i=0; i<x.n_args; i++) {
+        for (size_t i=0; i<c_args.size(); i++) {
             std::string arg_name = sym_name + "_arg_" + std::to_string(i);
             arg_name = to_lower(arg_name);
             ASR::expr_t *var_expr = c_args[i].m_value;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -15407,6 +15407,7 @@ public:
             ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             c_args.push_back(al, {expr->base.loc, expr});
         }
+        // Reserve spot for compiler's `__lfortran_alt_ret` 
         if (has_alt_returns) {
             ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc,
                 compiler_options.po.default_integer_kind));


### PR DESCRIPTION
Fix ICE on alternate-return args with --implicit-interface

create_implicit_interface_function called visit_expr_list over all
SubroutineCall args, which asserted m_end != nullptr. Alternate-return
args (*label) have m_end == nullptr, triggering the assert.

Skip alt-return positions when building the implicit interface's args
and append a trailing Integer parameter to match the hidden
__lfortran_alt_ret argument that visit_SubroutineCall later adds to
the actual call.
resolves #11343