### PR TITLE
Fix : Append symtab counter to indentify different symbolTypes

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2400,6 +2400,7 @@ RUN(NAME derived_types_137 LABELS gfortran llvm)
 RUN(NAME derived_types_138 LABELS gfortran llvm)
 RUN(NAME derived_types_139 LABELS gfortran llvm)
 RUN(NAME derived_types_140 LABELS gfortran llvm)
+RUN(NAME derived_types_141 LABELS gfortran llvm)
 RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 

--- a/integration_tests/derived_types_141.f90
+++ b/integration_tests/derived_types_141.f90
@@ -1,0 +1,50 @@
+! Test that 2 derived type of same name `tt`
+! will produce 2 different type in LLVM backend
+module derived_types_141_mod
+   implicit none
+contains
+   subroutine foo()
+      call ss()
+
+      contains 
+
+      subroutine ss() 
+         type :: tt
+            integer :: b
+            integer :: c
+         end type
+         type(tt) :: idx
+         idx%b = 1
+         print *, idx%b
+         if(idx%b /= 1) error stop
+
+      end subroutine
+
+   end subroutine 
+
+   subroutine foo1()
+      call ss()
+
+      contains
+
+      subroutine ss()
+         type :: tt
+            integer :: a
+         end type 
+         type(tt) :: idx
+         idx%a = 2
+         print *, idx%a
+         if(idx%a /= 2) error stop
+      end subroutine
+   end subroutine
+
+end module
+
+program derived_types_141
+   use derived_types_141_mod
+   implicit none
+
+   call foo()
+
+   call foo1()
+end program 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -15235,7 +15235,7 @@ public:
             case ASR::ttypeType::UnionType: {
                 ASR::Union_t* der_type = ASR::down_cast<ASR::Union_t>(
                     ASRUtils::symbol_get_past_external(x->m_type_declaration));
-                current_der_type_name = get_type_key(der_type);
+                current_der_type_name = get_type_key(&der_type->base);
                 uint32_t h = get_hash((ASR::asr_t*)x);
                 if( llvm_symtab.find(h) != llvm_symtab.end() ) {
                     tmp = llvm_symtab[h];

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -531,7 +531,7 @@ namespace LCompilers {
 
     llvm::Type* LLVMUtils::getUnion(ASR::Union_t* union_type,
         llvm::Module* module, bool is_pointer) {
-        std::string union_type_name = get_type_key(union_type);
+        std::string union_type_name = get_type_key(&union_type->base);
         llvm::StructType* union_type_llvm = nullptr;
         if( name2dertype.find(union_type_name) != name2dertype.end() ) {
             union_type_llvm = name2dertype[union_type_name];

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -40,50 +40,27 @@ class ASRToLLVMVisitor;
         return (uint64_t)node;
     }
 
-    // Returns a scope-qualified key for a Struct_t, for use in name2dertype
-    // and related maps. E.g., struct "object_t" inside module "mod_a" becomes
-    // "mod_a.object_t", preventing collisions between same-named types in
-    // different modules. Unlimited polymorphic types (starting with "~") are
-    // global sentinels and are never qualified.
-    inline std::string get_type_key(ASR::Struct_t* struct_type) {
-        std::string name = struct_type->m_name;
-        // Skip qualification for internal sentinel types like ~unlimited_polymorphic_type
-        if (!name.empty() && name[0] == '~') {
-            return name;
-        }
-        if (struct_type->m_symtab && struct_type->m_symtab->parent &&
-                struct_type->m_symtab->parent->asr_owner &&
-                ASR::is_a<ASR::symbol_t>(*struct_type->m_symtab->parent->asr_owner)) {
-            ASR::symbol_t* parent_sym = ASR::down_cast<ASR::symbol_t>(
-                struct_type->m_symtab->parent->asr_owner);
-            name = std::string(ASRUtils::symbol_name(parent_sym)) + "." + name;
-        }
-        return name;
-    }
 
-    // Returns a scope-qualified key for a Union_t.
-    inline std::string get_type_key(ASR::Union_t* union_type) {
-        std::string name = union_type->m_name;
-        if (union_type->m_symtab && union_type->m_symtab->parent &&
-                union_type->m_symtab->parent->asr_owner &&
-                ASR::is_a<ASR::symbol_t>(*union_type->m_symtab->parent->asr_owner)) {
-            ASR::symbol_t* parent_sym = ASR::down_cast<ASR::symbol_t>(
-                union_type->m_symtab->parent->asr_owner);
-            name = std::string(ASRUtils::symbol_name(parent_sym)) + "." + name;
-        }
-        return name;
-    }
-
-    // Returns a scope-qualified key for a symbol_t* that may be Struct or Union.
-    // Resolves ExternalSymbol automatically.
+    // Return symbolName
+    // Adds unqiue symtab ID for Struct and Union
     inline std::string get_type_key(ASR::symbol_t* sym) {
         sym = ASRUtils::symbol_get_past_external(sym);
-        if (ASR::is_a<ASR::Struct_t>(*sym)) {
-            return get_type_key(ASR::down_cast<ASR::Struct_t>(sym));
-        } else if (ASR::is_a<ASR::Union_t>(*sym)) {
-            return get_type_key(ASR::down_cast<ASR::Union_t>(sym));
+        std::string name = ASRUtils::symbol_name(sym);
+        if (!name.empty() && name[0] == '~') return name; // global sentinels for UPoly 
+
+        if(ASR::is_a<ASR::Struct_t>(*sym) || ASR::is_a<ASR::Union_t>(*sym)){
+            ASR::Module_t* mod = ASRUtils::get_sym_module(sym);
+            if(mod) {
+                name = ASRUtils::symbol_name(&mod->base) + 
+                        std::string(".") + name;
+            }
+            name += "." + ASRUtils::symbol_symtab(sym)->get_counter();
         }
-        return std::string(ASRUtils::symbol_name(sym));
+
+        return name;
+    }
+    inline std::string get_type_key(ASR::Struct_t* sym){
+        return get_type_key(&sym->base);
     }
 
     namespace {

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "d83526d1b40115e1484584801f84789bbe5aaea196be40c25f709357",
+    "stdout_hash": "e8650db0dd50f9530a86249aeb840c737cec2bff9f68f89f3bab7bea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -2,11 +2,11 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%module_call_subroutine_without_type_01.mytype_class = type <{ i32 (...)**, %module_call_subroutine_without_type_01.mytype* }>
-%module_call_subroutine_without_type_01.mytype = type { float }
+%module_call_subroutine_without_type_01.mytype.3_class = type <{ i32 (...)**, %module_call_subroutine_without_type_01.mytype.3* }>
+%module_call_subroutine_without_type_01.mytype.3 = type { float }
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__get_i__self = global %module_call_subroutine_without_type_01.mytype_class* null
+@__module___lcompilers_created__nested_context__get_i__self = global %module_call_subroutine_without_type_01.mytype.3_class* null
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,R4\00", align 1
 @string_const_data = private constant [4 x i8] c"r = "
@@ -17,7 +17,7 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_mytype = private unnamed_addr constant [7 x i8] c"mytype\00", align 1
 @_Type_Info_mytype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_mytype, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_mytype = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_mytype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly to i8*), i8* bitcast (void (%module_call_subroutine_without_type_01.mytype_class*)* @__module_module_call_subroutine_without_type_01_get_i to i8*)] }, align 8
+@_VTable_mytype = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_mytype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly to i8*), i8* bitcast (void (%module_call_subroutine_without_type_01.mytype.3_class*)* @__module_module_call_subroutine_without_type_01_get_i to i8*)] }, align 8
 @4 = private unnamed_addr constant [4 x i8] c"obj\00", align 1
 @5 = private unnamed_addr constant [63 x i8] c"tests/../integration_tests/call_subroutine_without_type_01.f90\00", align 1
 @6 = private unnamed_addr constant [22 x i8] c"'%s' unallocated here\00", align 1
@@ -27,35 +27,35 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @11 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
 
-define void @__module_module_call_subroutine_without_type_01_get_i(%module_call_subroutine_without_type_01.mytype_class* %self) {
+define void @__module_module_call_subroutine_without_type_01_get_i(%module_call_subroutine_without_type_01.mytype.3_class* %self) {
 .entry:
-  %0 = icmp eq %module_call_subroutine_without_type_01.mytype_class* %self, null
+  %0 = icmp eq %module_call_subroutine_without_type_01.mytype.3_class* %self, null
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store %module_call_subroutine_without_type_01.mytype_class* null, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %1 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %2 = icmp eq %module_call_subroutine_without_type_01.mytype_class* %1, null
+  %1 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %2 = icmp eq %module_call_subroutine_without_type_01.mytype.3_class* %1, null
   br i1 %2, label %then1, label %else2
 
 then1:                                            ; preds = %else
   %3 = call i8* @_lfortran_get_default_allocator()
   %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 16, i1 false)
-  %5 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype_class*
-  store %module_call_subroutine_without_type_01.mytype_class* %5, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %5 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype.3_class*
+  store %module_call_subroutine_without_type_01.mytype.3_class* %5, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
   br label %ifcont
 
 else2:                                            ; preds = %else
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
-  %6 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %7 = bitcast %module_call_subroutine_without_type_01.mytype_class* %6 to i8*
-  %8 = bitcast %module_call_subroutine_without_type_01.mytype_class* %self to i8*
+  %6 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %7 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %6 to i8*
+  %8 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %self to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* %7, i8* %8, i32 16, i1 false)
   br label %ifcont3
 
@@ -75,10 +75,10 @@ define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %2, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %3, align 8
-  %5 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %4, i32 0, i32 0
+  %2 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %2, i32 0, i32 1
+  %4 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
+  %5 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %4, i32 0, i32 0
   %6 = load float, float* %5, align 4
   %7 = alloca float, align 4
   store float %6, float* %7, align 4
@@ -102,10 +102,10 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %18 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %19 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %18, i32 0, i32 1
-  %20 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %19, align 8
-  %21 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %20, i32 0, i32 0
+  %18 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %19 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %18, i32 0, i32 1
+  %20 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %19, align 8
+  %21 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %20, i32 0, i32 0
   %22 = load float, float* %21, align 4
   %23 = fcmp une float %22, 1.000000e+00
   br i1 %23, label %then, label %else
@@ -155,26 +155,26 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %obj = alloca %module_call_subroutine_without_type_01.mytype_class*, align 8
-  store %module_call_subroutine_without_type_01.mytype_class* null, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
+  %obj = alloca %module_call_subroutine_without_type_01.mytype.3_class*, align 8
+  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
   %3 = call i8* @_lfortran_get_default_allocator()
   %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
   %5 = call i8* @_lfortran_get_default_allocator()
   %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 16, i1 false)
-  %7 = bitcast i8* %6 to %module_call_subroutine_without_type_01.mytype_class*
-  store %module_call_subroutine_without_type_01.mytype_class* %7, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %8 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %9 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %8, i32 0, i32 1
-  %10 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype*
-  store %module_call_subroutine_without_type_01.mytype* %10, %module_call_subroutine_without_type_01.mytype** %9, align 8
-  %11 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %9, align 8
-  %12 = bitcast %module_call_subroutine_without_type_01.mytype_class* %7 to i32 (...)***
+  %7 = bitcast i8* %6 to %module_call_subroutine_without_type_01.mytype.3_class*
+  store %module_call_subroutine_without_type_01.mytype.3_class* %7, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  %8 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  %9 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %8, i32 0, i32 1
+  %10 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype.3*
+  store %module_call_subroutine_without_type_01.mytype.3* %10, %module_call_subroutine_without_type_01.mytype.3** %9, align 8
+  %11 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %9, align 8
+  %12 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %7 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
-  %13 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %11, i32 0, i32 0
-  %14 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %15 = ptrtoint %module_call_subroutine_without_type_01.mytype_class* %14 to i64
+  %13 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %11, i32 0, i32 0
+  %14 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  %15 = ptrtoint %module_call_subroutine_without_type_01.mytype.3_class* %14 to i64
   %16 = icmp eq i64 %15, 0
   br i1 %16, label %then, label %ifcont
 
@@ -209,12 +209,12 @@ then:                                             ; preds = %.entry
   unreachable
 
 ifcont:                                           ; preds = %.entry
-  %33 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %14, i32 0, i32 1
-  %34 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %33, align 8
-  %35 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %34, i32 0, i32 0
+  %33 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %14, i32 0, i32 1
+  %34 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %33, align 8
+  %35 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %34, i32 0, i32 0
   store float 1.000000e+00, float* %35, align 4
-  %36 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %37 = ptrtoint %module_call_subroutine_without_type_01.mytype_class* %36 to i64
+  %36 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  %37 = ptrtoint %module_call_subroutine_without_type_01.mytype.3_class* %36 to i64
   %38 = icmp eq i64 %37, 0
   br i1 %38, label %then1, label %ifcont2
 
@@ -249,12 +249,12 @@ then1:                                            ; preds = %ifcont
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %55 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  %56 = bitcast %module_call_subroutine_without_type_01.mytype_class* %55 to void (%module_call_subroutine_without_type_01.mytype_class*)***
-  %57 = load void (%module_call_subroutine_without_type_01.mytype_class*)**, void (%module_call_subroutine_without_type_01.mytype_class*)*** %56, align 8
-  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %57, i32 3
-  %59 = load void (%module_call_subroutine_without_type_01.mytype_class*)*, void (%module_call_subroutine_without_type_01.mytype_class*)** %58, align 8
-  call void %59(%module_call_subroutine_without_type_01.mytype_class* %55)
+  %55 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  %56 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %55 to void (%module_call_subroutine_without_type_01.mytype.3_class*)***
+  %57 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)**, void (%module_call_subroutine_without_type_01.mytype.3_class*)*** %56, align 8
+  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %57, i32 3
+  %59 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %58, align 8
+  call void %59(%module_call_subroutine_without_type_01.mytype.3_class* %55)
   br label %return
 
 return:                                           ; preds = %ifcont2
@@ -264,8 +264,8 @@ FINALIZE_SYMTABLE_call_subroutine_without_type_01: ; preds = %return
   br label %Finalize_Variable_obj
 
 Finalize_Variable_obj:                            ; preds = %FINALIZE_SYMTABLE_call_subroutine_without_type_01
-  %60 = load %module_call_subroutine_without_type_01.mytype_class*, %module_call_subroutine_without_type_01.mytype_class** %obj, align 8
-  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %60)
+  %60 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %60)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
@@ -274,11 +274,11 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 
 define linkonce_odr void @_copy_module_call_subroutine_without_type_01_mytype(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype*
-  %3 = bitcast i8* %1 to %module_call_subroutine_without_type_01.mytype*
-  %4 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype.3*
+  %3 = bitcast i8* %1 to %module_call_subroutine_without_type_01.mytype.3*
+  %4 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %3, i32 0, i32 0
+  %6 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -299,22 +299,22 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %module_call_subroutine_without_type_01.mytype_class*
-  %5 = bitcast %module_call_subroutine_without_type_01.mytype_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %module_call_subroutine_without_type_01.mytype.3_class*
+  %5 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %4, i32 0, i32 1
+  %6 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %module_call_subroutine_without_type_01.mytype*
-  store %module_call_subroutine_without_type_01.mytype* %9, %module_call_subroutine_without_type_01.mytype** %6, align 8
-  %10 = getelementptr %module_call_subroutine_without_type_01.mytype, %module_call_subroutine_without_type_01.mytype* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %module_call_subroutine_without_type_01.mytype.3*
+  store %module_call_subroutine_without_type_01.mytype.3* %9, %module_call_subroutine_without_type_01.mytype.3** %6, align 8
+  %10 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype*
+  %1 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype.3*
   ret void
 }
 
@@ -322,21 +322,21 @@ declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
 
 declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
 
