### PR TITLE
fix: memory leak for intent(out) structs with nested allocatable members

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4374,6 +4374,7 @@ RUN(NAME intent_out_array_01 LABELS gfortran llvm)
 RUN(NAME intent_out_allocatable_component_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_struct_member_no_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
+RUN(NAME intent_out_nested_allocatable_01 LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_neg_extent_01 LABELS gfortran llvm)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4375,6 +4375,7 @@ RUN(NAME intent_out_allocatable_component_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_struct_member_no_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_nested_allocatable_01 LABELS gfortran llvm)
+RUN(NAME intent_out_array_structs_01 LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_neg_extent_01 LABELS gfortran llvm)
 

--- a/integration_tests/intent_out_array_structs_01.f90
+++ b/integration_tests/intent_out_array_structs_01.f90
@@ -1,0 +1,22 @@
+module m
+    type :: regex_token
+        integer :: id
+        character(len=:), allocatable :: ccl
+    end type
+
+    type :: regex_pattern
+        type(regex_token), dimension(5) :: pattern
+    end type
+contains
+    subroutine parse_pattern(this)
+        type(regex_pattern), intent(out) :: this
+        this%pattern(1)%id = 1
+    end subroutine
+end module
+
+program intent_out_array_structs
+    use m
+    type(regex_pattern) :: p
+    call parse_pattern(p)
+    if (p%pattern(1)%id /= 1) error stop
+end program

--- a/integration_tests/intent_out_array_structs_01.f90
+++ b/integration_tests/intent_out_array_structs_01.f90
@@ -1,4 +1,4 @@
-module m
+module intent_out_array_structs_01_mod
     type :: regex_token
         integer :: id
         character(len=:), allocatable :: ccl
@@ -15,7 +15,7 @@ contains
 end module
 
 program intent_out_array_structs
-    use m
+    use intent_out_array_structs_01_mod
     type(regex_pattern) :: p
     call parse_pattern(p)
     if (p%pattern(1)%id /= 1) error stop

--- a/integration_tests/intent_out_nested_allocatable_01.f90
+++ b/integration_tests/intent_out_nested_allocatable_01.f90
@@ -1,0 +1,25 @@
+program intent_out_nested_allocatable_01
+   implicit none
+
+   type tt2
+      integer, allocatable :: xx
+   end type tt2
+   
+   type tt
+      type(tt2) :: internal
+   end type
+   
+   type(tt) :: instance
+
+   allocate(instance%internal%xx)
+   call ss(instance)
+
+contains 
+   subroutine ss(kk)
+      type(tt), intent(out) :: kk
+      if (allocated(kk%internal%xx)) then
+          error stop "Test failed: intent(out) did not deallocate nested allocatable."
+      end if
+      print *, "Test passed: intent(out) successfully deallocated nested allocatable."
+   end subroutine
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6526,7 +6526,8 @@ public:
                 } else if (ASR::is_a<ASR::StructType_t>(*symbol_type) && !ASRUtils::is_class_type(symbol_type)) {
                     ASR::Struct_t* struct_sym = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(
                         ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration));
-                    allocate_array_members_of_struct(struct_sym, ptr_member, symbol_type);
+                    allocate_array_members_of_struct(struct_sym, ptr_member, symbol_type,
+                        is_intent_out, initialize_val, skip_allocatable_array_descriptor_init);
                 }  else if(ASRUtils::is_string_only(symbol_type) && !is_intent_out) {
                     // Skip string descriptor setup for bind(C) struct non-pointer character members
                     bool is_bindc = (struct_type_t->m_abi == ASR::abiType::BindC);
@@ -7349,8 +7350,10 @@ public:
                         allocate_array_members_of_struct_arrays(var_expr, ptr, v->m_type);
                     }
                 } else {
+                    bool is_intent_out_var = (v->m_intent == ASR::intentType::Out);
                     allocate_array_members_of_struct(ASR::down_cast<ASR::Struct_t>(
-                        ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(var_expr))), ptr, v->m_type);
+                        ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(var_expr))), ptr, v->m_type,
+                        is_intent_out_var);
                 }
                 if (struct_skip_bb != nullptr) {
                     builder->CreateBr(struct_skip_bb);

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -453,13 +453,14 @@ public:
                     }
                 }
 
