### PR TITLE
fix: NEWUNIT to assign negative unit numbers and resolve runtime IO bounds

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2879,6 +2879,7 @@ RUN(NAME file_open_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME file_open_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME file_open_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_open_08 LABELS gfortran llvm)
+RUN(NAME file_open_09 LABELS gfortran llvm)
 
 RUN(NAME file_overwrite LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/file_open_09.f90
+++ b/integration_tests/file_open_09.f90
@@ -1,0 +1,18 @@
+program open_newunit
+  use iso_fortran_env
+  implicit none
+
+  integer :: io_lun
+
+  open (newunit=io_lun, file='open_newunit.dat', status='replace', form='formatted')
+  print *, "PASS"
+
+! Test for the first few conditions specified by F2023 12.5.6.13:
+  if (io_lun >= -1) error stop 'newunit >= -1'
+  if (io_lun == ERROR_UNIT) error stop 'newunit == ERROR_UNIT'
+  if (io_lun == INPUT_UNIT) error stop 'newunit == INPUT_UNIT'
+  if (io_lun == OUTPUT_UNIT) error stop 'newunit == OUTPUT_UNIT'
+
+  close (io_lun, status='delete')
+
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5520,33 +5520,34 @@ int32_t last_index_used = -1;
 struct UNIT_FILE unit_to_file[MAXUNITS];
 
 // Pending bytes for sequential unformatted records per unit (shared by all types).
-static int32_t seq_unf_pending[MAXUNITS];
-static int32_t seq_unf_record_len[MAXUNITS];
+#define STATE_INDEX(u) ((u) >= 0 ? (u) : (MAXUNITS - (u)))
+static int32_t seq_unf_pending[MAXUNITS*2];
+static int32_t seq_unf_record_len[MAXUNITS*2];
 
 // Pending list-directed null-repeat state per unit.
-static int32_t lf_list_dir_null_remaining[MAXUNITS];
+static int32_t lf_list_dir_null_remaining[MAXUNITS*2];
 
 // Child I/O mode per unit (for DTIO: suppress record terminators in child writes).
-static int32_t lf_child_io_mode[MAXUNITS];
+static int32_t lf_child_io_mode[MAXUNITS*2];
 
 static inline void seq_unf_state_reset(int32_t unit_num) {
-    if (unit_num < 0 || unit_num >= MAXUNITS) return;
-    seq_unf_pending[unit_num] = 0;
-    seq_unf_record_len[unit_num] = 0;
+    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return;
+    seq_unf_pending[STATE_INDEX(unit_num)] = 0;
+    seq_unf_record_len[STATE_INDEX(unit_num)] = 0;
 }
 
 // Begin reading from a sequential unformatted record if not already in one.
 // Returns 0 on success, -1 on EOF, 1 on error.
 static inline int seq_unf_begin_record(int32_t unit_num, FILE* filep) {
-    if (unit_num < 0 || unit_num >= MAXUNITS) return 1;
-    if (seq_unf_pending[unit_num] == 0) {
+    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return 1;
+    if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
         int32_t marker = 0;
         if (fread(&marker, sizeof(int32_t), 1, filep) != 1) {
             return feof(filep) ? -1 : 1;
         }
         if (marker < 0) return 1;
-        seq_unf_pending[unit_num] = marker;
-        seq_unf_record_len[unit_num] = marker;
+        seq_unf_pending[STATE_INDEX(unit_num)] = marker;
+        seq_unf_record_len[STATE_INDEX(unit_num)] = marker;
     }
     return 0;
 }
@@ -5554,13 +5555,13 @@ static inline int seq_unf_begin_record(int32_t unit_num, FILE* filep) {
 // Finish reading a sequential unformatted record if all bytes consumed.
 // Returns 0 on success, 1 on error.
 static inline int seq_unf_finish_record(int32_t unit_num, FILE* filep) {
-    if (unit_num < 0 || unit_num >= MAXUNITS) return 1;
-    if (seq_unf_pending[unit_num] == 0 && seq_unf_record_len[unit_num] > 0) {
+    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return 1;
+    if (seq_unf_pending[STATE_INDEX(unit_num)] == 0 && seq_unf_record_len[STATE_INDEX(unit_num)] > 0) {
         int32_t end_marker = 0;
         if (fread(&end_marker, sizeof(int32_t), 1, filep) != 1) {
             return 1;
         }
-        if (end_marker != seq_unf_record_len[unit_num]) {
+        if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
             return 1;
         }
         seq_unf_state_reset(unit_num);
@@ -5569,13 +5570,13 @@ static inline int seq_unf_finish_record(int32_t unit_num, FILE* filep) {
 }
 
 static inline void list_dir_state_reset(int32_t unit_num) {
-    if (unit_num < 0 || unit_num >= MAXUNITS) return;
-    lf_list_dir_null_remaining[unit_num] = 0;
+    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return;
+    lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = 0;
 }
 
 LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child) {
-    if (unit_num >= 0 && unit_num < MAXUNITS) {
-        lf_child_io_mode[unit_num] = is_child;
+    if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
+        lf_child_io_mode[STATE_INDEX(unit_num)] = is_child;
     }
 }
 
@@ -6516,10 +6517,11 @@ LFORTRAN_API void _lfortran_inquire(const fchar* f_name_data, int64_t f_name_len
             *exists = false;
         }
         int u_num = -1;
-        for(int i=0; i<1000; i++) {
-            char* unit_name = get_file_name_from_unit(i, &unit_file_bin);
+        for(int i=0; i<=last_index_used; i++) {
+            char* unit_name = unit_to_file[i].filename;
             if (unit_name != NULL && strcmp(unit_name, c_f_name_data) == 0) {
-                u_num = i;
+                u_num = unit_to_file[i].unit;
+                unit_file_bin = unit_to_file[i].unit_file_bin;
                 break;
             }
         }
@@ -7320,9 +7322,9 @@ static void skip_list_directed_comma(FILE *filep) {
 }
 
 static int list_directed_check_null_repeat(int32_t unit_num) {
-    if (unit_num >= 0 && unit_num < MAXUNITS
-            && lf_list_dir_null_remaining[unit_num] > 0) {
-        lf_list_dir_null_remaining[unit_num]--;
+    if (unit_num > -MAXUNITS && unit_num < MAXUNITS
+            && lf_list_dir_null_remaining[STATE_INDEX(unit_num)] > 0) {
+        lf_list_dir_null_remaining[STATE_INDEX(unit_num)]--;
         return 1;
     }
     return 0;
@@ -7424,7 +7426,7 @@ LFORTRAN_API void _lfortran_read_int16(int16_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for int16_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(int16_t)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int16_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int16_t.\n");
                 exit(1);
@@ -7434,7 +7436,7 @@ LFORTRAN_API void _lfortran_read_int16(int16_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read int16_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(int16_t);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int16_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading int16_t.\n");
@@ -7521,7 +7523,7 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Internal Compiler Error: Failed to read record marker for int32_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(int32_t)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int32_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Internal Compiler Error: Record too short for int32_t.\n");
                 exit(1);
@@ -7531,7 +7533,7 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Internal Compiler Error: Failed to read int32_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(int32_t);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int32_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Internal Compiler Error: Invalid trailing record marker while reading int32_t.\n");
@@ -7616,7 +7618,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for int64_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(int64_t)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int64_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int64_t.\n");
                 exit(1);
@@ -7626,7 +7628,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read int64_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(int64_t);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int64_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading int64_t.\n");
@@ -7709,7 +7711,7 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
                 fprintf(stderr, "Error: Failed to read record marker for logical.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(int32_t)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int32_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for logical.\n");
                 exit(1);
@@ -7719,7 +7721,7 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
                 fprintf(stderr, "Error: Failed to read logical from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(int32_t);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int32_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading logical.\n");
@@ -7829,7 +7831,7 @@ LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t s
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int8_t));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int8 array.\n");
                 exit(1);
@@ -7851,7 +7853,7 @@ LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t s
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int8 array read.\n");
@@ -7932,7 +7934,7 @@ LFORTRAN_API void _lfortran_read_array_logical(void *p, int array_size, int kind
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * kind);
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for logical array.\n");
                 exit(1);
@@ -7959,7 +7961,7 @@ LFORTRAN_API void _lfortran_read_array_logical(void *p, int array_size, int kind
                     memcpy((char*)p + (int64_t)i * (int64_t)stride * kind, tmp, kind);
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in logical array read.\n");
@@ -8045,7 +8047,7 @@ LFORTRAN_API void _lfortran_read_array_int16(int16_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int16_t));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int16 array.\n");
                 exit(1);
@@ -8067,7 +8069,7 @@ LFORTRAN_API void _lfortran_read_array_int16(int16_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int16 array read.\n");
@@ -8148,7 +8150,7 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int32_t));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int32 array.\n");
                 exit(1);
@@ -8170,7 +8172,7 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int32 array read.\n");
@@ -8250,7 +8252,7 @@ LFORTRAN_API void _lfortran_read_array_int64(int64_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int64_t));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int64 array.\n");
                 exit(1);
@@ -8272,7 +8274,7 @@ LFORTRAN_API void _lfortran_read_array_int64(int64_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int64 array read.\n");
@@ -8349,7 +8351,7 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
             pad_with_spaces(*p, data_length, p_len);
         } else {
 
-            if (seq_unf_pending[unit_num] == 0) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
                 int32_t marker = 0;
                 if (fread(&marker, sizeof(int32_t), 1, filep) != 1) {
                     if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
@@ -8361,11 +8363,11 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
                     printf("Error: Invalid record marker while reading character data.\n");
                     exit(1);
                 }
-                seq_unf_pending[unit_num] = marker;
-                seq_unf_record_len[unit_num] = marker;
+                seq_unf_pending[STATE_INDEX(unit_num)] = marker;
+                seq_unf_record_len[STATE_INDEX(unit_num)] = marker;
             }
 
-            int32_t data_length = seq_unf_pending[unit_num];
+            int32_t data_length = seq_unf_pending[STATE_INDEX(unit_num)];
             if (data_length > p_len) data_length = (int32_t)p_len;
 
             if (data_length > 0 && fread(*p, sizeof(char), data_length, filep) != (size_t)data_length) {
@@ -8374,16 +8376,16 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
                 exit(1);
             }
 
-            seq_unf_pending[unit_num] -= data_length;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= data_length;
 
-            if (seq_unf_pending[unit_num] == 0) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
                 int32_t end_marker = 0;
                 if (fread(&end_marker, sizeof(int32_t), 1, filep) != 1) {
                     if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
                     printf("Error reading trailing record marker from file.\n");
                     exit(1);
                 }
-                if (end_marker != seq_unf_record_len[unit_num]) {
+                if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
                     if (iostat) { *iostat = 1; return; }
                     printf("Error: Mismatched record markers while reading character data.\n");
                     exit(1);
@@ -8655,7 +8657,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
                 fprintf(stderr, "Error: Failed to read record marker for float.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(float)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(float)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for float.\n");
                 exit(1);
@@ -8665,7 +8667,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
                 fprintf(stderr, "Error: Failed to read float from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(float);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(float);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading float.\n");
@@ -8710,8 +8712,8 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
+                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
             }
             return;
         }
@@ -8761,7 +8763,7 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 fprintf(stderr, "Error: Failed to read record marker for complex float.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(struct _lfortran_complex_32)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(struct _lfortran_complex_32)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex float.\n");
                 exit(1);
@@ -8771,7 +8773,7 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 fprintf(stderr, "Error: Failed to read complex float from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(struct _lfortran_complex_32);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(struct _lfortran_complex_32);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading complex float.\n");
@@ -8800,8 +8802,8 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
+                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
             }
             return;
         }
@@ -8875,7 +8877,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 fprintf(stderr, "Error: Failed to read record marker for complex double.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(struct _lfortran_complex_64)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(struct _lfortran_complex_64)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex double.\n");
                 exit(1);
@@ -8885,7 +8887,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 fprintf(stderr, "Error: Failed to read complex double from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(struct _lfortran_complex_64);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(struct _lfortran_complex_64);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading complex double.\n");
@@ -8914,8 +8916,8 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
+                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
             }
             return;
         }