-define internal void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0) {
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %module_call_subroutine_without_type_01.mytype_class* %0, null
+  %2 = icmp ne %module_call_subroutine_without_type_01.mytype.3_class* %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %0)
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %0, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype*, %module_call_subroutine_without_type_01.mytype** %3, align 8
-  %5 = icmp ne %module_call_subroutine_without_type_01.mytype* %4, null
+  call void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0)
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 1
+  %4 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
+  %5 = icmp ne %module_call_subroutine_without_type_01.mytype.3* %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %module_call_subroutine_without_type_01.mytype* %4 to i8*
+  %6 = bitcast %module_call_subroutine_without_type_01.mytype.3* %4 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %6)
   br label %is_allocated.ifcont
 
@@ -344,7 +344,7 @@ is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %module_call_subroutine_without_type_01.mytype_class* %0 to i8*
+  %7 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %0 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %7)
   br label %is_allocated.ifcont3
 
@@ -355,13 +355,13 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype_class* %0) {
+define internal void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0) {
 entry:
-  %1 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %0, i32 0, i32 0
+  %1 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 0
   %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype_class, %module_call_subroutine_without_type_01.mytype_class* %0, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype**, %module_call_subroutine_without_type_01.mytype** %3, align 8
-  %5 = bitcast %module_call_subroutine_without_type_01.mytype** %4 to i8*
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 1
+  %4 = load %module_call_subroutine_without_type_01.mytype.3**, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
+  %5 = bitcast %module_call_subroutine_without_type_01.mytype.3** %4 to i8*
   %6 = icmp ne i32 (...)** %2, null
   br i1 %6, label %is_allocated.then, label %is_allocated.else2
 

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "9a175a23d9cb859eb7a243be6a781b2d9b4f7058f8d94ee5ebf32b50",
+    "stdout_hash": "b78533f938453da6836df7277c749551768ce05840ff655f9197f4a9",
     "stderr": "llvm-class_01-82031c0.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -3,13 +3,13 @@ source_filename = "LFortran"
 target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
-%class_circle1.circle_class = type <{ i32 (...)**, %class_circle1.circle* }>
-%class_circle1.circle = type { float }
+%class_circle1.circle.3_class = type <{ i32 (...)**, %class_circle1.circle.3* }>
+%class_circle1.circle.3 = type { float }
 
 @__module_class_circle1_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle1_for_UPoly to i8*), i8* bitcast (float (%class_circle1.circle_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle1_for_UPoly to i8*), i8* bitcast (float (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
@@ -18,13 +18,13 @@ target datalayout = "..."
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.1, i32 0, i32 0), i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_class_circle1_circle_area(%class_circle1.circle_class* %this) {
+define float @__module_class_circle1_circle_area(%class_circle1.circle.3_class* %this) {
 .entry:
   %area = alloca float, align 4
   %0 = load float, float* @__module_class_circle1_pi, align 4
-  %1 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %this, i32 0, i32 1
-  %2 = load %class_circle1.circle*, %class_circle1.circle** %1, align 8
-  %3 = getelementptr %class_circle1.circle, %class_circle1.circle* %2, i32 0, i32 0
+  %1 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %this, i32 0, i32 1
+  %2 = load %class_circle1.circle.3*, %class_circle1.circle.3** %1, align 8
+  %3 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %2, i32 0, i32 0
   %4 = load float, float* %3, align 4
   %simplified_pow_operation = fmul float %4, %4
   %5 = fmul float %0, %simplified_pow_operation
@@ -39,21 +39,21 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
   ret float %6
 }
 
-define void @__module_class_circle1_circle_print(%class_circle1.circle_class* %this) {
+define void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %area = alloca float, align 4
-  %1 = bitcast %class_circle1.circle_class* %this to float (%class_circle1.circle_class*)***
-  %2 = load float (%class_circle1.circle_class*)**, float (%class_circle1.circle_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %2, i32 3
-  %4 = load float (%class_circle1.circle_class*)*, float (%class_circle1.circle_class*)** %3, align 8
-  %5 = call float %4(%class_circle1.circle_class* %this)
+  %1 = bitcast %class_circle1.circle.3_class* %this to float (%class_circle1.circle.3_class*)***
+  %2 = load float (%class_circle1.circle.3_class*)**, float (%class_circle1.circle.3_class*)*** %1, align 8
+  %3 = getelementptr inbounds float (%class_circle1.circle.3_class*)*, float (%class_circle1.circle.3_class*)** %2, i32 3
+  %4 = load float (%class_circle1.circle.3_class*)*, float (%class_circle1.circle.3_class*)** %3, align 8
+  %5 = call float %4(%class_circle1.circle.3_class* %this)
   store float %5, float* %area, align 4
   %6 = alloca i64, align 8
-  %7 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %this, i32 0, i32 1
-  %8 = load %class_circle1.circle*, %class_circle1.circle** %7, align 8
-  %9 = getelementptr %class_circle1.circle, %class_circle1.circle* %8, i32 0, i32 0
+  %7 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %this, i32 0, i32 1
+  %8 = load %class_circle1.circle.3*, %class_circle1.circle.3** %7, align 8
+  %9 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %8, i32 0, i32 0
   %10 = load float, float* %9, align 4
   %11 = alloca float, align 4
   store float %10, float* %11, align 4
@@ -88,11 +88,11 @@ FINALIZE_SYMTABLE_circle_print:                   ; preds = %return
 
 define linkonce_odr void @_copy_class_circle1_circle(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %class_circle1.circle*
-  %3 = bitcast i8* %1 to %class_circle1.circle*
-  %4 = getelementptr %class_circle1.circle, %class_circle1.circle* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %class_circle1.circle.3*
+  %3 = bitcast i8* %1 to %class_circle1.circle.3*
+  %4 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %class_circle1.circle, %class_circle1.circle* %3, i32 0, i32 0
+  %6 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -113,22 +113,22 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %class_circle1.circle_class*
-  %5 = bitcast %class_circle1.circle_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %class_circle1.circle.3_class*
+  %5 = bitcast %class_circle1.circle.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %4, i32 0, i32 1
+  %6 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %class_circle1.circle*
-  store %class_circle1.circle* %9, %class_circle1.circle** %6, align 8
-  %10 = getelementptr %class_circle1.circle, %class_circle1.circle* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %class_circle1.circle.3*
+  store %class_circle1.circle.3* %9, %class_circle1.circle.3** %6, align 8
+  %10 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__circle_3_of_class_circle1_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %class_circle1.circle*
+  %1 = bitcast i8* %0 to %class_circle1.circle.3*
   ret void
 }
 
@@ -147,25 +147,25 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
-  %2 = alloca %class_circle1.circle_class, align 8
-  %3 = alloca %class_circle1.circle_class, align 8
+  %2 = alloca %class_circle1.circle.3_class, align 8
+  %3 = alloca %class_circle1.circle.3_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c = alloca %class_circle1.circle, align 8
-  %4 = getelementptr %class_circle1.circle, %class_circle1.circle* %c, i32 0, i32 0
-  %5 = getelementptr %class_circle1.circle, %class_circle1.circle* %c, i32 0, i32 0
+  %c = alloca %class_circle1.circle.3, align 8
+  %4 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
+  %5 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
   store float 1.500000e+00, float* %5, align 4
-  %6 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %3, i32 0, i32 0
+  %6 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %3, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
-  %7 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %3, i32 0, i32 1
-  store %class_circle1.circle* %c, %class_circle1.circle** %7, align 8
-  call void @__module_class_circle1_circle_print(%class_circle1.circle_class* %3)
-  %8 = getelementptr %class_circle1.circle, %class_circle1.circle* %c, i32 0, i32 0
+  %7 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %3, i32 0, i32 1
+  store %class_circle1.circle.3* %c, %class_circle1.circle.3** %7, align 8
+  call void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %3)
+  %8 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
   store float 2.000000e+00, float* %8, align 4
-  %9 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %2, i32 0, i32 0
+  %9 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %2, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %9, align 8
-  %10 = getelementptr %class_circle1.circle_class, %class_circle1.circle_class* %2, i32 0, i32 1
-  store %class_circle1.circle* %c, %class_circle1.circle** %10, align 8
-  call void @__module_class_circle1_circle_print(%class_circle1.circle_class* %2)
+  %10 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %2, i32 0, i32 1
+  store %class_circle1.circle.3* %c, %class_circle1.circle.3** %10, align 8
+  call void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %2)
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "86982d107645669c47e2b8a1d56c0234f130d98750a688c7890d15a2",
+    "stdout_hash": "c42a69db27055df0a09471939b6d933a4b90a7820b109c07b8c7a50e",
     "stderr": "llvm-class_02-82c2f9c.stderr",
     "stderr_hash": "cbe4c6f9d712b9d5ee417de42e2ce3b69d43ea5a0b463256ad71acfe",
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -3,13 +3,13 @@ source_filename = "LFortran"
 target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
-%class_circle2.circle_class = type <{ i32 (...)**, %class_circle2.circle* }>
-%class_circle2.circle = type { float }
+%class_circle2.circle.3_class = type <{ i32 (...)**, %class_circle2.circle.3* }>
+%class_circle2.circle.3 = type { float }
 
 @__module_class_circle2_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle2_for_UPoly to i8*), i8* bitcast (float (%class_circle2.circle_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle2_for_UPoly to i8*), i8* bitcast (float (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
@@ -18,13 +18,13 @@ target datalayout = "..."
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.1, i32 0, i32 0), i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_class_circle2_circle_area(%class_circle2.circle_class* %this) {
+define float @__module_class_circle2_circle_area(%class_circle2.circle.3_class* %this) {
 .entry:
   %circle_area = alloca float, align 4
   %0 = load float, float* @__module_class_circle2_pi, align 4
-  %1 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %this, i32 0, i32 1
-  %2 = load %class_circle2.circle*, %class_circle2.circle** %1, align 8
-  %3 = getelementptr %class_circle2.circle, %class_circle2.circle* %2, i32 0, i32 0
+  %1 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %this, i32 0, i32 1
+  %2 = load %class_circle2.circle.3*, %class_circle2.circle.3** %1, align 8
+  %3 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %2, i32 0, i32 0
   %4 = load float, float* %3, align 4
   %simplified_pow_operation = fmul float %4, %4
   %5 = fmul float %0, %simplified_pow_operation
@@ -39,21 +39,21 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
   ret float %6
 }
 
-define void @__module_class_circle2_circle_print(%class_circle2.circle_class* %this) {
+define void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %area = alloca float, align 4
-  %1 = bitcast %class_circle2.circle_class* %this to float (%class_circle2.circle_class*)***
-  %2 = load float (%class_circle2.circle_class*)**, float (%class_circle2.circle_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %2, i32 3
-  %4 = load float (%class_circle2.circle_class*)*, float (%class_circle2.circle_class*)** %3, align 8
-  %5 = call float %4(%class_circle2.circle_class* %this)
+  %1 = bitcast %class_circle2.circle.3_class* %this to float (%class_circle2.circle.3_class*)***
+  %2 = load float (%class_circle2.circle.3_class*)**, float (%class_circle2.circle.3_class*)*** %1, align 8
+  %3 = getelementptr inbounds float (%class_circle2.circle.3_class*)*, float (%class_circle2.circle.3_class*)** %2, i32 3
+  %4 = load float (%class_circle2.circle.3_class*)*, float (%class_circle2.circle.3_class*)** %3, align 8
+  %5 = call float %4(%class_circle2.circle.3_class* %this)
   store float %5, float* %area, align 4
   %6 = alloca i64, align 8
-  %7 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %this, i32 0, i32 1
-  %8 = load %class_circle2.circle*, %class_circle2.circle** %7, align 8
-  %9 = getelementptr %class_circle2.circle, %class_circle2.circle* %8, i32 0, i32 0
+  %7 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %this, i32 0, i32 1
+  %8 = load %class_circle2.circle.3*, %class_circle2.circle.3** %7, align 8
+  %9 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %8, i32 0, i32 0
   %10 = load float, float* %9, align 4
   %11 = alloca float, align 4
   store float %10, float* %11, align 4
@@ -88,18 +88,18 @@ FINALIZE_SYMTABLE_circle_print:                   ; preds = %return
 
 define void @__module_class_circle2__xx_lcompilers_changed_main_xx() {
 .entry:
-  %0 = alloca %class_circle2.circle_class, align 8
-  %c = alloca %class_circle2.circle, align 8
-  %1 = getelementptr %class_circle2.circle, %class_circle2.circle* %c, i32 0, i32 0
-  %2 = getelementptr %class_circle2.circle, %class_circle2.circle* %c, i32 0, i32 0
+  %0 = alloca %class_circle2.circle.3_class, align 8
+  %c = alloca %class_circle2.circle.3, align 8
+  %1 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
+  %2 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
   store float 1.000000e+00, float* %2, align 4
-  %3 = getelementptr %class_circle2.circle, %class_circle2.circle* %c, i32 0, i32 0
+  %3 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
   store float 1.500000e+00, float* %3, align 4
-  %4 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %0, i32 0, i32 0
+  %4 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %0, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
-  %5 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %0, i32 0, i32 1
-  store %class_circle2.circle* %c, %class_circle2.circle** %5, align 8
-  call void @__module_class_circle2_circle_print(%class_circle2.circle_class* %0)
+  %5 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %0, i32 0, i32 1
+  store %class_circle2.circle.3* %c, %class_circle2.circle.3** %5, align 8
+  call void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* %0)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -111,11 +111,11 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 
 define linkonce_odr void @_copy_class_circle2_circle(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %class_circle2.circle*
-  %3 = bitcast i8* %1 to %class_circle2.circle*
-  %4 = getelementptr %class_circle2.circle, %class_circle2.circle* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %class_circle2.circle.3*
+  %3 = bitcast i8* %1 to %class_circle2.circle.3*
+  %4 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %class_circle2.circle, %class_circle2.circle* %3, i32 0, i32 0
+  %6 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -136,22 +136,22 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %class_circle2.circle_class*
-  %5 = bitcast %class_circle2.circle_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %class_circle2.circle.3_class*
+  %5 = bitcast %class_circle2.circle.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %class_circle2.circle_class, %class_circle2.circle_class* %4, i32 0, i32 1
+  %6 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %class_circle2.circle*
-  store %class_circle2.circle* %9, %class_circle2.circle** %6, align 8
-  %10 = getelementptr %class_circle2.circle, %class_circle2.circle* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %class_circle2.circle.3*
+  store %class_circle2.circle.3* %9, %class_circle2.circle.3** %6, align 8
+  %10 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__circle_3_of_class_circle2_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %class_circle2.circle*
+  %1 = bitcast i8* %0 to %class_circle2.circle.3*
   ret void
 }
 

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "913044b2e897c2360cba8706bea105d2f71c70c34239a22ecc22ba0c",
+    "stdout_hash": "be71c90d75876f5f3a56a47ce168203150a156c5e6dfda8dfa857107",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -3,12 +3,12 @@ source_filename = "LFortran"
 target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
-%main.foo_c = type { %main.foo_b, %main.bar_c }
-%main.foo_b = type { %main.foo_a, %main.bar_b }
-%main.foo_a = type { %main.bar_a }
-%main.bar_a = type { i32 }
-%main.bar_b = type { %main.bar_a, i32 }
-%main.bar_c = type { %main.bar_b, i32 }
+%foo_c.8 = type { %foo_b.7, %bar_c.6 }
+%foo_b.7 = type { %foo_a.4, %bar_b.5 }
+%foo_a.4 = type { %bar_a.3 }
+%bar_a.3 = type { i32 }
+%bar_b.5 = type { %bar_a.3, i32 }
+%bar_c.6 = type { %bar_b.5, i32 }
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -30,38 +30,38 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %foo = alloca %main.foo_c, align 8
-  %3 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %4 = getelementptr %main.bar_c, %main.bar_c* %3, i32 0, i32 1
-  %5 = getelementptr %main.bar_c, %main.bar_c* %3, i32 0, i32 0
-  %6 = getelementptr %main.bar_b, %main.bar_b* %5, i32 0, i32 1
-  %7 = getelementptr %main.bar_b, %main.bar_b* %5, i32 0, i32 0
-  %8 = getelementptr %main.bar_a, %main.bar_a* %7, i32 0, i32 0
-  %9 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %10 = getelementptr %main.foo_b, %main.foo_b* %9, i32 0, i32 1
-  %11 = getelementptr %main.bar_b, %main.bar_b* %10, i32 0, i32 1
-  %12 = getelementptr %main.bar_b, %main.bar_b* %10, i32 0, i32 0
-  %13 = getelementptr %main.bar_a, %main.bar_a* %12, i32 0, i32 0
-  %14 = getelementptr %main.foo_b, %main.foo_b* %9, i32 0, i32 0
-  %15 = getelementptr %main.foo_a, %main.foo_a* %14, i32 0, i32 0
-  %16 = getelementptr %main.bar_a, %main.bar_a* %15, i32 0, i32 0
-  %17 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %18 = getelementptr %main.foo_b, %main.foo_b* %17, i32 0, i32 0
-  %19 = getelementptr %main.foo_a, %main.foo_a* %18, i32 0, i32 0
-  %20 = getelementptr %main.bar_a, %main.bar_a* %19, i32 0, i32 0
+  %foo = alloca %foo_c.8, align 8
+  %3 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
+  %4 = getelementptr %bar_c.6, %bar_c.6* %3, i32 0, i32 1
+  %5 = getelementptr %bar_c.6, %bar_c.6* %3, i32 0, i32 0
+  %6 = getelementptr %bar_b.5, %bar_b.5* %5, i32 0, i32 1
+  %7 = getelementptr %bar_b.5, %bar_b.5* %5, i32 0, i32 0
+  %8 = getelementptr %bar_a.3, %bar_a.3* %7, i32 0, i32 0
+  %9 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %10 = getelementptr %foo_b.7, %foo_b.7* %9, i32 0, i32 1
+  %11 = getelementptr %bar_b.5, %bar_b.5* %10, i32 0, i32 1
+  %12 = getelementptr %bar_b.5, %bar_b.5* %10, i32 0, i32 0
+  %13 = getelementptr %bar_a.3, %bar_a.3* %12, i32 0, i32 0
+  %14 = getelementptr %foo_b.7, %foo_b.7* %9, i32 0, i32 0
+  %15 = getelementptr %foo_a.4, %foo_a.4* %14, i32 0, i32 0
+  %16 = getelementptr %bar_a.3, %bar_a.3* %15, i32 0, i32 0
+  %17 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %18 = getelementptr %foo_b.7, %foo_b.7* %17, i32 0, i32 0
+  %19 = getelementptr %foo_a.4, %foo_a.4* %18, i32 0, i32 0
+  %20 = getelementptr %bar_a.3, %bar_a.3* %19, i32 0, i32 0
   store i32 -20, i32* %20, align 4
-  %21 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %22 = getelementptr %main.foo_b, %main.foo_b* %21, i32 0, i32 1
-  %23 = getelementptr %main.bar_b, %main.bar_b* %22, i32 0, i32 1
+  %21 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %22 = getelementptr %foo_b.7, %foo_b.7* %21, i32 0, i32 1
+  %23 = getelementptr %bar_b.5, %bar_b.5* %22, i32 0, i32 1
   store i32 9, i32* %23, align 4
-  %24 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %25 = getelementptr %main.bar_c, %main.bar_c* %24, i32 0, i32 1
+  %24 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
+  %25 = getelementptr %bar_c.6, %bar_c.6* %24, i32 0, i32 1
   store i32 11, i32* %25, align 4
   %26 = alloca i64, align 8
-  %27 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %28 = getelementptr %main.foo_b, %main.foo_b* %27, i32 0, i32 0
-  %29 = getelementptr %main.foo_a, %main.foo_a* %28, i32 0, i32 0
-  %30 = getelementptr %main.bar_a, %main.bar_a* %29, i32 0, i32 0
+  %27 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %28 = getelementptr %foo_b.7, %foo_b.7* %27, i32 0, i32 0
+  %29 = getelementptr %foo_a.4, %foo_a.4* %28, i32 0, i32 0
+  %30 = getelementptr %bar_a.3, %bar_a.3* %29, i32 0, i32 0
   %31 = load i32, i32* %30, align 4
   %32 = alloca i32, align 4
   store i32 %31, i32* %32, align 4
@@ -86,9 +86,9 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %43 = alloca i64, align 8
-  %44 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %45 = getelementptr %main.foo_b, %main.foo_b* %44, i32 0, i32 1
-  %46 = getelementptr %main.bar_b, %main.bar_b* %45, i32 0, i32 1
+  %44 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %45 = getelementptr %foo_b.7, %foo_b.7* %44, i32 0, i32 1
+  %46 = getelementptr %bar_b.5, %bar_b.5* %45, i32 0, i32 1
   %47 = load i32, i32* %46, align 4
   %48 = alloca i32, align 4
   store i32 %47, i32* %48, align 4
@@ -113,8 +113,8 @@ free_nonnull2:                                    ; preds = %free_done
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %59 = alloca i64, align 8
-  %60 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %61 = getelementptr %main.bar_c, %main.bar_c* %60, i32 0, i32 1
+  %60 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
+  %61 = getelementptr %bar_c.6, %bar_c.6* %60, i32 0, i32 1
   %62 = load i32, i32* %61, align 4
   %63 = alloca i32, align 4
   store i32 %62, i32* %63, align 4
@@ -138,18 +138,18 @@ free_nonnull5:                                    ; preds = %free_done3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %74 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %75 = getelementptr %main.foo_b, %main.foo_b* %74, i32 0, i32 0
-  %76 = getelementptr %main.foo_a, %main.foo_a* %75, i32 0, i32 0
-  %77 = getelementptr %main.bar_a, %main.bar_a* %76, i32 0, i32 0
+  %74 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %75 = getelementptr %foo_b.7, %foo_b.7* %74, i32 0, i32 0
+  %76 = getelementptr %foo_a.4, %foo_a.4* %75, i32 0, i32 0
+  %77 = getelementptr %bar_a.3, %bar_a.3* %76, i32 0, i32 0
   %78 = load i32, i32* %77, align 4
-  %79 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 0
-  %80 = getelementptr %main.foo_b, %main.foo_b* %79, i32 0, i32 1
-  %81 = getelementptr %main.bar_b, %main.bar_b* %80, i32 0, i32 1
+  %79 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
+  %80 = getelementptr %foo_b.7, %foo_b.7* %79, i32 0, i32 1
+  %81 = getelementptr %bar_b.5, %bar_b.5* %80, i32 0, i32 1
   %82 = load i32, i32* %81, align 4
   %83 = add i32 %78, %82
-  %84 = getelementptr %main.foo_c, %main.foo_c* %foo, i32 0, i32 1
-  %85 = getelementptr %main.bar_c, %main.bar_c* %84, i32 0, i32 1
+  %84 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
+  %85 = getelementptr %bar_c.6, %bar_c.6* %84, i32 0, i32 1
   %86 = load i32, i32* %85, align 4
   %87 = add i32 %83, %86
   %88 = icmp ne i32 %87, 0

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "606310611870be8d2e544178f1bf15c9a540ddc6b2e425f10609f7f8",
+    "stdout_hash": "54f31b894aca870b9b6a48a3a0625eac546ba6bc0e1cc5352e96859b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -2,13 +2,13 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%xx.base_class = type <{ i32 (...)**, %xx.base* }>
-%xx.base = type { i32 }
+%xx.base.3_class = type <{ i32 (...)**, %xx.base.3* }>
+%xx.base.3 = type { i32 }
 %string_descriptor = type <{ i8*, i64 }>
 
 @_Name_base = private unnamed_addr constant [5 x i8] c"base\00", align 1
 @_Type_Info_base = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @_Name_base, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_base = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_base to i8*), i8* bitcast (void (i8*, i8*)* @_copy_xx_base to i8*), i8* bitcast (void (i8**)* @_allocate_struct_xx_base to i8*), i8* bitcast (void (i8*)* @finalize_StructType__base_3_of_xx_for_UPoly to i8*), i8* bitcast (void (%xx.base_class*)* @__module_xx_show_x to i8*)] }, align 8
+@_VTable_base = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_base to i8*), i8* bitcast (void (i8*, i8*)* @_copy_xx_base to i8*), i8* bitcast (void (i8**)* @_allocate_struct_xx_base to i8*), i8* bitcast (void (i8*)* @finalize_StructType__base_3_of_xx_for_UPoly to i8*), i8* bitcast (void (%xx.base.3_class*)* @__module_xx_show_x to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -16,11 +16,11 @@ target datalayout = "..."
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_xx_show_x(%xx.base_class* %this) {
+define void @__module_xx_show_x(%xx.base.3_class* %this) {
 .entry:
-  %0 = getelementptr %xx.base_class, %xx.base_class* %this, i32 0, i32 1
-  %1 = load %xx.base*, %xx.base** %0, align 8
-  %2 = getelementptr %xx.base, %xx.base* %1, i32 0, i32 0
+  %0 = getelementptr %xx.base.3_class, %xx.base.3_class* %this, i32 0, i32 1
+  %1 = load %xx.base.3*, %xx.base.3** %0, align 8
+  %2 = getelementptr %xx.base.3, %xx.base.3* %1, i32 0, i32 0
   store i32 12, i32* %2, align 4
   br label %return
 
@@ -35,19 +35,19 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = call i8* @_lfortran_get_default_allocator()
-  %3 = alloca %xx.base_class, align 8
+  %3 = alloca %xx.base.3_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %b = alloca %xx.base, align 8
-  %4 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
-  %5 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
+  %b = alloca %xx.base.3, align 8
+  %4 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
+  %5 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
   store i32 10, i32* %5, align 4
-  %6 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 0
+  %6 = getelementptr %xx.base.3_class, %xx.base.3_class* %3, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
-  %7 = getelementptr %xx.base_class, %xx.base_class* %3, i32 0, i32 1
-  store %xx.base* %b, %xx.base** %7, align 8
-  call void @__module_xx_show_x(%xx.base_class* %3)
+  %7 = getelementptr %xx.base.3_class, %xx.base.3_class* %3, i32 0, i32 1
+  store %xx.base.3* %b, %xx.base.3** %7, align 8
+  call void @__module_xx_show_x(%xx.base.3_class* %3)
   %8 = alloca i64, align 8
-  %9 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
+  %9 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
   %10 = load i32, i32* %9, align 4
   %11 = alloca i32, align 4
   store i32 %10, i32* %11, align 4
@@ -71,7 +71,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %22 = getelementptr %xx.base, %xx.base* %b, i32 0, i32 0
+  %22 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
   %23 = load i32, i32* %22, align 4
   %24 = icmp ne i32 %23, 12
   br i1 %24, label %then, label %else
@@ -100,11 +100,11 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 
 define linkonce_odr void @_copy_xx_base(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %xx.base*
-  %3 = bitcast i8* %1 to %xx.base*
-  %4 = getelementptr %xx.base, %xx.base* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %xx.base.3*
+  %3 = bitcast i8* %1 to %xx.base.3*
+  %4 = getelementptr %xx.base.3, %xx.base.3* %2, i32 0, i32 0
   %5 = load i32, i32* %4, align 4
-  %6 = getelementptr %xx.base, %xx.base* %3, i32 0, i32 0
+  %6 = getelementptr %xx.base.3, %xx.base.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -125,22 +125,22 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %xx.base_class*
-  %5 = bitcast %xx.base_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %xx.base.3_class*
+  %5 = bitcast %xx.base.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %xx.base_class, %xx.base_class* %4, i32 0, i32 1
+  %6 = getelementptr %xx.base.3_class, %xx.base.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %xx.base*
-  store %xx.base* %9, %xx.base** %6, align 8
-  %10 = getelementptr %xx.base, %xx.base* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %xx.base.3*
+  store %xx.base.3* %9, %xx.base.3** %6, align 8
+  %10 = getelementptr %xx.base.3, %xx.base.3* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__base_3_of_xx_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %xx.base*
+  %1 = bitcast i8* %0 to %xx.base.3*
   ret void
 }
 

--- a/tests/reference/llvm-classes2-f926d51.json
+++ b/tests/reference/llvm-classes2-f926d51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes2-f926d51.stdout",
-    "stdout_hash": "b0485f66a2d3268e6be30c9b0a7e37b9353f6702a62147f07d04fb8f",
+    "stdout_hash": "0f3bd3d832853a7d5949aebacab368d284e81ae9d23aa03d9f9dfcb4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes2-f926d51.stdout
+++ b/tests/reference/llvm-classes2-f926d51.stdout
@@ -2,32 +2,32 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%defs.point_class = type <{ i32 (...)**, %defs.point* }>
-%defs.point = type {}
-%defs.point2d_class = type <{ i32 (...)**, %defs.point2d* }>
-%defs.point2d = type { %defs.point, float, float }
+%defs.point.3_class = type <{ i32 (...)**, %defs.point.3* }>
+%defs.point.3 = type {}
+%defs.point2d.5_class = type <{ i32 (...)**, %defs.point2d.5* }>
+%defs.point2d.5 = type { %defs.point.3, float, float }
 
 @_Name_point = private unnamed_addr constant [6 x i8] c"point\00", align 1
 @_Type_Info_point = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_point, i32 0, i32 0), i8* null, i8* null }, align 8
 @_VTable_point = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point_3_of_defs_for_UPoly to i8*), i8* null] }, align 8
 @_Name_point2d = private unnamed_addr constant [8 x i8] c"point2d\00", align 1
 @_Type_Info_point2d = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_Name_point2d, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*) }, align 8
