### PR TITLE
Allow intrinsic operator template instantiation on mixed types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3210,6 +3210,7 @@ RUN(NAME template_sort_02 LABELS llvm llvm_wasm llvm_wasm_emcc NOFAST_TILL_LLVM1
 RUN(NAME template_lapack_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME template_interface_01 LABELS llvm llvm_wasm llvm_wasm_emcc)                   # FIXME: add visit_OverloadedBinOp to wasm
 RUN(NAME template_commutative LABELS llvm llvm_wasm llvm_wasm_emcc)                    # FIXME: add visit_OverloadedBinOp to wasm
+RUN(NAME template_intrinsic_func_01 LABELS llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME statement1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3211,6 +3211,7 @@ RUN(NAME template_lapack_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME template_interface_01 LABELS llvm llvm_wasm llvm_wasm_emcc)                   # FIXME: add visit_OverloadedBinOp to wasm
 RUN(NAME template_commutative LABELS llvm llvm_wasm llvm_wasm_emcc)                    # FIXME: add visit_OverloadedBinOp to wasm
 RUN(NAME template_intrinsic_func_01 LABELS llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME template_intrinsic_op_01 LABELS llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME statement1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/template_intrinsic_func_01.f90
+++ b/integration_tests/template_intrinsic_func_01.f90
@@ -1,0 +1,42 @@
+module template_intrinsic_func_01_m
+    implicit none
+
+    requirement op_R(T, V, op_func)
+        type, deferred :: T
+        type, deferred :: V
+        pure elemental function op_func(lhs, rhs) result(res)
+            type(T), intent(in) :: lhs
+            type(T), intent(in) :: rhs
+            type(V) :: res
+        end function
+    end requirement
+
+    template op_t(T, V, op_func)
+        require :: op_R(T, V, op_func)
+    contains
+        pure elemental function call_op_func(x, y) result(res)
+            type(V) :: res
+            type(T) :: x, y
+            res = op_func(x, y)
+        end function
+    end template
+end module
+
+program template_intrinsic_func_01
+    use template_intrinsic_func_01_m
+    implicit none
+
+    instantiate op_t(integer, integer, min), only: int_min => call_op_func
+    instantiate op_t(integer, integer, max), only: int_max => call_op_func
+    instantiate op_t(real, real, min), only: real_min => call_op_func
+    instantiate op_t(real, real, max), only: real_max => call_op_func
+
+    if (int_min(3, 7) /= 3) error stop
+    if (int_max(3, 7) /= 7) error stop
+    if (int_min(-2, -9) /= -9) error stop
+    if (int_max(-2, -9) /= -2) error stop
+    if (abs(real_min(1.5, 2.5) - 1.5) > 1.0e-6) error stop
+    if (abs(real_max(1.5, 2.5) - 2.5) > 1.0e-6) error stop
+
+    print *, "OK"
+end program

--- a/integration_tests/template_intrinsic_op_01.f90
+++ b/integration_tests/template_intrinsic_op_01.f90
@@ -1,0 +1,42 @@
+module template_intrinsic_op_01_m
+    implicit none
+
+    requirement op_R(T, V, op_func)
+        type, deferred :: T
+        type, deferred :: V
+        pure elemental function op_func(lhs, rhs) result(res)
+            type(T), intent(in) :: lhs
+            type(T), intent(in) :: rhs
+            type(V) :: res
+        end function
+    end requirement
+
+    template op_t(T, V, op_func)
+        require :: op_R(T, V, op_func)
+    contains
+        pure elemental function call_op_func(x) result(res)
+            type(V) :: res
+            type(T) :: x
+            res = op_func(x, x)
+        end function
+    end template
+end module
+
+program template_intrinsic_op_01
+    use template_intrinsic_op_01_m
+    implicit none
+
+    instantiate op_t(integer, integer, operator(+)), only: int_add => call_op_func
+    instantiate op_t(integer, real,    operator(+)), only: int_add_r => call_op_func
+    instantiate op_t(integer, real,    operator(-)), only: int_sub_r => call_op_func
+    instantiate op_t(integer, real,    operator(*)), only: int_mul_r => call_op_func
+    instantiate op_t(integer, real,    operator(/)), only: int_div_r => call_op_func
+
+    if (int_add(5) /= 10) error stop
+    if (abs(int_add_r(5) - 10.0) > 1.0e-6) error stop
+    if (abs(int_sub_r(5) -  0.0) > 1.0e-6) error stop
+    if (abs(int_mul_r(5) - 25.0) > 1.0e-6) error stop
+    if (abs(int_div_r(5) -  1.0) > 1.0e-6) error stop
+
+    print *, "OK"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -17527,9 +17527,8 @@ public:
                         return_type = ASRUtils::duplicate_type(al, ftype);
                         value = ASRUtils::EXPR(ASRUtils::make_Binop_util(al, loc, binop, left, right, dest_type));
                         if (!ASRUtils::check_equal_type(dest_type, return_type, f->m_args[1], f->m_return_var)) {
-                            diag.add(Diagnostic("Unapplicable types for intrinsic operator " + op_name,
-                                Level::Error, Stage::Semantic, {Label("", {loc})}));
-                            throw SemanticAbort();
+                            ImplicitCastRules::set_converted_value(al, loc,
+                                &value, dest_type, return_type, diag);
                         }
                     } else {
                         return_type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, compiler_options.po.default_integer_kind));

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -4897,11 +4897,8 @@ public:
                         return_type = ASRUtils::duplicate_type(al, ftype);
                         value = ASRUtils::EXPR(ASRUtils::make_Binop_util(al, x.base.base.loc, binop, left, right, dest_type));
                         if (!ASRUtils::check_equal_type(dest_type, return_type, f->m_args[1], f->m_return_var)) {
-                            diag.add(diag::Diagnostic(
-                                "Unapplicable types for intrinsic operator " + op_name,
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                    diag::Label("", {x.base.base.loc})}));
-                            throw SemanticAbort();
+                            ImplicitCastRules::set_converted_value(al, x.base.base.loc,
+                                &value, dest_type, return_type, diag);
                         }
                     } else {
                         return_type = ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -4616,24 +4616,117 @@ public:
                     // Handling functions passed as instantiate's arguments
                     ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(param_sym);
                     ASR::symbol_t *f_arg0 = current_scope->resolve_symbol(arg);
-                    if (!f_arg0) {
-                        diag.add(diag::Diagnostic(
-                            "The function argument " + arg + " is not found",
-                            diag::Level::Error, diag::Stage::Semantic, {
-                                diag::Label("", {x.m_args[i]->base.loc})}));
-                        throw SemanticAbort();
+                    if (!f_arg0
+                            && ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(arg)) {
+                        // Handling intrinsic function (e.g. min, max) as
+                        // instantiate's argument: build a wrapper function that
+                        // calls the intrinsic with the restriction's signature.
+                        SymbolTable *parent_scope = current_scope;
+                        current_scope = al.make_new<SymbolTable>(parent_scope);
+                        Vec<ASR::expr_t*> wargs;
+                        wargs.reserve(al, f->n_args);
+                        Vec<ASR::expr_t*> call_args;
+                        call_args.reserve(al, f->n_args);
+                        for (size_t j=0; j<f->n_args; j++) {
+                            ASR::ttype_t *var_type = ASRUtils::duplicate_type(al,
+                                ASRUtils::subs_expr_type(type_subs, f->m_args[j]));
+                            ASR::symbol_t *var_type_decl =
+                                ASRUtils::get_struct_sym_from_struct_expr(f->m_args[j]);
+                            std::string var_name = "arg" + std::to_string(j);
+                            ASR::asr_t *v = ASRUtils::make_Variable_t_util(al,
+                                x.m_args[i]->base.loc, current_scope,
+                                s2c(al, var_name), nullptr, 0, ASR::intentType::In,
+                                nullptr, nullptr, ASR::storage_typeType::Default,
+                                var_type, var_type_decl, ASR::abiType::Source,
+                                ASR::accessType::Private, ASR::presenceType::Required,
+                                false);
+                            current_scope->add_symbol(var_name,
+                                ASR::down_cast<ASR::symbol_t>(v));
+                            ASR::expr_t *var_expr = ASRUtils::EXPR(ASR::make_Var_t(al,
+                                x.m_args[i]->base.loc, current_scope->get_symbol(var_name)));
+                            wargs.push_back(al, var_expr);
+                            call_args.push_back(al, var_expr);
+                        }
+
+                        ASRUtils::create_intrinsic_function create_func =
+                            ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(arg);
+                        ASR::expr_t *call_value = ASRUtils::EXPR(create_func(al,
+                            x.m_args[i]->base.loc, call_args, diag));
+
+                        ASR::ttype_t *return_type = ASRUtils::duplicate_type(al,
+                            ASRUtils::subs_expr_type(type_subs, f->m_return_var));
+                        ASR::asr_t *return_v = ASRUtils::make_Variable_t_util(al,
+                            x.m_args[i]->base.loc, current_scope, s2c(al, "ret"),
+                            nullptr, 0, ASR::intentType::ReturnVar, nullptr, nullptr,
+                            ASR::storage_typeType::Default, return_type,
+                            ASRUtils::get_struct_sym_from_struct_expr(call_value),
+                            ASR::abiType::Source, ASR::accessType::Private,
+                            ASR::presenceType::Required, false);
+                        current_scope->add_symbol("ret",
+                            ASR::down_cast<ASR::symbol_t>(return_v));
+                        ASR::expr_t *return_expr = ASRUtils::EXPR(ASR::make_Var_t(al,
+                            x.m_args[i]->base.loc, current_scope->get_symbol("ret")));
+
+                        if (!ASRUtils::check_equal_type(
+                                ASRUtils::expr_type(call_value), return_type,
+                                call_value, f->m_return_var)) {
+                            diag.add(diag::Diagnostic(
+                                "Unapplicable types for intrinsic function " + arg,
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                    diag::Label("", {x.m_args[i]->base.loc})}));
+                            throw SemanticAbort();
+                        }
+
+                        Vec<ASR::stmt_t*> body;
+                        body.reserve(al, 1);
+                        ASRUtils::make_ArrayBroadcast_t_util(al,
+                            x.m_args[i]->base.loc, return_expr, call_value);
+                        ASR::stmt_t *assignment = ASRUtils::STMT(
+                            ASRUtils::make_Assignment_t_util(al,
+                                x.m_args[i]->base.loc, return_expr, call_value,
+                                nullptr, false, false));
+                        body.push_back(al, assignment);
+
+                        std::string func_name = parent_scope->get_unique_name(
+                            arg + "_intrinsic");
+                        ASR::FunctionType_t *req_type =
+                            ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                        ASR::asr_t *op_function = ASRUtils::make_Function_t_util(
+                            al, x.m_args[i]->base.loc, current_scope,
+                            s2c(al, func_name), nullptr, 0, wargs.p, wargs.size(),
+                            body.p, body.size(), return_expr,
+                            ASR::abiType::Source, ASR::accessType::Public,
+                            ASR::deftypeType::Implementation, nullptr,
+                            req_type->m_elemental, req_type->m_pure,
+                            req_type->m_module, req_type->m_inline,
+                            req_type->m_static, nullptr, 0, f->m_deterministic,
+                            f->m_side_effect_free, true);
+                        ASR::symbol_t *op_sym =
+                            ASR::down_cast<ASR::symbol_t>(op_function);
+                        parent_scope->add_symbol(func_name, op_sym);
+
+                        current_scope = parent_scope;
+                        symbol_subs[f->m_name] = op_sym;
+                    } else {
+                        if (!f_arg0) {
+                            diag.add(diag::Diagnostic(
+                                "The function argument " + arg + " is not found",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                    diag::Label("", {x.m_args[i]->base.loc})}));
+                            throw SemanticAbort();
+                        }
+                        ASR::symbol_t *f_arg = ASRUtils::symbol_get_past_external(f_arg0);
+                        if (!ASR::is_a<ASR::Function_t>(*f_arg)) {
+                            diag.add(diag::Diagnostic(
+                                "The argument for " + param + " must be a function",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                    diag::Label("", {x.m_args[i]->base.loc})}));
+                            throw SemanticAbort();
+                        }
+                        check_restriction(type_subs,
+                            symbol_subs, f, f_arg0, x.m_args[i]->base.loc, diag,
+                            []() { throw SemanticAbort(); });
                     }
