### PR TITLE
Fix abs() over an associate-name target

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2599,6 +2599,7 @@ RUN(NAME associate_47 LABELS gfortran llvm)
 RUN(NAME associate_48 LABELS gfortran llvm)
 RUN(NAME associate_49 LABELS gfortran llvm)
 RUN(NAME associate_50 LABELS gfortran llvm)
+RUN(NAME associate_51 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_51.f90
+++ b/integration_tests/associate_51.f90
@@ -1,0 +1,10 @@
+program associate_51
+implicit none
+real(8) :: a, b
+a = -2.0_8
+associate( x => a )
+    b = 4.0_8 * abs(x)
+end associate
+if (abs(b - 8.0_8) > 1e-12_8) error stop
+print *, "All tests passed"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3447,8 +3447,15 @@ public:
     }
 
     void generate_Abs(ASR::expr_t* m_arg) {
+        // Mirror visit_RealBinOp: if the argument has a Pointer wrapper
+        // (e.g. an associate-name target), load twice so we reach the
+        // underlying scalar value before applying fabs/select.
+        int64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = LLVM::is_llvm_pointer(*ASRUtils::expr_type(m_arg)) ? 2 : 1;
         this->visit_expr_wrapper(m_arg, true);
+        ptr_loads = ptr_loads_copy;
         llvm::Value *item = tmp;
+        load_non_array_non_character_pointers(m_arg, ASRUtils::expr_type(m_arg), item);
         llvm::Type *item_type = item->getType();
         if (item_type->isFloatingPointTy()) {
 #if LLVM_VERSION_MAJOR >= 12


### PR DESCRIPTION
When the argument to the abs() intrinsic is an associate-name (e.g. 'associate(x => a)'), the variable has Pointer-typed storage in ASR. generate_Abs in the LLVM backend visited the argument with the ambient ptr_loads (1), so it only stripped one level of pointer and left an LLVM 'double*' on the stack instead of the loaded 'double'. The verifier then rejected the surrounding floating-point binop, e.g.: '%5 = fmul double 4.000000e+00, double* %4'.

Mirror the pattern already used by visit_RealBinOp: when the argument's ASR type is wrapped in Pointer, request ptr_loads = 2 around the visit, then call load_non_array_non_character_pointers before applying fabs / the integer select.

Adds integration_tests/associate_51.f90 to cover the case.

Fixes #11469.