### PR TITLE
fix: Associate substring assignment does not update original string output 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2594,6 +2594,8 @@ RUN(NAME associate_48 LABELS gfortran llvm)
 RUN(NAME associate_49 LABELS gfortran llvm)
 RUN(NAME associate_50 LABELS gfortran llvm)
 
+RUN(NAME associate_52 LABELS gfortran llvm)
+
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_52.f90
+++ b/integration_tests/associate_52.f90
@@ -1,0 +1,15 @@
+program associate_51
+    implicit none
+    character(len=50) :: s
+    s = repeat('*', len(s))
+    call sub(s)
+    if (s /= "**123*********************************************") error stop
+    print *, "test passed"
+contains
+    subroutine sub(str)
+        character(len=*), intent(inout) :: str
+        associate(substr => str(3:5))
+            substr = '123'
+        end associate
+    end subroutine sub
+end program associate_51

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2805,6 +2805,8 @@ public:
                 create_associate_stmt = true;
                 ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(tmp_expr);
                 tmp_type = sim->m_type;
+            } else if (ASR::is_a<ASR::StringSection_t>(*tmp_expr)) {
+                create_associate_stmt = true;
             } else if( ASR::is_a<ASR::ArraySection_t>(*tmp_expr) ) {
                 create_associate_stmt = true;
                 ASR::ArraySection_t* tmp_array_section = ASR::down_cast<ASR::ArraySection_t>(tmp_expr);


### PR DESCRIPTION
fixes #11398