### PR TITLE
fix: refresh dependencies after dead code removal

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -566,6 +566,7 @@ RUN(NAME if_03 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c
 RUN(NAME if_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME if_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c fortran)
 RUN(NAME if_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # select case range
+RUN(NAME if_07 LABELS gfortran llvm EXTRA_ARGS --fast NO_FAST)
 
 RUN(NAME while_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME while_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -566,7 +566,7 @@ RUN(NAME if_03 FAIL LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c
 RUN(NAME if_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME if_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c fortran)
 RUN(NAME if_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # select case range
-RUN(NAME if_07 LABELS gfortran llvm EXTRA_ARGS --fast NO_FAST)
+RUN(NAME if_07 LABELS gfortran llvm)
 
 RUN(NAME while_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 RUN(NAME while_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm c fortran)

--- a/integration_tests/if_07.f90
+++ b/integration_tests/if_07.f90
@@ -1,0 +1,29 @@
+module if_07_module
+implicit none
+
+contains
+
+subroutine with_side_stepped_code()
+    integer(4), parameter :: iflag = 0
+    integer(4) :: j
+    real(8) :: tmp
+
+    if (iflag == 1) then
+        do j = 1, 10
+            tmp = real(j) / real(10)
+        end do
+    else
+        tmp = 0.d0
+    end if
+
+    if (tmp /= 0.d0) error stop
+end subroutine
+
+end module
+
+program if_07
+use if_07_module, only: with_side_stepped_code
+implicit none
+
+call with_side_stepped_code()
+end program

--- a/src/libasr/pass/dead_code_removal.cpp
+++ b/src/libasr/pass/dead_code_removal.cpp
@@ -99,6 +99,8 @@ void pass_dead_code_removal(Allocator &al, ASR::TranslationUnit_t &unit,
     std::string rl_path = pass_options.runtime_library_dir;
     DeadCodeRemovalVisitor v(al, rl_path);
     v.visit_TranslationUnit(unit);
+    PassUtils::UpdateDependenciesVisitor update_dependencies(al);
+    update_dependencies.visit_TranslationUnit(unit);
 }
 
 


### PR DESCRIPTION
The dead_code_removal pass can remove a constant-false branch that contains
intrinsic helper calls such as real(i). After the branch is removed, the
function body no longer references the generated helper symbol, but the
function dependency list can still contain it.

This leaves stale dependencies in ASR and causes verification to fail with
messages like:

Function with_side_stepped_code doesn't depend on _lcompilers_real_i32
but is found in its dependency list.

Recompute ASR dependencies after dead_code_removal rewrites the function body.
fixes #11489