-@_VTable_point2d = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point2d to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point2d to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point2d to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point2d_5_of_defs_for_UPoly to i8*), i8* bitcast (float (%defs.point2d_class*)* @__module_defs_r2d to i8*)] }, align 8
+@_VTable_point2d = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point2d to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point2d to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point2d to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point2d_5_of_defs_for_UPoly to i8*), i8* bitcast (float (%defs.point2d.5_class*)* @__module_defs_r2d to i8*)] }, align 8
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_defs_r2d(%defs.point2d_class* %this) {
+define float @__module_defs_r2d(%defs.point2d.5_class* %this) {
 .entry:
   %r2d = alloca float, align 4
-  %0 = getelementptr %defs.point2d_class, %defs.point2d_class* %this, i32 0, i32 1
-  %1 = load %defs.point2d*, %defs.point2d** %0, align 8
-  %2 = getelementptr %defs.point2d, %defs.point2d* %1, i32 0, i32 1
+  %0 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %this, i32 0, i32 1
+  %1 = load %defs.point2d.5*, %defs.point2d.5** %0, align 8
+  %2 = getelementptr %defs.point2d.5, %defs.point2d.5* %1, i32 0, i32 1
   %3 = load float, float* %2, align 4
   %simplified_pow_operation = fmul float %3, %3
-  %4 = getelementptr %defs.point2d_class, %defs.point2d_class* %this, i32 0, i32 1
-  %5 = load %defs.point2d*, %defs.point2d** %4, align 8
-  %6 = getelementptr %defs.point2d, %defs.point2d* %5, i32 0, i32 2
+  %4 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %this, i32 0, i32 1
+  %5 = load %defs.point2d.5*, %defs.point2d.5** %4, align 8
+  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %5, i32 0, i32 2
   %7 = load float, float* %6, align 4
   %simplified_pow_operation1 = fmul float %7, %7
   %8 = fadd float %simplified_pow_operation, %simplified_pow_operation1
@@ -50,45 +50,45 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %p2d = alloca %defs.point2d, align 8
-  %3 = getelementptr %defs.point2d, %defs.point2d* %p2d, i32 0, i32 1
-  %4 = getelementptr %defs.point2d, %defs.point2d* %p2d, i32 0, i32 2
-  %5 = getelementptr %defs.point2d, %defs.point2d* %p2d, i32 0, i32 0
-  %ptr = alloca %defs.point_class*, align 8
-  store %defs.point_class* null, %defs.point_class** %ptr, align 8
+  %p2d = alloca %defs.point2d.5, align 8
+  %3 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 1
+  %4 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 2
+  %5 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 0
+  %ptr = alloca %defs.point.3_class*, align 8
+  store %defs.point.3_class* null, %defs.point.3_class** %ptr, align 8
   %res = alloca float, align 4
-  %6 = getelementptr %defs.point2d, %defs.point2d* %p2d, i32 0, i32 1
+  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 1
   store float 3.000000e+00, float* %6, align 4
-  %7 = getelementptr %defs.point2d, %defs.point2d* %p2d, i32 0, i32 2
+  %7 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 2
   store float 4.000000e+00, float* %7, align 4
-  %8 = load %defs.point_class*, %defs.point_class** %ptr, align 8
-  %9 = icmp eq %defs.point_class* %8, null
+  %8 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
+  %9 = icmp eq %defs.point.3_class* %8, null
   br i1 %9, label %then, label %else
 
 then:                                             ; preds = %.entry
   %10 = call i8* @_lfortran_get_default_allocator()
   %11 = call i8* @_lfortran_malloc_alloc(i8* %10, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %11, i8 0, i32 16, i1 false)
-  %12 = bitcast i8* %11 to %defs.point_class*
-  store %defs.point_class* %12, %defs.point_class** %ptr, align 8
+  %12 = bitcast i8* %11 to %defs.point.3_class*
+  store %defs.point.3_class* %12, %defs.point.3_class** %ptr, align 8
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %13 = load %defs.point_class*, %defs.point_class** %ptr, align 8
-  %14 = bitcast %defs.point_class* %13 to i32 (...)***
+  %13 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
+  %14 = bitcast %defs.point.3_class* %13 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
-  %15 = getelementptr %defs.point_class, %defs.point_class* %13, i32 0, i32 1
-  %16 = bitcast %defs.point2d* %p2d to %defs.point*
-  store %defs.point* %16, %defs.point** %15, align 8
-  %17 = load %defs.point_class*, %defs.point_class** %ptr, align 8
-  %18 = bitcast %defs.point_class* %17 to float (%defs.point_class*)***
-  %19 = load float (%defs.point_class*)**, float (%defs.point_class*)*** %18, align 8
-  %20 = getelementptr inbounds float (%defs.point_class*)*, float (%defs.point_class*)** %19, i32 3
-  %21 = load float (%defs.point_class*)*, float (%defs.point_class*)** %20, align 8
-  %22 = call float %21(%defs.point_class* %17)
+  %15 = getelementptr %defs.point.3_class, %defs.point.3_class* %13, i32 0, i32 1
+  %16 = bitcast %defs.point2d.5* %p2d to %defs.point.3*
+  store %defs.point.3* %16, %defs.point.3** %15, align 8
+  %17 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
+  %18 = bitcast %defs.point.3_class* %17 to float (%defs.point.3_class*)***
+  %19 = load float (%defs.point.3_class*)**, float (%defs.point.3_class*)*** %18, align 8
+  %20 = getelementptr inbounds float (%defs.point.3_class*)*, float (%defs.point.3_class*)** %19, i32 3
+  %21 = load float (%defs.point.3_class*)*, float (%defs.point.3_class*)** %20, align 8
+  %22 = call float %21(%defs.point.3_class* %17)
   store float %22, float* %res, align 4
   %23 = load float, float* %res, align 4
   %24 = fcmp une float %23, 5.000000e+00
@@ -113,12 +113,12 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   br label %Finalize_Variable_ptr
 
 Finalize_Variable_ptr:                            ; preds = %FINALIZE_SYMTABLE_main
-  %25 = load %defs.point_class*, %defs.point_class** %ptr, align 8
-  %26 = icmp ne %defs.point_class* %25, null
+  %25 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
+  %26 = icmp ne %defs.point.3_class* %25, null
   br i1 %26, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %Finalize_Variable_ptr
-  %27 = bitcast %defs.point_class* %25 to i8*
+  %27 = bitcast %defs.point.3_class* %25 to i8*
   call void @_lfortran_free_alloc(i8* %2, i8* %27)
   br label %is_allocated.ifcont
 
@@ -141,8 +141,8 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 
 define linkonce_odr void @_copy_defs_point(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %defs.point*
-  %3 = bitcast i8* %1 to %defs.point*
+  %2 = bitcast i8* %0 to %defs.point.3*
+  %3 = bitcast i8* %1 to %defs.point.3*
   ret void
 }
 
@@ -153,31 +153,31 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %defs.point_class*
-  %5 = bitcast %defs.point_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %defs.point.3_class*
+  %5 = bitcast %defs.point.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %defs.point_class, %defs.point_class* %4, i32 0, i32 1
+  %6 = getelementptr %defs.point.3_class, %defs.point.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
-  %9 = bitcast i8* %8 to %defs.point*
-  store %defs.point* %9, %defs.point** %6, align 8
+  %9 = bitcast i8* %8 to %defs.point.3*
+  store %defs.point.3* %9, %defs.point.3** %6, align 8
   ret void
 }
 
 define internal void @finalize_StructType__point_3_of_defs_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %defs.point*
+  %1 = bitcast i8* %0 to %defs.point.3*
   ret void
 }
 
 define linkonce_odr void @_copy_defs_point2d(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %defs.point2d*
-  %3 = bitcast i8* %1 to %defs.point2d*
-  %4 = getelementptr %defs.point2d, %defs.point2d* %2, i32 0, i32 1
+  %2 = bitcast i8* %0 to %defs.point2d.5*
+  %3 = bitcast i8* %1 to %defs.point2d.5*
+  %4 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %defs.point2d, %defs.point2d* %3, i32 0, i32 1
+  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -188,9 +188,9 @@ else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %defs.point2d, %defs.point2d* %2, i32 0, i32 2
+  %7 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 2
   %8 = load float, float* %7, align 4
-  %9 = getelementptr %defs.point2d, %defs.point2d* %3, i32 0, i32 2
+  %9 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
@@ -201,8 +201,8 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %10 = getelementptr %defs.point2d, %defs.point2d* %2, i32 0, i32 0
-  %11 = getelementptr %defs.point2d, %defs.point2d* %3, i32 0, i32 0
+  %10 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 0
+  %11 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 0
   ret void
 }
 
