### PR TITLE
fix: allow allocatable logical scalar in if condition

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2506,6 +2506,7 @@ RUN(NAME allocate_67 LABELS gfortran llvm)
 RUN(NAME allocate_68 LABELS gfortran llvm)
 RUN(NAME allocate_69 LABELS gfortran llvm)
 RUN(NAME allocate_70 LABELS gfortran llvm)
+RUN(NAME allocate_71 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_71.f90
+++ b/integration_tests/allocate_71.f90
@@ -1,0 +1,13 @@
+program allocate_71
+    logical, allocatable :: tf
+    integer :: counter
+    counter = 0
+    allocate(tf)
+    tf = .true.
+    if (tf) counter = counter + 1
+    tf = .false.
+    if (tf) counter = counter + 10
+    if (.not. tf) counter = counter + 100
+    if (counter /= 101) error stop
+    deallocate(tf)
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8228,7 +8228,7 @@ public:
         all_loops_blocks_nesting++;
         visit_expr(*x.m_test);
         ASR::expr_t *test = ASRUtils::EXPR(tmp);
-        ASR::ttype_t *test_type = ASRUtils::type_get_past_pointer(ASRUtils::expr_type(test));
+        ASR::ttype_t *test_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(test));
         if (!ASR::is_a<ASR::Logical_t>(*test_type)) {
             diag.add(diag::Diagnostic("Expected logical expression in if statement, but recieved " +
                 ASRUtils::type_to_str_with_kind(test_type, test) + " instead",


### PR DESCRIPTION
The if-statement type check used type_get_past_pointer, which did not unwrap Allocatable. As a result, a scalar logical allocatable was rejected with 'Expected logical expression in if statement'.

Use type_get_past_allocatable_pointer so allocatable logical scalars are accepted, while allocatable logical arrays are still rejected (unwraps to Array(Logical), not Logical_t).

Fixes #11439