### PR TITLE
fix: semantic evaluation of pointer and allocatable arrays in COMMON blocks

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3704,6 +3704,7 @@ RUN(NAME common_36 LABELS gfortran llvm)
 RUN(NAME common_37 LABELS gfortran llvm)
 RUN(NAME common_38 LABELS gfortran llvm)
 RUN(NAME common_39 LABELS gfortran llvm)
+RUN(NAME common_40 LABELS gfortran llvm)
 RUN(NAME common_substring_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME statement_01 LABELS llvm gfortran llvmImplicit)

--- a/integration_tests/common_40.f90
+++ b/integration_tests/common_40.f90
@@ -1,0 +1,28 @@
+program common_40
+    implicit none
+    call init()
+    call check()
+end program
+
+subroutine init()
+    implicit none
+    real, pointer :: p(:)
+    common /block/ p
+    if (associated(p)) error stop
+    allocate(p(3))
+    p = [1.0, 2.0, 3.0]
+    if (.not. associated(p)) error stop
+    if (size(p) /= 3) error stop
+    if (abs(sum(p) - 6.0) > 1e-6) error stop
+end subroutine init
+
+subroutine check()
+    implicit none
+    real, pointer :: p(:)
+    common /block/ p
+    if (.not. associated(p)) error stop
+    if (size(p) /= 3) error stop
+    if (p(2) /= 2.0) error stop
+    deallocate(p)
+    if (associated(p)) error stop
+end subroutine check

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4304,7 +4304,15 @@ public:
     }
 
     ASR::ttype_t* evaluate_type_bounds(Allocator& al, ASR::ttype_t* type, const Location& loc) {
-        if (ASRUtils::is_array(type)) {
+        if (ASR::is_a<ASR::Pointer_t>(*type)) {
+            ASR::Pointer_t* p = ASR::down_cast<ASR::Pointer_t>(type);
+            ASR::ttype_t* inner_type = evaluate_type_bounds(al, p->m_type, loc);
+            return ASRUtils::TYPE(ASR::make_Pointer_t(al, p->base.base.loc, inner_type));
+        } else if (ASR::is_a<ASR::Allocatable_t>(*type)) {
+            ASR::Allocatable_t* a = ASR::down_cast<ASR::Allocatable_t>(type);
+            ASR::ttype_t* inner_type = evaluate_type_bounds(al, a->m_type, loc);
+            return ASRUtils::TYPE(ASR::make_Allocatable_t(al, a->base.base.loc, inner_type));
+        } else if (ASR::is_a<ASR::Array_t>(*type)) {
             ASR::Array_t* arr = ASR::down_cast<ASR::Array_t>(type);
             Vec<ASR::dimension_t> new_dims;
             new_dims.reserve(al, arr->n_dims);


### PR DESCRIPTION
fixes #11540


* Updated `evaluate_type_bounds` in `ast_common_visitor.h` to properly recurse into `Pointer_t` and `Allocatable_t` instead of erroneously downcasting them directly to `Array_t` via `ASRUtils::is_array`.
* This resolves a compiler assertion failure (`AssertFailed: is_a<T>(*f)`) when pointer or allocatable arrays are declared inside a COMMON block.
* Added `common_40.f90` integration test to verify that pointer arrays inside COMMON blocks compile correctly and can be associated, used, and deallocated across multiple subroutines.
