### PR TITLE
test: add common block nonconstant bounds errors

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -720,4 +720,17 @@ program continue_compilation_1
         missing_required_arg_func = 0
         stat = 0
     end function
+    subroutine sub_common_block_nonconstant_lower_bound(n)
+        implicit none
+        integer, intent(in) :: n
+        integer :: arr(n:10)
+        common /common_nonconstant_lower_bound/ arr
+    end subroutine sub_common_block_nonconstant_lower_bound
+
+    subroutine sub_common_block_nonconstant_upper_bound(n)
+        implicit none
+        integer, intent(in) :: n
+        integer :: arr(1:n)
+        common /common_nonconstant_upper_bound/ arr
+    end subroutine sub_common_block_nonconstant_upper_bound
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "97cd365121ec7bacaa7c520899dc60e5904080dccf73c24bb2aff434",
+    "infile_hash": "af494774e7ae588d42f9a11f135d27d19659c0ee11e43d8fd75d8c9e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "b22efbe0953c3b8028dc0d56853dac21a0be37ac4d2ddfba25e9d236",
+    "stderr_hash": "035214eaad0a5f5b80afd1983e9c8941faabb26f8b8ab0eaba9dcd45",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -451,6 +451,18 @@ semantic error: Pointer array 'y' must have a deferred shape or assumed rank
 715 |         integer,pointer  :: y(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
+semantic error: COMMON block array bounds must be constant expressions
+   --> tests/errors/continue_compilation_1.f90:726:20
+    |
+726 |         integer :: arr(n:10)
+    |                    ^^^^^^^^^ 
+
+semantic error: COMMON block array bounds must be constant expressions
+   --> tests/errors/continue_compilation_1.f90:733:20
+    |
+733 |         integer :: arr(1:n)
+    |                    ^^^^^^^^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |


### PR DESCRIPTION
resolves 
https://github.com/lfortran/lfortran/pull/11462#pullrequestreview-4273424601