### PR TITLE
fix: codegen for module var initialized to c_null_ptr/c_null_funptr

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3772,6 +3772,7 @@ RUN(NAME c_ptr_12 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_13 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_14 LABELS gfortran llvm)
 RUN(NAME c_ptr_15 LABELS gfortran llvm)
+RUN(NAME c_ptr_17 LABELS gfortran llvm EXTRAFILES c_ptr_17_module.f90)
 
 RUN(NAME c_f_proc_ptr_01 LABELS gfortran llvm EXTRAFILES c_f_proc_ptr_01.c) # c_f_procpointer
 

--- a/integration_tests/c_ptr_17.f90
+++ b/integration_tests/c_ptr_17.f90
@@ -1,0 +1,11 @@
+program c_ptr_17
+  use c_ptr_17_module, only: ptrs, N
+  use, intrinsic :: iso_c_binding, only: c_associated
+  implicit none
+  integer :: i
+  if (size(ptrs) /= N) error stop "wrong size"
+  do i = 1, N
+    if (c_associated(ptrs(i))) error stop "default-init not null"
+  end do
+  print *, "ok"
+end program

--- a/integration_tests/c_ptr_17_module.f90
+++ b/integration_tests/c_ptr_17_module.f90
@@ -1,0 +1,7 @@
+module c_ptr_17_module
+  use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
+  implicit none
+  integer, parameter :: N = 4
+  type(c_ptr) :: ptrs(N) = c_null_ptr
+end module c_ptr_17_module
+

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5459,9 +5459,15 @@ public:
                         value = x.m_symbolic_value;
                     }
                     if (value) {
-                        llvm::Constant* initializer = get_const_array(value, type->getArrayElementType());
-                        module->getNamedGlobal(llvm_var_name)->setInitializer(initializer);
-                    } else {
+
+                         if (ASR::is_a<ASR::PointerNullConstant_t>(*value)) {
+                             module->getNamedGlobal(llvm_var_name)->setInitializer(
+                                llvm::ConstantArray::getNullValue(type));
+                          } else {
+                             llvm::Constant* initializer = get_const_array(value, type->getArrayElementType());
+                             module->getNamedGlobal(llvm_var_name)->setInitializer(initializer);
+                          }
+                      } else {
                         module->getNamedGlobal(llvm_var_name)->setInitializer(llvm::ConstantArray::getNullValue(type));
                         set_global_variable_linkage_as_common(ptr, x);
                     }


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/11478

A related but distinct [bug](https://github.com/lfortran/lfortran/issues/11482) remains when the same default initializer is on a derived type field:

```fortran
type t
type(c_ptr) :: a(N) = c_null_ptr
end
```
its out of scope for this PR. will fix separately.


