### PR TITLE
fix class array dealloc

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2421,6 +2421,7 @@ RUN(NAME derived_types_apply_clip_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_types_143 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME derived_types_144 LABELS gfortran llvm)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_144.f90
+++ b/integration_tests/derived_types_144.f90
@@ -1,0 +1,18 @@
+program derived_types_144
+    implicit none
+
+    type base_t
+        integer, allocatable :: buf(:)
+    end type base_t
+
+    type holder_t
+        class(base_t), allocatable :: obj(:)
+    end type holder_t
+
+    type(holder_t) :: x
+
+    allocate(x%obj(2))
+    deallocate(x%obj)
+
+    print *, "ok"
+end program derived_types_144

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -2531,6 +2531,12 @@ class ASRToLLVMVisitor;
                 case ASR::Array: {
                     ASR::Array_t* const arr_t = ASR::down_cast<ASR::Array_t>(t_past);
                     if (arr_t->m_type->type != ASR::StructType) { return; }
+                    auto *const arr_llvm_t = get_llvm_type(t_past, struct_sym);
+                    llvm::Value* arr_ptr = ptr;
+                    if (!arr_ptr->getType()->isPointerTy()) {
+                        arr_ptr = builder_->CreateAlloca(arr_llvm_t, nullptr, "dealloc_arr_desc");
+                        builder_->CreateStore(ptr, arr_ptr);
+                    }
 
                     if (ASRUtils::is_class_type(arr_t->m_type)
                         && ASRUtils::is_unlimited_polymorphic_type(arr_t->m_type)) {
@@ -2538,10 +2544,9 @@ class ASRToLLVMVisitor;
                         // descriptor.data -> wrapper {vptr, i8* payload}.
                         // For explicit deallocate, finalize all elements and free payload;
                         // wrapper is freed by call_lfortran_free() in asr_to_llvm.
-                        auto *const arr_llvm_t = get_llvm_type(t_past, struct_sym);
                         auto *const elem_llvm_t = get_llvm_type(arr_t->m_type, struct_sym);
                         llvm::Value* const wrapper_ptr_ref =
-                            llvm_utils_->create_gep2(arr_llvm_t, ptr, 0);
+                            llvm_utils_->create_gep2(arr_llvm_t, arr_ptr, 0);
                         llvm::Value* const wrapper_ptr = builder_->CreateLoad(
                             elem_llvm_t->getPointerTo(), wrapper_ptr_ref);
                         llvm::Value* const wrapper_not_null = builder_->CreateICmpNE(
@@ -2550,7 +2555,7 @@ class ASRToLLVMVisitor;
                                 llvm::cast<llvm::PointerType>(elem_llvm_t->getPointerTo())));
                         llvm_utils_->create_if_else(wrapper_not_null, [&]() {
                             llvm::Value* arr_size = llvm_utils_->get_array_size(
-                                ptr, arr_llvm_t, t_past, &asr_to_llvm_visitor_);
+                                arr_ptr, arr_llvm_t, t_past, &asr_to_llvm_visitor_);
                             finalize_upoly_array_elements(wrapper_ptr,
                                 ASR::down_cast<ASR::StructType_t>(arr_t->m_type),
                                 struct_sym, arr_size);
@@ -2560,13 +2565,12 @@ class ASRToLLVMVisitor;
 
                     if (!is_finalizable_type(arr_t->m_type, struct_sym, in_struct)) { return; }
                     // Finalize array elements but don't free the array data itself
-                    auto *const arr_llvm_t = get_llvm_type(t_past, struct_sym);
                     auto *const arrayType_llvm_t = get_llvm_type(arr_t->m_type, struct_sym);
                     auto const array_size_lazy = [&]() {
-                        return llvm_utils_->get_array_size(ptr, arr_llvm_t, t_past, &asr_to_llvm_visitor_);
+                        return llvm_utils_->get_array_size(arr_ptr, arr_llvm_t, t_past, &asr_to_llvm_visitor_);
                     };
                     auto const data = builder_->CreateLoad(arrayType_llvm_t->getPointerTo(),
-                        llvm_utils_->create_gep2(arr_llvm_t, ptr, 0));
+                        llvm_utils_->create_gep2(arr_llvm_t, arr_ptr, 0));
                     check_if_allocated_then_finalize(data, arr_t->m_type, struct_sym, [&](){
                         free_array_data(data, arr_t->m_type, struct_sym, array_size_lazy);
                     });


### PR DESCRIPTION
deallocate() could hit an LLVM assertion for allocatable polymorphic arrays when the array descriptor was passed as a value during finalization.

I made the finalization path use an addressable descriptor before reading array fields, and added an integration test for the issue case.

Tested with `cmake --build build -j2` and `cd integration_tests && ./run_tests.py -b llvm -t derived_types_144`.

Fixes #11526