### PR TITLE
Fix implicit-typing leak of array-constructor implied-do iterator

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2103,6 +2103,7 @@ RUN(NAME implicit_typing_08 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran EXTRA_ARGS --implicit-typing --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME implicit_typing_10 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 RUN(NAME implicit_typing_11 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
+RUN(NAME implicit_typing_12 LABELS gfortran llvm EXTRA_ARGS --implicit-typing)
 
 RUN(NAME generic_name_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_typing_12.f90
+++ b/integration_tests/implicit_typing_12.f90
@@ -1,0 +1,40 @@
+program implicit_typing_12
+    ! Regression test: with --implicit-typing, an array-constructor
+    ! implied-do iterator (here `i`) must be local to the implied-do
+    ! and must NOT leak into the program scope, otherwise it would be
+    ! host-associated in the contained procedures below.
+    integer ii
+    integer, parameter :: jmin(1:10) = (/ (i, i = 1, 10) /)
+    integer, parameter :: kmin(1:10) = (/ (ii, ii = 1, 10) /)
+    integer, parameter :: lmin(1:10) = (/ (iii, iii = 1, 10) /)
+    integer iii
+
+    if (jmin(1) /= 1 .or. jmin(10) /= 10) error stop
+    if (kmin(1) /= 1 .or. kmin(10) /= 10) error stop
+    if (lmin(1) /= 1 .or. lmin(10) /= 10) error stop
+
+    call two
+
+contains
+
+    subroutine one
+        i = 99
+        ii = 99
+        iii = 999
+    end subroutine
+
+    subroutine two
+        i = 0
+        ii = 0
+        iii = 0
+        call one
+
+        ! `i` is NOT host-associated (not declared in the program), so
+        ! `one` modifies a separate local `i`. `ii` and `iii` ARE
+        ! declared at program scope and so are host-associated.
+        if (i /= 0) error stop
+        if (ii /= 99) error stop
+        if (iii /= 999) error stop
+    end subroutine
+
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -15961,6 +15961,14 @@ public:
                 }
             }
         }
+        // Per the Fortran standard, an array-constructor implied-do variable
+        // has scope local to the implied-do. With --implicit-typing, we must
+        // not leak this variable into the enclosing scope (where it would
+        // become host-associated in contained procedures). Track whether the
+        // implied-do variable is already visible so we can remove the
+        // implicit declaration after the implied-do is processed.
+        std::string idl_var_name_lower = to_lower(x.m_var);
+        bool idl_var_pre_existing = (current_scope->resolve_symbol(idl_var_name_lower) != nullptr);
         idl_nesting_level++;
         Vec<ASR::expr_t*> a_values_vec;
         ASR::expr_t *a_start, *a_end, *a_increment;
@@ -16032,8 +16040,29 @@ public:
 
         // fetch loop variables
         std::vector<ASR::symbol_t*> loop_vars; fetch_implied_do_loop_variables(idl, loop_vars);
+        auto rename_implicit_idl_var = [&]() {
+            // Per the Fortran standard, an array-constructor implied-do
+            // variable has scope local to the implied-do. With
+            // --implicit-typing, the variable would be added to the enclosing
+            // scope and then host-associated by contained procedures. To
+            // avoid that, rename the implicit symbol to a unique name so
+            // name lookups for the original identifier in contained
+            // procedures don't resolve to it (they then get their own
+            // implicit declaration locally).
+            if (!compiler_options.implicit_typing || idl_var_pre_existing) return;
+            ASR::symbol_t* implicit_sym = current_scope->get_symbol(idl_var_name_lower);
+            if (implicit_sym == nullptr) return;
+            if (!ASR::is_a<ASR::Variable_t>(*implicit_sym)) return;
+            std::string unique_name = current_scope->get_unique_name(
+                "__implicit_idl_" + idl_var_name_lower);
+            current_scope->erase_symbol(idl_var_name_lower);
+            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(implicit_sym);
+            var->m_name = s2c(al, unique_name);
+            current_scope->add_symbol(unique_name, implicit_sym);
+        };
         if (is_body_visitor) {
             idl_nesting_level--;
+            rename_implicit_idl_var();
             return;
         }
         // check compiletime evaluation possibility
@@ -16117,6 +16146,7 @@ public:
             }
         }
         idl_nesting_level--;
+        rename_implicit_idl_var();
     }
 
     ASR::asr_t* create_Shifta(const Location &loc, Vec<ASR::call_arg_t> args) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -16054,7 +16054,7 @@ public:
             if (implicit_sym == nullptr) return;
             if (!ASR::is_a<ASR::Variable_t>(*implicit_sym)) return;
             std::string unique_name = current_scope->get_unique_name(
-                "__implicit_idl_" + idl_var_name_lower);
+                "lfortran_implicit_idl_" + idl_var_name_lower);
             current_scope->erase_symbol(idl_var_name_lower);
             ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(implicit_sym);
             var->m_name = s2c(al, unique_name);


### PR DESCRIPTION
With --implicit-typing, an implied-do iterator used only inside an array constructor (e.g. `(/ (i, i = 1, 10) /)`) was implicitly declared in the enclosing program/module scope. Contained procedures then host-associated to that variable instead of getting their own implicit local declaration, producing wrong runtime behavior.

Per the Fortran standard, an array-constructor implied-do variable has scope local to the implied-do. After processing the implied-do, rename the implicitly-created symbol to a unique
`__implicit_idl_<name>` so that name lookups in contained procedures no longer resolve to it and instead trigger proper local implicit typing. Existing ASR `Var_t` references remain valid since they are direct pointers.

Adds integration test `implicit_typing_12` covering the bug.

Fixes https://github.com/lfortran/lfortran/issues/11448.