### PR TITLE
fix : semantic error with single-element implied-do loop in DATA statements

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3681,6 +3681,7 @@ RUN(NAME data_implied_do_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortra
 RUN(NAME data_implied_do_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME data_implied_do_07 LABELS gfortran llvm)
 RUN(NAME data_implied_do_08 LABELS gfortran llvm)
+RUN(NAME data_implied_do_09 LABELS gfortran llvm)
 
 RUN(NAME save_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME save_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/data_implied_do_09.f90
+++ b/integration_tests/data_implied_do_09.f90
@@ -1,0 +1,13 @@
+module data_implied_do_09_mod
+   integer, parameter :: nc = 1
+   real(8), dimension(nc,2), target :: coeff
+   integer :: n
+   data ( coeff(n,1),n=1,1 ) /1.0d0/
+end module data_implied_do_09_mod
+
+program data_implied_do_09
+   use data_implied_do_09_mod
+   implicit none
+   print *, coeff(1,1)
+   if (coeff(1,1) /= 1.0d0) error stop
+end program data_implied_do_09

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4161,8 +4161,8 @@ public:
                     this->visit_expr(*a->m_object[0]);
                     ASR::expr_t* object = ASRUtils::EXPR(tmp);
                     ASR::ttype_t* obj_type = ASRUtils::expr_type(object);
+                    size_t curr_value = 0;
                     if (ASRUtils::is_array(obj_type)) { // it is an array
-                        size_t curr_value = 0;
                         handle_array_data_stmt(x, a, obj_type, object, curr_value);
                     } else if (ASR::is_a<ASR::ImpliedDoLoop_t>(*object)) {
                         /*
@@ -4170,7 +4170,7 @@ public:
                             Here the implied do loop gets expanded to:
                             DATA a(1), a(2), a(3), a(4), a(5) /1.0, 2.0, 0.0, 0.0, 0.0/
                         */
-                        handle_implied_do_loop_data_stmt(x, a, object, i);
+                        handle_implied_do_loop_data_stmt(x, a, object, curr_value);
                     } else {
                         diag.add(Diagnostic(
                             "There is one variable and multiple values, but the variable is not an array",
@@ -4219,6 +4219,8 @@ public:
                     ASR::ttype_t* obj_type = ASRUtils::expr_type(object);
                     if (ASRUtils::is_array(obj_type)) {
                         handle_array_data_stmt(x, a, obj_type, object, j);
+                    } else if (ASR::is_a<ASR::ImpliedDoLoop_t>(*object)) {
+                        handle_implied_do_loop_data_stmt(x, a, object, j);
                     } else {
                         handle_scalar_data_stmt(x, a, i, j);
                     }


### PR DESCRIPTION
fixes #11457

This commit fixes an issue where a `DATA` statement containing exactly one object
and one value would fail to compile with "The variable (object) type is not supported"
if the object was an implied-do loop.

Changes:
* In `ast_common_visitor.h`, updated the `visit_DataStmt` branch handling `n_object == n_value`
  to correctly check for and dispatch `ASR::ImpliedDoLoop_t` objects to `handle_implied_do_loop_data_stmt` 
  instead of falling through to the unsupported scalar handler.
* Fixed an indexing bug in `handle_implied_do_loop_data_stmt` for single-object assignments 
  by passing a localized `curr_value` variable instead of mistakenly passing the outer 
  statement-parsing loop index `i`.
