### PR TITLE
fix : ICE in nested_vars due to premature scope reassignment

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3337,6 +3337,7 @@ RUN(NAME nested_vars_02 LABELS gfortran llvm)
 RUN(NAME nested_vars_03 LABELS gfortran llvm)
 RUN(NAME nested_vars_04 LABELS gfortran llvm)
 RUN(NAME nested_vars_05 LABELS gfortran llvm)
+RUN(NAME nested_vars_06 LABELS gfortran llvm)
 
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3337,7 +3337,7 @@ RUN(NAME nested_vars_02 LABELS gfortran llvm)
 RUN(NAME nested_vars_03 LABELS gfortran llvm)
 RUN(NAME nested_vars_04 LABELS gfortran llvm)
 RUN(NAME nested_vars_05 LABELS gfortran llvm)
-RUN(NAME nested_vars_06 LABELS gfortran llvm)
+RUN(NAME nested_vars_06 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/nested_vars_06.f90
+++ b/integration_tests/nested_vars_06.f90
@@ -1,26 +1,25 @@
 program nested_vars_06
-    implicit none
-    real :: xt
+    real xt
+
     xt = 5.0
     call b1(xt)
+
     if (abs(xt - 10.0) > 1e-5) error stop 1
+end program
 
-contains
+subroutine b1(xt)
+    real xt
+    real bvalu
+    real x, h
+    real g8
 
-    subroutine b1(xt)
-        real :: xt
-        real :: x, h
-        real :: g8
+    g8(x, h) = bvalu(xt)
 
-        ! Statement function with function call
-        g8(x, h) = bvalu(xt)
+    xt = g8(1.2, 3.4)
+end subroutine
 
-        xt = g8(1.2, 3.4)
-    end subroutine b1
+real function bvalu(x)
+    real x
 
-    real function bvalu(xt)
-        real :: xt
-        bvalu = xt * 2.0
-    end function bvalu
-
-end program nested_vars_06
+    bvalu = x * 2.0
+end function

--- a/integration_tests/nested_vars_06.f90
+++ b/integration_tests/nested_vars_06.f90
@@ -1,0 +1,26 @@
+program nested_vars_06
+    implicit none
+    real :: xt
+    xt = 5.0
+    call b1(xt)
+    if (abs(xt - 10.0) > 1e-5) error stop 1
+
+contains
+
+    subroutine b1(xt)
+        real :: xt
+        real :: x, h
+        real :: g8
+
+        ! Statement function with function call
+        g8(x, h) = bvalu(xt)
+
+        xt = g8(1.2, 3.4)
+    end subroutine b1
+
+    real function bvalu(xt)
+        real :: xt
+        bvalu = xt * 2.0
+    end function bvalu
+
+end program nested_vars_06

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -195,8 +195,6 @@ public:
                     }
                 }
             } else if (ASR::is_a<ASR::Function_t>(*item.second)) {
-                ASR::symbol_t* par_func_sym_copy = par_func_sym;
-                par_func_sym = cur_func_sym;
                 ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(
                     item.second);
                 if (!is_func_visited) {
@@ -206,6 +204,8 @@ public:
                     }
                 }
 
+                ASR::symbol_t* par_func_sym_copy = par_func_sym;
+                par_func_sym = cur_func_sym;
                 visit_Function(*s);
                 par_func_sym = par_func_sym_copy;
             } else {

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -1112,10 +1112,17 @@ public:
             }
             assigns_at_end.clear();
             loop_end_syncs.clear();
+            ASR::symbol_t *assigned_target_sym = nullptr;
+            if (ASR::is_a<ASR::Assignment_t>(*m_body[i])) {
+                ASR::Assignment_t *assignment = ASR::down_cast<ASR::Assignment_t>(m_body[i]);
+                assigned_target_sym = get_root_host_symbol(assignment->m_target);
+            }
             visit_stmt(*m_body[i]);
             if (cur_func_sym != nullptr && (calls_present || calls_in_loop_condition)) {
                 if (nesting_map.find(cur_func_sym) != nesting_map.end()) {
                     for (auto &sym: nesting_map[cur_func_sym]) {
+                        bool skip_sync_back = ASR::is_a<ASR::Assignment_t>(*m_body[i]) &&
+                            assigned_target_sym == ASRUtils::symbol_get_past_external(sym);
                         std::string m_name = nested_var_to_ext_var[sym].first;
                         ASR::symbol_t *t = nested_var_to_ext_var[sym].second;
                         ASR::symbol_t *ext_sym = nullptr;
@@ -1225,7 +1232,8 @@ public:
                                 // First push allocate stmt for LHS
                                 body.push_back(al, assignment);
                                 if( ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter &&
-                                        ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In ) {
+                                        ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In &&
+                                        !skip_sync_back) {
                                     assignment = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(al, t->base.loc,
                                         val, target, nullptr, true, true));
                                     // Now push the assignment from LHS to RHS at end of function
@@ -1239,7 +1247,8 @@ public:
                                 if(ASRUtils::is_array(ASRUtils::symbol_type(sym)) &&
                                     is_ext_sym_allocatable_or_pointer && is_sym_allocatable_or_pointer
                                     && ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter
-                                    && ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In ) {
+                                    && ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In
+                                    && !skip_sync_back) {
                                     associate = ASRUtils::STMT(ASRUtils::make_Associate_t_util(al, t->base.loc,
                                         val, target));
                                     assigns_at_end.push_back(associate);
@@ -1257,7 +1266,8 @@ public:
                                 body.push_back(al, assignment);
                             }
                             if (ASRUtils::EXPR2VAR(val)->m_storage != ASR::storage_typeType::Parameter &&
-                                    ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In) {
+                                    ASRUtils::EXPR2VAR(val)->m_intent != ASR::intentType::In &&
+                                    !skip_sync_back) {
                                 assignment = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(al, t->base.loc,
                                                 val, target, nullptr, false, false));
                                 /* Allocatable RHS Needs A Check `IF allocated --> assign` (Based On Fortran Standards) */


### PR DESCRIPTION
fixes #11435 


* Issue: The `nested_vars` pass was incorrectly changing the "parent scope" tracker (`par_func_sym`) *before* it finished reading the current function's body. Because of this, variables inside a statement function were wrongly assigned to the statement function's own isolated scope instead of the actual parent subroutine, confusing the compiler and causing a crash (ICE) during LLVM code generation.

* Fix: Moved the `par_func_sym` scope update in `NestedVarVisitor::visit_procedure` to happen *after* the function's body is fully processed. This ensures variables are mapped to their correct parent scope.

This a1bf662e0ad8d35a6ace0340f95a7c1b203e60fd fixes following issue
* When a statement function or nested procedure call captured a host variable in
an assignment like `xt = g8(...)`, the nested-vars pass synced the old host
value into the generated context before the call, then synced that context value
back after the assignment. This overwrote the assignment result and left `xt`
with its old value.

* Skip the final sync-back only when the current top-level statement directly
assigns to the same captured variable. This preserves normal sync behavior for
nested calls in conditions and other compound statements.


