### PR TITLE
Fix double free on struct with pointer array component

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2403,6 +2403,7 @@ RUN(NAME derived_types_138 LABELS gfortran llvm)
 RUN(NAME derived_types_139 LABELS gfortran llvm)
 RUN(NAME derived_types_140 LABELS gfortran llvm)
 RUN(NAME derived_types_141 LABELS gfortran llvm)
+RUN(NAME derived_types_142 LABELS gfortran llvm)
 RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 

--- a/integration_tests/derived_types_142.f90
+++ b/integration_tests/derived_types_142.f90
@@ -1,0 +1,33 @@
+program derived_types_142
+    implicit none
+
+    type :: t
+        integer, pointer :: p(:)
+    end type t
+
+    type(t) :: x, y
+    integer, target :: arr(3)
+
+    arr = [10, 20, 30]
+
+    ! Associate y%p with arr
+    y%p => arr
+
+    ! Intrinsic assignment: pointer component gets pointer-assigned
+    x = y
+
+    ! Both x%p and y%p should be associated with arr
+    if (x%p(1) /= 10) error stop
+    if (x%p(2) /= 20) error stop
+    if (x%p(3) /= 30) error stop
+    if (y%p(1) /= 10) error stop
+    if (y%p(2) /= 20) error stop
+    if (y%p(3) /= 30) error stop
+
+    ! Modify through x%p; y%p should see the change (same target)
+    x%p(2) = 99
+    if (y%p(2) /= 99) error stop
+    if (arr(2) /= 99) error stop
+
+    print *, "PASS"
+end program derived_types_142

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -3812,6 +3812,25 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(Allocator& al, 
                     llvm::Type* fn_ptr_type = get_type_from_ttype_t_util(src_expr, pointer_type->m_type, module);
                     src = CreateLoad2(fn_ptr_type, src);
                     LLVM::CreateStore(*builder, src, dest);
+                } else if (ASR::is_a<ASR::Array_t>(*pointer_type->m_type) &&
+                           ASRUtils::is_array_physically_descriptor(pointer_type->m_type)) {
+                    // For pointer descriptor-array components inside structs,
+                    // the descriptor is heap-allocated. Copy the descriptor
+                    // contents (memcpy) rather than the pointer itself so that
+                    // each struct instance keeps its own descriptor and
+                    // finalization does not double-free.
+                    llvm::Type* descr_type = get_type_from_ttype_t_util(
+                        src_expr, pointer_type->m_type, module);
+                    llvm::Value* src_descr = CreateLoad2(
+                        descr_type->getPointerTo(), src);
+                    llvm::Value* dest_descr = CreateLoad2(
+                        descr_type->getPointerTo(), dest);
+                    llvm::DataLayout data_layout(module->getDataLayout());
+                    uint64_t descr_size = data_layout.getTypeAllocSize(descr_type);
+                    llvm::Value* size_val = llvm::ConstantInt::get(
+                        context, llvm::APInt(64, descr_size));
+                    builder->CreateMemCpy(dest_descr, llvm::MaybeAlign(),
+                                          src_descr, llvm::MaybeAlign(), size_val);
                 } else {
                     src = CreateLoad2(get_type_from_ttype_t_util(src_expr, pointer_type->m_type, module)->getPointerTo(), src);
                     LLVM::CreateStore(*builder, src, dest);


### PR DESCRIPTION
When a derived type with a pointer array component was intrinsic- assigned (x = y), the deepcopy copied the raw descriptor pointer, making both variables share the same heap-allocated descriptor. At scope exit, finalization freed the descriptor twice, causing a 'pointer being freed was not allocated' crash.

Fix: for Pointer(Array(DescriptorArray)) components, memcpy the descriptor contents instead of copying the pointer. Each variable keeps its own descriptor while sharing the same data target, which matches Fortran standard semantics and avoids double-free.

An integration test (derived_types_142) is added.

Fixes #11401.