### PR TITLE
fix: case sensitivity bug in len_trim intrinsic signature

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1771,6 +1771,7 @@ RUN(NAME intrinsics_459 LABELS gfortran llvm) # minval over array with runtime b
 RUN(NAME intrinsics_460 LABELS gfortran llvm) # random_seed put/get round-trip
 RUN(NAME intrinsics_461 LABELS gfortran llvm) # MVbits with array (treated as elemental function)
 RUN(NAME intrinsics_462 LABELS gfortran llvm) # nested spread over array section preserves result shape
+RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants
 

--- a/integration_tests/intrinsics_len_trim_01.f90
+++ b/integration_tests/intrinsics_len_trim_01.f90
@@ -1,0 +1,21 @@
+program intrinsics_len_trim_01
+    use iso_c_binding, only: c_int
+    implicit none
+    character(len=10) :: s
+    integer(c_int) :: n
+
+    s = "hello  "
+    n = len_trim(s, kind=c_int)
+
+    if (n /= 5_c_int) then
+        print *, "Error: expected 5, got ", n
+        error stop 1
+    end if
+
+    if (len_trim("world   ", kind=c_int) /= 5_c_int) then
+        print *, "Error: expected 5, got ", len_trim("world   ", kind=c_int)
+        error stop 2
+    end if
+
+    print *, "OK"
+end program intrinsics_len_trim_01

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1771,7 +1771,7 @@ public:
         {"out_of_range", IntrinsicSignature({"value", "mold", "round"}, 2, 3)},
         {"same_type_as", IntrinsicSignature({"a", "b"}, 2, 2)},
         {"extends_type_of", IntrinsicSignature({"a", "mold"}, 2, 2)},
-        {"len_trim", IntrinsicSignature({"String", "Kind"}, 1, 2)},
+        {"len_trim", IntrinsicSignature({"string", "kind"}, 1, 2)},
         {"int", IntrinsicSignature({"i", "kind"}, 1, 2)},
         {"random_number", IntrinsicSignature({"harvest"}, 1, 1)},
         {"abs", IntrinsicSignature({"a"}, 1, 1)},


### PR DESCRIPTION
fixes #11552 


The intrinsic signature for `len_trim` was defined with capitalized keyword arguments `{"String", "Kind"}`. Since `handle_intrinsic_node_args` converts keyword arguments to lowercase before matching, the capitalized keywords caused `len_trim` to fail signature verification with a "No matching signature found" error when the `kind` argument was explicitly provided (e.g., `len_trim(s, kind=...)`).

This commit updates the `len_trim` signature in `ast_common_visitor.h` to use lowercase `{"string", "kind"}`, matching the convention of other intrinsics and allowing keyword argument resolution to succeed.
