### PR TITLE
Fix DTIO child writes producing extra newlines

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2394,6 +2394,7 @@ RUN(NAME derived_types_135 LABELS gfortran llvm)
 RUN(NAME derived_types_136 LABELS gfortran llvm)
 RUN(NAME derived_types_137 LABELS gfortran llvm)
 RUN(NAME derived_types_138 LABELS gfortran llvm)
+RUN(NAME derived_types_139 LABELS gfortran llvm)
 RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 

--- a/integration_tests/derived_types_139.f90
+++ b/integration_tests/derived_types_139.f90
@@ -1,0 +1,40 @@
+module m_dtio_child
+   implicit none
+   type :: t
+   contains
+      procedure, private :: write_t
+      generic, public :: write(formatted) => write_t
+   end type t
+contains
+   subroutine write_t(self, unit, iotype, v_list, iostat, iomsg)
+      class(t), intent(in) :: self
+      integer, intent(in) :: unit
+      character(*), intent(in) :: iotype
+      integer, intent(in) :: v_list(:)
+      integer, intent(out) :: iostat
+      character(*), intent(inout) :: iomsg
+      iostat = 0
+      ! Child writes should share the parent record (no extra newlines)
+      write(unit, '(a)') 'AB'
+      write(unit, '(a)') 'CD'
+   end subroutine write_t
+end module m_dtio_child
+
+program main
+   use m_dtio_child, only: t
+   implicit none
+   type(t) :: x
+   character(len=100) :: line
+
+   ! Write to a file and read back to verify output
+   open(unit=20, file='_dtio_test_139.txt', status='replace')
+   write(20, '(dt)') x
+   close(20)
+
+   open(unit=20, file='_dtio_test_139.txt', status='old')
+   read(20, '(a)') line
+   close(20, status='delete')
+
+   if (trim(line) /= 'ABCD') error stop
+   print *, "OK"
+end program main

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -19378,7 +19378,67 @@ public:
 
     void visit_FileWrite(const ASR::FileWrite_t &x) {
         if( x.m_overloaded ) {
+            // DTIO: set child I/O mode to suppress record terminators in
+            // child writes, call the user-defined I/O subroutine, then
+            // clear child mode and write the parent record terminator.
+            llvm::Value *unit_val;
+            if (x.m_unit == nullptr) {
+                unit_val = llvm::ConstantInt::get(
+                    llvm::Type::getInt32Ty(context), llvm::APInt(32, 6, true));
+            } else {
+                this->visit_expr_wrapper(x.m_unit, true);
+                unit_val = tmp;
+                if (unit_val->getType()->isIntegerTy() &&
+                    unit_val->getType()->getIntegerBitWidth() > 32) {
+                    unit_val = builder->CreateTrunc(
+                        unit_val, llvm::Type::getInt32Ty(context));
+                }
+            }
+
+            // _lfortran_set_child_io(unit, 1)
+            {
+                std::string func_name = "_lfortran_set_child_io";
+                llvm::Function *fn = module->getFunction(func_name);
+                if (!fn) {
+                    llvm::FunctionType *ft = llvm::FunctionType::get(
+                        llvm::Type::getVoidTy(context),
+                        {llvm::Type::getInt32Ty(context),
+                         llvm::Type::getInt32Ty(context)}, false);
+                    fn = llvm::Function::Create(ft,
+                        llvm::Function::ExternalLinkage, func_name,
+                        module.get());
+                }
+                llvm::Value *one = llvm::ConstantInt::get(
+                    llvm::Type::getInt32Ty(context), llvm::APInt(32, 1, true));
+                builder->CreateCall(fn, {unit_val, one});
+            }
+
             this->visit_stmt(*x.m_overloaded);
+
+            // _lfortran_set_child_io(unit, 0)
+            {
+                std::string func_name = "_lfortran_set_child_io";
+                llvm::Function *fn = module->getFunction(func_name);
+                llvm::Value *zero = llvm::ConstantInt::get(
+                    llvm::Type::getInt32Ty(context), llvm::APInt(32, 0, true));
+                builder->CreateCall(fn, {unit_val, zero});
+            }
+
+            // Write parent record terminator
+            {
+                std::string func_name = "_lfortran_file_write_newline";
+                llvm::Function *fn = module->getFunction(func_name);
+                if (!fn) {
+                    llvm::FunctionType *ft = llvm::FunctionType::get(
+                        llvm::Type::getVoidTy(context),
+                        {llvm::Type::getInt32Ty(context)}, false);
+                    fn = llvm::Function::Create(ft,
+                        llvm::Function::ExternalLinkage, func_name,
+                        module.get());
+                }
+                builder->CreateCall(fn, {unit_val});
+            }
+
             return ;
         }
 

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -786,10 +786,12 @@ public:
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
         Vec<ASR::call_arg_t> call_args;
         call_args.reserve(al, 1);
+        bool args_modified = false;
 
         for (size_t i=0; i<x.n_args; i++) {
             ASR::expr_t* val = x.m_args[i].m_value;
             if (val && ASR::is_a<ASR::IntrinsicElementalFunction_t>(*val) && ASR::is_a<ASR::SymbolicExpression_t>(*ASRUtils::expr_type(val))) {
+                args_modified = true;
                 ASR::IntrinsicElementalFunction_t* intrinsic_func = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(val);
                 ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_SymbolicExpression_t(al, x.base.base.loc));
                 std::string symengine_var = symengine_stack.push();
@@ -815,6 +817,7 @@ public:
             } else if (val && ASR::is_a<ASR::Cast_t>(*val)) {
                 ASR::Cast_t* cast_t = ASR::down_cast<ASR::Cast_t>(val);
                 if(cast_t->m_kind != ASR::cast_kindType::IntegerToSymbolicExpression) return;
+                args_modified = true;
                 this->visit_Cast(*cast_t);
                 ASR::symbol_t *var_sym = current_scope->get_symbol(symengine_stack.pop());
                 ASR::expr_t* target = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, var_sym));