@@ -213,24 +213,24 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %defs.point2d_class*
-  %5 = bitcast %defs.point2d_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %defs.point2d.5_class*
+  %5 = bitcast %defs.point2d.5_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %defs.point2d_class, %defs.point2d_class* %4, i32 0, i32 1
+  %6 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %defs.point2d*
-  store %defs.point2d* %9, %defs.point2d** %6, align 8
-  %10 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 1
-  %11 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 2
-  %12 = getelementptr %defs.point2d, %defs.point2d* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %defs.point2d.5*
+  store %defs.point2d.5* %9, %defs.point2d.5** %6, align 8
+  %10 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 1
+  %11 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 2
+  %12 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__point2d_5_of_defs_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %defs.point2d*
+  %1 = bitcast i8* %0 to %defs.point2d.5*
   ret void
 }
 

--- a/tests/reference/llvm-codegen_function_polymorphic-834d4d1.json
+++ b/tests/reference/llvm-codegen_function_polymorphic-834d4d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-codegen_function_polymorphic-834d4d1.stdout",
-    "stdout_hash": "a36199d2878322961bb2c7b68a87289503ab8f6e260bb7e660bbfa93",
+    "stdout_hash": "6f5fb1e8ee314b319ba6c82623c2832261542cd206c22254c09ba570",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-codegen_function_polymorphic-834d4d1.stdout
+++ b/tests/reference/llvm-codegen_function_polymorphic-834d4d1.stdout
@@ -2,27 +2,27 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%codegen_function_polymorphic.abstype_class = type <{ i32 (...)**, %codegen_function_polymorphic.abstype* }>
-%codegen_function_polymorphic.abstype = type {}
+%codegen_function_polymorphic.abstype.3_class = type <{ i32 (...)**, %codegen_function_polymorphic.abstype.3* }>
+%codegen_function_polymorphic.abstype.3 = type {}
 
-define void @__module_codegen_function_polymorphic_my_func(%codegen_function_polymorphic.abstype_class** %obj) {
+define void @__module_codegen_function_polymorphic_my_func(%codegen_function_polymorphic.abstype.3_class** %obj) {
 .entry:
   %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load %codegen_function_polymorphic.abstype_class*, %codegen_function_polymorphic.abstype_class** %obj, align 8
-  %2 = ptrtoint %codegen_function_polymorphic.abstype_class* %1 to i64
+  %1 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
+  %2 = ptrtoint %codegen_function_polymorphic.abstype.3_class* %1 to i64
   %3 = icmp ne i64 %2, 0
   br i1 %3, label %then, label %else2
 
 then:                                             ; preds = %.entry
-  %4 = load %codegen_function_polymorphic.abstype_class*, %codegen_function_polymorphic.abstype_class** %obj, align 8
-  %5 = load %codegen_function_polymorphic.abstype_class*, %codegen_function_polymorphic.abstype_class** %obj, align 8
-  %6 = ptrtoint %codegen_function_polymorphic.abstype_class* %5 to i64
+  %4 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
+  %5 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
+  %6 = ptrtoint %codegen_function_polymorphic.abstype.3_class* %5 to i64
   %7 = icmp ne i64 %6, 0
   br i1 %7, label %then1, label %else
 
 then1:                                            ; preds = %then
-  call void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype_class* %5)
-  store %codegen_function_polymorphic.abstype_class* null, %codegen_function_polymorphic.abstype_class** %obj, align 8
+  call void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %5)
+  store %codegen_function_polymorphic.abstype.3_class* null, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
   br label %ifcont
 
 else:                                             ; preds = %then
@@ -48,21 +48,21 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare i8* @_lfortran_get_default_allocator()
 
-define internal void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0) {
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %codegen_function_polymorphic.abstype_class* %0, null
+  %2 = icmp ne %codegen_function_polymorphic.abstype.3_class* %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype_class* %0)
-  %3 = getelementptr %codegen_function_polymorphic.abstype_class, %codegen_function_polymorphic.abstype_class* %0, i32 0, i32 1
-  %4 = load %codegen_function_polymorphic.abstype*, %codegen_function_polymorphic.abstype** %3, align 8
-  %5 = icmp ne %codegen_function_polymorphic.abstype* %4, null
+  call void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0)
+  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 1
+  %4 = load %codegen_function_polymorphic.abstype.3*, %codegen_function_polymorphic.abstype.3** %3, align 8
+  %5 = icmp ne %codegen_function_polymorphic.abstype.3* %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %codegen_function_polymorphic.abstype* %4 to i8*
+  %6 = bitcast %codegen_function_polymorphic.abstype.3* %4 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %6)
   br label %is_allocated.ifcont
 
@@ -70,7 +70,7 @@ is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %codegen_function_polymorphic.abstype_class* %0 to i8*
+  %7 = bitcast %codegen_function_polymorphic.abstype.3_class* %0 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %7)
   br label %is_allocated.ifcont3
 