-                    ASR::symbol_t *f_arg = ASRUtils::symbol_get_past_external(f_arg0);
-                    if (!ASR::is_a<ASR::Function_t>(*f_arg)) {
-                        diag.add(diag::Diagnostic(
-                            "The argument for " + param + " must be a function",
-                            diag::Level::Error, diag::Stage::Semantic, {
-                                diag::Label("", {x.m_args[i]->base.loc})}));
-                        throw SemanticAbort();
-                    }
-                    check_restriction(type_subs,
-                        symbol_subs, f, f_arg0, x.m_args[i]->base.loc, diag,
-                        []() { throw SemanticAbort(); });
                 } else {
                     ASR::ttype_t *param_type = ASRUtils::symbol_type(param_sym);
                     if (ASRUtils::is_type_parameter(*param_type)) {


### PR DESCRIPTION
When a template's deferred return type V differs from the deferred
argument type T (e.g. instantiate op_t(integer, real, operator(+))),
the synthesized intrinsic-operator function was rejected with
'Unapplicable types for intrinsic operator ~add' because the binop's
result type was compared for strict equality with the template return
type V.

Replace the strict check with ImplicitCastRules::set_converted_value,
which inserts the implicit numeric cast when legal (matching the
behaviour of an ordinary assignment res = op_func(x,x)) and emits a
proper error otherwise.

Adds integration test template_intrinsic_op_01 covering +, -, *, /
with (integer, real) and the existing (integer, integer) case.

Fixes #11460.

Depends on #11471.