### PR TITLE
 Fix: I/O Implied-Do Loop Variable After Loop

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3246,6 +3246,7 @@ RUN(NAME implied_do_loops35 LABELS gfortran llvm)
 RUN(NAME implied_do_loops36 LABELS gfortran llvm)
 
 RUN(NAME implied_do_loops37 LABELS gfortran llvm)
+RUN(NAME implied_do_loops38 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops38.f90
+++ b/integration_tests/implied_do_loops38.f90
@@ -19,6 +19,7 @@ program implied_do_loops38
     i = -42
     inquire(iolength=iol) (data(i), i = 1, size(data))
     if (i /= size(data) + 1) error stop
+    if (iol /= size(data) * 4) error stop
 
     open(10, status="scratch", form="formatted")
     write(10, "(*(i5))") (data(i), i = 1, size(data), 2)
@@ -33,6 +34,7 @@ program implied_do_loops38
     i = -42
     inquire(iolength=iol) (data(i), i = 1, size(data), 2)
     if (i /= size(data) + 2) error stop
+    if (iol /= 6 * 4) error stop
 
     open(10, status="scratch", form="formatted")
     write(10, "(*(i5))") (data(i), i = size(data), 1, -2)
@@ -47,4 +49,5 @@ program implied_do_loops38
     i = -42
     inquire(iolength=iol) (data(i), i = size(data), 1, -2)
     if (i /= -1) error stop
+    if (iol /= 6 * 4) error stop
 end program implied_do_loops38

--- a/integration_tests/implied_do_loops38.f90
+++ b/integration_tests/implied_do_loops38.f90
@@ -1,0 +1,22 @@
+program implied_do_loops38
+    implicit none
+
+    integer :: data(11)
+    integer :: i, iol
+
+    data = [(i, i = 1, size(data))]
+
+    open(10, status="scratch", form="formatted")
+    write(10, "(*(i5))") (data(i), i = 1, size(data))
+
+    rewind(10)
+    i = -42
+    read(10, "(*(i5))") (data(i), i = 1, size(data))
+    if (i /= size(data) + 1) error stop
+
+    close(10)
+
+    i = -42
+    inquire(iolength=iol) (data(i), i = 1, size(data))
+    if (i /= size(data) + 1) error stop
+end program implied_do_loops38

--- a/integration_tests/implied_do_loops38.f90
+++ b/integration_tests/implied_do_loops38.f90
@@ -19,4 +19,32 @@ program implied_do_loops38
     i = -42
     inquire(iolength=iol) (data(i), i = 1, size(data))
     if (i /= size(data) + 1) error stop
+
+    open(10, status="scratch", form="formatted")
+    write(10, "(*(i5))") (data(i), i = 1, size(data), 2)
+
+    rewind(10)
+    i = -42
+    read(10, "(*(i5))") (data(i), i = 1, size(data), 2)
+    if (i /= size(data) + 2) error stop
+
+    close(10)
+
+    i = -42
+    inquire(iolength=iol) (data(i), i = 1, size(data), 2)
+    if (i /= size(data) + 2) error stop
+
+    open(10, status="scratch", form="formatted")
+    write(10, "(*(i5))") (data(i), i = size(data), 1, -2)
+
+    rewind(10)
+    i = -42
+    read(10, "(*(i5))") (data(i), i = size(data), 1, -2)
+    if (i /= -1) error stop
+
+    close(10)
+
+    i = -42
+    inquire(iolength=iol) (data(i), i = size(data), 1, -2)
+    if (i /= -1) error stop
 end program implied_do_loops38

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18211,6 +18211,26 @@ public:
                 builder->CreateBr(loop_cond_bb);
 
                 builder->SetInsertPoint(loop_end_bb);
+                if (compiler_options.po.use_loop_variable_after_loop) {
+                    llvm::Value* cur_val = builder->CreateLoad(
+                        llvm::Type::getInt64Ty(context), loop_var_alloca);
+                    llvm::Type* loop_var_type = llvm_utils->get_type_from_ttype_t_util(
+                        idl->m_var, ASRUtils::expr_type(idl->m_var), module.get());
+                    cur_val = llvm_utils->convert_kind(cur_val, loop_var_type);
+
+                    int ptr_copy_inner = ptr_loads;
+                    ptr_loads = 0;
+                    bool iat_copy_inner = is_assignment_target;
+                    is_assignment_target = true;
+                    this->visit_expr(*idl->m_var);
+                    llvm::Value* real_var_ptr = tmp;
+                    is_assignment_target = iat_copy_inner;
+                    ptr_loads = ptr_copy_inner;
+
+                    if (real_var_ptr && real_var_ptr->getType()->isPointerTy()) {
+                        builder->CreateStore(cur_val, real_var_ptr);
+                    }
+                }
             } else {
                 emit_single_formatted_read(val_expr, unit_val, loop_iostat, read_size,
                                            no_advance_str, no_advance_len,
@@ -18823,7 +18843,14 @@ public:
             
             for (size_t i = 0; i < x.n_iolength_vars; i++) {
                 ASR::expr_t* var_expr = x.m_iolength_vars[i];
-                ASR::ttype_t* var_type = ASRUtils::expr_type(var_expr);
+                ASR::ImpliedDoLoop_t* idl = nullptr;
+                ASR::expr_t* size_expr = var_expr;
+                if (ASR::is_a<ASR::ImpliedDoLoop_t>(*var_expr)) {
+                    idl = ASR::down_cast<ASR::ImpliedDoLoop_t>(var_expr);
+                    LCOMPILERS_ASSERT(idl->n_values > 0);
+                    size_expr = idl->m_values[0];
+                }
+                ASR::ttype_t* var_type = ASRUtils::expr_type(size_expr);
                 ASR::ttype_t* var_type_base = ASRUtils::type_get_past_array(
                     ASRUtils::type_get_past_allocatable(
                         ASRUtils::type_get_past_pointer(var_type)));
@@ -18849,10 +18876,97 @@ public:
                 if (ASRUtils::is_array(var_type)) {
                     ASR::ttype_t* int_type = ASRUtils::TYPE(
                         ASR::make_Integer_t(al, x.base.base.loc, 4));
-                    visit_ArraySizeUtil(var_expr, int_type, nullptr, nullptr);
+                    visit_ArraySizeUtil(size_expr, int_type, nullptr, nullptr);
                     llvm::Value* num_elements = builder->CreateZExtOrTrunc(
                         tmp, llvm::Type::getInt64Ty(context));
                     var_size = builder->CreateMul(elem_size, num_elements);
+                }
+                if (idl) {
+                    int ptr_copy = ptr_loads;
+                    ptr_loads = 0;
+                    this->visit_expr_wrapper(idl->m_start, true);
+                    llvm::Value* loop_start = tmp;
+                    ptr_loads = ptr_copy;
+                    if (loop_start->getType()->isPointerTy()) {
+                        ASR::ttype_t* t = ASRUtils::expr_type(idl->m_start);
+                        llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
+                            idl->m_start, t, module.get());
+                        loop_start = llvm_utils->CreateLoad2(ty, loop_start);
+                    }
+                    loop_start = llvm_utils->convert_kind(loop_start,
+                        llvm::Type::getInt64Ty(context));
+
+                    ptr_copy = ptr_loads;
+                    ptr_loads = 0;
+                    this->visit_expr_wrapper(idl->m_end, true);
+                    llvm::Value* loop_end = tmp;
+                    ptr_loads = ptr_copy;
+                    if (loop_end->getType()->isPointerTy()) {
+                        ASR::ttype_t* t = ASRUtils::expr_type(idl->m_end);
+                        llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
+                            idl->m_end, t, module.get());
+                        loop_end = llvm_utils->CreateLoad2(ty, loop_end);
+                    }
+                    loop_end = llvm_utils->convert_kind(loop_end,
+                        llvm::Type::getInt64Ty(context));
+
+                    llvm::Value* loop_step = llvm::ConstantInt::get(
+                        llvm::Type::getInt64Ty(context), 1);
+                    if (idl->m_increment) {
+                        ptr_copy = ptr_loads;
+                        ptr_loads = 0;
+                        this->visit_expr_wrapper(idl->m_increment, true);
+                        loop_step = tmp;
+                        ptr_loads = ptr_copy;
+                        if (loop_step->getType()->isPointerTy()) {
+                            ASR::ttype_t* t = ASRUtils::expr_type(idl->m_increment);
+                            llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
+                                idl->m_increment, t, module.get());
+                            loop_step = llvm_utils->CreateLoad2(ty, loop_step);
+                        }
+                        loop_step = llvm_utils->convert_kind(loop_step,
+                            llvm::Type::getInt64Ty(context));
+                    }
+
+                    llvm::Type* int64_type = llvm::Type::getInt64Ty(context);
+                    llvm::Value* zero = llvm::ConstantInt::get(int64_type, 0);
+                    llvm::Value* one = llvm::ConstantInt::get(int64_type, 1);
+                    llvm::Value* step_is_pos = builder->CreateICmpSGT(loop_step, zero);
+                    llvm::Value* pos_has_iters = builder->CreateICmpSLE(loop_start, loop_end);
+                    llvm::Value* neg_has_iters = builder->CreateICmpSGE(loop_start, loop_end);
+                    llvm::Value* has_iters = builder->CreateSelect(
+                        step_is_pos, pos_has_iters, neg_has_iters);
+                    llvm::Value* pos_span = builder->CreateSub(loop_end, loop_start);
+                    llvm::Value* neg_span = builder->CreateSub(loop_start, loop_end);
+                    llvm::Value* span = builder->CreateSelect(step_is_pos, pos_span, neg_span);
+                    llvm::Value* abs_step = builder->CreateSelect(
+                        step_is_pos, loop_step, builder->CreateNeg(loop_step));
+                    llvm::Value* count = builder->CreateAdd(
+                        builder->CreateSDiv(span, abs_step), one);
+                    count = builder->CreateSelect(has_iters, count, zero);
+
+                    var_size = builder->CreateMul(var_size, count);
+
+                    if (compiler_options.po.use_loop_variable_after_loop) {
+                        llvm::Value* final_val = builder->CreateAdd(
+                            loop_start, builder->CreateMul(count, loop_step));
+                        llvm::Type* loop_var_type = llvm_utils->get_type_from_ttype_t_util(
+                            idl->m_var, ASRUtils::expr_type(idl->m_var), module.get());
+                        final_val = llvm_utils->convert_kind(final_val, loop_var_type);
+
+                        ptr_copy = ptr_loads;
+                        ptr_loads = 0;
+                        bool iat_copy = is_assignment_target;
+                        is_assignment_target = true;
+                        this->visit_expr(*idl->m_var);
+                        llvm::Value* real_var_ptr = tmp;
+                        is_assignment_target = iat_copy;
+                        ptr_loads = ptr_copy;
+
+                        if (real_var_ptr && real_var_ptr->getType()->isPointerTy()) {
+                            builder->CreateStore(final_val, real_var_ptr);
+                        }
+                    }
                 }
 
                 total_size = builder->CreateAdd(total_size, var_size);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18905,21 +18905,15 @@ public:
                         loop_step = get_int64_value(idl->m_increment);
                     }
 