@@ -81,13 +81,13 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype_class* %0) {
+define internal void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0) {
 entry:
-  %1 = getelementptr %codegen_function_polymorphic.abstype_class, %codegen_function_polymorphic.abstype_class* %0, i32 0, i32 0
+  %1 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 0
   %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %codegen_function_polymorphic.abstype_class, %codegen_function_polymorphic.abstype_class* %0, i32 0, i32 1
-  %4 = load %codegen_function_polymorphic.abstype**, %codegen_function_polymorphic.abstype** %3, align 8
-  %5 = bitcast %codegen_function_polymorphic.abstype** %4 to i8*
+  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 1
+  %4 = load %codegen_function_polymorphic.abstype.3**, %codegen_function_polymorphic.abstype.3** %3, align 8
+  %5 = bitcast %codegen_function_polymorphic.abstype.3** %4 to i8*
   %6 = icmp ne i32 (...)** %2, null
   br i1 %6, label %is_allocated.then, label %is_allocated.else2
 

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-common_linkage_separate_compilation_01-4003f83.stdout",
-    "stdout_hash": "e41cdd6483888f46e592c246582e36d81d19768671a3094fadc13b1b",
+    "stdout_hash": "86ac0b2ceac08dd70933fd94e8b7fcd7a9c5674f244183c16ceb3cbc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
@@ -2,9 +2,9 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%file_common_block_blk.blk = type { i32 }
+%file_common_block_blk.blk.4 = type { i32 }
 
-@__module_file_common_block_blk_struct_instance_blk = common global %file_common_block_blk.blk zeroinitializer
+@__module_file_common_block_blk_struct_instance_blk = common global %file_common_block_blk.blk.4 zeroinitializer
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [8 x i8] c"%s %d%s\00", align 1
@@ -12,8 +12,8 @@ target datalayout = "..."
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 5, i32* getelementptr inbounds (%file_common_block_blk.blk, %file_common_block_blk.blk* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
-  %2 = load i32, i32* getelementptr inbounds (%file_common_block_blk.blk, %file_common_block_blk.blk* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
+  store i32 5, i32* getelementptr inbounds (%file_common_block_blk.blk.4, %file_common_block_blk.blk.4* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
+  %2 = load i32, i32* getelementptr inbounds (%file_common_block_blk.blk.4, %file_common_block_blk.blk.4* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
   %3 = icmp ne i32 %2, 5
   br i1 %3, label %then, label %else
 

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "da050356680c05eb461027bc64c083592bcab6b9615e704004c336d0",
+    "stdout_hash": "af1628df27940e0c59e79f47f249c1653a0a946e6343597206ecebea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -2,7 +2,7 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%derived_types_45_mod.myint = type { i32 }
+%derived_types_45_mod.myint.3 = type { i32 }
 
 @0 = private unnamed_addr constant [4 x i8] c"ins\00", align 1
 @1 = private unnamed_addr constant [48 x i8] c"tests/../integration_tests/derived_types_45.f90\00", align 1
@@ -16,34 +16,34 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %ins = alloca %derived_types_45_mod.myint*, align 8
-  store %derived_types_45_mod.myint* null, %derived_types_45_mod.myint** %ins, align 8
-  %temp_struct_var__ = alloca %derived_types_45_mod.myint, align 8
-  %3 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %temp_struct_var__, i32 0, i32 0
-  %4 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %temp_struct_var__, i32 0, i32 0
+  %ins = alloca %derived_types_45_mod.myint.3*, align 8
+  store %derived_types_45_mod.myint.3* null, %derived_types_45_mod.myint.3** %ins, align 8
+  %temp_struct_var__ = alloca %derived_types_45_mod.myint.3, align 8
+  %3 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
+  %4 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
   store i32 44, i32* %4, align 4
-  %5 = load %derived_types_45_mod.myint*, %derived_types_45_mod.myint** %ins, align 8
-  %6 = icmp eq %derived_types_45_mod.myint* %5, null
+  %5 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
+  %6 = icmp eq %derived_types_45_mod.myint.3* %5, null
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %derived_types_45_mod.myint*
-  store %derived_types_45_mod.myint* %9, %derived_types_45_mod.myint** %ins, align 8
-  %10 = load %derived_types_45_mod.myint*, %derived_types_45_mod.myint** %ins, align 8
-  %11 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %10, i32 0, i32 0
+  %9 = bitcast i8* %8 to %derived_types_45_mod.myint.3*
+  store %derived_types_45_mod.myint.3* %9, %derived_types_45_mod.myint.3** %ins, align 8
+  %10 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
+  %11 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %10, i32 0, i32 0
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load %derived_types_45_mod.myint*, %derived_types_45_mod.myint** %ins, align 8
-  %13 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %temp_struct_var__, i32 0, i32 0
+  %12 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
+  %13 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
   %14 = load i32, i32* %13, align 4
-  %15 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %12, i32 0, i32 0
+  %15 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %12, i32 0, i32 0
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
@@ -54,8 +54,8 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %16 = load %derived_types_45_mod.myint*, %derived_types_45_mod.myint** %ins, align 8
-  %17 = ptrtoint %derived_types_45_mod.myint* %16 to i64
+  %16 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
+  %17 = ptrtoint %derived_types_45_mod.myint.3* %16 to i64
   %18 = icmp eq i64 %17, 0
   br i1 %18, label %then4, label %ifcont5
 
@@ -90,7 +90,7 @@ then4:                                            ; preds = %ifcont3
   unreachable
 
 ifcont5:                                          ; preds = %ifcont3
-  %35 = getelementptr %derived_types_45_mod.myint, %derived_types_45_mod.myint* %16, i32 0, i32 0
+  %35 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %16, i32 0, i32 0
   %36 = load i32, i32* %35, align 4
   %37 = icmp ne i32 %36, 44
   br i1 %37, label %then6, label %else7
@@ -114,8 +114,8 @@ FINALIZE_SYMTABLE_derived_types_45:               ; preds = %return
   br label %Finalize_Variable_ins
 
 Finalize_Variable_ins:                            ; preds = %FINALIZE_SYMTABLE_derived_types_45
-  %38 = load %derived_types_45_mod.myint*, %derived_types_45_mod.myint** %ins, align 8
-  call void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint* %38)
+  %38 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
+  call void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint.3* %38)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
@@ -139,14 +139,14 @@ declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-define internal void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint* %0) {
+define internal void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint.3* %0) {
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %derived_types_45_mod.myint* %0, null
+  %2 = icmp ne %derived_types_45_mod.myint.3* %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  %3 = bitcast %derived_types_45_mod.myint* %0 to i8*
+  %3 = bitcast %derived_types_45_mod.myint.3* %0 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %3)
   br label %is_allocated.ifcont
 

--- a/tests/reference/llvm-finalize_02-cfb24d5.json
+++ b/tests/reference/llvm-finalize_02-cfb24d5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_02-cfb24d5.stdout",
-    "stdout_hash": "e30150564e9a6c911217adf980cff0b082c6a9e4ab098ae3554af99f",
+    "stdout_hash": "4abb0d7747c5163ad52a8e33fc02b47ce7288bad61a139dc23c8acef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.stdout
+++ b/tests/reference/llvm-finalize_02-cfb24d5.stdout
@@ -6,9 +6,9 @@ target datalayout = "..."
 %array.1.1 = type { %string_descriptor*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
 %array.1.0 = type { i32*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
-%array.1 = type { %finalize_02.tt*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
-%finalize_02.tt = type { float, %finalize_02.t }
-%finalize_02.t = type { i32 }
+%array.1 = type { %tt.4*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%tt.4 = type { float, %t.3 }
+%t.3 = type { i32 }
 
 @deep_0 = internal global i32 0
 
@@ -55,7 +55,7 @@ define void @ss(i32* %nang) {
   %8 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
   store i8 1, i8* %8, align 1
   %9 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store %finalize_02.tt* null, %finalize_02.tt** %9, align 8
+  store %tt.4* null, %tt.4** %9, align 8
   store %array.1* %arr_desc, %array.1** %arr_01, align 8
   %arr_02 = alloca %array.1.0*, align 8
   store %array.1.0* null, %array.1.0** %arr_02, align 8
@@ -256,8 +256,8 @@ entry:
   %2 = alloca i32, align 4
   %3 = alloca i64, align 8
   %4 = getelementptr %array.1, %array.1* %0, i32 0, i32 0
-  %5 = load %finalize_02.tt*, %finalize_02.tt** %4, align 8
-  %6 = icmp ne %finalize_02.tt* %5, null
+  %5 = load %tt.4*, %tt.4** %4, align 8
+  %6 = icmp ne %tt.4* %5, null
   br i1 %6, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
@@ -292,19 +292,19 @@ loop.body:                                        ; preds = %loop.head
 
 loop.end:                                         ; preds = %loop.head
   %21 = load i64, i64* %3, align 8
-  call void @finalize_array_data_StructType__tt_4(%finalize_02.tt* %5, i64 %21)
+  call void @finalize_array_data_StructType__tt_4(%tt.4* %5, i64 %21)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %loop.end
-  %22 = ptrtoint %finalize_02.tt* %5 to i64
+  %22 = ptrtoint %tt.4* %5 to i64
   %23 = icmp ne i64 %22, 0
   br i1 %23, label %then, label %else
 
 then:                                             ; preds = %is_allocated.ifcont
-  %24 = bitcast %finalize_02.tt* %5 to i8*
+  %24 = bitcast %tt.4* %5 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %24)
   br label %ifcont
 
@@ -315,7 +315,7 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define internal void @finalize_array_data_StructType__tt_4(%finalize_02.tt* %0, i64 %1) {
+define internal void @finalize_array_data_StructType__tt_4(%tt.4* %0, i64 %1) {
 entry:
   %arrSize_iter = alloca i64, align 8
   store i64 -1, i64* %arrSize_iter, align 8
@@ -330,7 +330,7 @@ Finalize_array_of_structs.head:                   ; preds = %Finalize_array_of_s
 
 Finalize_array_of_structs.body:                   ; preds = %Finalize_array_of_structs.head
   %5 = load i64, i64* %arrSize_iter, align 8
-  %6 = getelementptr inbounds %finalize_02.tt, %finalize_02.tt* %0, i64 %5
+  %6 = getelementptr inbounds %tt.4, %tt.4* %0, i64 %5
   br label %Finalize_array_of_structs.head
 
 Finalize_array_of_structs.end:                    ; preds = %Finalize_array_of_structs.head

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "f19dc08b28a12fa1219626f5b0fcabbbec21abb5a85ca1843035f192",
+    "stdout_hash": "d234d25eb0558c1ba9fe38fb862b2295e26f9742767f59270f3b4272",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -3,8 +3,8 @@ source_filename = "LFortran"
 target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
-%complex_module.complextype_class = type <{ i32 (...)**, %complex_module.complextype* }>
-%complex_module.complextype = type { float, float }
+%complex_module.complextype.3_class = type <{ i32 (...)**, %complex_module.complextype.3* }>
+%complex_module.complextype.3 = type { float, float }
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [27 x i8] c"Calling integer_add_subrout"
@@ -16,7 +16,7 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_complextype = private unnamed_addr constant [12 x i8] c"complextype\00", align 1
 @_Type_Info_complextype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_Name_complextype, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* null }, align 8
-@_VTable_complextype = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_complextype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_complex_module_complextype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_complex_module_complextype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__complextype_3_of_complex_module_for_UPoly to i8*), i8* bitcast (void (%complex_module.complextype_class*, i32*, i32*, %complex_module.complextype*)* @__module_complex_module_integer_add_subrout to i8*), i8* bitcast (void (%complex_module.complextype_class*, float*, float*, %complex_module.complextype*)* @__module_complex_module_real_add_subrout to i8*)] }, align 8
+@_VTable_complextype = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_complextype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_complex_module_complextype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_complex_module_complextype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__complextype_3_of_complex_module_for_UPoly to i8*), i8* bitcast (void (%complex_module.complextype.3_class*, i32*, i32*, %complex_module.complextype.3*)* @__module_complex_module_integer_add_subrout to i8*), i8* bitcast (void (%complex_module.complextype.3_class*, float*, float*, %complex_module.complextype.3*)* @__module_complex_module_real_add_subrout to i8*)] }, align 8
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [6 x i8] c"R4,R4\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -33,25 +33,25 @@ target datalayout = "..."
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_complex_module_integer_add_subrout(%complex_module.complextype_class* %this, i32* %r, i32* %i, %complex_module.complextype* %sum) {
+define void @__module_complex_module_integer_add_subrout(%complex_module.complextype.3_class* %this, i32* %r, i32* %i, %complex_module.complextype.3* %sum) {
 .entry:
-  %0 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 1
-  %1 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 0
+  %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
+  %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %3 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 0
-  %4 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %this, i32 0, i32 1
-  %5 = load %complex_module.complextype*, %complex_module.complextype** %4, align 8
-  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %5, i32 0, i32 0
+  %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
+  %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
+  %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
+  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %5, i32 0, i32 0
   %7 = load float, float* %6, align 4
   %8 = load i32, i32* %r, align 4
   %9 = sitofp i32 %8 to float
   %10 = fadd float %7, %9
   store float %10, float* %3, align 4
-  %11 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 1
-  %12 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %this, i32 0, i32 1
-  %13 = load %complex_module.complextype*, %complex_module.complextype** %12, align 8
-  %14 = getelementptr %complex_module.complextype, %complex_module.complextype* %13, i32 0, i32 1
+  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
+  %12 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
+  %13 = load %complex_module.complextype.3*, %complex_module.complextype.3** %12, align 8
+  %14 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %13, i32 0, i32 1
   %15 = load float, float* %14, align 4
   %16 = load i32, i32* %i, align 4
   %17 = sitofp i32 %16 to float
@@ -66,24 +66,24 @@ FINALIZE_SYMTABLE_integer_add_subrout:            ; preds = %return
   ret void
 }
 
-define void @__module_complex_module_real_add_subrout(%complex_module.complextype_class* %this, float* %r, float* %i, %complex_module.complextype* %sum) {
+define void @__module_complex_module_real_add_subrout(%complex_module.complextype.3_class* %this, float* %r, float* %i, %complex_module.complextype.3* %sum) {
 .entry:
-  %0 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 1
-  %1 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 0
+  %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
+  %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i32 24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %3 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 0
-  %4 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %this, i32 0, i32 1
-  %5 = load %complex_module.complextype*, %complex_module.complextype** %4, align 8
-  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %5, i32 0, i32 0
+  %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
+  %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
+  %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
+  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %5, i32 0, i32 0
   %7 = load float, float* %6, align 4
   %8 = load float, float* %r, align 4
   %9 = fadd float %7, %8
   store float %9, float* %3, align 4
-  %10 = getelementptr %complex_module.complextype, %complex_module.complextype* %sum, i32 0, i32 1
-  %11 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %this, i32 0, i32 1
-  %12 = load %complex_module.complextype*, %complex_module.complextype** %11, align 8
-  %13 = getelementptr %complex_module.complextype, %complex_module.complextype* %12, i32 0, i32 1
+  %10 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
+  %11 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
+  %12 = load %complex_module.complextype.3*, %complex_module.complextype.3** %11, align 8
+  %13 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %12, i32 0, i32 1
   %14 = load float, float* %13, align 4
   %15 = load float, float* %i, align 4
   %16 = fadd float %14, %15
@@ -102,17 +102,17 @@ declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %2 = alloca %complex_module.complextype_class, align 8
+  %2 = alloca %complex_module.complextype.3_class, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
   %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = alloca %complex_module.complextype_class, align 8
+  %4 = alloca %complex_module.complextype.3_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %a = alloca %complex_module.complextype, align 8
-  %5 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
-  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
-  %c = alloca %complex_module.complextype, align 8
-  %7 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
-  %8 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
+  %a = alloca %complex_module.complextype.3, align 8
+  %5 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
+  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
+  %c = alloca %complex_module.complextype.3, align 8
+  %7 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 1
+  %8 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 0
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
@@ -125,23 +125,23 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %ione, align 4
   store i32 0, i32* %izero, align 4
   store float -1.000000e+00, float* %negfpone, align 4
-  %9 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 0
+  %9 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 0
   %10 = load float, float* %fpone, align 4
   store float %10, float* %9, align 4
-  %11 = getelementptr %complex_module.complextype, %complex_module.complextype* %c, i32 0, i32 1
+  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 1
   %12 = load float, float* %fptwo, align 4
   store float %12, float* %11, align 4
-  %13 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 0
+  %13 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
-  %14 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 1
-  store %complex_module.complextype* %c, %complex_module.complextype** %14, align 8
-  call void @__module_complex_module_integer_add_subrout(%complex_module.complextype_class* %4, i32* %ione, i32* %izero, %complex_module.complextype* %a)
+  %14 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 1
+  store %complex_module.complextype.3* %c, %complex_module.complextype.3** %14, align 8
+  call void @__module_complex_module_integer_add_subrout(%complex_module.complextype.3_class* %4, i32* %ione, i32* %izero, %complex_module.complextype.3* %a)
   %15 = alloca i64, align 8
-  %16 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %16 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
   %17 = load float, float* %16, align 4
   %18 = alloca float, align 4
   store float %17, float* %18, align 4
-  %19 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %19 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
   %20 = load float, float* %19, align 4
   %21 = alloca float, align 4
   store float %20, float* %21, align 4
@@ -165,7 +165,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %32 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %32 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
   %33 = load float, float* %32, align 4
   %34 = fcmp une float %33, 2.000000e+00
   br i1 %34, label %then, label %else
@@ -180,7 +180,7 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %35 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %35 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
   %36 = load float, float* %35, align 4
   %37 = fcmp une float %36, 2.000000e+00
   br i1 %37, label %then1, label %else2
@@ -195,17 +195,17 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %38 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 0
+  %38 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %2, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %38, align 8
-  %39 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %2, i32 0, i32 1
-  store %complex_module.complextype* %c, %complex_module.complextype** %39, align 8
-  call void @__module_complex_module_real_add_subrout(%complex_module.complextype_class* %2, float* %fpzero, float* %negfpone, %complex_module.complextype* %a)
+  %39 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %2, i32 0, i32 1
+  store %complex_module.complextype.3* %c, %complex_module.complextype.3** %39, align 8
+  call void @__module_complex_module_real_add_subrout(%complex_module.complextype.3_class* %2, float* %fpzero, float* %negfpone, %complex_module.complextype.3* %a)
   %40 = alloca i64, align 8
-  %41 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %41 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
   %42 = load float, float* %41, align 4
   %43 = alloca float, align 4
   store float %42, float* %43, align 4
-  %44 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %44 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
   %45 = load float, float* %44, align 4
   %46 = alloca float, align 4
   store float %45, float* %46, align 4
@@ -229,7 +229,7 @@ free_nonnull5:                                    ; preds = %ifcont3
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %ifcont3
-  %57 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 0
+  %57 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
   %58 = load float, float* %57, align 4
   %59 = fcmp une float %58, 1.000000e+00
   br i1 %59, label %then7, label %else8
@@ -244,7 +244,7 @@ else8:                                            ; preds = %free_done6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %60 = getelementptr %complex_module.complextype, %complex_module.complextype* %a, i32 0, i32 1
+  %60 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
   %61 = load float, float* %60, align 4
   %62 = fcmp une float %61, 1.000000e+00
   br i1 %62, label %then10, label %else11
@@ -273,11 +273,11 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 
 define linkonce_odr void @_copy_complex_module_complextype(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %complex_module.complextype*
-  %3 = bitcast i8* %1 to %complex_module.complextype*
-  %4 = getelementptr %complex_module.complextype, %complex_module.complextype* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %complex_module.complextype.3*
+  %3 = bitcast i8* %1 to %complex_module.complextype.3*
+  %4 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %2, i32 0, i32 0
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %complex_module.complextype, %complex_module.complextype* %3, i32 0, i32 0
+  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -288,9 +288,9 @@ else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %complex_module.complextype, %complex_module.complextype* %2, i32 0, i32 1
+  %7 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %2, i32 0, i32 1
   %8 = load float, float* %7, align 4
-  %9 = getelementptr %complex_module.complextype, %complex_module.complextype* %3, i32 0, i32 1
+  %9 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %3, i32 0, i32 1
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
@@ -311,23 +311,23 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %complex_module.complextype_class*
-  %5 = bitcast %complex_module.complextype_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %complex_module.complextype.3_class*
+  %5 = bitcast %complex_module.complextype.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %complex_module.complextype_class, %complex_module.complextype_class* %4, i32 0, i32 1
+  %6 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %complex_module.complextype*
-  store %complex_module.complextype* %9, %complex_module.complextype** %6, align 8
-  %10 = getelementptr %complex_module.complextype, %complex_module.complextype* %9, i32 0, i32 1
-  %11 = getelementptr %complex_module.complextype, %complex_module.complextype* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %complex_module.complextype.3*
+  store %complex_module.complextype.3* %9, %complex_module.complextype.3** %6, align 8
+  %10 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %9, i32 0, i32 1
+  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__complextype_3_of_complex_module_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %complex_module.complextype*
+  %1 = bitcast i8* %0 to %complex_module.complextype.3*
   ret void
 }
 

--- a/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.json
+++ b/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-module_struct_global_separate_compilation_01-043bc7f.stdout",
-    "stdout_hash": "b82ecf848076f71fba483f0cb5472ca2b80d316b04b57ada4171b6ed",
+    "stdout_hash": "3312f21b19cb099a6045658030b4bdfaef3d2d6169a25cb520da9567",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.stdout
+++ b/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.stdout
@@ -2,14 +2,14 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%module_struct_global_separate_compilation_01.t = type { i32 }
+%module_struct_global_separate_compilation_01.t.3 = type { i32 }
 
-@__module_module_struct_global_separate_compilation_01_targets = global %module_struct_global_separate_compilation_01.t zeroinitializer
+@__module_module_struct_global_separate_compilation_01_targets = global %module_struct_global_separate_compilation_01.t.3 zeroinitializer
 
 define void @__module_module_struct_global_separate_compilation_01_set_targets(i32* %v) {
 .entry:
   %0 = load i32, i32* %v, align 4
-  store i32 %0, i32* getelementptr inbounds (%module_struct_global_separate_compilation_01.t, %module_struct_global_separate_compilation_01.t* @__module_module_struct_global_separate_compilation_01_targets, i32 0, i32 0), align 4
+  store i32 %0, i32* getelementptr inbounds (%module_struct_global_separate_compilation_01.t.3, %module_struct_global_separate_compilation_01.t.3* @__module_module_struct_global_separate_compilation_01_targets, i32 0, i32 0), align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "3f307de9c697b81b0716b2fdca34d97eaade7a49c033197e3ad95a1a",
+    "stdout_hash": "1724cc9d5e541fc032458fbde64d574cdd2845f450086e2c8a656651",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -3,10 +3,10 @@ source_filename = "LFortran"
 target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
-%modules_36_fpm_main_01.fpm_run_settings_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_run_settings* }>
-%modules_36_fpm_main_01.fpm_run_settings = type { %modules_36_fpm_main_01.fpm_build_settings, %string_descriptor, %string_descriptor, %string_descriptor, i32 }
-%modules_36_fpm_main_01.fpm_build_settings = type { i32 }
-%modules_36_fpm_main_01.fpm_build_settings_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_build_settings* }>
+%modules_36_fpm_main_01.fpm_run_settings.4_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_run_settings.4* }>
+%modules_36_fpm_main_01.fpm_run_settings.4 = type { %modules_36_fpm_main_01.fpm_build_settings.3, %string_descriptor, %string_descriptor, %string_descriptor, i32 }
+%modules_36_fpm_main_01.fpm_build_settings.3 = type { i32 }
+%modules_36_fpm_main_01.fpm_build_settings.3_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_build_settings.3* }>
 
 @0 = private unnamed_addr constant [47 x i8] c"__libasr_created__intrinsic_array_function_Any\00", align 1
 @1 = private unnamed_addr constant [42 x i8] c"tests/../integration_tests/modules_36.f90\00", align 1
@@ -128,7 +128,7 @@ FINALIZE_SYMTABLE__lcompilers_Any_4_1_0_logical____0: ; preds = %return
   ret i32 %43
 }
 
