### PR TITLE
fix: ICE for invalid mixed-type CASE range selector 

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3782,6 +3782,39 @@ public:
             }
         }
 
+        ASR::ttype_t* select_type = ASRUtils::expr_type(a_test);
+        auto check_case_expr_type = [&](ASR::expr_t* expr) {
+            if (!expr) {
+                return;
+            }
+            ASR::ttype_t* expr_type = ASRUtils::expr_type(expr);
+            if (ASRUtils::extract_type(select_type)->type != ASRUtils::extract_type(expr_type)->type) {
+                std::string type_str = ASRUtils::type_to_str_fortran_expr(expr_type, expr);
+                diag.add(Diagnostic(
+                    "Expression in case selector cannot be " + type_str,
+                    Level::Error, Stage::Semantic, {Label("", {expr->base.loc})}));
+                throw SemanticAbort();
+            }
+        };
+        for (size_t i = 0; i < a_body_vec.size(); i++) {
+            ASR::case_stmt_t* case_stmt = a_body_vec[i];
+            switch (case_stmt->type) {
+                case ASR::case_stmtType::CaseStmt: {
+                    ASR::CaseStmt_t* case_expr = ASR::down_cast<ASR::CaseStmt_t>(case_stmt);
+                    for (size_t j = 0; j < case_expr->n_test; j++) {
+                        check_case_expr_type(case_expr->m_test[j]);
+                    }
+                    break;
+                }
+                case ASR::case_stmtType::CaseStmt_Range: {
+                    ASR::CaseStmt_Range_t* case_range = ASR::down_cast<ASR::CaseStmt_Range_t>(case_stmt);
+                    check_case_expr_type(case_range->m_end);
+                    check_case_expr_type(case_range->m_start);
+                    break;
+                }
+            }
+        }
+
         tmp = ASR::make_Select_t(al, x.base.base.loc, x.m_stmt_name, a_test, a_body_vec.p,
                            a_body_vec.size(), def_body.p, def_body.size(), false);
     }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -654,6 +654,10 @@ program continue_compilation_1
     dimension :: m(3)
     open(newunit=u, file="test.dat", status="replace", asynchronous=1)
     open(newunit=u, file="test.dat", status="replace", asynchronous="yes", asynchronous="no")
+    select case (bad_x)
+        case ('3' : 1.)
+    end select
+
     contains
     subroutine test_uminus_struct()
         use continue_compilation_1_mod, only: MyClass

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "1152101fab560eac88ef949257a00e60d18569983d864ac854cab2ec",
+    "infile_hash": "e719f2f4f8a34f90288138b9f0a7a0803e17fdaa56b7418b5b9fda84",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2d895109555bd9ab407f8b8650eb5aaf4d82905d57bcf807e2702539",
+    "stderr_hash": "2417a534813fae47eb5f4163a3c17d88b29c1093d5a1ab4bef1b7611",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -446,39 +446,39 @@ semantic error: Dimensions specified for 'm' after its initialization
     |                  ^^^^ 
 
 semantic error: Cannot convert LOGICAL to REAL
-   --> tests/errors/continue_compilation_1.f90:687:24
+   --> tests/errors/continue_compilation_1.f90:688:24
     |
-687 |         real :: adwf = .true.
+688 |         real :: adwf = .true.
     |                        ^^^^^^ 
 
 warning: Assuming implicit save attribute for variable declaration
-   --> tests/errors/continue_compilation_1.f90:691:23
+   --> tests/errors/continue_compilation_1.f90:692:23
     |
-691 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
+692 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
 
 semantic error: Allocatable array 'x' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:717:9
+   --> tests/errors/continue_compilation_1.f90:718:9
     |