+                    // count = max(0, (end - start) / step + 1)
                     llvm::Value* zero = llvm::ConstantInt::get(int64_type, 0);
                     llvm::Value* one = llvm::ConstantInt::get(int64_type, 1);
-                    llvm::Value* step_is_pos = builder->CreateICmpSGT(loop_step, zero);
-                    llvm::Value* pos_has_iters = builder->CreateICmpSLE(loop_start, loop_end);
-                    llvm::Value* neg_has_iters = builder->CreateICmpSGE(loop_start, loop_end);
-                    llvm::Value* has_iters = builder->CreateSelect(
-                        step_is_pos, pos_has_iters, neg_has_iters);
-                    llvm::Value* pos_span = builder->CreateSub(loop_end, loop_start);
-                    llvm::Value* neg_span = builder->CreateSub(loop_start, loop_end);
-                    llvm::Value* span = builder->CreateSelect(step_is_pos, pos_span, neg_span);
-                    llvm::Value* abs_step = builder->CreateSelect(
-                        step_is_pos, loop_step, builder->CreateNeg(loop_step));
                     llvm::Value* count = builder->CreateAdd(
-                        builder->CreateSDiv(span, abs_step), one);
-                    count = builder->CreateSelect(has_iters, count, zero);
+                        builder->CreateSDiv(
+                            builder->CreateSub(loop_end, loop_start), loop_step),
+                        one);
+                    count = builder->CreateSelect(
+                        builder->CreateICmpSGT(count, zero), count, zero);
 
                     var_size = builder->CreateMul(var_size, count);
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18882,53 +18882,29 @@ public:
                     var_size = builder->CreateMul(elem_size, num_elements);
                 }
                 if (idl) {
-                    int ptr_copy = ptr_loads;
-                    ptr_loads = 0;
-                    this->visit_expr_wrapper(idl->m_start, true);
-                    llvm::Value* loop_start = tmp;
-                    ptr_loads = ptr_copy;
-                    if (loop_start->getType()->isPointerTy()) {
-                        ASR::ttype_t* t = ASRUtils::expr_type(idl->m_start);
-                        llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
-                            idl->m_start, t, module.get());
-                        loop_start = llvm_utils->CreateLoad2(ty, loop_start);
-                    }
-                    loop_start = llvm_utils->convert_kind(loop_start,
-                        llvm::Type::getInt64Ty(context));
-
-                    ptr_copy = ptr_loads;
-                    ptr_loads = 0;
-                    this->visit_expr_wrapper(idl->m_end, true);
-                    llvm::Value* loop_end = tmp;
-                    ptr_loads = ptr_copy;
-                    if (loop_end->getType()->isPointerTy()) {
-                        ASR::ttype_t* t = ASRUtils::expr_type(idl->m_end);
-                        llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
-                            idl->m_end, t, module.get());
-                        loop_end = llvm_utils->CreateLoad2(ty, loop_end);
-                    }
-                    loop_end = llvm_utils->convert_kind(loop_end,
-                        llvm::Type::getInt64Ty(context));
-
-                    llvm::Value* loop_step = llvm::ConstantInt::get(
-                        llvm::Type::getInt64Ty(context), 1);
-                    if (idl->m_increment) {
-                        ptr_copy = ptr_loads;
-                        ptr_loads = 0;
-                        this->visit_expr_wrapper(idl->m_increment, true);
-                        loop_step = tmp;
-                        ptr_loads = ptr_copy;
-                        if (loop_step->getType()->isPointerTy()) {
-                            ASR::ttype_t* t = ASRUtils::expr_type(idl->m_increment);
-                            llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
-                                idl->m_increment, t, module.get());
-                            loop_step = llvm_utils->CreateLoad2(ty, loop_step);
-                        }
-                        loop_step = llvm_utils->convert_kind(loop_step,
-                            llvm::Type::getInt64Ty(context));
-                    }
-
                     llvm::Type* int64_type = llvm::Type::getInt64Ty(context);
