### PR TITLE
fix: allow stat= to be any assignable integer expression in allocate

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2516,6 +2516,7 @@ RUN(NAME allocate_68 LABELS gfortran llvm)
 RUN(NAME allocate_69 LABELS gfortran llvm)
 RUN(NAME allocate_70 LABELS gfortran llvm)
 RUN(NAME allocate_71 LABELS gfortran llvm)
+RUN(NAME allocate_72 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_72.f90
+++ b/integration_tests/allocate_72.f90
@@ -1,0 +1,29 @@
+program allocate_72
+    ! STAT= can be any assignable integer expression: a plain variable,
+    ! a struct member, a nested struct member, or an array element.
+    implicit none
+    type :: t1
+        integer :: err
+    end type
+    type :: t2
+        type(t1) :: e
+    end type
+    type(t1) :: a
+    type(t2) :: b
+    integer  :: errs(3)
+    integer  :: scalar
+    real, allocatable :: arr1(:), arr2(:), arr3(:), arr4(:)
+
+    allocate(arr1(10), stat=scalar)
+    if (scalar /= 0) error stop 1
+
+    allocate(arr2(10), stat=a%err)
+    if (a%err /= 0) error stop 2
+
+    allocate(arr3(10), stat=b%e%err)
+    if (b%e%err /= 0) error stop 3
+
+    errs = -1
+    allocate(arr4(10), stat=errs(2))
+    if (errs(2) /= 0) error stop 4
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2403,19 +2403,18 @@ public:
             }
         }
         if (m_stat) {
-            ASR::Variable_t *asr_target = EXPR2VAR(m_stat);
-            uint32_t h = get_hash((ASR::asr_t*)asr_target);
-            if (llvm_symtab.find(h) != llvm_symtab.end()) {
-                llvm::Value *target, *value;
-                target = llvm_symtab[h];
-                // Store 0 (success) in the stat variable
-                ASR::ttype_t* stat_type = ASRUtils::expr_type(m_stat);
-                int kind = ASRUtils::extract_kind_from_ttype_t(stat_type);
-                value = llvm::ConstantInt::get(context, llvm::APInt(8*kind, 0));
-                builder->CreateStore(value, target);
-            } else {
-                throw CodeGenError("Stat variable in allocate not found in LLVM symtab");
-            }
+            // m_stat is any assignable integer expression (Var, struct member,
+            // array element); evaluate as an lvalue and store 0 (success).
+            int64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 0;
+            this->visit_expr_wrapper(m_stat, false);
+            ptr_loads = ptr_loads_copy;
+            llvm::Value *target = tmp;
+            ASR::ttype_t* stat_type = ASRUtils::expr_type(m_stat);
+            int kind = ASRUtils::extract_kind_from_ttype_t(stat_type);
+            llvm::Value *value = llvm::ConstantInt::get(context,
+                llvm::APInt(8*kind, 0));
+            builder->CreateStore(value, target);
         }
     }
 


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/11504

Allow stat= to be any assignable integer expression in allocate. regression tests are added.

