### PR TITLE
runtime: move per-unit I/O state into UNIT_FILE struct

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5547,48 +5547,47 @@ struct UNIT_FILE {
     int encoding; // 0=unknown, 1=UTF-8, 2=default
     int round_mode; // 0=processor_defined, 1=up, 2=down, 3=zero, 4=nearest, 5=compatible
     int pad_mode; // 1=YES (default), 0=NO
+    // Pending bytes for sequential unformatted records (shared by all types).
+    int32_t seq_unf_pending;
+    int32_t seq_unf_record_len;
+    // Pending list-directed null-repeat state.
+    int32_t lf_list_dir_null_remaining;
+    // Child I/O mode (for DTIO: suppress record terminators in child writes).
+    int32_t lf_child_io_mode;
 };
 
 int32_t last_index_used = -1;
 
 struct UNIT_FILE unit_to_file[MAXUNITS];
 
-// Pending bytes for sequential unformatted records per unit (shared by all types).
-// The Fortran standard mandates that the NEWUNIT specifier generates unique negative
-// unit numbers. To track the I/O state (such as pending bytes) for these negative units
-// without changing the data structure drastically, we allocate double the capacity
-// (MAXUNITS * 2).
-// Positive units [0, MAXUNITS-1] map to indices [0, MAXUNITS-1].
-// Negative units [-MAXUNITS+1, -1] map to indices [MAXUNITS+1, 2*MAXUNITS-1].
-// The STATE_INDEX macro provides this seamless mapping.
-#define STATE_INDEX(u) ((u) >= 0 ? (u) : (MAXUNITS - (u)))
-static int32_t seq_unf_pending[MAXUNITS*2];
-static int32_t seq_unf_record_len[MAXUNITS*2];
+// Locate the UNIT_FILE entry for a given unit number. Returns NULL if not
+// connected.
+static inline struct UNIT_FILE* find_unit(int32_t unit_num) {
+    for (int i = 0; i <= last_index_used; i++) {
+        if (unit_to_file[i].unit == unit_num) return &unit_to_file[i];
+    }
+    return NULL;
+}
 
