### PR TITLE
fix: nested_vars pass for intent(in) allocatable arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2767,6 +2767,7 @@ RUN(NAME nested_23 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_25 LABELS gfortran llvm)
 RUN(NAME nested_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_27 LABELS gfortran llvm)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/nested_27.f90
+++ b/integration_tests/nested_27.f90
@@ -1,0 +1,22 @@
+module nested
+contains
+   subroutine outer(x)
+      real(8), allocatable, intent(in) :: x(:,:)
+      print *, 'outer: lbound(x,1) is ', lbound(x,1)
+      print *, 'outer: ubound(x,1) is ', ubound(x,1)
+      call inner()
+   contains
+      subroutine inner()
+         print *, 'inner: lbound(x,1) is ', lbound(x,1)
+         print *, 'inner: ubound(x,1) is ', ubound(x,1)
+      end subroutine inner      
+   end subroutine outer
+end module nested
+
+program main
+   use nested
+   implicit none
+   real(8), dimension(:,:), allocatable :: x
+   allocate( x(-4:44,3) )
+   call outer(x)
+end program main

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -492,6 +492,14 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                 bool is_allocatable = ASRUtils::is_allocatable(var->m_type);
                 bool is_pointer = ASRUtils::is_pointer(var->m_type);
                 LCOMPILERS_ASSERT(!(is_allocatable && is_pointer));
+                // For intent(IN) allocatable arrays, use a Pointer in the
+                // context module instead of Allocatable. This ensures
+                // the sync uses Associate (pointer association) which
+                // preserves the original array bounds. Assignment would
+                // reset lower bounds to 1.
+                if (is_allocatable && var->m_intent == ASR::intentType::In) {
+                    is_allocatable = false;
+                }
                 ASR::ttype_t* var_type = ASRUtils::type_get_past_allocatable(
                     ASRUtils::type_get_past_pointer(var->m_type));
                 ASR::ttype_t* var_type_ = ASRUtils::type_get_past_array(var_type);
@@ -1216,7 +1224,8 @@ public:
                                                             target, val, nullptr, true, true));
                                 // First push allocate stmt for LHS
                                 body.push_back(al, assignment);
-                                if( ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter ) {
+                                if( ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter &&
+                                        ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In ) {
                                     assignment = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(al, t->base.loc,
                                         val, target, nullptr, true, true));
                                     // Now push the assignment from LHS to RHS at end of function
@@ -1229,7 +1238,8 @@ public:
                                 // TODO : Remove the following if block (See integration test `arrays_87.f90`)
                                 if(ASRUtils::is_array(ASRUtils::symbol_type(sym)) &&
                                     is_ext_sym_allocatable_or_pointer && is_sym_allocatable_or_pointer
-                                    && ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter ) {
+                                    && ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter
+                                    && ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In ) {
                                     associate = ASRUtils::STMT(ASRUtils::make_Associate_t_util(al, t->base.loc,
                                         val, target));
                                     assigns_at_end.push_back(associate);


### PR DESCRIPTION
fixes #11406
* Fixed an ASR verify error (assigning to intent(IN) variable) by preventing the `nested_vars` pass from generating write-back assignments for `intent(in)` arrays.
* Preserved array bounds inside nested subroutines by syncing `intent(in)` allocatable arrays via `Associate` (pointer association) rather than copy assignments, which incorrectly reset lower bounds to 1.