### PR TITLE
fix : Do not free the Pointer in derived type during finalization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2403,6 +2403,7 @@ RUN(NAME derived_types_138 LABELS gfortran llvm)
 RUN(NAME derived_types_139 LABELS gfortran llvm)
 RUN(NAME derived_types_140 LABELS gfortran llvm)
 RUN(NAME derived_types_141 LABELS gfortran llvm)
+RUN(NAME derived_types_142 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 

--- a/integration_tests/derived_types_142.f90
+++ b/integration_tests/derived_types_142.f90
@@ -1,0 +1,58 @@
+module mytypemod_derived_types_142
+
+   type :: MyType
+      real(8), pointer :: ptr(:)
+   end type MyType
+
+   interface MyType
+      procedure :: constructor
+   end interface MyType
+   
+contains
+
+   function constructor() result(self)
+      type(MyType) :: self   
+   end function constructor
+
+end module mytypemod_derived_types_142
+
+
+module wrappermod_derived_types_142
+   
+   use mytypemod_derived_types_142, only: MyType
+   
+   type :: WrapperType
+      private
+      class(MyType), allocatable :: obj
+   end type WrapperType
+   
+   interface WrapperType
+      procedure :: constructor
+   end interface WrapperType
+
+contains
+   
+   function constructor(obj) result(self)
+      class(MyType), intent(in) :: obj
+      type(WrapperType)         :: self
+      self%obj = obj
+   end function constructor
+
+end module wrappermod_derived_types_142
+
+
+program derived_types_142
+
+   use wrappermod_derived_types_142, only: WrapperType
+   use mytypemod_derived_types_142,  only: MyType
+   
+   call wrapping()
+   
+contains
+   
+   subroutine wrapping()
+      class(WrapperType), allocatable :: wrap
+      wrap = WrapperType(MyType())
+   end subroutine wrapping
+
+end program

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -999,7 +999,7 @@ class ASRToLLVMVisitor;
             if(ASRUtils::is_allocatable(t)){
                 finalize_allocatable(ptr, t, struct_sym, in_struct);
             } else if(ASRUtils::is_pointer(t)) {
-                finalize_pointer(ptr, t, struct_sym, in_struct);
+                finalize_pointer(ptr, t, struct_sym);
             } else {
                 finalize_type(ptr, t, struct_sym);
             }
@@ -1125,7 +1125,7 @@ class ASRToLLVMVisitor;
             }
         }
 
-        void finalize_pointer(llvm::Value* ptr, ASR::ttype_t* const t, [[maybe_unused]] ASR::Struct_t* const struct_sym, bool in_struct){
+        void finalize_pointer(llvm::Value* ptr, ASR::ttype_t* const t, [[maybe_unused]] ASR::Struct_t* const struct_sym){
             LCOMPILERS_ASSERT_MSG(ASRUtils::is_pointer(t), "Must be finalizable pointer.")
             auto const t_past = ASRUtils::type_get_past_pointer(t);
             switch (t_past->type) {
@@ -1137,7 +1137,6 @@ class ASRToLLVMVisitor;
                                         llvm_utils_->create_gep2(get_llvm_type(t_past, struct_sym), ptr, 0));
                         llvm_utils_->lfortran_free_nocheck(wrapper);
                     }
-                    if(in_struct) { llvm_utils_->lfortran_free_nocheck(ptr); }
                 }
                 break;
                 case ASR::StructType:


### PR DESCRIPTION
Fixes #11401

This PR fixes a double-free issue during finalization of pointer components in derived types. The crash occurred because pointer descriptors were shallow-copied during assignment (self%obj = obj), causing multiple objects to free the same descriptor memory during finalization. The fix prevents freeing pointer descriptor during finalization to avoid this issue.

This can lead to small descriptor-memory leaks. But other option is to create a deep copy during assignments instead of shallow copy which again leads to high memory utilization and so, I think that this PR provides a feasible approach to solve this double free issue.