-// Pending list-directed null-repeat state per unit.
-static int32_t lf_list_dir_null_remaining[MAXUNITS*2];
-
-// Child I/O mode per unit (for DTIO: suppress record terminators in child writes).
-static int32_t lf_child_io_mode[MAXUNITS*2];
-
-static inline void seq_unf_state_reset(int32_t unit_num) {
-    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return;
-    seq_unf_pending[STATE_INDEX(unit_num)] = 0;
-    seq_unf_record_len[STATE_INDEX(unit_num)] = 0;
+static inline void seq_unf_state_reset(struct UNIT_FILE *uf) {
+    if (!uf) return;
+    uf->seq_unf_pending = 0;
+    uf->seq_unf_record_len = 0;
 }
 
 // Begin reading from a sequential unformatted record if not already in one.
 // Returns 0 on success, -1 on EOF, 1 on error.
 static inline int seq_unf_begin_record(int32_t unit_num, FILE* filep) {
-    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return 1;
-    if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
+    struct UNIT_FILE *uf = find_unit(unit_num);
+    if (!uf) return 1;
+    if (uf->seq_unf_pending == 0) {
         int32_t marker = 0;
         if (fread(&marker, sizeof(int32_t), 1, filep) != 1) {
             return feof(filep) ? -1 : 1;
         }
         if (marker < 0) return 1;
-        seq_unf_pending[STATE_INDEX(unit_num)] = marker;
-        seq_unf_record_len[STATE_INDEX(unit_num)] = marker;
+        uf->seq_unf_pending = marker;
+        uf->seq_unf_record_len = marker;
     }
     return 0;
 }
@@ -5596,29 +5595,29 @@ static inline int seq_unf_begin_record(int32_t unit_num, FILE* filep) {
 // Finish reading a sequential unformatted record if all bytes consumed.
 // Returns 0 on success, 1 on error.
 static inline int seq_unf_finish_record(int32_t unit_num, FILE* filep) {
-    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return 1;
-    if (seq_unf_pending[STATE_INDEX(unit_num)] == 0 && seq_unf_record_len[STATE_INDEX(unit_num)] > 0) {
+    struct UNIT_FILE *uf = find_unit(unit_num);
+    if (!uf) return 1;
+    if (uf->seq_unf_pending == 0 && uf->seq_unf_record_len > 0) {
         int32_t end_marker = 0;
         if (fread(&end_marker, sizeof(int32_t), 1, filep) != 1) {
             return 1;
         }
-        if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
+        if (end_marker != uf->seq_unf_record_len) {
             return 1;
         }
-        seq_unf_state_reset(unit_num);
+        seq_unf_state_reset(uf);
     }
     return 0;
 }
 
-static inline void list_dir_state_reset(int32_t unit_num) {
-    if (unit_num <= -MAXUNITS || unit_num >= MAXUNITS) return;
-    lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = 0;
+static inline void list_dir_state_reset(struct UNIT_FILE *uf) {
+    if (!uf) return;
+    uf->lf_list_dir_null_remaining = 0;
 }
 
 LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child) {
-    if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
-        lf_child_io_mode[STATE_INDEX(unit_num)] = is_child;
-    }
+    struct UNIT_FILE *uf = find_unit(unit_num);
+    if (uf) uf->lf_child_io_mode = is_child;
 }
 
 // Pre-connect standard Fortran units at program startup.
@@ -5711,8 +5710,6 @@ static int32_t count_newlines_up_to(FILE *fp, long end_pos) {
 
 void store_unit_file(int32_t unit_num, char* filename, FILE* filep, bool unit_file_bin, int access_id, bool read_access, bool write_access, int delim, bool blank_zero, int32_t record_length, int sign_mode, int decimal_mode, int encoding, int round_mode, int pad_mode) {
     _lfortran_init_standard_units();
-    seq_unf_state_reset(unit_num);
-    list_dir_state_reset(unit_num);
     for( int i = 0; i <= last_index_used; i++ ) {
         if( unit_to_file[i].unit == unit_num ) {
             // Update existing entry - only update filename if explicitly provided (not NULL)
@@ -5732,6 +5729,8 @@ void store_unit_file(int32_t unit_num, char* filename, FILE* filep, bool unit_fi
             unit_to_file[i].encoding = encoding;
             unit_to_file[i].round_mode = round_mode;
             unit_to_file[i].pad_mode = pad_mode;
+            seq_unf_state_reset(&unit_to_file[i]);
+            list_dir_state_reset(&unit_to_file[i]);
             return;  // Don't add duplicate entry
         }
     }
@@ -5756,6 +5755,8 @@ void store_unit_file(int32_t unit_num, char* filename, FILE* filep, bool unit_fi
     unit_to_file[last_index_used].encoding = encoding;
     unit_to_file[last_index_used].round_mode = round_mode;
     unit_to_file[last_index_used].pad_mode = pad_mode;
+    seq_unf_state_reset(&unit_to_file[last_index_used]);
+    list_dir_state_reset(&unit_to_file[last_index_used]);
 }
 
 FILE* get_file_pointer_from_unit(int32_t unit_num, bool *unit_file_bin, int *access_id, bool *read_access, bool *write_access, int *delim, bool *blank_zero, int32_t *recl, int *sign_mode, int *decimal_mode, int *encoding_mode, int *round_mode, int *pad_mode) {
@@ -5806,8 +5807,6 @@ char* get_file_name_from_unit(int32_t unit_num, bool *unit_file_bin) {
 }
 
 void remove_from_unit_to_file(int32_t unit_num) {
-    seq_unf_state_reset(unit_num);
-    list_dir_state_reset(unit_num);
     int index = -1;
     for( int i = 0; i <= last_index_used; i++ ) {
         if( unit_to_file[i].unit == unit_num ) {
@@ -7204,8 +7203,8 @@ LFORTRAN_API void _lfortran_rewind(int32_t unit_num, int32_t* iostat, char* ioms
         }
     }
     rewind(filep);
-    seq_unf_state_reset(unit_num);
-    list_dir_state_reset(unit_num);
+    seq_unf_state_reset(find_unit(unit_num));
+    list_dir_state_reset(find_unit(unit_num));
 }
 
 LFORTRAN_API void _lfortran_endfile(int32_t unit_num)
@@ -7363,9 +7362,9 @@ static void skip_list_directed_comma(FILE *filep) {
 }
 
 static int list_directed_check_null_repeat(int32_t unit_num) {
-    if (unit_num > -MAXUNITS && unit_num < MAXUNITS
-            && lf_list_dir_null_remaining[STATE_INDEX(unit_num)] > 0) {
-        lf_list_dir_null_remaining[STATE_INDEX(unit_num)]--;
+    struct UNIT_FILE *uf = find_unit(unit_num);
+    if (uf && uf->lf_list_dir_null_remaining > 0) {
+        uf->lf_list_dir_null_remaining--;
         return 1;
     }
     return 0;
@@ -7432,8 +7431,9 @@ static list_directed_token_status read_list_directed_token(FILE *filep,
 
     int null_count = list_directed_parse_null_repeat(buffer);
     if (null_count > 0) {
-        if (unit_num >= 0 && unit_num < MAXUNITS) {
-            lf_list_dir_null_remaining[unit_num] = null_count - 1;
+        {
+            struct UNIT_FILE *uf_ = find_unit(unit_num);
+            if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
         }
         if (consume_repeat_trailing_comma && c != ',') {
             skip_trailing_comma(filep);
@@ -7532,7 +7532,7 @@ LFORTRAN_API void _lfortran_read_int16(int16_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for int16_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int16_t)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(int16_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int16_t.\n");
                 exit(1);
@@ -7542,7 +7542,7 @@ LFORTRAN_API void _lfortran_read_int16(int16_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read int16_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int16_t);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(int16_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading int16_t.\n");
@@ -7589,8 +7589,9 @@ LFORTRAN_API void _lfortran_read_int16(int16_t *p, int32_t unit_num, int32_t *io
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -7671,7 +7672,7 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Internal Compiler Error: Failed to read record marker for int32_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int32_t)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(int32_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Internal Compiler Error: Record too short for int32_t.\n");
                 exit(1);
@@ -7681,7 +7682,7 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Internal Compiler Error: Failed to read int32_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int32_t);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(int32_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Internal Compiler Error: Invalid trailing record marker while reading int32_t.\n");
@@ -7728,8 +7729,9 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num, int32_t *io
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num >= 0 && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[unit_num] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -7808,7 +7810,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for int64_t.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int64_t)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(int64_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int64_t.\n");
                 exit(1);
@@ -7818,7 +7820,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read int64_t from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int64_t);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(int64_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading int64_t.\n");
@@ -7911,7 +7913,7 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
                 fprintf(stderr, "Error: Failed to read record marker for logical.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(int32_t)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(int32_t)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for logical.\n");
                 exit(1);
@@ -7921,7 +7923,7 @@ LFORTRAN_API void _lfortran_read_logical(bool *p, int32_t unit_num, int32_t *ios
                 fprintf(stderr, "Error: Failed to read logical from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(int32_t);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(int32_t);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading logical.\n");
@@ -8010,7 +8012,7 @@ LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t s
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int8_t));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int8 array.\n");
                 exit(1);
@@ -8032,7 +8034,7 @@ LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t s
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int8 array read.\n");
@@ -8113,7 +8115,7 @@ LFORTRAN_API void _lfortran_read_array_logical(void *p, int array_size, int kind
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * kind);
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for logical array.\n");
                 exit(1);
@@ -8140,7 +8142,7 @@ LFORTRAN_API void _lfortran_read_array_logical(void *p, int array_size, int kind
                     memcpy((char*)p + (int64_t)i * (int64_t)stride * kind, tmp, kind);
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in logical array read.\n");
@@ -8226,7 +8228,7 @@ LFORTRAN_API void _lfortran_read_array_int16(int16_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int16_t));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int16 array.\n");
                 exit(1);
@@ -8248,7 +8250,7 @@ LFORTRAN_API void _lfortran_read_array_int16(int16_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int16 array read.\n");
@@ -8329,7 +8331,7 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int32_t));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int32 array.\n");
                 exit(1);
@@ -8351,7 +8353,7 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int32 array read.\n");
@@ -8431,7 +8433,7 @@ LFORTRAN_API void _lfortran_read_array_int64(int64_t *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(int64_t));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for int64 array.\n");
                 exit(1);
@@ -8453,7 +8455,7 @@ LFORTRAN_API void _lfortran_read_array_int64(int64_t *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in int64 array read.\n");
@@ -8530,7 +8532,7 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
             pad_with_spaces(*p, data_length, p_len);
         } else {
 
-            if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
+            if (find_unit(unit_num)->seq_unf_pending == 0) {
                 int32_t marker = 0;
                 if (fread(&marker, sizeof(int32_t), 1, filep) != 1) {
                     if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
@@ -8542,11 +8544,11 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
                     printf("Error: Invalid record marker while reading character data.\n");
                     exit(1);
                 }
-                seq_unf_pending[STATE_INDEX(unit_num)] = marker;
-                seq_unf_record_len[STATE_INDEX(unit_num)] = marker;
+                find_unit(unit_num)->seq_unf_pending = marker;
+                find_unit(unit_num)->seq_unf_record_len = marker;
             }
 
-            int32_t data_length = seq_unf_pending[STATE_INDEX(unit_num)];
+            int32_t data_length = find_unit(unit_num)->seq_unf_pending;
             if (data_length > p_len) data_length = (int32_t)p_len;
 
             if (data_length > 0 && fread(*p, sizeof(char), data_length, filep) != (size_t)data_length) {
@@ -8555,21 +8557,21 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
                 exit(1);
             }
 
-            seq_unf_pending[STATE_INDEX(unit_num)] -= data_length;
+            find_unit(unit_num)->seq_unf_pending -= data_length;
 
-            if (seq_unf_pending[STATE_INDEX(unit_num)] == 0) {
+            if (find_unit(unit_num)->seq_unf_pending == 0) {
                 int32_t end_marker = 0;
                 if (fread(&end_marker, sizeof(int32_t), 1, filep) != 1) {
                     if (iostat) { *iostat = feof(filep) ? -1 : 1; return; }
                     printf("Error reading trailing record marker from file.\n");
                     exit(1);
                 }
-                if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
+                if (end_marker != find_unit(unit_num)->seq_unf_record_len) {
                     if (iostat) { *iostat = 1; return; }
                     printf("Error: Mismatched record markers while reading character data.\n");
                     exit(1);
                 }
-                seq_unf_state_reset(unit_num);
+                seq_unf_state_reset(find_unit(unit_num));
             }
 
             pad_with_spaces(*p, data_length, p_len);
@@ -8849,7 +8851,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
                 fprintf(stderr, "Error: Failed to read record marker for float.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(float)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(float)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for float.\n");
                 exit(1);
@@ -8859,7 +8861,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
                 fprintf(stderr, "Error: Failed to read float from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(float);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(float);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading float.\n");
@@ -8904,8 +8906,9 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num, int32_t *iost
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -8955,7 +8958,7 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 fprintf(stderr, "Error: Failed to read record marker for complex float.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(struct _lfortran_complex_32)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(struct _lfortran_complex_32)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex float.\n");
                 exit(1);
@@ -8965,7 +8968,7 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
                 fprintf(stderr, "Error: Failed to read complex float from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(struct _lfortran_complex_32);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(struct _lfortran_complex_32);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading complex float.\n");
@@ -8994,8 +8997,9 @@ LFORTRAN_API void _lfortran_read_complex_float(struct _lfortran_complex_32 *p, i
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -9069,7 +9073,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 fprintf(stderr, "Error: Failed to read record marker for complex double.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(struct _lfortran_complex_64)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(struct _lfortran_complex_64)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex double.\n");
                 exit(1);
@@ -9079,7 +9083,7 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
                 fprintf(stderr, "Error: Failed to read complex double from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(struct _lfortran_complex_64);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(struct _lfortran_complex_64);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading complex double.\n");
@@ -9108,8 +9112,9 @@ LFORTRAN_API void _lfortran_read_complex_double(struct _lfortran_complex_64 *p, 
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -9191,7 +9196,7 @@ LFORTRAN_API void _lfortran_read_array_complex_float(struct _lfortran_complex_32
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(struct _lfortran_complex_32));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex float array.\n");
                 exit(1);
@@ -9213,7 +9218,7 @@ LFORTRAN_API void _lfortran_read_array_complex_float(struct _lfortran_complex_32
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in complex float array read.\n");
@@ -9346,7 +9351,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(struct _lfortran_complex_64));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for complex double array.\n");
                 exit(1);
@@ -9368,7 +9373,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in complex double array read.\n");
@@ -9504,7 +9509,7 @@ LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t s
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(float));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for float array.\n");
                 exit(1);
@@ -9526,7 +9531,7 @@ LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t s
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in float array read.\n");
@@ -9616,7 +9621,7 @@ LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t
                 exit(1);
             }
             int32_t bytes_needed = (int32_t)(array_size * sizeof(double));
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < bytes_needed) {
+            if (find_unit(unit_num)->seq_unf_pending < bytes_needed) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for double array.\n");
                 exit(1);
@@ -9638,7 +9643,7 @@ LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t
                     p[(int64_t)i * (int64_t)stride] = val;
                 }
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= bytes_needed;
+            find_unit(unit_num)->seq_unf_pending -= bytes_needed;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in double array read.\n");
@@ -9716,7 +9721,7 @@ LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_s
                 fprintf(stderr, "Error: Failed to read record marker for char array.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)want) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)want) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for char array.\n");
                 exit(1);
@@ -9728,7 +9733,7 @@ LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_s
             if (got < want) {
                 memset(p + got, ' ', want - got);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)want;
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)want;
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker in char array read.\n");
@@ -9796,7 +9801,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read record marker for double.\n");
                 exit(1);
             }
-            if (seq_unf_pending[STATE_INDEX(unit_num)] < (int32_t)sizeof(double)) {
+            if (find_unit(unit_num)->seq_unf_pending < (int32_t)sizeof(double)) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Record too short for double.\n");
                 exit(1);
@@ -9806,7 +9811,7 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
                 fprintf(stderr, "Error: Failed to read double from sequential binary file.\n");
                 exit(1);
             }
-            seq_unf_pending[STATE_INDEX(unit_num)] -= (int32_t)sizeof(double);
+            find_unit(unit_num)->seq_unf_pending -= (int32_t)sizeof(double);
             if (seq_unf_finish_record(unit_num, filep) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Invalid trailing record marker while reading double.\n");
@@ -9852,8 +9857,9 @@ LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num, int32_t *io
         }
         int null_count = list_directed_parse_null_repeat(buffer);
         if (null_count > 0) {
-            if (unit_num > -MAXUNITS && unit_num < MAXUNITS) {
-                lf_list_dir_null_remaining[STATE_INDEX(unit_num)] = null_count - 1;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) uf_->lf_list_dir_null_remaining = null_count - 1;
             }
             return;
         }
@@ -11320,8 +11326,8 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_
                 exit(1);
             }
         }
-        if (seq_unf_pending[STATE_INDEX(unit_num)] > 0) {
-            if (fseek(fp, (long)seq_unf_pending[STATE_INDEX(unit_num)], SEEK_CUR) != 0) {
+        if (find_unit(unit_num)->seq_unf_pending > 0) {
+            if (fseek(fp, (long)find_unit(unit_num)->seq_unf_pending, SEEK_CUR) != 0) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error skipping remaining record data in file.\n");
                 exit(1);
@@ -11332,13 +11338,13 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_
                 fprintf(stderr, "Error reading trailing record marker from file.\n");
                 exit(1);
             }
-            if (end_marker != seq_unf_record_len[STATE_INDEX(unit_num)]) {
+            if (end_marker != find_unit(unit_num)->seq_unf_record_len) {
                 if (iostat) { *iostat = 1; return; }
                 fprintf(stderr, "Error: Mismatched record markers while finalizing read.\n");
                 exit(1);
             }
-            seq_unf_state_reset(unit_num);
-        } else if (no_values && seq_unf_record_len[STATE_INDEX(unit_num)] == 0) {
+            seq_unf_state_reset(find_unit(unit_num));
+        } else if (no_values && find_unit(unit_num)->seq_unf_record_len == 0) {
             // Empty record (marker was 0): read trailing marker
             int32_t end_marker = 0;
             if (fread(&end_marker, sizeof(int32_t), 1, fp) != 1) {
@@ -11351,7 +11357,7 @@ LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_
                 fprintf(stderr, "Error: Mismatched record markers while finalizing read.\n");
                 exit(1);
             }
-            seq_unf_state_reset(unit_num);
+            seq_unf_state_reset(find_unit(unit_num));
         }
     }
 }
@@ -11638,8 +11644,11 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
         } else {
             // Sequential / stream access: write as before
             // In child I/O mode (DTIO), suppress the record terminator
-            bool is_child = (unit_num > -MAXUNITS && unit_num < MAXUNITS &&
-                             lf_child_io_mode[STATE_INDEX(unit_num)]);
+            bool is_child = false;
+            {
+                struct UNIT_FILE *uf_ = find_unit(unit_num);
+                if (uf_) is_child = uf_->lf_child_io_mode != 0;
+            }
             if (end != NULL && !is_child) {
                 if(open_delim != '\0') {
                     fprintf(filep, "%c%.*s%c%.*s",


### PR DESCRIPTION
Move the global per-unit arrays (seq_unf_pending, seq_unf_record_len, lf_list_dir_null_remaining, lf_child_io_mode) into the UNIT_FILE struct and remove the MAXUNITS*2 doubling and STATE_INDEX mapping that was required to support NEWUNIT's negative unit numbers.

Introduce a find_unit() helper to look up the UNIT_FILE entry and update all access sites to use it. seq_unf_state_reset() and list_dir_state_reset() now take a UNIT_FILE*, and the reset is performed inside store_unit_file()/remove_from_unit_to_file() at the right place.

Fixes #11107.