### PR TITLE
fix: report missing required arguments in procedure calls

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7682,7 +7682,7 @@ public:
                             if (args.empty()) {
                                 diag.add(diag::Diagnostic(
                                     "Required argument `" + std::string(v->m_name) +
-                                    "` is missing in function call",
+                                    "` is missing in procedure call",
                                     diag::Level::Error, diag::Stage::Semantic, {
                                         diag::Label("", {x.base.base.loc})
                                     }));
@@ -7693,7 +7693,7 @@ public:
                             diag.add(diag::Diagnostic(
                                 "Required argument `" + std::string(v->m_name) +
                                 "` at position " + std::to_string(i + 1) +
-                                " is missing in function call",
+                                " is missing in procedure call",
                                 diag::Level::Error, diag::Stage::Semantic, {
                                     diag::Label("", {args_loc})
                                 }));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10955,6 +10955,7 @@ public:
             ADD_ASR_DEPENDENCIES(current_scope, final_sym, current_function_dependencies);
         }
         ASRUtils::insert_module_dependency(final_sym, al, current_module_dependencies);
+        validate_missing_required_arguments(loc, args, func);
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
         return ASRUtils::make_FunctionCall_t_util(al, loc,
             final_sym, v, args.p, args.size(), return_type,
@@ -11094,6 +11095,8 @@ public:
             }
         }
         ASRUtils::insert_module_dependency(v, al, current_module_dependencies);
+        validate_missing_required_arguments(loc, args, func, v_expr,
+            v_class_proc->m_is_nopass);
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al, v_expr, v_class_proc->m_is_nopass);
         ASR::call_arg_t* call_args = args.p;
         size_t n_call_args = args.size();
@@ -11150,6 +11153,7 @@ public:
                 ADD_ASR_DEPENDENCIES(current_scope, final_sym, current_function_dependencies);
             }
             ASRUtils::insert_module_dependency(final_sym, al, current_module_dependencies);
+            validate_missing_required_arguments(loc, args, func);
             ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
             return ASRUtils::make_FunctionCall_t_util(al, loc,
                 final_sym, v, args.p, args.size(), type,
@@ -11216,6 +11220,7 @@ public:
                 for (size_t i = 1; i < args.size(); i++) {
                     args_without_dt.push_back(al, args[i]);
                 }
+                validate_missing_required_arguments(loc, args, func);
                 ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
                 ASR::call_arg_t* call_args = args_without_dt.p;
                 size_t n_call_args = args_without_dt.size();
@@ -11230,6 +11235,7 @@ public:
                 }
                 ASRUtils::insert_module_dependency(v, al, current_module_dependencies);
                 ASRUtils::insert_module_dependency(final_sym, al, current_module_dependencies);
+                validate_missing_required_arguments(loc, args, func);
                 ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
                 return ASRUtils::make_FunctionCall_t_util(al, loc,
                     final_sym, v, args.p, args.size(), type,
@@ -11839,6 +11845,41 @@ public:
         }
     }
 
+    void validate_missing_required_arguments(const Location &loc,
+                Vec<ASR::call_arg_t>& args, ASR::Function_t* func,
+                ASR::expr_t* dt=nullptr, bool nopass=false) {
+        const int offset = (dt != nullptr && !nopass) ? 1 : 0;
+        for (size_t i = 0; i + offset < func->n_args; i++) {
+            ASR::expr_t* dummy = func->m_args[i + offset];
+            ASR::symbol_t* dummy_sym = nullptr;
+            if (ASR::is_a<ASR::Var_t>(*dummy)) {
+                dummy_sym = ASRUtils::symbol_get_past_external(
+                    ASR::down_cast<ASR::Var_t>(dummy)->m_v);
+            }
+            if (dummy_sym == nullptr) {
+                continue;
+            }
+            std::string dummy_name;
+            bool is_required = false;
+            if (ASR::is_a<ASR::Variable_t>(*dummy_sym)) {
+                ASR::Variable_t* dummy_var = ASR::down_cast<ASR::Variable_t>(dummy_sym);
+                dummy_name = dummy_var->m_name;
+                is_required = dummy_var->m_presence != ASR::presenceType::Optional;
+            } else if (ASR::is_a<ASR::Function_t>(*dummy_sym)) {
+                dummy_name = ASR::down_cast<ASR::Function_t>(dummy_sym)->m_name;
+                is_required = true;
+            }
+            if (is_required && (i >= args.size() || args[i].m_value == nullptr)) {
+                diag.add(diag::Diagnostic(
+                    "Missing actual argument for argument '" +
+                    dummy_name + "'",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {loc})}));
+                throw SemanticAbort();
+            }
+        }
+    }
+
     ASR::asr_t* create_Function(const Location &loc,
                 Vec<ASR::call_arg_t>& args, ASR::symbol_t *v) {
         ASR::symbol_t *f2 = ASRUtils::symbol_get_past_external(v);
@@ -11854,7 +11895,6 @@ public:
         }
         
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(f2);
-        
         if (ASRUtils::get_FunctionType(func)->m_abi == ASR::abiType::Intrinsic) {
             std::string func_name = std::string(func->m_name);
             
@@ -11886,6 +11926,16 @@ public:
             }
         }
         
