### PR TITLE
 Skip runtime shape-conformance checks for assumed-shape dummy assignments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4443,6 +4443,7 @@ RUN(NAME intent_out_struct_member_no_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_module_dealloc LABELS gfortran llvm)
 RUN(NAME intent_out_nested_allocatable_01 LABELS gfortran llvm)
 RUN(NAME intent_out_array_structs_01 LABELS gfortran llvm)
+RUN(NAME intent_out_assumed_shape_dummy_01 LABELS gfortran llvm)
 RUN(NAME array_shape_func_call LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_neg_extent_01 LABELS gfortran llvm)
 

--- a/integration_tests/intent_out_assumed_shape_dummy_01.f90
+++ b/integration_tests/intent_out_assumed_shape_dummy_01.f90
@@ -1,0 +1,51 @@
+! Issue #11563: lfortran should not raise a runtime shape-mismatch
+! error when the LHS of an assignment is a non-allocatable assumed-shape
+! intent(out) dummy argument. The shape is fixed by the caller and a
+! shape mismatch there is undefined behavior per the Fortran standard,
+! but gfortran's default (without -fcheck=bounds) silently accepts it.
+! This test only verifies that the program reaches the end without
+! aborting; it does not inspect the contents of the dummy after the
+! mismatched assignment (which would be UB).
+module m_intent_out_assumed_shape_dummy_01
+    use, intrinsic :: iso_fortran_env, only: real32
+    implicit none
+
+    type :: array_type
+        real(real32), dimension(:,:), allocatable :: val
+    contains
+        procedure, pass(this) :: write_partial
+    end type array_type
+
+contains
+
+    subroutine write_partial(this, upstream_grad, output)
+        class(array_type), intent(in) :: this
+        real(real32), dimension(:,:), intent(in) :: upstream_grad
+        real(real32), dimension(:,:), intent(out) :: output
+        output = upstream_grad * 2.0_real32
+    end subroutine write_partial
+
+end module m_intent_out_assumed_shape_dummy_01
+
+
+program intent_out_assumed_shape_dummy_01
+    use, intrinsic :: iso_fortran_env, only: real32
+    use m_intent_out_assumed_shape_dummy_01
+    implicit none
+
+    type(array_type) :: a
+    real(real32) :: ug(8, 1)
+    real(real32), allocatable :: out(:,:)
+
+    allocate(a%val(8, 1))
+    allocate(out(1, 1))
+    ug = 1.0_real32
+    out = 0.0_real32
+
+    call a%write_partial(ug, out)
+
+    if (size(out, 1) /= 1) error stop 1
+    if (size(out, 2) /= 1) error stop 2
+
+    print *, "PASS"
+end program intent_out_assumed_shape_dummy_01

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1931,20 +1931,40 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
             ASRUtils::is_array(ASRUtils::expr_type(x.m_target)) &&
             ASRUtils::is_array(ASRUtils::expr_type(x.m_value)) &&
             ASRUtils::get_expr_size_expr(x.m_target) != nullptr) {
-            ASRUtils::ExprStmtDuplicator expr_duplicator(al);
-            ASR::expr_t* d_target = expr_duplicator.duplicate_expr(x.m_target);
-            ASR::expr_t* d_value = expr_duplicator.duplicate_expr(x.m_value);
+            bool skip_shape_check = false;
+            if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
+                ASR::symbol_t* tgt_sym = ASRUtils::symbol_get_past_external(
+                    ASR::down_cast<ASR::Var_t>(x.m_target)->m_v);
+                if (tgt_sym && ASR::is_a<ASR::Variable_t>(*tgt_sym)) {
+                    ASR::Variable_t* tgt_var = ASR::down_cast<ASR::Variable_t>(tgt_sym);
+                    if (ASRUtils::is_arg_dummy(tgt_var->m_intent) &&
+                            !ASRUtils::is_allocatable(tgt_var->m_type) &&
+                            !ASRUtils::is_pointer(tgt_var->m_type)) {
+                        ASR::dimension_t* d_dims = nullptr;
+                        size_t d_n = ASRUtils::extract_dimensions_from_ttype(
+                            tgt_var->m_type, d_dims);
+                        if (d_n > 0 && ASRUtils::is_dimension_empty(d_dims, d_n)) {
+                            skip_shape_check = true;
+                        }
+                    }
+                }
+            }
+            if (!skip_shape_check) {
+                ASRUtils::ExprStmtDuplicator expr_duplicator(al);
+                ASR::expr_t* d_target = expr_duplicator.duplicate_expr(x.m_target);
+                ASR::expr_t* d_value = expr_duplicator.duplicate_expr(x.m_value);
 
-            Vec<ASR::expr_t*> vars;
-            vars.reserve(al, 1);
+                Vec<ASR::expr_t*> vars;
+                vars.reserve(al, 1);
 
-            CollectComponentsFromElementalExpr cv(al, vars);
-            cv.visit_expr(*d_value);
+                CollectComponentsFromElementalExpr cv(al, vars);
+                cv.visit_expr(*d_value);
 
-            if (debug_inserted.find(&x) == debug_inserted.end()) {
-                pass_result.push_back(al, ASRUtils::STMT(ASR::make_DebugCheckArrayBounds_t(al, x.base.base.loc, d_target, vars.p, vars.n, x.m_move_allocation)));
-                if (!x.m_move_allocation) {
-                    debug_inserted.insert(&x);
+                if (debug_inserted.find(&x) == debug_inserted.end()) {
+                    pass_result.push_back(al, ASRUtils::STMT(ASR::make_DebugCheckArrayBounds_t(al, x.base.base.loc, d_target, vars.p, vars.n, x.m_move_allocation)));
+                    if (!x.m_move_allocation) {
+                        debug_inserted.insert(&x);
+                    }
                 }
             }
         }


### PR DESCRIPTION
fixes: https://github.com/lfortran/lfortran/issues/11563