### PR TITLE
fix: Throw semantic error when dimensions are specified after initialization

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2751,6 +2751,13 @@ public:
 	    }
 
 	    if ( v->m_type ) {
+		if (v->m_symbolic_value != nullptr || v->m_value != nullptr) {
+		    diag.add(diag::Diagnostic(
+		        "Dimensions specified for '" + std::string(s.m_name) + "' after its initialization",
+		        diag::Level::Error, diag::Stage::Semantic, {
+		            diag::Label("", {s.loc})}));
+		    throw SemanticAbort();
+		}
 		ASR::abiType abi = is_proc_arg ? current_procedure_abi_type
 		                               : ASR::abiType::Source;
 	        if (!ASRUtils::ttype_set_dimensions(&(v->m_type), dims.data(),

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -650,8 +650,8 @@ program continue_compilation_1
     call print_len_non_char("  Hello World  ")
     print  *, 9.99e+99
     a5 = missing_required_arg_func()
-
-
+    integer :: m = 7
+    dimension :: m(3)
 
 
     contains

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "af494774e7ae588d42f9a11f135d27d19659c0ee11e43d8fd75d8c9e",
+    "infile_hash": "79df486172db4835d1478732993325ecef0ee484536ed847b908f08c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "035214eaad0a5f5b80afd1983e9c8941faabb26f8b8ab0eaba9dcd45",
+    "stderr_hash": "2f57d9ff9212f50d40f804121c37909946338336b125e1ec9e344cb7",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -427,6 +427,12 @@ semantic error: Type mismatch in pointer initialization of `ptr_type_mismatch`
 646 |     type(Base), target :: ptr_tgt_base
     |                           ~~~~~~~~~~~~ target declared here
 
+semantic error: Dimensions specified for 'm' after its initialization
+   --> tests/errors/continue_compilation_1.f90:654:18
+    |
+654 |     dimension :: m(3)
+    |                  ^^^^ 
+
 semantic error: Cannot convert LOGICAL to REAL
    --> tests/errors/continue_compilation_1.f90:684:24
     |


### PR DESCRIPTION
fixes #11542 


Previously, `lfortran` would quietly allow a `dimension` attribute or statement
to modify a variable's type to an array even after it had been initialized with
a scalar value. This resulted in an LLVM code generation crash due to a type
mismatch (`Stored value type does not match pointer operand type`).

This commit updates `dimension_variable` in `ast_common_visitor.h` to check
if the variable's `m_symbolic_value` or `m_value` is set. If the variable
is already initialized, it now emits a semantic error matching `gfortran`:
"Dimensions specified for '<var>' after its initialization".