-                // Recursively collect deallocation statements for all allocatable
-                // components nested at any depth within the struct hierarchy.
-                // parent_expr is the base access expression (e.g., arg, arg%member, etc.)
-                // parent_sym is the symbol corresponding to parent_expr
-                std::function<void(ASR::Struct_t*, ASR::expr_t*, ASR::symbol_t*)>
-                    collect_nested_deallocs = [&](ASR::Struct_t* st,
-                        ASR::expr_t* parent_expr, ASR::symbol_t* parent_sym) {
+                 // collect deallocation statements for all allocatable
+                // components nested at any depth within the struct hierarchy are handled recursively.
+                // @param parent_expr is the base access expression (e.g., arg, arg%member, etc.)
+                // @param parent_sym is the symbol (structSymbol) corresponding to parent_expr
+                // @param self pass self lambda to recurise call.
+                // TODO : Clean into regular function
+                auto collect_deallocs_of_struct = [&](auto self,
+                    ASR::Struct_t* st, ASR::expr_t* parent_expr, ASR::symbol_t* parent_sym) -> void {
                     ASR::Struct_t* current_st = st;
                     SymbolTable* sym_table = current_st->m_symtab;
                     while (sym_table != nullptr) {
@@ -500,6 +501,7 @@ public:
                                 ASR::stmt_t* wrapped_stmt = wrap_optional_check(loc, root_var_expr, arg_var->m_presence, if_stmt);
                                 dealloc_stmts.push_back(al, wrapped_stmt);
                             } else if (ASR::is_a<ASR::StructType_t>(*ASRUtils::type_get_past_array(mem_type))) {
+                                if (ASRUtils::is_array(mem_type)) continue;
                                 // Non-allocatable struct member: recurse into it
                                 ASR::Variable_t* mem_var = ASR::down_cast<ASR::Variable_t>(struct_member.second);
                                 if (!mem_var->m_type_declaration) continue;
@@ -512,7 +514,7 @@ public:
                                     (ASR::asr_t*)parent_expr, parent_sym,
                                     struct_member.second, x.m_symtab));
 
-                                collect_nested_deallocs(
+                                 self(self,
                                     ASR::down_cast<ASR::Struct_t>(nested_struct_sym),
                                     member_expr, struct_member.second);
                             }
@@ -528,7 +530,7 @@ public:
                 };
 
                 ASR::expr_t* base_var_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg_sym));
-                collect_nested_deallocs(struct_type, base_var_expr, arg_sym);
+                collect_deallocs_of_struct(collect_deallocs_of_struct, struct_type, base_var_expr, arg_sym);
             }
         }
 

--- a/src/libasr/pass/insert_deallocate.cpp
+++ b/src/libasr/pass/insert_deallocate.cpp
@@ -453,56 +453,82 @@ public:
                     }
                 }
 
