### PR TITLE
fix: load array dimension lower bound with correct element type

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1748,6 +1748,7 @@ RUN(NAME intrinsics_455 LABELS gfortran llvm) # intrinsic declaration scope isol
 RUN(NAME intrinsics_456 LABELS gfortran llvm) # move_alloc preserves lower bounds
 RUN(NAME intrinsics_457 LABELS gfortran llvm) # eoshift on 2D array with dim
 RUN(NAME intrinsics_458 LABELS gfortran llvm) # sign with common block variables
+RUN(NAME intrinsics_459 LABELS gfortran llvm) # minval over array with runtime bounds (--fast regression)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_459.f90
+++ b/integration_tests/intrinsics_459.f90
@@ -1,0 +1,20 @@
+program intrinsics_459
+   integer :: lb(3), ub(3)
+   real(8) :: res
+   lb = 1
+   ub = 10
+   call test_proc(lb, ub, res)
+   print *, res
+   if (abs(res - 1.0d0) > 1d-12) error stop
+contains
+   subroutine test_proc(lb, ub, res)
+      integer, intent(in)  :: lb(:), ub(:)
+      real(8), intent(out) :: res
+      integer :: i
+      real(8) :: work(lb(1):ub(1))
+      do i = lb(1), ub(1)
+         work(i) = 1.d0
+      end do
+      res = minval(work)
+   end subroutine test_proc
+end program intrinsics_459

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -859,7 +859,12 @@ public:
         for( int r = 0; r < n_dims; r++ ) {
             ASR::dimension_t m_dim = m_dims[r];
             LCOMPILERS_ASSERT(m_dim.m_start != nullptr);
-            visit_expr(*(m_dim.m_start));
+            // Use visit_expr_wrapper with load_ref=true so that ArrayItem and
+            // similar reference expressions are loaded with the correct
+            // element width (e.g. i32) before being widened to the descriptor's
+            // index type. Plain visit_expr can leave them as raw pointers,
+            // which downstream code would then load with the wrong type.
+            visit_expr_wrapper(m_dim.m_start, true);
             llvm::Value* start = tmp;
             LCOMPILERS_ASSERT(m_dim.m_length != nullptr);
             load_array_size_deep_copy(m_dim.m_length);


### PR DESCRIPTION
In fill_array_details, the dimension start expression was visited with bare visit_expr, which for ArrayItem on a PointerArray returns a GEP pointer to the element rather than a loaded value. Downstream code then loaded that pointer as i64 (the descriptor index type), reading 8 bytes from a 4-byte i32 slot and producing a garbage offset that segfaulted at runtime.

Use visit_expr_wrapper(..., true) instead, matching the sibling overload and the load_array_size_deep_copy helper used immediately after for m_length, so the lower-bound is loaded with the proper element width before being widened to the descriptor's index type.

The bug was latent until --fast's inline_function_calls pass produced an ArrayPhysicalCast(... DescriptorArray, dims=[lb(1), ub(1)-lb(1)+1]) that exercised this code path.

Fixes #11431.