### PR TITLE
fix: infinite loop in fixed-form prescanner on trailing whitespaces at EOF

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -457,6 +457,7 @@ RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form 
 RUN(NAME fixed_form_select_case_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_select_rank_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_blank_line_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_io_keyword_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_io_keyword_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_goto LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)

--- a/integration_tests/fixed_form_blank_line_01.f90
+++ b/integration_tests/fixed_form_blank_line_01.f90
@@ -1,0 +1,12 @@
+c     This is a fixed-form test
+      program fixed_form_blank_line
+      call test()
+      end program
+
+      subroutine test()
+	 
+      integer :: n
+      parameter ( n=10 )
+      if (n .ne. 10) error stop 1
+      return
+      end

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -454,6 +454,15 @@ enum LineType {
 // The line ends with either `\n` or `\0`.  Only used for fixed-form
 LineType determine_line_type(const unsigned char *pos)
 {
+    const unsigned char *p = pos;
+    while (*p == ' ' || *p == '\t') p++;
+    if (*p == '\0') {
+        return LineType::EndOfFile;
+    }
+    if (*p == '\n' || (*p == '\r' && *(p+1) == '\n')) {
+        return LineType::Comment;
+    }
+
     int col=1;
     if (*pos == '\n') {
         // Empty line => classified as comment


### PR DESCRIPTION
fixes #11531 
When compiling fixed-form code with trailing whitespaces without a newline, `determine_line_type` incorrectly classified the null terminator as a comment, causing `skip_rest_of_line` to hang endlessly. Fixed by explicitly returning `LineType::EndOfFile` when `\0 ` is encountered after spaces/tabs. Also added a fixed-form integration test to cover this scenario.