@@ -827,6 +830,7 @@ public:
                 call_args.push_back(al, x.m_args[i]);
             }
         }
+        if (!args_modified) return;
         ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_SubroutineCall_t(al, x.base.base.loc, x.m_name,
             x.m_name, call_args.p, call_args.n, x.m_dt, x.m_strict_bounds_checking));
         pass_result.push_back(al, stmt);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5526,6 +5526,9 @@ static int32_t seq_unf_record_len[MAXUNITS];
 // Pending list-directed null-repeat state per unit.
 static int32_t lf_list_dir_null_remaining[MAXUNITS];
 
+// Child I/O mode per unit (for DTIO: suppress record terminators in child writes).
+static int32_t lf_child_io_mode[MAXUNITS];
+
 static inline void seq_unf_state_reset(int32_t unit_num) {
     if (unit_num < 0 || unit_num >= MAXUNITS) return;
     seq_unf_pending[unit_num] = 0;
@@ -5568,6 +5571,12 @@ static inline int seq_unf_finish_record(int32_t unit_num, FILE* filep) {
 static inline void list_dir_state_reset(int32_t unit_num) {
     if (unit_num < 0 || unit_num >= MAXUNITS) return;
     lf_list_dir_null_remaining[unit_num] = 0;
+}
+
+LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child) {
+    if (unit_num >= 0 && unit_num < MAXUNITS) {
+        lf_child_io_mode[unit_num] = is_child;
+    }
 }
 
 // Pre-connect standard Fortran units at program startup.
@@ -5628,6 +5637,21 @@ static void _lfortran_init_standard_units(void) {
     unit_to_file[2].pad_mode = 1;
 
     last_index_used = 2;
+}
+
+LFORTRAN_API void _lfortran_file_write_newline(int32_t unit_num) {
+    _lfortran_init_standard_units();
+    bool unit_file_bin;
+    int access_id;
+    bool read_access, write_access;
+    int delim;
+    FILE* filep = get_file_pointer_from_unit(unit_num, &unit_file_bin,
+        &access_id, &read_access, &write_access, &delim, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL);
+    if (!filep) {
+        filep = stdout;
+    }
+    fprintf(filep, "\n");
 }
 
 static int32_t count_newlines_up_to(FILE *fp, long end_pos) {
@@ -11367,7 +11391,10 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
             internal_free(combined);
         } else {
             // Sequential / stream access: write as before
-            if (end != NULL) {
+            // In child I/O mode (DTIO), suppress the record terminator
+            bool is_child = (unit_num >= 0 && unit_num < MAXUNITS &&
+                             lf_child_io_mode[unit_num]);
+            if (end != NULL && !is_child) {
                 if(open_delim != '\0') {
                     fprintf(filep, "%c%.*s%c%.*s",
                         open_delim, (int)str_len, str, close_delim,

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -352,6 +352,8 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
         bool is_array_unit, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
         int64_t format_len, ...);
 LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const char* format_data, int64_t format_len, ...);
+LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child);
+LFORTRAN_API void _lfortran_file_write_newline(int32_t unit_num);
 LFORTRAN_API void _lfortran_string_read_i8(char *str, int64_t len, char *format, int8_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i16(char *str, int64_t len, char *format, int16_t *i, int32_t *iostat, int64_t *offset);
 LFORTRAN_API void _lfortran_string_read_i32(char *str, int64_t len, char *format, int32_t *i, int32_t *iostat, int64_t *offset);


### PR DESCRIPTION
Writes inside a user-defined derived-type I/O (DTIO) subroutine are child data transfer statements that must share the parent record without adding record terminators (newlines). LFortran was producing separate lines for each write inside the DTIO subroutine.

The fix has three parts:

1. Runtime: Add _lfortran_set_child_io() to mark a unit as being in child I/O mode, and _lfortran_file_write_newline() to write the parent record terminator. In _lfortran_file_write(), suppress the end/newline character when child I/O mode is active.

2. Codegen: In visit_FileWrite when m_overloaded is set (DTIO call), emit calls to set child I/O mode before the DTIO subroutine call and clear it after, then write the parent record terminator.

3. Pass fix: The replace_symbolic pass was unconditionally pushing SubroutineCall nodes to pass_result even when no arguments were modified, which caused FileWrite nodes with m_overloaded to be erroneously replaced by standalone SubroutineCalls. Now only push when args are actually changed.

An integration test (derived_types_139) is added.

Fixes #11366.