### PR TITLE
fix: allow zero-sized arrays in COMMON declarations

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3668,6 +3668,7 @@ RUN(NAME common_35 LABELS gfortran llvm)
 RUN(NAME common_36 LABELS gfortran llvm)
 RUN(NAME common_37 LABELS gfortran llvm)
 RUN(NAME common_38 LABELS gfortran llvm)
+RUN(NAME common_39 LABELS gfortran llvm)
 RUN(NAME common_substring_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME statement_01 LABELS llvm gfortran llvmImplicit)

--- a/integration_tests/common_39.f90
+++ b/integration_tests/common_39.f90
@@ -1,0 +1,12 @@
+program common_39
+    implicit none
+    call test()
+end program
+
+subroutine test()
+    integer(4) :: n
+    real :: arr
+    parameter(n = 0)
+    common /cname/ arr(n)
+    if (n /= 0) error stop
+end subroutine test

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1959,6 +1959,7 @@ public:
     bool _processing_dimensions = false;
     bool _processing_char_len = false;
     bool _declaring_variable = false;
+    bool _processing_common_block_object = false;
     bool is_implicit_interface = false;
     Vec<ASR::stmt_t*> *current_body = nullptr;
 
@@ -4400,6 +4401,13 @@ public:
 	return var_;
     }
 
