### PR TITLE
fix: Do not store empty REPL inputs in history

### DIFF
--- a/src/bin/tpl/cpp-terminal/prompt0.h
+++ b/src/bin/tpl/cpp-terminal/prompt0.h
@@ -277,8 +277,12 @@ std::string prompt0(const Terminal &term, const std::string &prompt_string,
         line_skips += "\n";
     }
     std::cout << line_skips << std::flush;
-    history.push_back(concat(m.lines));
-    return concat(m.lines);
+    std::string current_entry = concat(m.lines);
+    if (current_entry.find_first_not_of(" \t\r\n") != std::string::npos) {
+        history.push_back(current_entry);
+    }
+   
+    return current_entry;
 }
 
 #endif // TERMINAL_PROMPT0_H


### PR DESCRIPTION
This PR avoids adding empty or whitespace-only REPL inputs to the history.
Previously, pressing `Enter` on an empty line stored a blank entry. When navigating history with the up/down arrows, the REPL would then cycle through these empty entries.

With this change, only inputs containing at least one non-whitespace character are stored in history. Multiline inputs are still preserved unchanged.
