### PR TITLE
fix: case_construct_name

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1944,6 +1944,7 @@ RUN(NAME case_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp)
 RUN(NAME case_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME case_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME case_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME case_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME select_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_type_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/case_10.f90
+++ b/integration_tests/case_10.f90
@@ -1,0 +1,29 @@
+program case_10
+   implicit none
+   integer :: i, result
+
+   result = 0
+   i = 1
+
+   swtch: select case (i)
+   case (1, 3) swtch
+      result = result + 10
+   case (2, 4) swtch
+      result = result + 20
+   case default swtch
+      result = result + 30
+   end select swtch
+
+   if (result /= 10) error stop 1
+
+   i = 2
+   pick: select case (i)
+   case (1) pick
+      result = -1
+   case default pick
+      result = 99
+   end select pick
+
+   if (result /= 99) error stop 2
+
+end program case_10

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -641,7 +641,7 @@ script_unit
     | implicit_statement
     | var_decl           %dprec 9
     | derived_type_decl
-    | union_type_decl 
+    | union_type_decl
     | enum_decl
     | statement          %dprec 7
     | expr sep           %dprec 8
@@ -1206,8 +1206,8 @@ implicit_spec_list
   We are using kind_arg_list rather than letter_spec_list to avoid conflicts
   in the parser.  The kind_args are translated into letter_specs in the
   IMPLICIT_SPEC macro.
-*/		
-   
+*/
+
 implicit_spec
     : KW_INTEGER "(" kind_arg_list ")" "(" kind_arg_list ")" {
             $$ = IMPLICIT_SPEC(ATTR_TYPE_KIND(Integer, $3, @$), $6, @$); }
@@ -1216,7 +1216,7 @@ implicit_spec
 	    WARN_INTEGERSTAR($3, @2);}
     | KW_INTEGER "(" kind_arg_list ")" {
             $$ = IMPLICIT_SPEC(ATTR_TYPE(Integer, @$), $3, @$); }
-	    
+
     | KW_CHARACTER "(" kind_arg_list ")" "(" kind_arg_list ")" {
             $$ = IMPLICIT_SPEC(ATTR_TYPE_KIND(Character, $3, @$), $6, @$); }
     | KW_CHARACTER "*" TK_INTEGER "(" kind_arg_list ")" {
@@ -1251,7 +1251,7 @@ implicit_spec
 	    WARN_COMPLEXSTAR($3, @2);}
     | KW_COMPLEX "(" kind_arg_list ")" {
             $$ = IMPLICIT_SPEC(ATTR_TYPE(Complex, @$), $3, @$); }
-	    
+
     | KW_DOUBLE KW_PRECISION "(" kind_arg_list ")" {
             $$ = IMPLICIT_SPEC(ATTR_TYPE(DoublePrecision, @$), $4, @$); }
     | KW_DOUBLE_PRECISION "(" kind_arg_list ")" {
@@ -1273,7 +1273,7 @@ implicit_spec
 implicit_none_spec_star
     : implicit_none_spec_star "," implicit_none_spec { $$ = $1; LIST_ADD($$, $3); }
     | implicit_none_spec { LIST_NEW($$); LIST_ADD($$, $1); }
-    | %empty { LIST_NEW($$); }	 
+    | %empty { LIST_NEW($$); }
     ;
 
 implicit_none_spec
@@ -2058,9 +2058,9 @@ case_statements
     ;
 
 case_statement
-    : KW_CASE "(" case_conditions ")" sep statements {
-            $$ = CASE_STMT($3, TRIVIA_AFTER($5, @$), $6, @$); }
-    | KW_CASE KW_DEFAULT sep statements { $$ = CASE_STMT_DEFAULT(TRIVIA_AFTER($3, @$), $4, @$); }
+    : KW_CASE "(" case_conditions ")" id_opt sep statements {
+            $$ = CASE_STMT($3, TRIVIA_AFTER($6, @$), $7, @$); }
+    | KW_CASE KW_DEFAULT id_opt sep statements { $$ = CASE_STMT_DEFAULT(TRIVIA_AFTER($4, @$), $5, @$); }
     ;
 
 case_conditions


### PR DESCRIPTION
The parser was rejecting valid named SELECT CASE constructs when the
construct name appeared after a CASE or CASE DEFAULT statement,
e.g. `case (1, 3) swtch`. The `case_statement` grammar rule was
missing `id_opt` between the closing paren and the separator.

Added `id_opt` to both alternatives of the rule, matching the same
pattern already used by `select_rank_case_stmt`. Tested with case_10.

Fixes #11498

