### PR TITLE
fix: handle blank tab-only lines in fixed-form prescanner

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -457,6 +457,7 @@ RUN(NAME fixed_form_select_case_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form 
 RUN(NAME fixed_form_select_case_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_select_rank_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_comment_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_blank_line_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_io_keyword_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_io_keyword_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_goto LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)

--- a/integration_tests/fixed_form_blank_line_01.f90
+++ b/integration_tests/fixed_form_blank_line_01.f90
@@ -1,0 +1,13 @@
+c     This is a fixed-form test exercising blank lines containing
+c     only whitespace (tabs and spaces), including at end of file.
+      program fixed_form_blank_line
+      call test()
+      end program
+
+      subroutine test()
+	
+      integer :: n
+      parameter ( n=10 )
+      if (n .ne. 10) error stop 1
+      return
+      end

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -465,17 +465,22 @@ LineType determine_line_type(const unsigned char *pos)
         return LineType::EndOfFile;
     } else if (*pos == '\t') {
         pos++;
-        if (*pos == '\0') {
+        // Skip any additional whitespace after the leading tab so that a
+        // line containing only whitespace is treated as a blank line
+        // rather than a (broken) statement.
+        const unsigned char *p = pos;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0') {
             return LineType::EndOfFile;
+        } else if (*p == '\n' || (*p == '\r' && *(p+1) == '\n')) {
+            // Blank line (tab followed only by whitespace) => comment
+            return LineType::Comment;
+        } else if (is_digit(*pos)) {
+            // A continuation line after a tab
+            return LineType::ContinuationTab;
         } else {
-            if (is_digit(*pos)) {
-                // A continuation line after a tab
-                return LineType::ContinuationTab;
-            } else {
-                // A statement line after a tab
-                return LineType::StatementTab;
-            }
-
+            // A statement line after a tab
+            return LineType::StatementTab;
         }
     } else {
         while (*pos == ' ') {


### PR DESCRIPTION
When a fixed-form source line begins with a tab followed only by more whitespace (spaces/tabs) before the end of line or end of file, determine_line_type previously returned StatementTab. The prescanner then attempted to copy a non-existent statement, which confused the tokenizer and produced an 'Expecting terminating symbol' error on the following construct.

Handle this case directly in the existing tab branch (mirroring the leading-spaces branch, which already classifies whitespace-only lines as Comment / EndOfFile).

Fixes #11531