### PR TITLE
driver: emit clear error when no main program is present

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1247,6 +1247,16 @@ int compile_src_to_object_file(const std::string &infile,
     if (!(compiler_options.separate_compilation || compiler_options.generate_code_for_global_procedures)
         && !LCompilers::ASRUtils::main_program_present(*asr)
         && !LCompilers::ASRUtils::global_function_present(*asr)) {
+        if (!arg_c) {
+            diagnostics.add(LCompilers::diag::Diagnostic(
+                "no main program found; cannot build an executable. "
+                "To compile this file as a library, use the `-c` option.",
+                LCompilers::diag::Level::Error,
+                LCompilers::diag::Stage::Semantic, {})
+            );
+            std::cerr << diagnostics.render(lm, compiler_options);
+            return 1;
+        }
         // Create an empty object file (things will be actually
         // compiled and linked when the main program is present):
         e.create_empty_object_file(outfile);
@@ -1605,7 +1615,8 @@ int compile_to_binary_wasm(const std::string &infile, const std::string &outfile
 int compile_to_object_file_cpp(const std::string &infile,
         const std::string &outfile, bool verbose,
         bool assembly, bool kokkos, const std::string &rtlib_header_dir,
-        CompilerOptions &compiler_options)
+        CompilerOptions &compiler_options,
+        bool arg_c = false)
 {
     std::string input = read_file_ok(infile);
 
@@ -1638,6 +1649,16 @@ int compile_to_object_file_cpp(const std::string &infile,
     }
 
     if (!LCompilers::ASRUtils::main_program_present(*asr)) {
+        if (!arg_c) {
+            diagnostics.add(LCompilers::diag::Diagnostic(
+                "no main program found; cannot build an executable. "
+                "To compile this file as a library, use the `-c` option.",
+                LCompilers::diag::Level::Error,
+                LCompilers::diag::Stage::Semantic, {})
+            );
+            std::cerr << diagnostics.render(lm, compiler_options);
+            return 1;
+        }
         // Create an empty object file (things will be actually
         // compiled and linked when the main program is present):
         if (compiler_options.platform == LCompilers::Platform::Windows) {
@@ -1718,7 +1739,8 @@ int compile_to_object_file_c(const std::string &infile,
         const std::string &outfile, bool verbose,
         bool assembly, const std::string &rtlib_header_dir,
         LCompilers::PassManager pass_manager,
-        CompilerOptions &compiler_options)
+        CompilerOptions &compiler_options,
+        bool arg_c = false)
 {
     std::string input = read_file_ok(infile);
 
@@ -1749,6 +1771,16 @@ int compile_to_object_file_c(const std::string &infile,
     }
 
     if (!LCompilers::ASRUtils::main_program_present(*asr)) {
+        if (!arg_c) {
+            diagnostics.add(LCompilers::diag::Diagnostic(
+                "no main program found; cannot build an executable. "
+                "To compile this file as a library, use the `-c` option.",
+                LCompilers::diag::Level::Error,
+                LCompilers::diag::Stage::Semantic, {})
+            );
+            std::cerr << diagnostics.render(lm, compiler_options);
+            return 1;
+        }
         // Create an empty object file (things will be actually
         // compiled and linked when the main program is present):
         if (compiler_options.platform == LCompilers::Platform::Windows) {
@@ -2810,10 +2842,10 @@ int main_app(int argc, char *argv[]) {
 #endif
         } else if (backend == Backend::c) {
             result = compile_to_object_file_c(opts.arg_file, outfile, opts.arg_v, false,
-                    rtlib_c_header_dir, lfortran_pass_manager, compiler_options);
+                    rtlib_c_header_dir, lfortran_pass_manager, compiler_options, opts.arg_c);
         } else if (backend == Backend::cpp) {
             result = compile_to_object_file_cpp(opts.arg_file, outfile, opts.arg_v, false,
-                    true, rtlib_c_header_dir, compiler_options);
+                    true, rtlib_c_header_dir, compiler_options, opts.arg_c);
         } else if (backend == Backend::x86) {
             result = compile_to_binary_x86(opts.arg_file, outfile, compiler_options.time_report, compiler_options);
         } else if (backend == Backend::wasm) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1185,7 +1185,8 @@ int compile_src_to_object_file(const std::string &infile,
         bool assembly,
         CompilerOptions &compiler_options,
         LCompilers::PassManager& lpm,
-        bool arg_c = false)
+        bool arg_c = false,
+        bool *found_main = nullptr)
 {
     int time_file_read=0;
     int time_src_to_asr=0;
@@ -1261,6 +1262,9 @@ int compile_src_to_object_file(const std::string &infile,
         // compiled and linked when the main program is present):
         e.create_empty_object_file(outfile);
         return 0;
+    }
+    if (found_main && LCompilers::ASRUtils::main_program_present(*asr)) {
+        *found_main = true;
     }
 
     // if compiler_options.generate_code_for_global_procedures is true, then mark all modules as external
@@ -1616,7 +1620,8 @@ int compile_to_object_file_cpp(const std::string &infile,
         const std::string &outfile, bool verbose,
         bool assembly, bool kokkos, const std::string &rtlib_header_dir,
         CompilerOptions &compiler_options,
-        bool arg_c = false)
+        bool arg_c = false,
+        bool *found_main = nullptr)
 {
     std::string input = read_file_ok(infile);
 
@@ -1686,6 +1691,9 @@ int compile_to_object_file_cpp(const std::string &infile,
         }
         return 0;
     }
+    if (found_main) {
+        *found_main = true;
+    }
 
     // ASR -> C++
     std::string src;
@@ -1740,7 +1748,8 @@ int compile_to_object_file_c(const std::string &infile,
         bool assembly, const std::string &rtlib_header_dir,
         LCompilers::PassManager pass_manager,
         CompilerOptions &compiler_options,
-        bool arg_c = false)
+        bool arg_c = false,
+        bool *found_main = nullptr)
 {
     std::string input = read_file_ok(infile);
 
@@ -1807,6 +1816,9 @@ int compile_to_object_file_c(const std::string &infile,
             }
         }
         return 0;
+    }
+    if (found_main) {
+        *found_main = true;
     }
 
     // ASR -> C
@@ -2879,6 +2891,8 @@ int main_app(int argc, char *argv[]) {
     // we need this separate vector to store temporary object files as some object files passed as arguments
     // are considered as it is and we do not want to delete them
     std::vector<std::string> temp_object_files;
+    bool found_main = false;
+    bool any_fortran_src = false;
     for (const auto &arg_file : opts.arg_files) {
         int err = 0;
         std::string tmp_o = (std::filesystem::path(LFORTRAN_TEMP_DIR) / std::filesystem::path(arg_file)
@@ -2886,6 +2900,7 @@ int main_app(int argc, char *argv[]) {
         temp_object_files.push_back(tmp_o);
         if (endswith(arg_file, ".f90") || endswith(arg_file, ".f") ||
             endswith(arg_file, ".F90") || endswith(arg_file, ".F")) {
+            any_fortran_src = true;
             if (backend == Backend::x86) {
                 return compile_to_binary_x86(arg_file, outfile,
                         compiler_options.time_report, compiler_options);
@@ -2893,17 +2908,17 @@ int main_app(int argc, char *argv[]) {
             if (backend == Backend::llvm) {
 #ifdef HAVE_LFORTRAN_LLVM
                 err = compile_src_to_object_file(arg_file, tmp_o, compiler_options.time_report, false,
-                    compiler_options, lfortran_pass_manager);
+                    compiler_options, lfortran_pass_manager, true, &found_main);
 #else
                 std::cerr << "Compiling Fortran files to object files requires the LLVM backend to be enabled. Recompile with `WITH_LLVM=yes`." << std::endl;
                 return 1;
 #endif
             } else if (backend == Backend::cpp) {
                 err = compile_to_object_file_cpp(arg_file, tmp_o, opts.arg_v, false,
-                        true, rtlib_header_dir, compiler_options);
+                        true, rtlib_header_dir, compiler_options, true, &found_main);
             } else if (backend == Backend::c) {
                 err = compile_to_object_file_c(arg_file, tmp_o, opts.arg_v,
-                        false, rtlib_c_header_dir, lfortran_pass_manager, compiler_options);
+                        false, rtlib_c_header_dir, lfortran_pass_manager, compiler_options, true, &found_main);
             } else if (backend == Backend::fortran) {
                 err = compile_to_binary_fortran(arg_file, tmp_o, compiler_options);
             } else if (backend == Backend::wasm) {
@@ -2941,6 +2956,16 @@ int main_app(int argc, char *argv[]) {
     if (object_files.size() == 0) {
         return err_;
     } else {
+        if (any_fortran_src && !found_main && err_ == 0
+                && backend != Backend::wasm && backend != Backend::x86) {
+            std::cerr << "semantic error: no main program found; "
+                "cannot build an executable. To compile this file as a "
+                "library, use the `-c` option." << std::endl;
+            for (const std::string &filename : temp_object_files) {
+                std::remove(filename.c_str());
+            }
+            return 1;
+        }
         int status_code = err_ + link_executable(object_files, outfile, compiler_options.time_report, runtime_library_dir,
                 backend, opts.static_link, opts.shared_link, opts.linker, opts.linker_path, true,
                 opts.arg_v, opts.arg_L, opts.arg_l, opts.linker_flags, compiler_options);

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2957,7 +2957,8 @@ int main_app(int argc, char *argv[]) {
         return err_;
     } else {
         if (any_fortran_src && !found_main && err_ == 0
-                && backend != Backend::wasm && backend != Backend::x86) {
+                && (backend == Backend::llvm || backend == Backend::c
+                    || backend == Backend::cpp)) {
             std::cerr << "semantic error: no main program found; "
                 "cannot build an executable. To compile this file as a "
                 "library, use the `-c` option." << std::endl;

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1185,8 +1185,8 @@ int compile_src_to_object_file(const std::string &infile,
         bool assembly,
         CompilerOptions &compiler_options,
         LCompilers::PassManager& lpm,
-        bool arg_c = false,
-        bool *found_main = nullptr)
+        bool arg_c,
+        bool *found_main)
 {
     int time_file_read=0;
     int time_src_to_asr=0;
@@ -1384,7 +1384,7 @@ int compile_to_assembly_file(const std::string &infile,
     const std::string &outfile, bool time_report, CompilerOptions &compiler_options,
     LCompilers::PassManager& lpm)
 {
-    return compile_src_to_object_file(infile, outfile, time_report, true, compiler_options, lpm);
+    return compile_src_to_object_file(infile, outfile, time_report, true, compiler_options, lpm, false, nullptr);
 }
 #endif // HAVE_LFORTRAN_LLVM
 
@@ -1620,8 +1620,8 @@ int compile_to_object_file_cpp(const std::string &infile,
         const std::string &outfile, bool verbose,
         bool assembly, bool kokkos, const std::string &rtlib_header_dir,
         CompilerOptions &compiler_options,
-        bool arg_c = false,
-        bool *found_main = nullptr)
+        bool arg_c,
+        bool *found_main)
 {
     std::string input = read_file_ok(infile);
 
@@ -1748,8 +1748,8 @@ int compile_to_object_file_c(const std::string &infile,
         bool assembly, const std::string &rtlib_header_dir,
         LCompilers::PassManager pass_manager,
         CompilerOptions &compiler_options,
-        bool arg_c = false,
-        bool *found_main = nullptr)
+        bool arg_c,
+        bool *found_main)
 {
     std::string input = read_file_ok(infile);
 
@@ -2847,17 +2847,17 @@ int main_app(int argc, char *argv[]) {
         if (backend == Backend::llvm) {
 #ifdef HAVE_LFORTRAN_LLVM
             result = compile_src_to_object_file(opts.arg_file, outfile, compiler_options.time_report, false,
-                compiler_options, lfortran_pass_manager, opts.arg_c);
+                compiler_options, lfortran_pass_manager, opts.arg_c, nullptr);
 #else
             std::cerr << "The -c option requires the LLVM backend to be enabled. Recompile with `WITH_LLVM=yes`." << std::endl;
             return 1;
 #endif
         } else if (backend == Backend::c) {
             result = compile_to_object_file_c(opts.arg_file, outfile, opts.arg_v, false,
-                    rtlib_c_header_dir, lfortran_pass_manager, compiler_options, opts.arg_c);
+                    rtlib_c_header_dir, lfortran_pass_manager, compiler_options, opts.arg_c, nullptr);
         } else if (backend == Backend::cpp) {
             result = compile_to_object_file_cpp(opts.arg_file, outfile, opts.arg_v, false,
-                    true, rtlib_c_header_dir, compiler_options, opts.arg_c);
+                    true, rtlib_c_header_dir, compiler_options, opts.arg_c, nullptr);
         } else if (backend == Backend::x86) {
             result = compile_to_binary_x86(opts.arg_file, outfile, compiler_options.time_report, compiler_options);
         } else if (backend == Backend::wasm) {

--- a/tests/no_main_program_1.f90
+++ b/tests/no_main_program_1.f90
@@ -1,0 +1,9 @@
+module no_main_program_1_mod
+    implicit none
+contains
+    function add(x, y) result(z)
+        integer, intent(in) :: x, y
+        integer :: z
+        z = x + y
+    end function add
+end module no_main_program_1_mod

--- a/tests/no_main_program_2.f90
+++ b/tests/no_main_program_2.f90
@@ -1,0 +1,9 @@
+module no_main_program_2_mod
+    implicit none
+contains
+    function add(x, y) result(z)
+        integer, intent(in) :: x, y
+        integer :: z
+        z = x + y
+    end function add
+end module no_main_program_2_mod

--- a/tests/no_main_program_3.f90
+++ b/tests/no_main_program_3.f90
@@ -1,0 +1,9 @@
+module no_main_program_3_mod
+    implicit none
+contains
+    function add(x, y) result(z)
+        integer, intent(in) :: x, y
+        integer :: z
+        z = x + y
+    end function add
+end module no_main_program_3_mod

--- a/tests/reference/run-no_main_program_1-bb6c43a.json
+++ b/tests/reference/run-no_main_program_1-bb6c43a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-no_main_program_1-bb6c43a",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/no_main_program_1.f90",
+    "infile_hash": "96ea2853ea417707fe8143e42793f2850a73b94222dfb21f9d7a4f8d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-no_main_program_1-bb6c43a.stderr",
+    "stderr_hash": "e00d7e91d3a8b18f928ac1083581e788ac5f16debd5ce7335de4dc7f",
+    "returncode": 1
+}

--- a/tests/reference/run-no_main_program_1-bb6c43a.stderr
+++ b/tests/reference/run-no_main_program_1-bb6c43a.stderr
@@ -1,0 +1,1 @@
+semantic error: no main program found; cannot build an executable. To compile this file as a library, use the `-c` option.

--- a/tests/reference/run-no_main_program_2-7846a7c.json
+++ b/tests/reference/run-no_main_program_2-7846a7c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-no_main_program_2-7846a7c",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/no_main_program_2.f90",
+    "infile_hash": "7d3b440d5100a62549460907ec11d9e99b5363663126ef8316ea38f5",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-no_main_program_2-7846a7c.stderr",
+    "stderr_hash": "e00d7e91d3a8b18f928ac1083581e788ac5f16debd5ce7335de4dc7f",
+    "returncode": 1
+}

--- a/tests/reference/run-no_main_program_2-7846a7c.stderr
+++ b/tests/reference/run-no_main_program_2-7846a7c.stderr
@@ -1,0 +1,1 @@
+semantic error: no main program found; cannot build an executable. To compile this file as a library, use the `-c` option.

--- a/tests/reference/run-no_main_program_3-0e6220f.json
+++ b/tests/reference/run-no_main_program_3-0e6220f.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-no_main_program_3-0e6220f",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/no_main_program_3.f90",
+    "infile_hash": "508735677713a7d0743d38af286625b50994b1eeb5c6269cdf92f75c",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-no_main_program_3-0e6220f.stderr",
+    "stderr_hash": "e00d7e91d3a8b18f928ac1083581e788ac5f16debd5ce7335de4dc7f",
+    "returncode": 1
+}

--- a/tests/reference/run-no_main_program_3-0e6220f.stderr
+++ b/tests/reference/run-no_main_program_3-0e6220f.stderr
@@ -1,0 +1,1 @@
+semantic error: no main program found; cannot build an executable. To compile this file as a library, use the `-c` option.

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5168,3 +5168,17 @@ asr = true
 [[test]]
 filename = "../integration_tests/read_83.f90"
 llvm = true
+
+[[test]]
+filename = "no_main_program_1.f90"
+run = true
+
+[[test]]
+filename = "no_main_program_2.f90"
+options = "--backend=c"
+run = true
+
+[[test]]
+filename = "no_main_program_3.f90"
+options = "--backend=cpp"
+run = true


### PR DESCRIPTION
When compiling a file that contains only modules/library code without the `-c` flag, lfortran silently produced an empty object file and then asked the linker to make an executable from it, resulting in a confusing "undefined reference to `main`" linker error (see issue #11350).

Use the existing `main_program_present` (and `global_function_present`) checks in the LLVM, C and C++ backends to detect this case before emitting the empty .o, and report a proper semantic diagnostic:

    semantic error: no main program found; cannot build an executable.
    To compile this file as a library, use the `-c` option.

The `-c` library-compile workflow is preserved: the empty-object-file path still runs when `arg_c` is true.

Fixes #11350.