### PR TITLE
feat : Implement type specification in Do Concurrent Header 

### DIFF
--- a/grammar/AST.asdl
+++ b/grammar/AST.asdl
@@ -449,7 +449,7 @@ use_symbol
     | UseWrite(identifier id)
     | UseRead(identifier id)
 
-concurrent_control = ConcurrentControl(identifier? var, expr? start, expr? end, expr? increment)
+concurrent_control = ConcurrentControl(decl_attribute? type, identifier? var, expr? start, expr? end, expr? increment)
 
 concurrent_locality
     = ConcurrentLocal(identifier *vars)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -708,6 +708,7 @@ RUN(NAME types_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm fortran
 
 # GFortran + LFortran C++
 RUN(NAME doconcurrentloop_01 LABELS gfortran cpp)
+RUN(NAME doconcurrentloop_03 LABELS llvm llvm_wasm llvm_wasm_emcc fortran) # type-spec in concurrent-header is not yet implemented by gfortran.
 
 RUN(NAME arrays_01 LABELS gfortran cpp llvm llvmStackArray wasm)
 RUN(NAME arrays_01_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm fortran)

--- a/integration_tests/doconcurrentloop_03.f90
+++ b/integration_tests/doconcurrentloop_03.f90
@@ -1,0 +1,12 @@
+program doconcurrentloop_03
+    integer :: verbose_levels, verbose_sum
+    verbose_levels = 5
+    verbose_sum = 0
+
+    do concurrent ( integer :: i = 1 : verbose_levels )
+        verbose_sum = verbose_sum + i
+    end do
+
+    print *, verbose_sum
+    if (verbose_sum /= 15) error stop
+end program

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -2160,9 +2160,13 @@ concurrent_control_list
 
 concurrent_control
     : id "=" expr ":" expr {
-            $$ = CONCURRENT_CONTROL1($1, $3, $5,     @$); }
+            $$ = CONCURRENT_CONTROL1(nullptr, $1, $3, $5, @$); }
     | id "=" expr ":" expr ":" expr {
-            $$ = CONCURRENT_CONTROL2($1, $3, $5, $7, @$); }
+            $$ = CONCURRENT_CONTROL2(nullptr, $1, $3, $5, $7, @$); }
+    | declaration_type_spec "::" id "=" expr ":" expr {
+            $$ = CONCURRENT_CONTROL1($1, $3, $5, $7, @$); }
+    | declaration_type_spec "::" id "=" expr ":" expr ":" expr {
+            $$ = CONCURRENT_CONTROL2($1, $3, $5, $7, $9, @$); }
     ;
 
 concurrent_locality_star

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -2169,10 +2169,18 @@ static inline void drop_trailing_matching_continue(
         0, nullptr, CONCURRENT_CONTROLS(conlist), conlist.size(), \
         EXPR(mask), down_cast<stmt_t>(assign), nullptr)
 
-#define CONCURRENT_CONTROL1(i, a, b, l) make_ConcurrentControl_t(p.m_a, l, \
+#define CONCURRENT_CONTROL1(t, i, a, b, l) \
+    make_ConcurrentControl_t(p.m_a, l, \
+        ((t) ? \
+            LCompilers::LFortran::AST::down_cast<LCompilers::LFortran::AST::decl_attribute_t>((LCompilers::LFortran::AST::ast_t*)(t)) \
+            : nullptr), \
         name2char(i), EXPR(a), EXPR(b), nullptr)
 
-#define CONCURRENT_CONTROL2(i, a, b, c, l) make_ConcurrentControl_t(p.m_a, l, \
+#define CONCURRENT_CONTROL2(t, i, a, b, c, l) \
+    make_ConcurrentControl_t(p.m_a, l, \
+        ((t) ? \
+            LCompilers::LFortran::AST::down_cast<LCompilers::LFortran::AST::decl_attribute_t>((LCompilers::LFortran::AST::ast_t*)(t)) \
+            : nullptr), \
         name2char(i), EXPR(a), EXPR(b), EXPR(c))
 
 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8635,7 +8635,25 @@ public:
                     }));
                 throw SemanticAbort();
             }
-            ASR::expr_t *var = ASRUtils::EXPR(resolve_variable(x.base.base.loc, to_lower(h.m_var)));
+            std::string var_name = to_lower(h.m_var);
+            ASR::expr_t *var = nullptr;
+            if (h.m_type) {
+                AST::decl_attribute_t *decl_type = h.m_type;
+                Vec<ASR::dimension_t> dims;
+                dims.reserve(al, 1);
+                ASR::symbol_t *type_declaration;
+                ASR::ttype_t *type = determine_type(x.base.base.loc, var_name, decl_type, false, false,
+                                                    dims, nullptr, type_declaration, ASR::abiType::Source);
+                ASR::symbol_t *var_sym = ASR::down_cast<ASR::symbol_t>(
+                    ASR::make_Variable_t(al, x.base.base.loc, current_scope, s2c(al, var_name),
+                        nullptr, 0, ASR::intentType::Local, nullptr, nullptr, ASR::storage_typeType::Default,
+                        type, nullptr, ASR::abiType::Source, ASR::Public, ASR::presenceType::Required, false,
+                        false, false, nullptr, false, false, ASR::pass_attrType::NotMethod, nullptr, nullptr, 0));
+                current_scope->add_symbol(var_name, var_sym);
+                var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, var_sym));                                    
+            } else {
+                var = ASRUtils::EXPR(resolve_variable(x.base.base.loc, var_name));
+            }
             visit_expr(*h.m_start);
             ASR::expr_t *start = ASRUtils::EXPR(tmp);
             visit_expr(*h.m_end);