@@ -8997,7 +8999,7 @@ LFORTRAN_API void _lfortran_read_array_complex_float(struct _lfortran_complex_32
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(struct _lfortran_complex_32));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex float array.\n");
                 exit(1);
@@ -9019,7 +9021,7 @@ LFORTRAN_API void _lfortran_read_array_complex_float(struct _lfortran_complex_32
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in complex float array read.\n");
@@ -9131,7 +9133,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(struct _lfortran_complex_64));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex double array.\n");
                 exit(1);
@@ -9153,7 +9155,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in complex double array read.\n");
@@ -9268,7 +9270,7 @@ LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t s
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(float));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for float array.\n");
                 exit(1);
@@ -9290,7 +9292,7 @@ LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t s
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in float array read.\n");
@@ -9380,7 +9382,7 @@ LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(double));
-            if (seq_unf_pending[unit_num] < bytes_needed) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for double array.\n");
                 exit(1);
@@ -9402,7 +9404,7 @@ LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[unit_num] -= bytes_needed;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in double array read.\n");
@@ -9480,7 +9482,7 @@ LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_s
                 fprintf(stderr, "Error: Failed to read record marker for char array.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)want) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)want) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for char array.\n");
                 exit(1);
@@ -9492,7 +9494,7 @@ LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_s
             if (got < want) {
                 memset(p + got, ' ', want - got);
             }
