### PR TITLE
semantics: remove process-global mutable caches

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -29,8 +29,6 @@ using LCompilers::diag::Diagnostic;
 
 namespace LCompilers::LFortran {
 
-static std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
-static std::map<std::string, int> assumed_rank_arrays;
 static int PDT_SENTINEL = 1000;
 
 template <typename T>
@@ -1608,6 +1606,8 @@ template <class Derived>
 class CommonVisitor : public AST::BaseVisitor<Derived> {
 public:
     diag::Diagnostics &diag;
+    std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
+    std::map<std::string, int> assumed_rank_arrays;
     std::map<AST::operatorType, std::string> binop2str = {
         {AST::operatorType::Mul, "~mul"},
         {AST::operatorType::Add, "~add"},


### PR DESCRIPTION
Move vars_with_deferred_struct_declaration and assumed_rank_arrays from file-scope static globals into plain members of CommonVisitor. They are now default-constructed and destroyed with each visitor instance, eliminating process-global mutable state without introducing any extra indirection.

Reference tests pass; integration tests pass (3595/3595 on llvm).