-                SymbolTable* sym_table_of_struct = struct_type->m_symtab;
-                while (sym_table_of_struct != nullptr) {
-                    for (auto& struct_member : sym_table_of_struct->get_scope()) {
-                        if (ASR::is_a<ASR::Variable_t>(*struct_member.second) &&
-                            ASRUtils::is_allocatable(ASRUtils::symbol_type(struct_member.second))) {
+                // Recursively collect deallocation statements for all allocatable
+                // components nested at any depth within the struct hierarchy.
+                // parent_expr is the base access expression (e.g., arg, arg%member, etc.)
+                // parent_sym is the symbol corresponding to parent_expr
+                std::function<void(ASR::Struct_t*, ASR::expr_t*, ASR::symbol_t*)>
+                    collect_nested_deallocs = [&](ASR::Struct_t* st,
+                        ASR::expr_t* parent_expr, ASR::symbol_t* parent_sym) {
+                    ASR::Struct_t* current_st = st;
+                    SymbolTable* sym_table = current_st->m_symtab;
+                    while (sym_table != nullptr) {
+                        for (auto& struct_member : sym_table->get_scope()) {
+                            if (!ASR::is_a<ASR::Variable_t>(*struct_member.second)) continue;
 
-                            // Create struct member access: arg%member
-                            ASR::expr_t* var_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg_sym));
-                            ASR::expr_t* member_expr = ASRUtils::EXPR(
-                                ASRUtils::getStructInstanceMember_t(al, loc,
-                                (ASR::asr_t*)var_expr, const_cast<ASR::symbol_t*>(arg_sym),
-                                struct_member.second, x.m_symtab));
+                            ASR::ttype_t* mem_type = ASRUtils::symbol_type(struct_member.second);
 
-                            // Create: if (allocated(arg%member)) deallocate(arg%member)
-                            Vec<ASR::expr_t*> allocated_args;
-                            allocated_args.reserve(al, 1);
-                            allocated_args.push_back(al, member_expr);
+                            if (ASRUtils::is_allocatable(mem_type)) {
+                                // Direct allocatable member: deallocate it
+                                ASR::expr_t* member_expr = ASRUtils::EXPR(
+                                    ASRUtils::getStructInstanceMember_t(al, loc,
+                                    (ASR::asr_t*)parent_expr, parent_sym,
+                                    struct_member.second, x.m_symtab));
 
-                            ASR::expr_t* is_allocated = ASRUtils::EXPR(ASR::make_IntrinsicImpureFunction_t(
-                                al, loc,
-                                static_cast<int64_t>(ASRUtils::IntrinsicImpureFunctions::Allocated),
-                                allocated_args.p, allocated_args.n, 0, logical_type, nullptr));
+                                Vec<ASR::expr_t*> allocated_args;
+                                allocated_args.reserve(al, 1);
+                                allocated_args.push_back(al, member_expr);
 
-                            // Create Deallocate statement for member
-                            Vec<ASR::expr_t*> dealloc_args;
-                            dealloc_args.reserve(al, 1);
-                            dealloc_args.push_back(al, member_expr);
-                            ASR::stmt_t* dealloc_stmt = ASRUtils::STMT(ASR::make_ExplicitDeallocate_t(
-                                al, loc, dealloc_args.p, dealloc_args.n));
+                                ASR::expr_t* is_allocated = ASRUtils::EXPR(ASR::make_IntrinsicImpureFunction_t(
+                                    al, loc,
+                                    static_cast<int64_t>(ASRUtils::IntrinsicImpureFunctions::Allocated),
+                                    allocated_args.p, allocated_args.n, 0, logical_type, nullptr));
 
-                            // Create If statement: if (allocated(arg%member)) deallocate(arg%member)
-                            Vec<ASR::stmt_t*> if_body;
-                            if_body.reserve(al, 1);
-                            if_body.push_back(al, dealloc_stmt);
-                            ASR::stmt_t* if_stmt = ASRUtils::STMT(ASR::make_If_t(
-                                al, loc, nullptr, is_allocated, if_body.p, if_body.n, nullptr, 0));
+                                Vec<ASR::expr_t*> dealloc_args;
+                                dealloc_args.reserve(al, 1);
+                                dealloc_args.push_back(al, member_expr);
+                                ASR::stmt_t* dealloc_stmt = ASRUtils::STMT(ASR::make_ExplicitDeallocate_t(
+                                    al, loc, dealloc_args.p, dealloc_args.n));
 
-                            // Wrap in optional presence check if needed (reuse var_expr from above)
-                            ASR::stmt_t* wrapped_stmt = wrap_optional_check(loc, var_expr, arg_var->m_presence, if_stmt);
-                            dealloc_stmts.push_back(al, wrapped_stmt);
+                                Vec<ASR::stmt_t*> if_body;
+                                if_body.reserve(al, 1);
+                                if_body.push_back(al, dealloc_stmt);
+                                ASR::stmt_t* if_stmt = ASRUtils::STMT(ASR::make_If_t(
+                                    al, loc, nullptr, is_allocated, if_body.p, if_body.n, nullptr, 0));
+
+                                ASR::expr_t* root_var_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg_sym));
+                                ASR::stmt_t* wrapped_stmt = wrap_optional_check(loc, root_var_expr, arg_var->m_presence, if_stmt);
+                                dealloc_stmts.push_back(al, wrapped_stmt);
+                            } else if (ASR::is_a<ASR::StructType_t>(*ASRUtils::type_get_past_array(mem_type))) {
+                                // Non-allocatable struct member: recurse into it
+                                ASR::Variable_t* mem_var = ASR::down_cast<ASR::Variable_t>(struct_member.second);
+                                if (!mem_var->m_type_declaration) continue;
+                                ASR::symbol_t* nested_struct_sym = ASRUtils::symbol_get_past_external(
+                                    mem_var->m_type_declaration);
+                                if (!ASR::is_a<ASR::Struct_t>(*nested_struct_sym)) continue;
+
+                                ASR::expr_t* member_expr = ASRUtils::EXPR(
+                                    ASRUtils::getStructInstanceMember_t(al, loc,
+                                    (ASR::asr_t*)parent_expr, parent_sym,
+                                    struct_member.second, x.m_symtab));
+
+                                collect_nested_deallocs(
+                                    ASR::down_cast<ASR::Struct_t>(nested_struct_sym),
+                                    member_expr, struct_member.second);
+                            }
+                        }
+                        if (current_st->m_parent != nullptr) {
+                            current_st = ASR::down_cast<ASR::Struct_t>(
+                                ASRUtils::symbol_get_past_external(current_st->m_parent));
+                            sym_table = current_st->m_symtab;
+                        } else {
+                            sym_table = nullptr;
                         }
                     }