-            seq_unf_pending[unit_num] -= (int32_t)want;
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)want;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in char array read.\n");
@@ -9560,7 +9562,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for double.\n");
                 exit(1);
             }
-            if (seq_unf_pending[unit_num] < (int32_t)sizeof(double)) {
+            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(double)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for double.\n");
                 exit(1);
@@ -9570,7 +9572,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read double from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[unit_num] -= (int32_t)sizeof(double);
+            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(double);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading double.\n");
@@ -9616,8 +9618,8 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
+                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
             }
             return;
         }
@@ -11074,8 +11076,8 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_
                 exit(1);
             }
         }
-        if (seq_unf_pending[unit_num] > 0) {
-            if (fseek(fp, (long)seq_unf_pending[unit_num], SEEK_CUR) != 0) {
+        if (seq_unf_pending[STATE_INDEX(unit_num)] > 0) {
+            if (fseek(fp, (long)seq_unf_pending[STATE_INDEX(unit_num)], SEEK_CUR) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error skipping remaining record data in file.\n");
                 exit(1);
@@ -11086,13 +11088,13 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_
                 fprintf(stderr, "Error reading trailing record marker from file.\n");
                 exit(1);
             }
-            if (end_marker != seq_unf_record_len[unit_num]) {
+            if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Mismatched record markers while finalizing read.\n");
                 exit(1);
             }
             seq_unf_state_reset(unit_num);
-        } else if (no_values && seq_unf_record_len[unit_num] == 0) {
+        } else if (no_values && seq_unf_record_len[STATE_INDEX(unit_num)] == 0) {
             // Empty record (marker was 0): read trailing marker
             int32_t end_marker = 0;
             if (fread(&end_marker, sizeof(int32_t), 1, fp) != 1) {
@@ -11392,8 +11394,8 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
         } else {
             // Sequential / stream access: write as before
             // In child I/O mode (DTIO), suppress the record terminator
-            bool is_child = (unit_num >= 0 && unit_num < MAXUNITS &&
-                             lf_child_io_mode[unit_num]);
+            bool is_child = (unit_num > -MAXUNITS && unit_num < MAXUNITS &&
+                             lf_child_io_mode[STATE_INDEX(unit_num)]);
             if (end != NULL && !is_child) {
                 if(open_delim != '\0') {
                     fprintf(filep, "%c%.*s%c%.*s",

--- a/src/runtime/custom/lfortran_intrinsic_custom.f90
+++ b/src/runtime/custom/lfortran_intrinsic_custom.f90
@@ -10,11 +10,11 @@ end interface
 
 contains
     function get_valid_newunit() result(unit)
-        integer, parameter :: LUN_MIN=0, LUN_MAX=1000
+        integer, parameter :: LUN_MIN=-1000, LUN_MAX=-10
         logical :: opened
         integer(4) :: lun 
         integer(4) :: unit ! no need for kind 8, we have limit of 1000 for now.
-        do lun=LUN_MIN,LUN_MAX
+        do lun=LUN_MAX,LUN_MIN,-1
             inquire(unit=lun,opened=opened)
             if (.not. opened) then
                 unit = lun
@@ -28,12 +28,14 @@ contains
     subroutine newunit_int_1(unit)
         implicit none
         integer(1), intent(out) :: unit
-        if(get_valid_newunit() >= 2**8) then
+        integer(4) :: valid_unit
+        valid_unit = get_valid_newunit()
+        if(valid_unit < -128) then
             print *, "integer(KIND=1) & 
             &is has small limit. Use larger kind for the unit number"
             error stop
         end if
-        unit =  INT(get_valid_newunit(),1)
+        unit =  INT(valid_unit,1)
     end subroutine newunit_int_1
 
     subroutine newunit_int_2(unit)

--- a/tests/reference/run-write_01-c968b4a.json
+++ b/tests/reference/run-write_01-c968b4a.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-write_01-c968b4a.stderr",
-    "stderr_hash": "b65bc0d80ed3f38265702bfd48f891f579ea1c8ec54cef7c4f9f59ed",
+    "stderr_hash": "b52244f7416c7199e45b6045c78b6dbda3e373673899ec05bf934bed",
     "returncode": 1
 }

--- a/tests/reference/run-write_01-c968b4a.stderr
+++ b/tests/reference/run-write_01-c968b4a.stderr
@@ -1,1 +1,1 @@
-Runtime Error: Format mismatch between OPEN statement and WRITE statement on unit 1.
+Runtime Error: Format mismatch between OPEN statement and WRITE statement on unit -10.

--- a/tests/reference/run-write_02-795afbb.json
+++ b/tests/reference/run-write_02-795afbb.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run-write_02-795afbb.stderr",
-    "stderr_hash": "b65bc0d80ed3f38265702bfd48f891f579ea1c8ec54cef7c4f9f59ed",
+    "stderr_hash": "b52244f7416c7199e45b6045c78b6dbda3e373673899ec05bf934bed",
     "returncode": 1
 }

--- a/tests/reference/run-write_02-795afbb.stderr
+++ b/tests/reference/run-write_02-795afbb.stderr
@@ -1,1 +1,1 @@
-Runtime Error: Format mismatch between OPEN statement and WRITE statement on unit 1.
+Runtime Error: Format mismatch between OPEN statement and WRITE statement on unit -10.


### PR DESCRIPTION
fixes #11228


Bug:
The `OPEN(NEWUNIT=...)` statement was incorrectly assigning positive unit
numbers (0 to 1000). The Fortran standard explicitly requires `NEWUNIT`
to assign a unique negative integer to prevent collisions with user-specified
or pre-connected standard units. Furthermore, the IO runtime inside 
`lfortran_intrinsics.c` incorrectly assumed unit numbers strictly fell
between `0` and `999`. It used the unit number directly as an array index 
for internal IO tracking (e.g., `seq_unf_pending`) and hardcoded 0-999 loops,
which caused `INQUIRE` statements to fail and crashed the compiler when
forced to handle negative units.

Fix:
- Modified `get_valid_newunit()` in `lfortran_intrinsic_custom.f90` to
  allocate negative unit identifiers starting from `-10` down to `-1000`, 
  safely avoiding common standard units (`-1`, `0`, `5`, `6`).
- Fixed `newunit_int_1` overflow bounds checking to safely validate the
  lower limit (`< -128`) instead of the upper limit, and optimized it
  to call `get_valid_newunit()` only once.
- Updated the C runtime IO arrays (`seq_unf_pending`, etc.) to double 
  their capacity (`MAXUNITS * 2`) and introduced a `STATE_INDEX` macro. 
  This seamlessly offsets negative unit numbers to safe array indices 
  without breaking existing performance or structs.
- Replaced the hardcoded `0` to `999` iteration loop inside `_lfortran_inquire` 
  with a dynamic iteration over `unit_to_file` tracking, resolving `INQUIRE(FILE=)` 
  test failures.
