### PR TITLE
fix: ignore non-ASCII keystrokes in REPL instead of crashing

### DIFF
--- a/src/bin/tpl/cpp-terminal/prompt0.h
+++ b/src/bin/tpl/cpp-terminal/prompt0.h
@@ -122,9 +122,7 @@ std::string prompt0(const Terminal &term, const std::string &prompt_string,
     bool not_complete = true;
     while (not_complete) {
         key = term.read_key();
-        if (  (key >= 'a' && key <= 'z') ||
-              (key >= 'A' && key <= 'Z') ||
-              (key >= 32 && key < 128 && !iscntrl(key)) ) {
+        if  (key >= 32 && key <= 126) {
             std::string before = m.lines[m.cursor_row-1].substr(0,
                     m.cursor_col-1);
             std::string newchar; newchar.push_back(key);

--- a/src/bin/tpl/cpp-terminal/prompt0.h
+++ b/src/bin/tpl/cpp-terminal/prompt0.h
@@ -124,7 +124,7 @@ std::string prompt0(const Terminal &term, const std::string &prompt_string,
         key = term.read_key();
         if (  (key >= 'a' && key <= 'z') ||
               (key >= 'A' && key <= 'Z') ||
-              (!iscntrl(key) && key < 128)  ) {
+              (key >= 32 && key < 128 && !iscntrl(key)) ) {
             std::string before = m.lines[m.cursor_row-1].substr(0,
                     m.cursor_col-1);
             std::string newchar; newchar.push_back(key);


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/938

The REPL was crashing when you type non-ascii characters like `ù`, `ä`. This PR fixes the crash by tightening the filter to only accept printable ascii (32..127), so unknown keys are silently ignored instead of corrupting the buffer.