### PR TITLE
fix: typo in error message when using max on invalid arguments

### DIFF
--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -7437,7 +7437,7 @@ namespace Max {
             if (!ASR::is_a<ASR::Integer_t>(*arg_type_idx) 
                 && !ASR::is_a<ASR::Real_t>(*arg_type_idx) 
                 && !ASR::is_a<ASR::String_t>(*arg_type_idx)) { 
-                append_error(diag, "Arguments to min0 must be of real, integer or character type", loc);
+                append_error(diag, "Arguments to max0 must be of real, integer or character type", loc);
                 return nullptr;
             }
         }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "4f61cb0b6a2b9952b3a562956c0e770c3ba59fb253c06593fdb4ffad",
+    "stderr_hash": "9c71187d462d4e35dc13731fde56ba7a4857677eaa583c53f8cc1e93",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -920,13 +920,13 @@ semantic error: Arguments to min0 must be of real, integer or character type
 518 |     print *, min(min_max, min_max)
     |              ^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: Arguments to min0 must be of real, integer or character type
+semantic error: Arguments to max0 must be of real, integer or character type
    --> tests/errors/continue_compilation_2.f90:520:14
     |
 520 |     print *, max(.true., .false.)
     |              ^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: Arguments to min0 must be of real, integer or character type
+semantic error: Arguments to max0 must be of real, integer or character type
    --> tests/errors/continue_compilation_2.f90:521:14
     |
 521 |     print *, max(min_max, min_max)


### PR DESCRIPTION
fixes #11568