-717 |         integer,allocatable  :: x(3)
+718 |         integer,allocatable  :: x(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Pointer array 'y' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:718:9
+   --> tests/errors/continue_compilation_1.f90:719:9
     |
-718 |         integer,pointer  :: y(3)
+719 |         integer,pointer  :: y(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:729:20
+   --> tests/errors/continue_compilation_1.f90:730:20
     |
-729 |         integer :: arr(n:10)
+730 |         integer :: arr(n:10)
     |                    ^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:736:20
+   --> tests/errors/continue_compilation_1.f90:737:20
     |
-736 |         integer :: arr(1:n)
+737 |         integer :: arr(1:n)
     |                    ^^^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -1527,44 +1527,50 @@ semantic error: Duplicate value of `asynchronous` found
 656 |     open(newunit=u, file="test.dat", status="replace", asynchronous="yes", asynchronous="no")
     |                                                                                         ^^^^ 
 
-semantic error: No matching `operator(-)` found for this operand type
-   --> tests/errors/continue_compilation_1.f90:665:18
+semantic error: Expression in case selector cannot be real
+   --> tests/errors/continue_compilation_1.f90:658:21
     |
-665 |         print *, -tt
+658 |         case ('3' : 1.)
+    |                     ^^ 
+
+semantic error: No matching `operator(-)` found for this operand type
+   --> tests/errors/continue_compilation_1.f90:666:18
+    |
+666 |         print *, -tt
     |                  ^^^ 
 
 semantic error: Variable 'k' is not declared
-   --> tests/errors/continue_compilation_1.f90:681:12
+   --> tests/errors/continue_compilation_1.f90:682:12
     |
-681 |         do k = 1, 3
+682 |         do k = 1, 3
     |            ^ 'k' is undeclared
 
 semantic error: Expected logical expression in if statement, but recieved logical[:] instead
-   --> tests/errors/continue_compilation_1.f90:692:13
+   --> tests/errors/continue_compilation_1.f90:693:13
     |
-692 |         if (abs(arr1)(1) /= 2471095) error stop
+693 |         if (abs(arr1)(1) /= 2471095) error stop
     |             ^^^^^^^^^^^^^^^^^^^^^^^ logical[:] expression, expected logical
 
 semantic error: Character intrinsic 'len' with class(*) argument must be inside 'type is (character(len=*))' guard
-   --> tests/errors/continue_compilation_1.f90:700:22
+   --> tests/errors/continue_compilation_1.f90:701:22
     |
-700 |         print *, len(generic)
+701 |         print *, len(generic)
     |                      ^^^^^^^ invalid use of character intrinsic with polymorphic argument
 
 semantic error: Argument of 'len' intrinsic must be CHARACTER, found integer instead.
-   --> tests/errors/continue_compilation_1.f90:701:22
+   --> tests/errors/continue_compilation_1.f90:702:22
     |
-701 |         print *, len(a)
+702 |         print *, len(a)
     |                      ^ 
 
 semantic error: `unit` must be of type Integer or Character
-   --> tests/errors/continue_compilation_1.f90:707:9
+   --> tests/errors/continue_compilation_1.f90:708:9
     |
-707 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
+708 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:713:9
+   --> tests/errors/continue_compilation_1.f90:714:9
     |
-713 |         x = [character(len=3) :: "aa", "bb", "aa"]
+714 |         x = [character(len=3) :: "aa", "bb", "aa"]
     |         ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch (integer[:] and string[:])

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -446,39 +446,39 @@ semantic error: Dimensions specified for 'm' after its initialization
     |                  ^^^^ 
 
 semantic error: Cannot convert LOGICAL to REAL
-   --> tests/errors/continue_compilation_1.f90:684:24
+   --> tests/errors/continue_compilation_1.f90:687:24
     |
-684 |         real :: adwf = .true.
+687 |         real :: adwf = .true.
     |                        ^^^^^^ 
 
 warning: Assuming implicit save attribute for variable declaration
-   --> tests/errors/continue_compilation_1.f90:688:23
+   --> tests/errors/continue_compilation_1.f90:691:23
     |
-688 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
+691 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
 
 semantic error: Allocatable array 'x' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:714:9
+   --> tests/errors/continue_compilation_1.f90:717:9
     |
-714 |         integer,allocatable  :: x(3)
+717 |         integer,allocatable  :: x(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Pointer array 'y' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:715:9
+   --> tests/errors/continue_compilation_1.f90:718:9
     |
-715 |         integer,pointer  :: y(3)
+718 |         integer,pointer  :: y(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:726:20
+   --> tests/errors/continue_compilation_1.f90:729:20
     |
-726 |         integer :: arr(n:10)
+729 |         integer :: arr(n:10)
     |                    ^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:733:20
+   --> tests/errors/continue_compilation_1.f90:736:20
     |
-733 |         integer :: arr(1:n)
+736 |         integer :: arr(1:n)
     |                    ^^^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -1528,43 +1528,43 @@ semantic error: Duplicate value of `asynchronous` found
     |                                                                                         ^^^^ 
 
 semantic error: No matching `operator(-)` found for this operand type
-   --> tests/errors/continue_compilation_1.f90:662:18
+   --> tests/errors/continue_compilation_1.f90:665:18
     |
-662 |         print *, -tt
+665 |         print *, -tt
     |                  ^^^ 
 
 semantic error: Variable 'k' is not declared
-   --> tests/errors/continue_compilation_1.f90:678:12
+   --> tests/errors/continue_compilation_1.f90:681:12
     |
-678 |         do k = 1, 3
+681 |         do k = 1, 3
     |            ^ 'k' is undeclared
 
 semantic error: Expected logical expression in if statement, but recieved logical[:] instead
-   --> tests/errors/continue_compilation_1.f90:689:13
+   --> tests/errors/continue_compilation_1.f90:692:13
     |
-689 |         if (abs(arr1)(1) /= 2471095) error stop
+692 |         if (abs(arr1)(1) /= 2471095) error stop
     |             ^^^^^^^^^^^^^^^^^^^^^^^ logical[:] expression, expected logical
 
 semantic error: Character intrinsic 'len' with class(*) argument must be inside 'type is (character(len=*))' guard
-   --> tests/errors/continue_compilation_1.f90:697:22
+   --> tests/errors/continue_compilation_1.f90:700:22
     |
-697 |         print *, len(generic)
+700 |         print *, len(generic)
     |                      ^^^^^^^ invalid use of character intrinsic with polymorphic argument
 
 semantic error: Argument of 'len' intrinsic must be CHARACTER, found integer instead.
-   --> tests/errors/continue_compilation_1.f90:698:22
+   --> tests/errors/continue_compilation_1.f90:701:22
     |
-698 |         print *, len(a)
+701 |         print *, len(a)
     |                      ^ 
 
 semantic error: `unit` must be of type Integer or Character
-   --> tests/errors/continue_compilation_1.f90:704:9
+   --> tests/errors/continue_compilation_1.f90:707:9
     |
-704 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
+707 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:710:9
+   --> tests/errors/continue_compilation_1.f90:713:9
     |
-710 |         x = [character(len=3) :: "aa", "bb", "aa"]
+713 |         x = [character(len=3) :: "aa", "bb", "aa"]
     |         ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch (integer[:] and string[:])


### PR DESCRIPTION
fixes #11582

Also added blankspaces in `continue_compilation_1.f90`