-define void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings_class* %settings, i32* %test) {
+define void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32* %test) {
 .entry:
   %call_arg_value = alloca i32, align 4
   %array_bound14 = alloca i32, align 4
@@ -409,9 +409,9 @@ ifcont23:                                         ; preds = %loop.end
   %119 = xor i32 %118, 1
   %120 = and i32 %117, %119
   %121 = load i32, i32* %toomany, align 4
-  %122 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %settings, i32 0, i32 1
-  %123 = load %modules_36_fpm_main_01.fpm_run_settings*, %modules_36_fpm_main_01.fpm_run_settings** %122, align 8
-  %124 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %123, i32 0, i32 3
+  %122 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32 0, i32 1
+  %123 = load %modules_36_fpm_main_01.fpm_run_settings.4*, %modules_36_fpm_main_01.fpm_run_settings.4** %122, align 8
+  %124 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %123, i32 0, i32 3
   %125 = getelementptr %string_descriptor, %string_descriptor* %124, i32 0, i32 0
   %126 = load i8*, i8** %125, align 8
   %127 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
@@ -420,10 +420,10 @@ ifcont23:                                         ; preds = %loop.end
   %130 = zext i1 %129 to i32
   %131 = and i32 %121, %130
   %132 = or i32 %120, %131
-  %133 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %settings, i32 0, i32 1
-  %134 = load %modules_36_fpm_main_01.fpm_run_settings*, %modules_36_fpm_main_01.fpm_run_settings** %133, align 8
-  %135 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %134, i32 0, i32 0
-  %136 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %135, i32 0, i32 0
+  %133 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32 0, i32 1
+  %134 = load %modules_36_fpm_main_01.fpm_run_settings.4*, %modules_36_fpm_main_01.fpm_run_settings.4** %133, align 8
+  %135 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %134, i32 0, i32 0
+  %136 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %135, i32 0, i32 0
   %137 = load i32, i32* %136, align 4
   %138 = xor i32 %137, 1
   %139 = and i32 %132, %138
@@ -460,10 +460,10 @@ declare i32 @str_compare(i8*, i64, i8*, i64)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  %2 = alloca %modules_36_fpm_main_01.fpm_run_settings_class, align 8
+  %2 = alloca %modules_36_fpm_main_01.fpm_run_settings.4_class, align 8
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %settings = alloca %modules_36_fpm_main_01.fpm_run_settings, align 8
-  %3 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %settings, i32 0, i32 2
+  %settings = alloca %modules_36_fpm_main_01.fpm_run_settings.4, align 8
+  %3 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 2
   store %string_descriptor zeroinitializer, %string_descriptor* %3, align 1
   %4 = getelementptr %string_descriptor, %string_descriptor* %3, i32 0, i32 1
   store i64 4, i64* %4, align 8
@@ -471,8 +471,8 @@ define i32 @main(i32 %0, i8** %1) {
   %6 = call i8* @_lfortran_get_default_allocator()
   %7 = call i8* @_lfortran_malloc_alloc(i8* %6, i64 4)
   store i8* %7, i8** %5, align 8
-  %8 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %settings, i32 0, i32 4
-  %9 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %settings, i32 0, i32 1
+  %8 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 4
+  %9 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 1
   store %string_descriptor zeroinitializer, %string_descriptor* %9, align 1
   %10 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 1
   store i64 5, i64* %10, align 8
@@ -480,7 +480,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = call i8* @_lfortran_malloc_alloc(i8* %11, i64 10)
   %13 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 0
   store i8* %12, i8** %13, align 8
-  %14 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %settings, i32 0, i32 3
+  %14 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 3
   store %string_descriptor zeroinitializer, %string_descriptor* %14, align 1
   %15 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 1
   store i64 6, i64* %15, align 8
@@ -488,15 +488,15 @@ define i32 @main(i32 %0, i8** %1) {
   %17 = call i8* @_lfortran_get_default_allocator()
   %18 = call i8* @_lfortran_malloc_alloc(i8* %17, i64 6)
   store i8* %18, i8** %16, align 8
-  %19 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %settings, i32 0, i32 0
-  %20 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %19, i32 0, i32 0
+  %19 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 0
+  %20 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %19, i32 0, i32 0
   store i32 0, i32* %20, align 4
-  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %2, i32 0, i32 0
+  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32 0, i32 0
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %21, align 8
-  %22 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %2, i32 0, i32 1
-  store %modules_36_fpm_main_01.fpm_run_settings* %settings, %modules_36_fpm_main_01.fpm_run_settings** %22, align 8
+  %22 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32 0, i32 1
+  store %modules_36_fpm_main_01.fpm_run_settings.4* %settings, %modules_36_fpm_main_01.fpm_run_settings.4** %22, align 8
   store i32 1, i32* %call_arg_value, align 4
-  call void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings_class* %2, i32* %call_arg_value)
+  call void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32* %call_arg_value)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -506,7 +506,7 @@ FINALIZE_SYMTABLE_modules_36:                     ; preds = %return
   br label %Finalize_Variable_settings
 
 Finalize_Variable_settings:                       ; preds = %FINALIZE_SYMTABLE_modules_36
-  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings* %settings)
+  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %settings)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
@@ -517,11 +517,11 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 
 define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_build_settings(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings*
-  %3 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_build_settings*
-  %4 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %2, i32 0, i32 0
+  %2 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings.3*
+  %3 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_build_settings.3*
+  %4 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %2, i32 0, i32 0
   %5 = load i32, i32* %4, align 4
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %3, i32 0, i32 0
+  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %3, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -542,23 +542,23 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_build_settings_class*
-  %5 = bitcast %modules_36_fpm_main_01.fpm_build_settings_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_build_settings.3_class*
+  %5 = bitcast %modules_36_fpm_main_01.fpm_build_settings.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_build_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings_class, %modules_36_fpm_main_01.fpm_build_settings_class* %4, i32 0, i32 1
+  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3_class, %modules_36_fpm_main_01.fpm_build_settings.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_build_settings*
-  store %modules_36_fpm_main_01.fpm_build_settings* %9, %modules_36_fpm_main_01.fpm_build_settings** %6, align 8
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_build_settings.3*
+  store %modules_36_fpm_main_01.fpm_build_settings.3* %9, %modules_36_fpm_main_01.fpm_build_settings.3** %6, align 8
+  %10 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %9, i32 0, i32 0
   store i32 0, i32* %10, align 4
   ret void
 }
 
 define internal void @finalize_StructType__fpm_build_settings_3_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings*
+  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings.3*
   ret void
 }
 
@@ -568,10 +568,10 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_run_settings(i8* %0, i8* %1) {
 entry:
   %2 = call i8* @_lfortran_get_default_allocator()
-  %3 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings*
-  %4 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_run_settings*
-  %5 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %3, i32 0, i32 1
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %4, i32 0, i32 1
+  %3 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings.4*
+  %4 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_run_settings.4*
+  %5 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 1
+  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -586,8 +586,8 @@ else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %3, i32 0, i32 2
-  %12 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %4, i32 0, i32 2
+  %11 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 2
+  %12 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
@@ -602,8 +602,8 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %17 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %3, i32 0, i32 3
-  %18 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %4, i32 0, i32 3
+  %17 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 3
+  %18 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 3
   br i1 true, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
@@ -618,9 +618,9 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %23 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %3, i32 0, i32 4
+  %23 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 4
   %24 = load i32, i32* %23, align 4
-  %25 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %4, i32 0, i32 4
+  %25 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 4
   br i1 true, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
@@ -631,11 +631,11 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %3, i32 0, i32 0
-  %27 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %4, i32 0, i32 0
-  %28 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %26, i32 0, i32 0
+  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 0
+  %27 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 0
+  %28 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %26, i32 0, i32 0
   %29 = load i32, i32* %28, align 4
-  %30 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %27, i32 0, i32 0
+  %30 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %27, i32 0, i32 0
   br i1 true, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
@@ -656,16 +656,16 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_run_settings_class*
-  %5 = bitcast %modules_36_fpm_main_01.fpm_run_settings_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_run_settings.4_class*
+  %5 = bitcast %modules_36_fpm_main_01.fpm_run_settings.4_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings_class, %modules_36_fpm_main_01.fpm_run_settings_class* %4, i32 0, i32 1
+  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 56)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 56, i1 false)
-  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_run_settings*
-  store %modules_36_fpm_main_01.fpm_run_settings* %9, %modules_36_fpm_main_01.fpm_run_settings** %6, align 8
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 2
+  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_run_settings.4*
+  store %modules_36_fpm_main_01.fpm_run_settings.4* %9, %modules_36_fpm_main_01.fpm_run_settings.4** %6, align 8
+  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 2
   store %string_descriptor zeroinitializer, %string_descriptor* %10, align 1
   %11 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 1
   store i64 4, i64* %11, align 8
@@ -673,8 +673,8 @@ entry:
   %13 = call i8* @_lfortran_get_default_allocator()
   %14 = call i8* @_lfortran_malloc_alloc(i8* %13, i64 4)
   store i8* %14, i8** %12, align 8
-  %15 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 4
-  %16 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 1
+  %15 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 4
+  %16 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 1
   store %string_descriptor zeroinitializer, %string_descriptor* %16, align 1
   %17 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 1
   store i64 5, i64* %17, align 8
@@ -682,7 +682,7 @@ entry:
   %19 = call i8* @_lfortran_malloc_alloc(i8* %18, i64 10)
   %20 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 0
   store i8* %19, i8** %20, align 8
-  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 3
+  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 3
   store %string_descriptor zeroinitializer, %string_descriptor* %21, align 1
   %22 = getelementptr %string_descriptor, %string_descriptor* %21, i32 0, i32 1
   store i64 6, i64* %22, align 8
@@ -690,26 +690,26 @@ entry:
   %24 = call i8* @_lfortran_get_default_allocator()
   %25 = call i8* @_lfortran_malloc_alloc(i8* %24, i64 6)
   store i8* %25, i8** %23, align 8
-  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %9, i32 0, i32 0
-  %27 = getelementptr %modules_36_fpm_main_01.fpm_build_settings, %modules_36_fpm_main_01.fpm_build_settings* %26, i32 0, i32 0
+  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 0
+  %27 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %26, i32 0, i32 0
   store i32 0, i32* %27, align 4
   ret void
 }
 
 define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings*
-  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings* %1)
+  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings.4*
+  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %1)
   ret void
 }
 
