### PR TITLE
fix: support array-valued shift in cshift intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1774,6 +1774,7 @@ RUN(NAME intrinsics_460 LABELS gfortran llvm) # random_seed put/get round-trip
 RUN(NAME intrinsics_461 LABELS gfortran llvm) # MVbits with array (treated as elemental function)
 RUN(NAME intrinsics_462 LABELS gfortran llvm) # nested spread over array section preserves result shape
 RUN(NAME intrinsics_463 LABELS llvm) # get_command (optional keyword arguments) -- gfortran on CI fails, other gfortran versions pass
+RUN(NAME intrinsics_464 LABELS gfortran llvm) # cshift with array shift
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants

--- a/integration_tests/intrinsics_464.f90
+++ b/integration_tests/intrinsics_464.f90
@@ -1,0 +1,20 @@
+program intrinsics_463
+    implicit none
+    
+    integer :: a(2, 3)
+    integer :: r(2, 3)
+    integer :: shifts(3)
+    real :: input_array(2, 0)
+    real :: result_array(2, 0)
+    integer :: zero_shifts(0)
+
+    a = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+    shifts = [1, 0, -1]
+    r = cshift(a, shifts)
+
+    if (any(r /= reshape([2, 1, 3, 4, 6, 5], [2, 3]))) error stop
+
+    result_array = cshift(input_array, zero_shifts)
+
+    if (size(result_array) /= 0) error stop
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2027,6 +2027,79 @@ namespace Shape {
 } // namespace Shape
 
 namespace Cshift {
+    static inline int get_cshift_actual_dim(int rank, int curr_idx,
+            int shifting_dim) {
+        int actual_dim = -1;
+        int count = 0;
+        for (int i = 1; i <= rank; i++) {
+            if (i == shifting_dim) continue;
+            if (count == curr_idx) {
+                actual_dim = i;
+                break;
+            }
+            count++;
+        }
+        return actual_dim;
+    }
+
+    static inline ASR::stmt_t* create_do_loop_helper_cshift_array_shift(
+            Allocator &al, const Location &loc,
+            std::vector<ASR::expr_t*> do_loop_variables, ASR::expr_t* j,
+            ASR::expr_t* i, ASR::expr_t* shift_val, ASR::expr_t* shift,
+            ASR::expr_t* array, ASR::expr_t* res, int curr_idx,
+            int shifting_dim, int index_kind) {
+        ASRBuilder b(al, loc);
+        int rank = (int)do_loop_variables.size() + 1;
+        int actual_dim = get_cshift_actual_dim(rank, curr_idx, shifting_dim);
+        if (curr_idx == (int)do_loop_variables.size() - 1) {
+            std::vector<ASR::expr_t*> array_vars(rank);
+            std::vector<ASR::expr_t*> res_vars(rank);
+
+            array_vars[shifting_dim - 1] = j;
+            res_vars[shifting_dim - 1] = i;
+
+            int k = 0;
+            for (int idim = 0; idim < rank; idim++) {
+                if (idim == shifting_dim - 1) continue;
+                array_vars[idim] = do_loop_variables[k];
+                res_vars[idim] = do_loop_variables[k];
+                k++;
+            }
+
+            ASR::stmt_t* copy_current_element = b.Assignment(
+                b.ArrayItem_01(res, res_vars), b.ArrayItem_01(array, array_vars));
+            ASR::expr_t* lbound = b.GetLBound(array, shifting_dim, index_kind);
+            ASR::expr_t* shift_start = b.Add(lbound, shift_val);
+            return b.DoLoop(do_loop_variables[curr_idx],
+                b.GetLBound(array, actual_dim, index_kind),
+                b.GetUBound(array, actual_dim, index_kind), {
+                    b.Assignment(shift_val, b.ArrayItem_01(shift, do_loop_variables)),
+                    b.If(b.Lt(shift_val, b.i_idx(0, index_kind)), {
+                        b.Assignment(shift_val, b.Add(shift_val,
+                            b.GetUBound(array, shifting_dim, index_kind)))
+                    }, {}),
+                    b.Assignment(i, lbound),
+                    b.DoLoop(j, shift_start,
+                        b.GetUBound(array, shifting_dim, index_kind), {
+                            copy_current_element,
+                            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                        }, nullptr),
+                    b.DoLoop(j, lbound,
+                        b.Sub(shift_start, b.i_idx(1, index_kind)), {
+                            copy_current_element,
+                            b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                        }, nullptr)
+                }, nullptr);
+        }
+        return b.DoLoop(do_loop_variables[curr_idx],
+            b.GetLBound(array, actual_dim, index_kind),
+            b.GetUBound(array, actual_dim, index_kind), {
+                create_do_loop_helper_cshift_array_shift(al, loc,
+                    do_loop_variables, j, i, shift_val, shift, array, res,
+                    curr_idx + 1, shifting_dim, index_kind)
+            }, nullptr);
+    }
+
     static inline void verify_args(const ASR::IntrinsicArrayFunction_t &x,
             diag::Diagnostics &diagnostics) {
         ASRUtils::require_impl(x.n_args == 2 || x.n_args == 3,
@@ -2111,6 +2184,11 @@ namespace Cshift {
         int array_dim = -1;
         extract_value(array_dims[0].m_length, array_dim);
         ASRUtils::require_impl(array_rank > 0, "The argument `array` in `cshift` must be of rank > 0", array->base.loc, diag);
+        int shift_rank = extract_n_dims_from_ttype(type_shift);
+        if (shift_rank != 0 && shift_rank != array_rank - 1) {
+            append_error(diag, "The argument `shift` in `cshift` must be scalar or have rank one less than `array`", shift->base.loc);
+            return nullptr;
+        }
         ASRBuilder b(al, loc);
         Vec<ASR::dimension_t> result_dims; result_dims.reserve(al, array_rank);
         int overload_id = 2;
@@ -2153,10 +2231,15 @@ namespace Cshift {
                 shifting_dim = (int)dim_val;
             }
         }
-        declare_basic_variables("_lcompilers_cshift");
-        if (shifting_dim != 1) {
-            fn_name += "_dim" + std::to_string(shifting_dim);
+        bool is_shift_array = ASRUtils::is_array(arg_types[1]);
+        std::string cshift_fn_name = "_lcompilers_cshift";
+        if (is_shift_array) {
+            cshift_fn_name += "_array_shift";
         }
+        if (shifting_dim != 1) {
+            cshift_fn_name += "_dim" + std::to_string(shifting_dim);
+        }
+        declare_basic_variables(cshift_fn_name);
         fill_func_arg("array", duplicate_type_with_empty_dims(al, arg_types[0]));
         fill_func_arg("shift", arg_types[1]);
         ASR::ttype_t* return_type_ = return_type;
@@ -2201,6 +2284,25 @@ namespace Cshift {
         ASR::expr_t *j = declare("j", b.int_type(index_kind), Local);
         int n_dims = extract_n_dims_from_ttype(return_type);
         ASR::expr_t* shift_val = declare("shift_val", b.int_type(index_kind), Local);
+        std::vector<ASR::expr_t*> do_loop_variables;
+        for(int i=0; i<n_dims-1; i++) {
+            ASR::expr_t* var = declare("i_" + std::to_string(i), b.int_type(index_kind), Local);
+            do_loop_variables.push_back(var);
+        }
+        if (is_shift_array) {
+            body.push_back(al, create_do_loop_helper_cshift_array_shift(al, loc,
+                do_loop_variables, j, i, shift_val, args[1], args[0], result, 0,
+                shifting_dim, index_kind));
+            body.push_back(al, b.Return());
+            ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep,
+                    args, body, nullptr, ASR::abiType::Source,
+                    ASR::deftypeType::Implementation, nullptr);
+            scope->add_symbol(fn_name, fn_sym);
+            Vec<ASR::call_arg_t> new_args; new_args.reserve(al, 2);
+            new_args.push_back(al, m_args[0]);
+            new_args.push_back(al, m_args[1]);
+            return b.Call(fn_sym, new_args, return_type, nullptr);
+        }
         body.push_back(al, b.Assignment(shift_val, args[1]));
         body.push_back(al, b.If(b.Lt(args[1], b.i_idx(0, index_kind)), {
             b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], shifting_dim, index_kind)))
@@ -2208,11 +2310,6 @@ namespace Cshift {
             b.Assignment(shift_val, shift_val)
         }
         ));
-        std::vector<ASR::expr_t*> do_loop_variables;
-        for(int i=0; i<n_dims-1; i++) {
-            ASR::expr_t* var = declare("i_" + std::to_string(i), b.int_type(index_kind), Local);
-            do_loop_variables.push_back(var);
-        }
         body.push_back(al, b.Assignment(i, b.GetLBound(args[0], shifting_dim, index_kind)));
         ASR::stmt_t *do_loop = PassUtils::create_do_loop_helper_cshift(al, loc, do_loop_variables, j, i, args[0], result, 0, shifting_dim);
         


### PR DESCRIPTION
fixes #11585 

Bug: cshift(array, shift) ICE’d when shift was an array, especially for cases like real :: input_array(2,0) with integer :: shifts(0). The intrinsic replacement pass lowered cshift as if shift were always scalar, then tried to compare/assign the whole integer array as a scalar value, causing an internal compiler error.

Fix: added a separate ASR lowering path for array-valued shift. It now computes the scalar shift per slice of the input array, while keeping the old scalar-shift path unchanged.
