### PR TITLE
Fix: ICE in template instantiation when intrinsic function is inapplicable

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -4651,8 +4651,12 @@ public:
 
                         ASRUtils::create_intrinsic_function create_func =
                             ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function(arg);
-                        ASR::expr_t *call_value = ASRUtils::EXPR(create_func(al,
-                            x.m_args[i]->base.loc, call_args, diag));
+                        ASR::asr_t *call_value_asr = create_func(al,
+                            x.m_args[i]->base.loc, call_args, diag);
+                        if (call_value_asr == nullptr) {
+                            throw SemanticAbort();
+                        }
+                        ASR::expr_t *call_value = ASRUtils::EXPR(call_value_asr);
 
                         ASR::ttype_t *return_type = ASRUtils::duplicate_type(al,
                             ASRUtils::subs_expr_type(type_subs, f->m_return_var));

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -300,7 +300,7 @@ program continue_compilation_1
     class(Derived), allocatable :: derived_cls
     integer, parameter :: z(1) = 2
     integer, parameter :: qval(2) = reshape([7, 8], -[z])
-
+    print *, min(c, c)
 
 
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -300,7 +300,7 @@ program continue_compilation_1
     class(Derived), allocatable :: derived_cls
     integer, parameter :: z(1) = 2
     integer, parameter :: qval(2) = reshape([7, 8], -[z])
-    print *, min(c, c)
+
 
 
 
@@ -509,7 +509,7 @@ program continue_compilation_1
     print *, present()
     print *, ieor(x)
     print *, ieor()
-
+    print *, min(c, c)
     exit
 
     ! calling function with less arguments

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "ab30a46783a43b418d707a9610f0b64a622cd5bff5f396a48444eccd",
+    "infile_hash": "bb5f378db414785415dda292997363f3e7aaccb2425e1735958f8161",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "8a21d617f65aff0dbb3a1718f0fa461b30421b7897c2c56537797c1d",
+    "stderr_hash": "873a04cbd1cfa71c2480b6f2f0d49cfa01eae1d802a479d1741ca5a8",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "3ab73cf1726662db01367ea7bb2759351b22de8109a431b94485fb51",
+    "infile_hash": "ab30a46783a43b418d707a9610f0b64a622cd5bff5f396a48444eccd",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "caca3230d59767c0a23a242088f9714feab3ec6c6619cdf83dd2ea4b",
+    "stderr_hash": "8a21d617f65aff0dbb3a1718f0fa461b30421b7897c2c56537797c1d",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -541,6 +541,12 @@ semantic error: Intrinsic 'not_real' is not recognized
 268 |     call sub(not_real)
     |              ^^^^^^^^ 'not_real' is not a known intrinsic function
 
+semantic error: Arguments to min0 must be of real, integer or character type
+   --> tests/errors/continue_compilation_1.f90:303:14
+    |
+303 |     print *, min(c, c)
+    |              ^^^^^^^^^ 
+
 semantic error: Array index 10 is out of bounds (1 to 3) in dimension 1
    --> tests/errors/continue_compilation_1.f90:328:14
     |

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -541,12 +541,6 @@ semantic error: Intrinsic 'not_real' is not recognized
 268 |     call sub(not_real)
     |              ^^^^^^^^ 'not_real' is not a known intrinsic function
 
-semantic error: Arguments to min0 must be of real, integer or character type
-   --> tests/errors/continue_compilation_1.f90:303:14
-    |
-303 |     print *, min(c, c)
-    |              ^^^^^^^^^ 
-
 semantic error: Array index 10 is out of bounds (1 to 3) in dimension 1
    --> tests/errors/continue_compilation_1.f90:328:14
     |
@@ -1131,6 +1125,12 @@ semantic error: Incorrect number of arguments passed to the 'ieor' intrinsic. It
     |
 511 |     print *, ieor()
     |              ^^^^^^ 
+
+semantic error: Arguments to min0 must be of real, integer or character type
+   --> tests/errors/continue_compilation_1.f90:512:14
+    |
+512 |     print *, min(c, c)
+    |              ^^^^^^^^^ 
 
 semantic error: `exit` statements cannot be outside of loops or blocks
    --> tests/errors/continue_compilation_1.f90:513:5


### PR DESCRIPTION
fixes #11575
The `create_func` for intrinsic elemental functions (e.g., `min`) can
return `nullptr` when the argument types are unsupported (e.g., complex).
Previously, the result was passed directly to `ASRUtils::EXPR()`, which
asserts non-null, causing an internal compiler error. Now we check for
`nullptr` and throw `SemanticAbort()` so the diagnostic is reported
cleanly.