-define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings* %0) {
+define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %0) {
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
   br label %"Finalize_struct_fpm_run_settings's_name_member"
 
 "Finalize_struct_fpm_run_settings's_name_member": ; preds = %entry
-  %2 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %0, i32 0, i32 1
+  %2 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 1
   %3 = getelementptr %string_descriptor, %string_descriptor* %2, i32 0, i32 0
   %4 = load i8*, i8** %3, align 8
   call void @_lfortran_free_alloc(i8* %1, i8* %4)
@@ -727,14 +727,14 @@ ifcont:                                           ; preds = %else, %then
   br label %"Finalize_struct_fpm_run_settings's_args_member"
 
 "Finalize_struct_fpm_run_settings's_args_member": ; preds = %ifcont
-  %7 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %0, i32 0, i32 2
+  %7 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 2
   %8 = getelementptr %string_descriptor, %string_descriptor* %7, i32 0, i32 0
   %9 = load i8*, i8** %8, align 8
   call void @_lfortran_free_alloc(i8* %1, i8* %9)
   br label %"Finalize_struct_fpm_run_settings's_runner_member"
 
 "Finalize_struct_fpm_run_settings's_runner_member": ; preds = %"Finalize_struct_fpm_run_settings's_args_member"
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings, %modules_36_fpm_main_01.fpm_run_settings* %0, i32 0, i32 3
+  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 3
   %11 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 0
   %12 = load i8*, i8** %11, align 8
   call void @_lfortran_free_alloc(i8* %1, i8* %12)

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "e86636d29e9587251accd63c3e97ffbfb37ecd476e7225e4a8a7bf4b",
+    "stdout_hash": "ec17e120d06afc299ab09e2bd16c3f51dbb5200b3493915a04afe5b6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -2,23 +2,23 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-%select_type_13_module.shape_class = type <{ i32 (...)**, %select_type_13_module.shape* }>
-%select_type_13_module.shape = type {}
+%select_type_13_module.shape.3_class = type <{ i32 (...)**, %select_type_13_module.shape.3* }>
+%select_type_13_module.shape.3 = type {}
 %string_descriptor = type <{ i8*, i64 }>
-%select_type_13_module.circle_class = type <{ i32 (...)**, %select_type_13_module.circle* }>
-%select_type_13_module.circle = type { %select_type_13_module.shape, float }
-%select_type_13_module.rectangle_class = type <{ i32 (...)**, %select_type_13_module.rectangle* }>
-%select_type_13_module.rectangle = type { %select_type_13_module.shape, float, float }
+%select_type_13_module.circle.5_class = type <{ i32 (...)**, %select_type_13_module.circle.5* }>
+%select_type_13_module.circle.5 = type { %select_type_13_module.shape.3, float }
+%select_type_13_module.rectangle.6_class = type <{ i32 (...)**, %select_type_13_module.rectangle.6* }>
+%select_type_13_module.rectangle.6 = type { %select_type_13_module.shape.3, float, float }
 
 @_Name_shape = private unnamed_addr constant [6 x i8] c"shape\00", align 1
 @_Type_Info_shape = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_shape, i32 0, i32 0), i8* null, i8* null }, align 8
 @_VTable_shape = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_shape to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_shape to i8*), i8* bitcast (void (i8*)* @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly to i8*), i8* null] }, align 8
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.circle_class*)* @__module_select_type_13_module_circle_area to i8*)] }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.circle.5_class*)* @__module_select_type_13_module_circle_area to i8*)] }, align 8
 @_Name_rectangle = private unnamed_addr constant [10 x i8] c"rectangle\00", align 1
 @_Type_Info_rectangle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([10 x i8], [10 x i8]* @_Name_rectangle, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_rectangle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.rectangle_class*)* @__module_select_type_13_module_rectangle_area to i8*)] }, align 8
+@_VTable_rectangle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.rectangle.6_class*)* @__module_select_type_13_module_rectangle_area to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [20 x i8] c"Matched as rectangle"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* @string_const_data, i32 0, i32 0), i64 20 }>
@@ -93,17 +93,17 @@ target datalayout = "..."
 @string_const.11 = private global %string_descriptor <{ i8* getelementptr inbounds ([16 x i8], [16 x i8]* @string_const_data.10, i32 0, i32 0), i64 16 }>
 @57 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_select_type_13_module_circle_area(%select_type_13_module.circle_class* %this) {
+define float @__module_select_type_13_module_circle_area(%select_type_13_module.circle.5_class* %this) {
 .entry:
   %circle_area = alloca float, align 4
-  %0 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %this, i32 0, i32 1
-  %1 = load %select_type_13_module.circle*, %select_type_13_module.circle** %0, align 8
-  %2 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %1, i32 0, i32 1
+  %0 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %this, i32 0, i32 1
+  %1 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %0, align 8
+  %2 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %1, i32 0, i32 1
   %3 = load float, float* %2, align 4
   %4 = fmul float 0x400921FA00000000, %3
-  %5 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %this, i32 0, i32 1
-  %6 = load %select_type_13_module.circle*, %select_type_13_module.circle** %5, align 8
-  %7 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %6, i32 0, i32 1
+  %5 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %this, i32 0, i32 1
+  %6 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %5, align 8
+  %7 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %6, i32 0, i32 1
   %8 = load float, float* %7, align 4
   %9 = fmul float %4, %8
   store float %9, float* %circle_area, align 4
@@ -117,16 +117,16 @@ FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
   ret float %10
 }
 
-define float @__module_select_type_13_module_rectangle_area(%select_type_13_module.rectangle_class* %this) {
+define float @__module_select_type_13_module_rectangle_area(%select_type_13_module.rectangle.6_class* %this) {
 .entry:
   %rectangle_area = alloca float, align 4
-  %0 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %this, i32 0, i32 1
-  %1 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %0, align 8
-  %2 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %1, i32 0, i32 1
+  %0 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %this, i32 0, i32 1
+  %1 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %0, align 8
+  %2 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %1, i32 0, i32 1
   %3 = load float, float* %2, align 4
-  %4 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %this, i32 0, i32 1
-  %5 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %4, align 8
-  %6 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %5, i32 0, i32 2
+  %4 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %this, i32 0, i32 1
+  %5 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %4, align 8
+  %6 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %5, i32 0, i32 2
   %7 = load float, float* %6, align 4
   %8 = fmul float %3, %7
   store float %8, float* %rectangle_area, align 4
@@ -146,31 +146,31 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %s1 = alloca %select_type_13_module.shape_class*, align 8
-  store %select_type_13_module.shape_class* null, %select_type_13_module.shape_class** %s1, align 8
-  %s2 = alloca %select_type_13_module.shape_class*, align 8
-  store %select_type_13_module.shape_class* null, %select_type_13_module.shape_class** %s2, align 8
+  %s1 = alloca %select_type_13_module.shape.3_class*, align 8
+  store %select_type_13_module.shape.3_class* null, %select_type_13_module.shape.3_class** %s1, align 8
+  %s2 = alloca %select_type_13_module.shape.3_class*, align 8
+  store %select_type_13_module.shape.3_class* null, %select_type_13_module.shape.3_class** %s2, align 8
   %3 = call i8* @_lfortran_get_default_allocator()
   %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
   %5 = call i8* @_lfortran_get_default_allocator()
   %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 16, i1 false)
-  %7 = bitcast i8* %6 to %select_type_13_module.shape_class*
-  store %select_type_13_module.shape_class* %7, %select_type_13_module.shape_class** %s1, align 8
-  %8 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %9 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %8, i32 0, i32 1
-  %10 = bitcast i8* %4 to %select_type_13_module.shape*
-  store %select_type_13_module.shape* %10, %select_type_13_module.shape** %9, align 8
-  %11 = load %select_type_13_module.shape*, %select_type_13_module.shape** %9, align 8
-  %12 = bitcast %select_type_13_module.shape* %11 to %select_type_13_module.circle*
-  %13 = bitcast %select_type_13_module.shape_class* %7 to i32 (...)***
+  %7 = bitcast i8* %6 to %select_type_13_module.shape.3_class*
+  store %select_type_13_module.shape.3_class* %7, %select_type_13_module.shape.3_class** %s1, align 8
+  %8 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %9 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %8, i32 0, i32 1
+  %10 = bitcast i8* %4 to %select_type_13_module.shape.3*
+  store %select_type_13_module.shape.3* %10, %select_type_13_module.shape.3** %9, align 8
+  %11 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %9, align 8
+  %12 = bitcast %select_type_13_module.shape.3* %11 to %select_type_13_module.circle.5*
+  %13 = bitcast %select_type_13_module.shape.3_class* %7 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
-  %14 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %12, i32 0, i32 1
-  %15 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %12, i32 0, i32 0
+  %14 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %12, i32 0, i32 1
+  %15 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %12, i32 0, i32 0
   %16 = alloca i1, align 1
-  %17 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %18 = ptrtoint %select_type_13_module.shape_class* %17 to i64
+  %17 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %18 = ptrtoint %select_type_13_module.shape.3_class* %17 to i64
   %19 = icmp eq i64 %18, 0
   br i1 %19, label %then1, label %else
 
@@ -187,7 +187,7 @@ then1:                                            ; preds = %.entry
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %24 = bitcast %select_type_13_module.shape_class* %17 to i8*
+  %24 = bitcast %select_type_13_module.shape.3_class* %17 to i8*
   %25 = call i8* @__lfortran_dynamic_cast(i8* %24, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
   %26 = icmp ne i8* %25, null
   store i1 %26, i1* %16, align 1
@@ -212,8 +212,8 @@ ifcont:                                           ; preds = %else, %then1
 
 else2:                                            ; preds = %ifcont
   %30 = alloca i1, align 1
-  %31 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %32 = ptrtoint %select_type_13_module.shape_class* %31 to i64
+  %31 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %32 = ptrtoint %select_type_13_module.shape.3_class* %31 to i64
   %33 = icmp eq i64 %32, 0
   br i1 %33, label %then4, label %else5
 
@@ -230,7 +230,7 @@ then4:                                            ; preds = %else2
   br label %ifcont6
 
 else5:                                            ; preds = %else2
-  %38 = bitcast %select_type_13_module.shape_class* %31 to i8*
+  %38 = bitcast %select_type_13_module.shape.3_class* %31 to i8*
   %39 = call i8* @__lfortran_dynamic_cast(i8* %38, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
   %40 = icmp ne i8* %39, null
   store i1 %40, i1* %30, align 1
@@ -244,8 +244,8 @@ ifcont6:                                          ; preds = %else5, %then4
   %42 = call i8* @llvm.stacksave()
   %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %44 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %45 = ptrtoint %select_type_13_module.shape_class** %44 to i64
+  %44 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
+  %45 = ptrtoint %select_type_13_module.shape.3_class** %44 to i64
   %46 = icmp eq i64 %45, 0
   br i1 %46, label %then7, label %ifcont8
 
@@ -280,17 +280,17 @@ then7:                                            ; preds = %"~select_type_block
   unreachable
 
 ifcont8:                                          ; preds = %"~select_type_block_1.start"
-  %63 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %64 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %63, align 1
-  %65 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %66 = bitcast %select_type_13_module.shape_class* %65 to %select_type_13_module.circle_class*
-  %67 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %66, i32 0, i32 1
-  %68 = load %select_type_13_module.circle*, %select_type_13_module.circle** %67, align 8
-  %69 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %68, i32 0, i32 1
+  %63 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %64 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %63, align 1
+  %65 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %66 = bitcast %select_type_13_module.shape.3_class* %65 to %select_type_13_module.circle.5_class*
+  %67 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %66, i32 0, i32 1
+  %68 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %67, align 8
+  %69 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %68, i32 0, i32 1
   store float 1.000000e+01, float* %69, align 4
   %70 = alloca i64, align 8
-  %71 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %72 = ptrtoint %select_type_13_module.shape_class** %71 to i64
+  %71 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
+  %72 = ptrtoint %select_type_13_module.shape.3_class** %71 to i64
   %73 = icmp eq i64 %72, 0
   br i1 %73, label %then9, label %ifcont10
 
@@ -325,13 +325,13 @@ then9:                                            ; preds = %ifcont8
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
-  %90 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %91 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %90, align 1
-  %92 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %93 = bitcast %select_type_13_module.shape_class* %92 to %select_type_13_module.circle_class*
-  %94 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %93, i32 0, i32 1
-  %95 = load %select_type_13_module.circle*, %select_type_13_module.circle** %94, align 8
-  %96 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %95, i32 0, i32 1
+  %90 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %91 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %90, align 1
+  %92 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %93 = bitcast %select_type_13_module.shape.3_class* %92 to %select_type_13_module.circle.5_class*
+  %94 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %93, i32 0, i32 1
+  %95 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %94, align 8
+  %96 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %95, i32 0, i32 1
   %97 = load float, float* %96, align 4
   %98 = alloca float, align 4
   store float %97, float* %98, align 4
@@ -355,8 +355,8 @@ free_nonnull:                                     ; preds = %ifcont10
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont10
-  %109 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s1, align 8
-  %110 = ptrtoint %select_type_13_module.shape_class** %109 to i64
+  %109 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
+  %110 = ptrtoint %select_type_13_module.shape.3_class** %109 to i64
   %111 = icmp eq i64 %110, 0
   br i1 %111, label %then11, label %ifcont12
 
@@ -391,13 +391,13 @@ then11:                                           ; preds = %free_done
   unreachable
 
 ifcont12:                                         ; preds = %free_done
-  %128 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %129 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %128, align 1
-  %130 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  %131 = bitcast %select_type_13_module.shape_class* %130 to %select_type_13_module.circle_class*
-  %132 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %131, i32 0, i32 1
-  %133 = load %select_type_13_module.circle*, %select_type_13_module.circle** %132, align 8
-  %134 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %133, i32 0, i32 1
+  %128 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %129 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %128, align 1
+  %130 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  %131 = bitcast %select_type_13_module.shape.3_class* %130 to %select_type_13_module.circle.5_class*
+  %132 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %131, i32 0, i32 1
+  %133 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %132, align 8
+  %134 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %133, i32 0, i32 1
   %135 = load float, float* %134, align 4
   %136 = fcmp une float %135, 1.000000e+01
   br i1 %136, label %then13, label %else14
@@ -444,22 +444,22 @@ ifcont17:                                         ; preds = %"FINALIZE_SYMTABLE_
   %141 = call i8* @_lfortran_get_default_allocator()
   %142 = call i8* @_lfortran_malloc_alloc(i8* %141, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %142, i8 0, i32 16, i1 false)
-  %143 = bitcast i8* %142 to %select_type_13_module.shape_class*
-  store %select_type_13_module.shape_class* %143, %select_type_13_module.shape_class** %s2, align 8
-  %144 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %145 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %144, i32 0, i32 1
-  %146 = bitcast i8* %140 to %select_type_13_module.shape*
-  store %select_type_13_module.shape* %146, %select_type_13_module.shape** %145, align 8
-  %147 = load %select_type_13_module.shape*, %select_type_13_module.shape** %145, align 8
-  %148 = bitcast %select_type_13_module.shape* %147 to %select_type_13_module.rectangle*
-  %149 = bitcast %select_type_13_module.shape_class* %143 to i32 (...)***
+  %143 = bitcast i8* %142 to %select_type_13_module.shape.3_class*
+  store %select_type_13_module.shape.3_class* %143, %select_type_13_module.shape.3_class** %s2, align 8
+  %144 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %145 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %144, i32 0, i32 1
+  %146 = bitcast i8* %140 to %select_type_13_module.shape.3*
+  store %select_type_13_module.shape.3* %146, %select_type_13_module.shape.3** %145, align 8
+  %147 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %145, align 8
+  %148 = bitcast %select_type_13_module.shape.3* %147 to %select_type_13_module.rectangle.6*
+  %149 = bitcast %select_type_13_module.shape.3_class* %143 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %149, align 8
-  %150 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 1
-  %151 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 2
-  %152 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %148, i32 0, i32 0
+  %150 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 1
+  %151 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 2
+  %152 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 0
   %153 = alloca i1, align 1
-  %154 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %155 = ptrtoint %select_type_13_module.shape_class* %154 to i64
+  %154 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %155 = ptrtoint %select_type_13_module.shape.3_class* %154 to i64
   %156 = icmp eq i64 %155, 0
   br i1 %156, label %then19, label %else20
 
@@ -476,7 +476,7 @@ then19:                                           ; preds = %ifcont17
   br label %ifcont21
 
 else20:                                           ; preds = %ifcont17
-  %161 = bitcast %select_type_13_module.shape_class* %154 to i8*
+  %161 = bitcast %select_type_13_module.shape.3_class* %154 to i8*
   %162 = call i8* @__lfortran_dynamic_cast(i8* %161, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
   %163 = icmp ne i8* %162, null
   store i1 %163, i1* %153, align 1
@@ -501,8 +501,8 @@ ifcont21:                                         ; preds = %else20, %then19
 
 else22:                                           ; preds = %ifcont21
   %167 = alloca i1, align 1
-  %168 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %169 = ptrtoint %select_type_13_module.shape_class* %168 to i64
+  %168 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %169 = ptrtoint %select_type_13_module.shape.3_class* %168 to i64
   %170 = icmp eq i64 %169, 0
   br i1 %170, label %then24, label %else25
 
@@ -519,7 +519,7 @@ then24:                                           ; preds = %else22
   br label %ifcont26
 
 else25:                                           ; preds = %else22
-  %175 = bitcast %select_type_13_module.shape_class* %168 to i8*
+  %175 = bitcast %select_type_13_module.shape.3_class* %168 to i8*
   %176 = call i8* @__lfortran_dynamic_cast(i8* %175, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
   %177 = icmp ne i8* %176, null
   store i1 %177, i1* %167, align 1
@@ -533,8 +533,8 @@ ifcont26:                                         ; preds = %else25, %then24
   %179 = call i8* @llvm.stacksave()
   %180 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %180, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
-  %181 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %182 = ptrtoint %select_type_13_module.shape_class** %181 to i64
+  %181 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %182 = ptrtoint %select_type_13_module.shape.3_class** %181 to i64
   %183 = icmp eq i64 %182, 0
   br i1 %183, label %then27, label %ifcont28
 
@@ -569,16 +569,16 @@ then27:                                           ; preds = %"~select_type_block
   unreachable
 
 ifcont28:                                         ; preds = %"~select_type_block_4.start"
-  %200 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %201 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %200, align 1
-  %202 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %203 = bitcast %select_type_13_module.shape_class* %202 to %select_type_13_module.rectangle_class*
-  %204 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %203, i32 0, i32 1
-  %205 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %204, align 8
-  %206 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %205, i32 0, i32 1
+  %200 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %201 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %200, align 1
+  %202 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %203 = bitcast %select_type_13_module.shape.3_class* %202 to %select_type_13_module.rectangle.6_class*
+  %204 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %203, i32 0, i32 1
+  %205 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %204, align 8
+  %206 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %205, i32 0, i32 1
   store float 5.000000e+00, float* %206, align 4
-  %207 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %208 = ptrtoint %select_type_13_module.shape_class** %207 to i64
+  %207 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %208 = ptrtoint %select_type_13_module.shape.3_class** %207 to i64
   %209 = icmp eq i64 %208, 0
   br i1 %209, label %then29, label %ifcont30
 
@@ -613,17 +613,17 @@ then29:                                           ; preds = %ifcont28
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %226 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %227 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %226, align 1
-  %228 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %229 = bitcast %select_type_13_module.shape_class* %228 to %select_type_13_module.rectangle_class*
-  %230 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %229, i32 0, i32 1
-  %231 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %230, align 8
-  %232 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %231, i32 0, i32 2
+  %226 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %227 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %226, align 1
+  %228 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %229 = bitcast %select_type_13_module.shape.3_class* %228 to %select_type_13_module.rectangle.6_class*
+  %230 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %229, i32 0, i32 1
+  %231 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %230, align 8
+  %232 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %231, i32 0, i32 2
   store float 4.000000e+00, float* %232, align 4
   %233 = alloca i64, align 8
-  %234 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %235 = ptrtoint %select_type_13_module.shape_class** %234 to i64
+  %234 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %235 = ptrtoint %select_type_13_module.shape.3_class** %234 to i64
   %236 = icmp eq i64 %235, 0
   br i1 %236, label %then31, label %ifcont32
 
@@ -658,18 +658,18 @@ then31:                                           ; preds = %ifcont30
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %253 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %254 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %253, align 1
-  %255 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %256 = bitcast %select_type_13_module.shape_class* %255 to %select_type_13_module.rectangle_class*
-  %257 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %256, i32 0, i32 1
-  %258 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %257, align 8
-  %259 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %258, i32 0, i32 1
+  %253 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %254 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %253, align 1
+  %255 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %256 = bitcast %select_type_13_module.shape.3_class* %255 to %select_type_13_module.rectangle.6_class*
+  %257 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %256, i32 0, i32 1
+  %258 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %257, align 8
+  %259 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %258, i32 0, i32 1
   %260 = load float, float* %259, align 4
   %261 = alloca float, align 4
   store float %260, float* %261, align 4
-  %262 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %263 = ptrtoint %select_type_13_module.shape_class** %262 to i64
+  %262 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %263 = ptrtoint %select_type_13_module.shape.3_class** %262 to i64
   %264 = icmp eq i64 %263, 0
   br i1 %264, label %then33, label %ifcont34
 
@@ -704,13 +704,13 @@ then33:                                           ; preds = %ifcont32
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %281 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %282 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %281, align 1
-  %283 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %284 = bitcast %select_type_13_module.shape_class* %283 to %select_type_13_module.rectangle_class*
-  %285 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %284, i32 0, i32 1
-  %286 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %285, align 8
-  %287 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %286, i32 0, i32 2
+  %281 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %282 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %281, align 1
+  %283 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %284 = bitcast %select_type_13_module.shape.3_class* %283 to %select_type_13_module.rectangle.6_class*
+  %285 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %284, i32 0, i32 1
+  %286 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %285, align 8
+  %287 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %286, i32 0, i32 2
   %288 = load float, float* %287, align 4
   %289 = alloca float, align 4
   store float %288, float* %289, align 4
@@ -734,8 +734,8 @@ free_nonnull36:                                   ; preds = %ifcont34
   br label %free_done37
 
 free_done37:                                      ; preds = %free_nonnull36, %ifcont34
-  %300 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %301 = ptrtoint %select_type_13_module.shape_class** %300 to i64
+  %300 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %301 = ptrtoint %select_type_13_module.shape.3_class** %300 to i64
   %302 = icmp eq i64 %301, 0
   br i1 %302, label %then38, label %ifcont39
 
@@ -770,13 +770,13 @@ then38:                                           ; preds = %free_done37
   unreachable
 
 ifcont39:                                         ; preds = %free_done37
-  %319 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %320 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %319, align 1
-  %321 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %322 = bitcast %select_type_13_module.shape_class* %321 to %select_type_13_module.rectangle_class*
-  %323 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %322, i32 0, i32 1
-  %324 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %323, align 8
-  %325 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %324, i32 0, i32 1
+  %319 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %320 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %319, align 1
+  %321 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %322 = bitcast %select_type_13_module.shape.3_class* %321 to %select_type_13_module.rectangle.6_class*
+  %323 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %322, i32 0, i32 1
+  %324 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %323, align 8
+  %325 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %324, i32 0, i32 1
   %326 = load float, float* %325, align 4
   %327 = fcmp une float %326, 5.000000e+00
   br i1 %327, label %then40, label %else41
@@ -791,8 +791,8 @@ else41:                                           ; preds = %ifcont39
   br label %ifcont42
 
 ifcont42:                                         ; preds = %else41, %then40
-  %328 = load %select_type_13_module.shape_class**, %select_type_13_module.shape_class** %s2, align 8
-  %329 = ptrtoint %select_type_13_module.shape_class** %328 to i64
+  %328 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
+  %329 = ptrtoint %select_type_13_module.shape.3_class** %328 to i64
   %330 = icmp eq i64 %329, 0
   br i1 %330, label %then43, label %ifcont44
 
@@ -827,13 +827,13 @@ then43:                                           ; preds = %ifcont42
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %347 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %348 = load %select_type_13_module.shape_class, %select_type_13_module.shape_class* %347, align 1
-  %349 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  %350 = bitcast %select_type_13_module.shape_class* %349 to %select_type_13_module.rectangle_class*
-  %351 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %350, i32 0, i32 1
-  %352 = load %select_type_13_module.rectangle*, %select_type_13_module.rectangle** %351, align 8
-  %353 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %352, i32 0, i32 2
+  %347 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %348 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %347, align 1
+  %349 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  %350 = bitcast %select_type_13_module.shape.3_class* %349 to %select_type_13_module.rectangle.6_class*
+  %351 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %350, i32 0, i32 1
+  %352 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %351, align 8
+  %353 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %352, i32 0, i32 2
   %354 = load float, float* %353, align 4
   %355 = fcmp une float %354, 4.000000e+00
   br i1 %355, label %then45, label %else46
@@ -883,13 +883,13 @@ FINALIZE_SYMTABLE_select_type_13:                 ; preds = %return
   br label %Finalize_Variable_s1
 
 Finalize_Variable_s1:                             ; preds = %FINALIZE_SYMTABLE_select_type_13
-  %358 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s1, align 8
-  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape_class* %358)
+  %358 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
+  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %358)
   br label %Finalize_Variable_s2
 
 Finalize_Variable_s2:                             ; preds = %Finalize_Variable_s1
-  %359 = load %select_type_13_module.shape_class*, %select_type_13_module.shape_class** %s2, align 8
-  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape_class* %359)
+  %359 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
+  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %359)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
@@ -905,8 +905,8 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 
 define linkonce_odr void @_copy_select_type_13_module_shape(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.shape*
-  %3 = bitcast i8* %1 to %select_type_13_module.shape*
+  %2 = bitcast i8* %0 to %select_type_13_module.shape.3*
+  %3 = bitcast i8* %1 to %select_type_13_module.shape.3*
   ret void
 }
 
@@ -917,31 +917,31 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.shape_class*
-  %5 = bitcast %select_type_13_module.shape_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %select_type_13_module.shape.3_class*
+  %5 = bitcast %select_type_13_module.shape.3_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %4, i32 0, i32 1
+  %6 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.shape*
-  store %select_type_13_module.shape* %9, %select_type_13_module.shape** %6, align 8
+  %9 = bitcast i8* %8 to %select_type_13_module.shape.3*
+  store %select_type_13_module.shape.3* %9, %select_type_13_module.shape.3** %6, align 8
   ret void
 }
 
 define internal void @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.shape*
+  %1 = bitcast i8* %0 to %select_type_13_module.shape.3*
   ret void
 }
 
 define linkonce_odr void @_copy_select_type_13_module_circle(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.circle*
-  %3 = bitcast i8* %1 to %select_type_13_module.circle*
-  %4 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %2, i32 0, i32 1
+  %2 = bitcast i8* %0 to %select_type_13_module.circle.5*
+  %3 = bitcast i8* %1 to %select_type_13_module.circle.5*
+  %4 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %3, i32 0, i32 1
+  %6 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %3, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -952,8 +952,8 @@ else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %2, i32 0, i32 0
-  %8 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %3, i32 0, i32 0
+  %7 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %2, i32 0, i32 0
+  %8 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %3, i32 0, i32 0
   ret void
 }
 