+        if (args.size() > func->n_args) {
+            const Location args_loc { ASRUtils::get_vec_loc(args) };
+            diag.add(diag::Diagnostic(
+                    "More actual than formal arguments in procedure call",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {args_loc})}));
+            throw SemanticAbort();
+        }
+        validate_missing_required_arguments(loc, args, func);
+
         ASR::ttype_t *return_type = nullptr;
         ASR::expr_t* first_array_arg = ASRUtils::find_first_array_arg_if_elemental(func, args);
         if (first_array_arg) {
@@ -11926,14 +11976,6 @@ public:
             current_module_dependencies.push_back(al, v_module->m_name);
         }
         ASRUtils::insert_module_dependency(v, al, current_module_dependencies);
-        if (args.size() > func->n_args) {
-            const Location args_loc { ASRUtils::get_vec_loc(args) };
-            diag.add(diag::Diagnostic(
-                    "More actual than formal arguments in procedure call",
-                    diag::Level::Error, diag::Stage::Semantic, {
-                        diag::Label("", {args_loc})}));
-            throw SemanticAbort();
-        }
         ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
         legacy_array_sections_helper(v, args, loc);
         validate_create_function_arguments(args, v);

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2985,8 +2985,14 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
             }
         }
         for( ; i < sub.n_args; i++ ) {
-            ASR::Variable_t *v = ASRUtils::EXPR2VAR(sub.m_args[i]);
-            if( v->m_presence != ASR::presenceType::Optional ) {
+            ASR::symbol_t* sub_arg_sym = symbol_get_past_external(
+                ASR::down_cast<ASR::Var_t>(sub.m_args[i])->m_v);
+            if (ASR::is_a<ASR::Variable_t>(*sub_arg_sym)) {
+                ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(sub_arg_sym);
+                if (v->m_presence != ASR::presenceType::Optional) {
+                    return false;
+                }
+            } else if (ASR::is_a<ASR::Function_t>(*sub_arg_sym)) {
                 return false;
             }
         }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -649,7 +649,7 @@ program continue_compilation_1
     derived_cls = base_var
     call print_len_non_char("  Hello World  ")
     print  *, 9.99e+99
-
+    a5 = missing_required_arg_func()
 
 
 
@@ -714,4 +714,10 @@ program continue_compilation_1
         integer,allocatable  :: x(3)
         integer,pointer  :: y(3)
     end subroutine
+
+    integer function missing_required_arg_func(stat)
+        integer, intent(out) :: stat
+        missing_required_arg_func = 0
+        stat = 0
+    end function
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "51a5f4432c1fca59b3ce75747760a07518c0d7dd6c281b5850a60263",
+    "stderr_hash": "b22efbe0953c3b8028dc0d56853dac21a0be37ac4d2ddfba25e9d236",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "e610e5360634c7c968bb4d2c4413cacbdaab20dc06eecdac295a3687",
+    "infile_hash": "97cd365121ec7bacaa7c520899dc60e5904080dccf73c24bb2aff434",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "70582a6d8706776620d58bee9e2294650e5904d8d86cc216c71e7cad",
+    "stderr_hash": "51a5f4432c1fca59b3ce75747760a07518c0d7dd6c281b5850a60263",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1108,19 +1108,19 @@ semantic error: `exit` statements cannot be outside of loops or blocks
 513 |     exit
     |     ^^^^ 
 
-semantic error: Required argument `y` at position 2 is missing in function call
+semantic error: Required argument `y` at position 2 is missing in procedure call
    --> tests/errors/continue_compilation_1.f90:516:18
     |
 516 |     call my_func(10)
     |                  ^^ 
 
-semantic error: Required argument `x` is missing in function call
+semantic error: Required argument `x` is missing in procedure call
    --> tests/errors/continue_compilation_1.f90:517:5
     |
 517 |     call my_func()
     |     ^^^^^^^^^^^^^^ 
 
-semantic error: Required argument `extra_arg` is missing in function call
+semantic error: Required argument `extra_arg` is missing in procedure call
    --> tests/errors/continue_compilation_1.f90:521:5
     |
 521 |     call obj%display()
@@ -1157,7 +1157,7 @@ semantic error: Argument was not specified
 528 |     call logger % add_log_file(filename=filename)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 1-th argument not specified for add_log_file
 
-semantic error: Required argument `unit` is missing in function call
+semantic error: Required argument `unit` is missing in procedure call
    --> tests/errors/continue_compilation_1.f90:529:5
     |
 529 |     call logger % add_log_file()

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1461,6 +1461,12 @@ warning: Real constant overflows its kind (4)
 651 |     print  *, 9.99e+99
     |               ^^^^^^^^ 
 
+semantic error: Missing actual argument for argument 'stat'
+   --> tests/errors/continue_compilation_1.f90:652:10
+    |
+652 |     a5 = missing_required_arg_func()
+    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: No matching `operator(-)` found for this operand type
    --> tests/errors/continue_compilation_1.f90:662:18
     |


### PR DESCRIPTION
Fixes: https://github.com/lfortran/lfortran/issues/11434

Emit a semantic error when a function/subruotine call is missing a required argument.