+    void visit_common_block_object_expr(AST::expr_t &expr) {
+        bool processing_common_block_object = _processing_common_block_object;
+        _processing_common_block_object = true;
+        this->visit_expr(expr);
+        _processing_common_block_object = processing_common_block_object;
+    }
+
 
     void populate_common_dictionary(const AST::Declaration_t &x, common_block_varsyms const & objs_by_blk) {
 	for (auto const & blk : objs_by_blk) {
@@ -4421,7 +4429,7 @@ public:
 		for (auto const &s : blk.second) {
 		    AST::expr_t* expr = s.m_initializer;
             LCOMPILERS_ASSERT(expr != nullptr)
-		    this->visit_expr(*expr);
+		    visit_common_block_object_expr(*expr);
 		    ASR::Variable_t* var_ = get_symtab_var_for_common(s);
 		    uint64_t hash = get_hash((ASR::asr_t*) var_);
 		    common_block_variables.push_back(ASRUtils::EXPR(tmp));
@@ -4448,7 +4456,7 @@ public:
 		    size_t byte_offset = common_block_byte_sizes[common_block_name];
 		    for (auto const &s : blk.second) {
 			AST::expr_t* expr = s.m_initializer;
-			this->visit_expr(*expr);
+			visit_common_block_object_expr(*expr);
 			ASR::Variable_t* var_ = get_symtab_var_for_common(s);
 			uint64_t hash = get_hash((ASR::asr_t*) var_);
 			common_block_variables.push_back(ASRUtils::EXPR(tmp));
@@ -4489,7 +4497,7 @@ public:
 		    for (auto const &s : blk.second) {
 			AST::expr_t* expr_ = s.m_initializer;
 			if (expr_) {
-			    this->visit_expr(*expr_);
+			    visit_common_block_object_expr(*expr_);
 			}
 			ASR::Variable_t* var__ = get_symtab_var_for_common(s);
 
@@ -10161,43 +10169,45 @@ public:
                         Level::Error, Stage::Semantic, {Label("", {loc})}));
                     throw SemanticAbort();
                 }
-                // Compile-time bounds check for fixed-size arrays
-                ASR::ttype_t* arr_type = ASRUtils::type_get_past_pointer(
-                    ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(v_Var)));
-                ASR::dimension_t* m_dims = nullptr;
-                size_t n_dims = ASRUtils::extract_dimensions_from_ttype(arr_type, m_dims);
-                for (size_t i = 0; i < std::min(n_dims, args.size()); i++) {
-                    // Only check scalar indices (m_left=null, m_step=null, m_right=index)
-                    if (args[i].m_left != nullptr || args[i].m_step != nullptr) {
-                        continue;
-                    }
-                    ASR::expr_t* idx_expr = args[i].m_right;
-                    if (idx_expr == nullptr) continue;
-                    ASR::expr_t* idx_value = ASRUtils::expr_value(idx_expr);
-                    int64_t idx = 0;
-                    if (idx_value && ASRUtils::extract_value(idx_value, idx)) {
-                        // Get lower bound (default 1)
-                        int64_t lb = 1;
-                        if (m_dims[i].m_start) {
-                            ASR::expr_t* start_val = ASRUtils::expr_value(m_dims[i].m_start);
-                            if (start_val) {
-                                ASRUtils::extract_value(start_val, lb);
-                            }
+                if (!_processing_common_block_object) {
+                    // Compile-time bounds check for fixed-size arrays
+                    ASR::ttype_t* arr_type = ASRUtils::type_get_past_pointer(
+                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(v_Var)));
+                    ASR::dimension_t* m_dims = nullptr;
+                    size_t n_dims = ASRUtils::extract_dimensions_from_ttype(arr_type, m_dims);
+                    for (size_t i = 0; i < std::min(n_dims, args.size()); i++) {
+                        // Only check scalar indices (m_left=null, m_step=null, m_right=index)
+                        if (args[i].m_left != nullptr || args[i].m_step != nullptr) {
+                            continue;
                         }
-                        // Get upper bound if length is known
-                        if (m_dims[i].m_length) {
-                            ASR::expr_t* len_val = ASRUtils::expr_value(m_dims[i].m_length);
-                            int64_t len = 0;
-                            if (len_val && ASRUtils::extract_value(len_val, len)) {
-                                int64_t ub = lb + len - 1;
-                                if (idx < lb || idx > ub) {
-                                    diag.add(Diagnostic(
-                                        "Array index " + std::to_string(idx) +
-                                        " is out of bounds (" + std::to_string(lb) +
-                                        " to " + std::to_string(ub) +
-                                        ") in dimension " + std::to_string(i + 1),
-                                        Level::Error, Stage::Semantic, {Label("", {loc})}));
-                                    throw SemanticAbort();
+                        ASR::expr_t* idx_expr = args[i].m_right;
+                        if (idx_expr == nullptr) continue;
+                        ASR::expr_t* idx_value = ASRUtils::expr_value(idx_expr);
+                        int64_t idx = 0;
+                        if (idx_value && ASRUtils::extract_value(idx_value, idx)) {
+                            // Get lower bound (default 1)
+                            int64_t lb = 1;
+                            if (m_dims[i].m_start) {
+                                ASR::expr_t* start_val = ASRUtils::expr_value(m_dims[i].m_start);
+                                if (start_val) {
+                                    ASRUtils::extract_value(start_val, lb);
+                                }
+                            }
+                            // Get upper bound if length is known
+                            if (m_dims[i].m_length) {
+                                ASR::expr_t* len_val = ASRUtils::expr_value(m_dims[i].m_length);
+                                int64_t len = 0;
+                                if (len_val && ASRUtils::extract_value(len_val, len)) {
+                                    int64_t ub = lb + len - 1;
+                                    if (idx < lb || idx > ub) {
+                                        diag.add(Diagnostic(
+                                            "Array index " + std::to_string(idx) +
+                                            " is out of bounds (" + std::to_string(lb) +
+                                            " to " + std::to_string(ub) +
+                                            ") in dimension " + std::to_string(i + 1),
+                                            Level::Error, Stage::Semantic, {Label("", {loc})}));
+                                        throw SemanticAbort();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
fixes #11487
LFortran incorrectly treated arr(n) in a COMMON statement as an executable array reference and rejected n = 0 with an out-of-bounds diagnostic. Track COMMON block object processing separately and skip compile-time array-index bounds checks for declarators, while keeping normal array access checks unchanged.