-                    if (struct_type->m_parent != nullptr) {
-                        struct_type = ASR::down_cast<ASR::Struct_t>(
-                            ASRUtils::symbol_get_past_external(struct_type->m_parent));
-                        sym_table_of_struct = struct_type->m_symtab;
-                    } else {
-                        sym_table_of_struct = nullptr;
-                    }
-                }
+                };
+
+                ASR::expr_t* base_var_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg_sym));
+                collect_nested_deallocs(struct_type, base_var_expr, arg_sym);
             }
         }
 


### PR DESCRIPTION
fixes #11455

This commit resolves a 4-byte memory leak that occurred when passing a 
derived type with intent(out) that contains allocatable components nested 
within non-allocatable sub-structs.

The fix addresses two separate issues working in tandem:

1. ASR Pass (`insert_deallocate.cpp`): 
   The `IntentOutDeallocateVisitor` previously only checked for direct 
   members of an intent(out) struct. It has been updated to use a recursive 
   traversal (`collect_nested_deallocs`) to correctly find and generate 
   ExplicitDeallocate statements for allocatable components at any nesting 
   depth.

2. LLVM Codegen (`asr_to_llvm.cpp`): 
   During local variable declaration (`declare_vars`), the codegen recursively 
   initializes struct members via `allocate_array_members_of_struct`. However, 
   the recursive calls failed to propagate the `is_intent_out` flag. This 
   caused nested allocatable members of intent(out) dummy arguments to be 
   incorrectly null-initialized at function entry, zeroing out the pointer 
   before the newly inserted deallocation statements could free the memory.
   The `is_intent_out` flag is now properly passed through the recursive calls.

