### PR TITLE
Fix: segfault on zero-size array parameter initialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3065,6 +3065,7 @@ RUN(NAME class_allocate_04 LABELS gfortran llvm)
 RUN(NAME class_allocate_05 LABELS gfortran llvm)
 RUN(NAME class_allocate_06 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME class_optional_01 LABELS gfortran llvm)
+RUN(NAME empty_array_01 LABELS gfortran llvm)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/empty_array_01.f90
+++ b/integration_tests/empty_array_01.f90
@@ -1,0 +1,10 @@
+program empty_array_01
+  integer, parameter :: x(0,0) = 0
+  integer :: y(0,0)
+  y = matmul(x, transpose(x))
+  if (size(x) /= 0) error stop
+  if (size(y) /= 0) error stop
+  if (size(x,1) /= 0) error stop
+  if (size(x,2) /= 0) error stop
+  print *, "ok"
+end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7766,10 +7766,17 @@ public:
                         for (int64_t i = 0; i < size; i++) {
                             args.push_back(al, tmp_init);
                         }
-                        init_expr = ASRUtils::expr_value(
-                            ASRUtils::EXPR(ASRUtils::make_ArrayConstructor_t_util(al, init_expr->base.loc,
-                                args.p, args.n, type, ASR::arraystorageType::ColMajor))
-                        );
+                        if (size == 0) {
+                            // Zero-size array: create an empty ArrayConstant directly
+                            init_expr = ASRUtils::EXPR(ASR::make_ArrayConstant_t(
+                                al, init_expr->base.loc, 0, nullptr, type,
+                                ASR::arraystorageType::ColMajor));
+                        } else {
+                            init_expr = ASRUtils::expr_value(
+                                ASRUtils::EXPR(ASRUtils::make_ArrayConstructor_t_util(al, init_expr->base.loc,
+                                    args.p, args.n, type, ASR::arraystorageType::ColMajor))
+                            );
+                        }
                         LCOMPILERS_ASSERT(ASR::is_a<ASR::ArrayConstant_t>(*init_expr));
                         value = init_expr;
                     }

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -1009,8 +1009,15 @@ class ASRBuilder {
         for (auto &x: elements) m_eles.push_back(al, x);
 
         ASR::ttype_t *fixed_size_type = Array({(int64_t) elements.size()}, base_type);
-        ASR::expr_t *arr_constant = EXPR(ASRUtils::make_ArrayConstructor_t_util(al, loc,
-            m_eles.p, m_eles.n, fixed_size_type, ASR::arraystorageType::ColMajor));
+        ASR::expr_t *arr_constant;
+        if (elements.size() == 0) {
+            // Zero-size array: create an empty ArrayConstant directly
+            arr_constant = EXPR(ASR::make_ArrayConstant_t(al, loc,
+                0, nullptr, fixed_size_type, ASR::arraystorageType::ColMajor));
+        } else {
+            arr_constant = EXPR(ASRUtils::make_ArrayConstructor_t_util(al, loc,
+                m_eles.p, m_eles.n, fixed_size_type, ASR::arraystorageType::ColMajor));
+        }
 
         // Set multi-dimensional type
         if (array_type) {


### PR DESCRIPTION
Fixes #11403
Bug:
Zero-size arrays like `integer, parameter :: x(0,0) = 0` caused a
segfault during semantic analysis. When broadcasting a scalar value
to fill an array, `get_fixed_size_of_array` returns 0, resulting in
an empty args list. `make_ArrayConstructor_t_util` with 0 args cannot
produce an `ArrayConstant_t` (by design, to preserve typed constructors
like `[string_t::]`), so `expr_value` returned nullptr, hitting an
assertion.

Similarly, calling intrinsics like `transpose` on zero-size parameter
arrays triggered a crash in the `ASRBuilder::ArrayConstant` method,
which also assumed non-empty elements.

Fix both call sites to directly create an empty `ArrayConstant_t` when
the array size is zero, bypassing `make_ArrayConstructor_t_util`.