--- a/tests/reference/ast-do_concurrent1-5fba0ee.json
+++ b/tests/reference/ast-do_concurrent1-5fba0ee.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-do_concurrent1-5fba0ee.stdout",
-    "stdout_hash": "10ac626ff924b2b7921c4bceaca4993b43897e130f39d66a0d89d947",
+    "stdout_hash": "41f5b2b2c7e84cc8cc5f59eade38977ef46539b619a0508a54e17c91",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-do_concurrent1-5fba0ee.stdout
+++ b/tests/reference/ast-do_concurrent1-5fba0ee.stdout
@@ -90,12 +90,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
                 ()
             )
             (ConcurrentControl
+                ()
                 j
                 1
                 N
@@ -234,6 +236,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 10
@@ -453,6 +456,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 10
@@ -672,6 +676,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 10

--- a/tests/reference/ast-do_concurrent2-80c03e1.json
+++ b/tests/reference/ast-do_concurrent2-80c03e1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-do_concurrent2-80c03e1.stdout",
-    "stdout_hash": "a70df883fcc6b8c546e8c45b808a98df215aba0e1c3d13042d58b833",
+    "stdout_hash": "8453b13d71357b563df819c30db05863cfcca709cbf2e5e2aa1bc188",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-do_concurrent2-80c03e1.stdout
+++ b/tests/reference/ast-do_concurrent2-80c03e1.stdout
@@ -86,6 +86,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 10

--- a/tests/reference/ast-do_concurrent_reduce-58dd849.json
+++ b/tests/reference/ast-do_concurrent_reduce-58dd849.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-do_concurrent_reduce-58dd849.stdout",
-    "stdout_hash": "7ed479c552c0ce3f4d28a00e6a9e87dfc161d764bef40fb9cfca3ee5",
+    "stdout_hash": "cb19c1f24c151b66be730690c674b132ff7866e19476102df9a6cbd8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-do_concurrent_reduce-58dd849.stdout
+++ b/tests/reference/ast-do_concurrent_reduce-58dd849.stdout
@@ -102,6 +102,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N

--- a/tests/reference/ast-do_concurrent_reduce2-1f96d95.json
+++ b/tests/reference/ast-do_concurrent_reduce2-1f96d95.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-do_concurrent_reduce2-1f96d95.stdout",
-    "stdout_hash": "0526bbede1282ffb3dc2d117dfb3ad0c5d4fe1c60e1f5a486173c266",
+    "stdout_hash": "cf4e5f10aba63fbdc6819b78c1f9dc0cd0083205764582635c5bf1c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-do_concurrent_reduce2-1f96d95.stdout
+++ b/tests/reference/ast-do_concurrent_reduce2-1f96d95.stdout
@@ -116,6 +116,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N

--- a/tests/reference/ast-do_concurrent_reduce3-9c6ccff.json
+++ b/tests/reference/ast-do_concurrent_reduce3-9c6ccff.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-do_concurrent_reduce3-9c6ccff.stdout",
-    "stdout_hash": "fedf187e13bfd5a66265908dbaf86807d3b5aaff55adbcfa82cf912c",
+    "stdout_hash": "d69b3d274f972bafe654e0a86d218c4119ee4904a90bad9598d40c92",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-do_concurrent_reduce3-9c6ccff.stdout
+++ b/tests/reference/ast-do_concurrent_reduce3-9c6ccff.stdout
@@ -102,6 +102,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
@@ -135,6 +136,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
@@ -168,6 +170,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N

--- a/tests/reference/ast-doconcurrentloop_02-b8757f0.json
+++ b/tests/reference/ast-doconcurrentloop_02-b8757f0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-doconcurrentloop_02-b8757f0.stdout",
-    "stdout_hash": "275c444c1a61effae091b2ec68fa2755d9d06c128ddc326e3ed60b4c",
+    "stdout_hash": "2f1e9ad63d2a5b1fe9860ede4ac2c6c0f70b801b5cd7587718042857",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-doconcurrentloop_02-b8757f0.stdout
+++ b/tests/reference/ast-doconcurrentloop_02-b8757f0.stdout
@@ -110,6 +110,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
@@ -226,6 +227,7 @@
                 0
                 ()
                 [(ConcurrentControl
+                    ()
                     i
                     1
                     N

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.json
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-fixed_form_interface-a8dfdb0.stdout",
-    "stdout_hash": "d248372139adf9d7e84d3bcb74e631c8e691f7f3ee4ed3de7dd58a17",
+    "stdout_hash": "957445d9f5c63f13c0d36d2f2bf20408664cd8893dfb830ea765e1d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
+++ b/tests/reference/ast-fixed_form_interface-a8dfdb0.stdout
@@ -413,6 +413,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 10

--- a/tests/reference/ast-forall1-50096b8.json
+++ b/tests/reference/ast-forall1-50096b8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-forall1-50096b8.stdout",
-    "stdout_hash": "c323ece1ee8c9f36314ce9f04a847d34b9bad6f8b9c28971a85820a4",
+    "stdout_hash": "afa2083a1a8bb2e13277034b76948222134a0014a62e1e90f4a8222d",
     "stderr": "ast-forall1-50096b8.stderr",
     "stderr_hash": "4d905b6e8f90b9042def4e125077632dced461f1a0aeea1763458479",
     "returncode": 0

--- a/tests/reference/ast-forall1-50096b8.stdout
+++ b/tests/reference/ast-forall1-50096b8.stdout
@@ -22,6 +22,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 n
@@ -64,12 +65,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 n
                 3
             )
             (ConcurrentControl
+                ()
                 j
                 1
                 n
@@ -126,12 +129,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 n
                 ()
             )
             (ConcurrentControl
+                ()
                 j
                 1
                 n
@@ -174,12 +179,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 n
                 ()
             )
             (ConcurrentControl
+                ()
                 j
                 1
                 m
@@ -240,12 +247,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 1000
                 ()
             )
             (ConcurrentControl
+                ()
                 j
                 1
                 1000
@@ -299,6 +308,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 j
                 1
                 n
@@ -316,6 +326,7 @@
                 0
                 ()
                 [(ConcurrentControl
+                    ()
                     i
                     1
                     j
@@ -365,6 +376,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
@@ -402,12 +414,14 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 3
                 (+ N 1)
                 ()
             )
             (ConcurrentControl
+                ()
                 j
                 3
                 (+ N 1)
@@ -536,6 +550,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 x
                 1
                 100
@@ -625,6 +640,7 @@
             0
             outer
             [(ConcurrentControl
+                ()
                 i
                 1
                 100
@@ -636,6 +652,7 @@
                 0
                 inner
                 [(ConcurrentControl
+                    ()
                     j
                     1
                     100

--- a/tests/reference/ast-forallloop_01-d1e2bfa.json
+++ b/tests/reference/ast-forallloop_01-d1e2bfa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-forallloop_01-d1e2bfa.stdout",
-    "stdout_hash": "48cf8df7768c436b3f0e12b372d913c72075c901a90a83c2bc6fa213",
+    "stdout_hash": "d77ce5939298eb49c3eb045291249d0362fd40395ba2faadf2cecbf9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-forallloop_01-d1e2bfa.stdout
+++ b/tests/reference/ast-forallloop_01-d1e2bfa.stdout
@@ -112,6 +112,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 nsize
@@ -309,6 +310,7 @@
                 0
                 ()
                 [(ConcurrentControl
+                    ()
                     i
                     1
                     N

--- a/tests/reference/ast-subroutine4-63e648f.json
+++ b/tests/reference/ast-subroutine4-63e648f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-subroutine4-63e648f.stdout",
-    "stdout_hash": "4a6262a6903ff0921272bbf98080c74b0039eed748f7eaacc59655c6",
+    "stdout_hash": "57485bbeb98c4b24a89109ce9cfa0a6be6d6b8b924850e6af9a23279",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-subroutine4-63e648f.stdout
+++ b/tests/reference/ast-subroutine4-63e648f.stdout
@@ -116,6 +116,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N

--- a/tests/reference/ast-subroutine6-a3aec97.json
+++ b/tests/reference/ast-subroutine6-a3aec97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast-subroutine6-a3aec97.stdout",
-    "stdout_hash": "4bece425307001572b06c85fe216838cc52f068a64ee07628af1c68c",
+    "stdout_hash": "0ea363b4d685e5be3f924036ca6eef77b2e4b9d08315acd058fb4e3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast-subroutine6-a3aec97.stdout
+++ b/tests/reference/ast-subroutine6-a3aec97.stdout
@@ -146,6 +146,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 i
                 1
                 N
@@ -200,6 +201,7 @@
             0
             ()
             [(ConcurrentControl
+                ()
                 j
                 1
                 N2


### PR DESCRIPTION
Fixes #11263
Fixes #11557

1. This PR adds support for typed loop variables in DO CONCURRENT constructs in LFortran. 
2. The parser and AST were extended to accept syntax such as do concurrent(integer :: i = 1:n) and preserve the declared type information in ConcurrentControl. 
3. Semantic handling was updated to create the loop variable locally using the existing declaration type resolution pipeline. This enables modern Fortran scoped loop-variable syntax while preserving compatibility with the existing untyped form.