### PR TITLE
fix (Windows, build): generate file `intrinsic_function_registry_util.h`

### DIFF
--- a/build0_win.xsh
+++ b/build0_win.xsh
@@ -10,4 +10,5 @@ pushd src/lfortran/parser && re2c -W -b tokenizer.re -o tokenizer.cpp && popd
 pushd src/lfortran/parser && re2c -W -b preprocessor.re -o preprocessor.cpp && popd
 pushd src/lfortran/parser && bison -Wall -d parser.yy && popd
 python src/libasr/wasm_instructions_visitor.py
+python src/libasr/intrinsic_func_registry_util_gen.py
 python src/server/generator/generate_lsp_code.py --schema src/server/generator/metaModel.json --target-language c++ --output-dir src/server


### PR DESCRIPTION
Fixes the below Windows build failure:

```console
Cannot open include file: 'libasr/pass/intrinsic_function_registry_util.h': No such file or directory
```