### PR TITLE
fix: Convert the template name to lowercase before adding it to symbol table

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3187,6 +3187,7 @@ RUN(NAME template_03 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 # DISABLED: #8115 - ASR verify: FunctionType contains types tied to scope after template instantiation
 # RUN(NAME template_04 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME template_05 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME template_06 LABELS llvm llvm_wasm llvm_wasm_emcc wasm fortran)
 RUN(NAME template_add_01 LABELS llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME template_add_01b LABELS llvm llvm_wasm llvm_wasm_emcc)             # FIXME: add visit_OverloadedBinOp to wasm
 RUN(NAME template_add_01c LABELS llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/template_06.f90
+++ b/integration_tests/template_06.f90
@@ -1,0 +1,23 @@
+module mod_template_06
+    implicit none
+    private
+    public :: error_T
+
+    template error_T(T, U)
+        type, deferred :: T
+        type, deferred :: U
+        private
+        public :: mycopy
+      contains
+        subroutine mycopy(lhs, rhs)
+            type(T), intent(out) :: lhs
+            type(T), intent(in) :: rhs
+            lhs = rhs
+        end subroutine
+    end template
+
+end module
+
+program template_06
+    print *, "Test drive"
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -4479,6 +4479,7 @@ public:
 
     void visit_Template(const AST::Template_t &x){
         is_template = true;
+        std::string template_name = to_lower(std::string(x.m_name));
         ASR::accessType dflt_access_copy = dflt_access;
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
@@ -4537,9 +4538,9 @@ public:
         }
 
         ASR::asr_t *temp = ASR::make_Template_t(al, x.base.base.loc,
-            current_scope, x.m_name, args.p, args.size(), reqs.p, reqs.size());
+            current_scope, s2c(al, template_name), args.p, args.size(), reqs.p, reqs.size());
 
-        parent_scope->add_symbol(x.m_name, ASR::down_cast<ASR::symbol_t>(temp));
+        parent_scope->add_symbol(template_name, ASR::down_cast<ASR::symbol_t>(temp));
         current_scope = parent_scope;
 
         // needs to rebuild the context prior to visiting template


### PR DESCRIPTION
Fixes #11454