### PR TITLE
Support CTRL+L to clear screen in interactive REPL

### DIFF
--- a/src/bin/tpl/cpp-terminal/prompt0.h
+++ b/src/bin/tpl/cpp-terminal/prompt0.h
@@ -140,6 +140,10 @@ std::string prompt0(const Terminal &term, const std::string &prompt_string,
             }
         } else {
             switch (key) {
+                case CTRL_KEY('l'):
+                    std::cout<< "\x1b[2J" << move_cursor(1,1) << std::flush;
+                    row = 1;
+                    break;
                 case Key::BACKSPACE:
                     if (m.cursor_col > 1) {
                         std::string before = m.lines[m.cursor_row-1].substr(0,


### PR DESCRIPTION
Implement the feature request in: https://github.com/lfortran/lfortran/issues/11351

Pressing `Ctrl+L` in the REPL now clears the screen and redraws the prompt at the top.