+                    auto get_int64_value = [&](ASR::expr_t* expr) {
+                        int ptr_copy = ptr_loads;
+                        ptr_loads = 0;
+                        this->visit_expr_wrapper(expr, true);
+                        llvm::Value* value = tmp;
+                        ptr_loads = ptr_copy;
+                        if (value->getType()->isPointerTy()) {
+                            ASR::ttype_t* t = ASRUtils::expr_type(expr);
+                            llvm::Type* ty = llvm_utils->get_type_from_ttype_t_util(
+                                expr, t, module.get());
+                            value = llvm_utils->CreateLoad2(ty, value);
+                        }
+                        return llvm_utils->convert_kind(value, int64_type);
+                    };
+
+                    llvm::Value* loop_start = get_int64_value(idl->m_start);
+                    llvm::Value* loop_end = get_int64_value(idl->m_end);
+                    llvm::Value* loop_step = llvm::ConstantInt::get(int64_type, 1);
+                    if (idl->m_increment) {
+                        loop_step = get_int64_value(idl->m_increment);
+                    }
+
                     llvm::Value* zero = llvm::ConstantInt::get(int64_type, 0);
                     llvm::Value* one = llvm::ConstantInt::get(int64_type, 1);
                     llvm::Value* step_is_pos = builder->CreateICmpSGT(loop_step, zero);
@@ -18954,7 +18930,7 @@ public:
                             idl->m_var, ASRUtils::expr_type(idl->m_var), module.get());
                         final_val = llvm_utils->convert_kind(final_val, loop_var_type);
 
-                        ptr_copy = ptr_loads;
+                        int ptr_copy = ptr_loads;
                         ptr_loads = 0;
                         bool iat_copy = is_assignment_target;
                         is_assignment_target = true;


### PR DESCRIPTION
Bug: with --use-loop-variable-after-loop, formatted READ and INQUIRE(IOLENGTH=...) did not leave the implied-do loop variable at the post-loop value. WRITE already behaved correctly, but READ only updated the real loop variable during each iteration, and INQUIRE computed size from the implied-do expression without applying the implied-do iteration semantics to the loop variable.

Fix: after formatted READ implied-do lowering reaches the loop end, store the final loop counter back to the user loop variable when --use-loop-variable-after-loop is enabled. For INQUIRE(IOLENGTH=...), compute the implied-do iteration count, multiply the item size by that count, and store start + count * step back to the loop variable under the same option.

Resolves #11393