### PR TITLE
Scope array-constructor implied-do variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3285,6 +3285,7 @@ RUN(NAME implied_do_loops36 LABELS gfortran llvm)
 
 RUN(NAME implied_do_loops37 LABELS gfortran llvm)
 RUN(NAME implied_do_loops38 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
+RUN(NAME implied_do_loops39 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops39.f90
+++ b/integration_tests/implied_do_loops39.f90
@@ -1,0 +1,35 @@
+program implied_do_loops39
+    integer ii
+    integer, parameter :: jmin(1:10) = (/ (i, i = 1, 10) /)
+    integer, parameter :: kmin(1:10) = (/ (ii, ii = 1, 10) /)
+    integer, parameter :: lmin(1:10) = (/ (iii, iii = 1, 10) /)
+    integer iii, n
+
+    do n = 1, 10
+        if (jmin(n) /= n) error stop 10
+        if (kmin(n) /= n) error stop 11
+        if (lmin(n) /= n) error stop 12
+    end do
+
+    call two
+
+contains
+
+    subroutine one
+        i = 99
+        ii = 99
+        iii = 999
+    end subroutine
+
+    subroutine two
+        i = 0
+        ii = 0
+        iii = 0
+        call one
+
+        if (i /= 0) error stop 1
+        if (ii /= 99) error stop 2
+        if (iii /= 999) error stop 3
+    end subroutine
+
+end program implied_do_loops39

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1961,6 +1961,7 @@ public:
     bool _declaring_variable = false;
     bool _processing_common_block_object = false;
     bool is_implicit_interface = false;
+    int array_initializer_depth = 0;
     Vec<ASR::stmt_t*> *current_body = nullptr;
 
     std::map<std::string, ASR::ttype_t*> implicit_dictionary;
@@ -10636,6 +10637,11 @@ public:
         bool use_descriptorArray = false; // Set to true if any argument has no fixed size (array arguments).
         ASR::ttype_t* extracted_type { type ? ASRUtils::extract_type(type) : nullptr };
         size_t n_elements = 0;
+        struct ArrayInitializerDepthGuard {
+            int &depth;
+            ArrayInitializerDepthGuard(int &depth) : depth(depth) { depth++; }
+            ~ArrayInitializerDepthGuard() { depth--; }
+        } array_initializer_depth_guard(array_initializer_depth);
         for (size_t i=0; i<x.n_args; i++) {
             this->visit_expr(*x.m_args[i]);
             ASR::expr_t *expr = ASRUtils::EXPR(tmp);
@@ -15962,6 +15968,8 @@ public:
             }
         }
         idl_nesting_level++;
+        std::string idl_var_name = to_lower(x.m_var);
+        ASR::symbol_t* pre_existing_sym = current_scope->resolve_symbol(idl_var_name);
         Vec<ASR::expr_t*> a_values_vec;
         ASR::expr_t *a_start, *a_end, *a_increment;
         a_start = a_end = a_increment = nullptr;
@@ -16020,6 +16028,23 @@ public:
                     Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
                 throw SemanticAbort();
             }
+        }
+        // Hide the implied-do control variable from the enclosing scope when
+        // it was implicitly created just for this array-constructor implied-do
+        // (issue #11448). Without this, implicit typing leaks the loop
+        // variable into the surrounding program/subprogram scope, allowing
+        // contained procedures to incorrectly resolve their own implicit
+        // variable to that loop variable.
+        if (pre_existing_sym == nullptr && array_initializer_depth > 0
+                && a_sym != nullptr
+                && ASR::is_a<ASR::Variable_t>(*a_sym)
+                && current_scope->get_symbol(idl_var_name) == a_sym) {
+            current_scope->erase_symbol(idl_var_name);
+            std::string hidden = current_scope->get_unique_name(
+                "__lcompilers_implied_do_" + idl_var_name);
+            ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(a_sym);
+            v->m_name = s2c(al, hidden);
+            current_scope->add_symbol(hidden, a_sym);
         }
         ASR::expr_t* a_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, a_sym));
         if( !unique_type ) {


### PR DESCRIPTION
Array-constructor implied-do control variables were declared in the surrounding symbol table when implicit typing was enabled. A variable such as 'i' from (/ (i, i = 1, 10) /) leaked into the enclosing program scope, so contained procedures could incorrectly resolve their own implicit 'i' to that constructor loop variable and produce wrong runtime behavior.

Track array-constructor nesting with a small depth counter set by visit_ArrayInitializer. In visit_ImpliedDoLoop, if the loop variable did not exist in the enclosing scope before this implied-do was visited and we are inside an array constructor, rename the implicitly created symbol to a hidden, unique name after the visit. ImpliedDoLoop value nodes refer to the symbol by pointer, so the rename keeps them valid while removing the user-facing name from the enclosing scope.

Add integration test implied_do_loops39.f90 covering parameter array constructors with implied-do variables alongside contained procedures that use implicit local variables of the same names.

Fixes #11448