@@ -964,33 +964,33 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.circle_class*
-  %5 = bitcast %select_type_13_module.circle_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %select_type_13_module.circle.5_class*
+  %5 = bitcast %select_type_13_module.circle.5_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.circle_class, %select_type_13_module.circle_class* %4, i32 0, i32 1
+  %6 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.circle*
-  store %select_type_13_module.circle* %9, %select_type_13_module.circle** %6, align 8
-  %10 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 1
-  %11 = getelementptr %select_type_13_module.circle, %select_type_13_module.circle* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %select_type_13_module.circle.5*
+  store %select_type_13_module.circle.5* %9, %select_type_13_module.circle.5** %6, align 8
+  %10 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %9, i32 0, i32 1
+  %11 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.circle*
+  %1 = bitcast i8* %0 to %select_type_13_module.circle.5*
   ret void
 }
 
 define linkonce_odr void @_copy_select_type_13_module_rectangle(i8* %0, i8* %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.rectangle*
-  %3 = bitcast i8* %1 to %select_type_13_module.rectangle*
-  %4 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %2, i32 0, i32 1
+  %2 = bitcast i8* %0 to %select_type_13_module.rectangle.6*
+  %3 = bitcast i8* %1 to %select_type_13_module.rectangle.6*
+  %4 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 1
   %5 = load float, float* %4, align 4
-  %6 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %3, i32 0, i32 1
+  %6 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
@@ -1001,9 +1001,9 @@ else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %2, i32 0, i32 2
+  %7 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 2
   %8 = load float, float* %7, align 4
-  %9 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %3, i32 0, i32 2
+  %9 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
@@ -1014,8 +1014,8 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %10 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %2, i32 0, i32 0
-  %11 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %3, i32 0, i32 0
+  %10 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 0
+  %11 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 0
   ret void
 }
 
@@ -1026,24 +1026,24 @@ entry:
   call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
   store i8* %2, i8** %0, align 8
   %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.rectangle_class*
-  %5 = bitcast %select_type_13_module.rectangle_class* %4 to i32 (...)***
+  %4 = bitcast i8* %3 to %select_type_13_module.rectangle.6_class*
+  %5 = bitcast %select_type_13_module.rectangle.6_class* %4 to i32 (...)***
   store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.rectangle_class, %select_type_13_module.rectangle_class* %4, i32 0, i32 1
+  %6 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %4, i32 0, i32 1
   %7 = call i8* @_lfortran_get_default_allocator()
   %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
   call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.rectangle*
-  store %select_type_13_module.rectangle* %9, %select_type_13_module.rectangle** %6, align 8
-  %10 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 1
-  %11 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 2
-  %12 = getelementptr %select_type_13_module.rectangle, %select_type_13_module.rectangle* %9, i32 0, i32 0
+  %9 = bitcast i8* %8 to %select_type_13_module.rectangle.6*
+  store %select_type_13_module.rectangle.6* %9, %select_type_13_module.rectangle.6** %6, align 8
+  %10 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 1
+  %11 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 2
+  %12 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 0
   ret void
 }
 
 define internal void @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly(i8* %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.rectangle*
+  %1 = bitcast i8* %0 to %select_type_13_module.rectangle.6*
   ret void
 }
 
@@ -1071,21 +1071,21 @@ declare void @_lcompilers_print_error(i8*, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-define internal void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0) {
 entry:
   %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %select_type_13_module.shape_class* %0, null
+  %2 = icmp ne %select_type_13_module.shape.3_class* %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape_class* %0)
-  %3 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %0, i32 0, i32 1
-  %4 = load %select_type_13_module.shape*, %select_type_13_module.shape** %3, align 8
-  %5 = icmp ne %select_type_13_module.shape* %4, null
+  call void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0)
+  %3 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 1
+  %4 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %3, align 8
+  %5 = icmp ne %select_type_13_module.shape.3* %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %select_type_13_module.shape* %4 to i8*
+  %6 = bitcast %select_type_13_module.shape.3* %4 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %6)
   br label %is_allocated.ifcont
 
@@ -1093,7 +1093,7 @@ is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %select_type_13_module.shape_class* %0 to i8*
+  %7 = bitcast %select_type_13_module.shape.3_class* %0 to i8*
   call void @_lfortran_free_alloc(i8* %1, i8* %7)
   br label %is_allocated.ifcont3
 
@@ -1104,13 +1104,13 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape_class* %0) {
+define internal void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0) {
 entry:
-  %1 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %0, i32 0, i32 0
+  %1 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 0
   %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %select_type_13_module.shape_class, %select_type_13_module.shape_class* %0, i32 0, i32 1
-  %4 = load %select_type_13_module.shape**, %select_type_13_module.shape** %3, align 8
-  %5 = bitcast %select_type_13_module.shape** %4 to i8*
+  %3 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 1
+  %4 = load %select_type_13_module.shape.3**, %select_type_13_module.shape.3** %3, align 8
+  %5 = bitcast %select_type_13_module.shape.3** %4 to i8*
   %6 = icmp ne i32 (...)** %2, null
   br i1 %6, label %is_allocated.then, label %is_allocated.else2
 


### PR DESCRIPTION
Fix : Append symtab counter to indentify different symbolTypes
instead of relying only on parent-scope's name.