### PR TITLE
fix: support array-valued shift in CSHIFT and EOSHIFT intrinsics

### DIFF
--- a/integration_tests/intrinsics_464.f90
+++ b/integration_tests/intrinsics_464.f90
@@ -1,0 +1,66 @@
+program intrinsics_464
+   implicit none
+
+   call test_cshift_rank2_dim1()
+   call test_cshift_rank2_dim2()
+   call test_cshift_zero_size()
+   call test_eoshift_rank2_dim1()
+   call test_eoshift_rank2_dim2()
+
+   print *, "All tests passed."
+
+contains
+
+   subroutine test_cshift_rank2_dim1()
+      integer :: a(2, 3), r(2, 3)
+      integer :: shifts(3)
+      a = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+      shifts = [1, 0, -1]
+      r = cshift(a, shifts)
+      if (r(1,1) /= 2 .or. r(2,1) /= 1) error stop 1
+      if (r(1,2) /= 3 .or. r(2,2) /= 4) error stop 2
+      if (r(1,3) /= 6 .or. r(2,3) /= 5) error stop 3
+   end subroutine
+
+   subroutine test_cshift_rank2_dim2()
+      integer :: a(3, 2), r(3, 2)
+      integer :: shifts(3)
+      a = reshape([1, 2, 3, 4, 5, 6], [3, 2])
+      shifts = [1, -1, 2]
+      r = cshift(a, shifts, dim=2)
+      if (r(1,1) /= 4 .or. r(1,2) /= 1) error stop 4
+      if (r(2,1) /= 5 .or. r(2,2) /= 2) error stop 5
+      if (r(3,1) /= 3 .or. r(3,2) /= 6) error stop 6
+   end subroutine
+
+   subroutine test_cshift_zero_size()
+      integer :: input_array(2, 0)
+      integer :: result_array(2, 0)
+      integer :: shifts(0)
+      result_array = cshift(input_array, shifts)
+      if (size(result_array) /= 0) error stop 7
+   end subroutine
+
+   subroutine test_eoshift_rank2_dim1()
+      integer :: a(2, 3), r(2, 3)
+      integer :: shifts(3)
+      a = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+      shifts = [1, 0, -1]
+      r = eoshift(a, shifts)
+      if (r(1,1) /= 2 .or. r(2,1) /= 0) error stop 8
+      if (r(1,2) /= 3 .or. r(2,2) /= 4) error stop 9
+      if (r(1,3) /= 0 .or. r(2,3) /= 5) error stop 10
+   end subroutine
+
+   subroutine test_eoshift_rank2_dim2()
+      integer :: a(3, 2), r(3, 2)
+      integer :: shifts(3)
+      a = reshape([1, 2, 3, 4, 5, 6], [3, 2])
+      shifts = [1, -1, 1]
+      r = eoshift(a, shifts, dim=2)
+      if (r(1,1) /= 4 .or. r(1,2) /= 0) error stop 11
+      if (r(2,1) /= 0 .or. r(2,2) /= 2) error stop 12
+      if (r(3,1) /= 6 .or. r(3,2) /= 0) error stop 13
+   end subroutine
+
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2111,6 +2111,11 @@ namespace Cshift {
         int array_dim = -1;
         extract_value(array_dims[0].m_length, array_dim);
         ASRUtils::require_impl(array_rank > 0, "The argument `array` in `cshift` must be of rank > 0", array->base.loc, diag);
+        int shift_rank = extract_n_dims_from_ttype(type_shift);
+        if (shift_rank > 0 && shift_rank != array_rank - 1) {
+            append_error(diag, "The argument `shift` in `cshift` must be scalar or have rank one less than `array`", shift->base.loc);
+            return nullptr;
+        }
         ASRBuilder b(al, loc);
         Vec<ASR::dimension_t> result_dims; result_dims.reserve(al, array_rank);
         int overload_id = 2;
@@ -2141,6 +2146,37 @@ namespace Cshift {
             m_args.p, m_args.n, overload_id, ret_type, value);
     }
 
+    static inline ASR::stmt_t* build_cshift_array_shift_loop(
+            Allocator &al, const Location &loc,
+            std::vector<ASR::expr_t*> &do_loop_variables,
+            std::vector<ASR::stmt_t*> &inner_body,
+            ASR::expr_t* array, int shifting_dim, int index_kind, int curr_idx) {
+        ASRUtils::ASRBuilder b(al, loc);
+        int rank = (int)do_loop_variables.size() + 1;
+        int actual_dim = -1;
+        int count = 0;
+        for(int i=1; i<=rank; i++) {
+            if(i == shifting_dim) continue;
+            if(count == curr_idx) {
+                actual_dim = i;
+                break;
+            }
+            count++;
+        }
+        if (curr_idx == (int)do_loop_variables.size() - 1) {
+            return b.DoLoop(do_loop_variables[curr_idx],
+                b.GetLBound(array, actual_dim, index_kind),
+                b.GetUBound(array, actual_dim, index_kind),
+                inner_body, nullptr);
+        }
+        return b.DoLoop(do_loop_variables[curr_idx],
+            b.GetLBound(array, actual_dim, index_kind),
+            b.GetUBound(array, actual_dim, index_kind), {
+                build_cshift_array_shift_loop(al, loc, do_loop_variables,
+                    inner_body, array, shifting_dim, index_kind, curr_idx + 1)
+            }, nullptr);
+    }
+
     static inline ASR::expr_t* instantiate_Cshift(Allocator &al,
             const Location &loc, SymbolTable *scope,
             Vec<ASR::ttype_t*> &arg_types, ASR::ttype_t *return_type,
@@ -2153,10 +2189,15 @@ namespace Cshift {
                 shifting_dim = (int)dim_val;
             }
         }
-        declare_basic_variables("_lcompilers_cshift");
-        if (shifting_dim != 1) {
-            fn_name += "_dim" + std::to_string(shifting_dim);
+        bool is_shift_array = ASRUtils::is_array(arg_types[1]);
+        std::string cshift_fn_name = "_lcompilers_cshift";
+        if (is_shift_array) {
+            cshift_fn_name += "_array_shift";
         }
+        if (shifting_dim != 1) {
+            cshift_fn_name += "_dim" + std::to_string(shifting_dim);
+        }
+        declare_basic_variables(cshift_fn_name);
         fill_func_arg("array", duplicate_type_with_empty_dims(al, arg_types[0]));
         fill_func_arg("shift", arg_types[1]);
         ASR::ttype_t* return_type_ = return_type;
@@ -2201,6 +2242,56 @@ namespace Cshift {
         ASR::expr_t *j = declare("j", b.int_type(index_kind), Local);
         int n_dims = extract_n_dims_from_ttype(return_type);
         ASR::expr_t* shift_val = declare("shift_val", b.int_type(index_kind), Local);
+        std::vector<ASR::expr_t*> do_loop_variables;
+        for(int i=0; i<n_dims-1; i++) {
+            ASR::expr_t* var = declare("i_" + std::to_string(i), b.int_type(index_kind), Local);
+            do_loop_variables.push_back(var);
+        }
+        if (is_shift_array) {
+            int rank = n_dims;
+            std::vector<ASR::expr_t*> array_vars(rank);
+            std::vector<ASR::expr_t*> res_vars(rank);
+            array_vars[shifting_dim - 1] = j;
+            res_vars[shifting_dim - 1] = i;
+            int kk = 0;
+            for(int idim = 0; idim < rank; idim++) {
+                if (idim == shifting_dim - 1) continue;
+                array_vars[idim] = do_loop_variables[kk];
+                res_vars[idim] = do_loop_variables[kk];
+                kk++;
+            }
+            ASR::stmt_t* copy_element = b.Assignment(
+                b.ArrayItem_01(result, res_vars), b.ArrayItem_01(args[0], array_vars));
+            ASR::expr_t* lb = b.GetLBound(args[0], shifting_dim, index_kind);
+            std::vector<ASR::stmt_t*> inner_body;
+            inner_body.push_back(b.Assignment(shift_val, b.ArrayItem_01(args[1], do_loop_variables)));
+            inner_body.push_back(b.If(b.Lt(shift_val, b.i_idx(0, index_kind)), {
+                b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], shifting_dim, index_kind)))
+            }, {}));
+            inner_body.push_back(b.Assignment(i, lb));
+            ASR::expr_t* sh_start = b.Add(lb, shift_val);
+            inner_body.push_back(b.DoLoop(j, sh_start,
+                b.GetUBound(args[0], shifting_dim, index_kind), {
+                    copy_element,
+                    b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                }, nullptr));
+            inner_body.push_back(b.DoLoop(j, lb,
+                b.Sub(sh_start, b.i_idx(1, index_kind)), {
+                    copy_element,
+                    b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                }, nullptr));
+            ASR::stmt_t* array_shift_loop = build_cshift_array_shift_loop(al, loc,
+                do_loop_variables, inner_body, args[0], shifting_dim, index_kind, 0);
+            body.push_back(al, array_shift_loop);
+            body.push_back(al, b.Return());
+            ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+                    body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+            scope->add_symbol(fn_name, fn_sym);
+            Vec<ASR::call_arg_t> new_args; new_args.reserve(al, 2);
+            new_args.push_back(al, m_args[0]);
+            new_args.push_back(al, m_args[1]);
+            return b.Call(fn_sym, new_args, return_type, nullptr);
+        }
         body.push_back(al, b.Assignment(shift_val, args[1]));
         body.push_back(al, b.If(b.Lt(args[1], b.i_idx(0, index_kind)), {
             b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], shifting_dim, index_kind)))
@@ -2208,11 +2299,6 @@ namespace Cshift {
             b.Assignment(shift_val, shift_val)
         }
         ));
-        std::vector<ASR::expr_t*> do_loop_variables;
-        for(int i=0; i<n_dims-1; i++) {
-            ASR::expr_t* var = declare("i_" + std::to_string(i), b.int_type(index_kind), Local);
-            do_loop_variables.push_back(var);
-        }
         body.push_back(al, b.Assignment(i, b.GetLBound(args[0], shifting_dim, index_kind)));
         ASR::stmt_t *do_loop = PassUtils::create_do_loop_helper_cshift(al, loc, do_loop_variables, j, i, args[0], result, 0, shifting_dim);
         
@@ -2743,6 +2829,11 @@ namespace Eoshift {
         int array_dim = -1;
         extract_value(array_dims[0].m_length, array_dim);
         ASRUtils::require_impl(array_rank > 0, "The argument `array` in `eoshift` must be of rank > 0", array->base.loc, diag);
+        int shift_rank = extract_n_dims_from_ttype(type_shift);
+        if (shift_rank > 0 && shift_rank != array_rank - 1) {
+            append_error(diag, "The argument `shift` in `eoshift` must be scalar or have rank one less than `array`", shift->base.loc);
+            return nullptr;
+        }
         ASRBuilder b(al, loc);
         Vec<ASR::dimension_t> result_dims; result_dims.reserve(al, array_rank);
         int overload_id = 2;
@@ -2796,6 +2887,10 @@ namespace Eoshift {
             }
         }
         declare_basic_variables("_lcompilers_eoshift");
+        bool is_shift_array = ASRUtils::is_array(arg_types[1]);
+        if (is_shift_array) {
+            fn_name += "_array_shift";
+        }
         if (shifting_dim != 1) {
             fn_name += "_dim" + std::to_string(shifting_dim);
         }
@@ -2836,6 +2931,69 @@ namespace Eoshift {
         for (int idx = 0; idx < n_dims - 1; idx++) {
             ASR::expr_t* var = declare("i_" + std::to_string(idx), b.int_type(index_kind), Local);
             do_loop_variables.push_back(var);
+        }
+
+        if (is_shift_array) {
+            int rank = n_dims;
+            std::vector<ASR::expr_t*> array_vars(rank);
+            std::vector<ASR::expr_t*> res_vars(rank);
+            array_vars[shifting_dim - 1] = j;
+            res_vars[shifting_dim - 1] = i;
+            int kk = 0;
+            for(int idim = 0; idim < rank; idim++) {
+                if (idim == shifting_dim - 1) continue;
+                array_vars[idim] = do_loop_variables[kk];
+                res_vars[idim] = do_loop_variables[kk];
+                kk++;
+            }
+            ASR::stmt_t* copy_element = b.Assignment(
+                b.ArrayItem_01(result, res_vars), b.ArrayItem_01(args[0], array_vars));
+            ASR::stmt_t* fill_element = b.Assignment(
+                b.ArrayItem_01(result, res_vars), boundary);
+            ASR::expr_t* lb = b.GetLBound(args[0], shifting_dim, index_kind);
+            std::vector<ASR::stmt_t*> inner_body;
+            inner_body.push_back(b.Assignment(shift_val, b.ArrayItem_01(args[1], do_loop_variables)));
+            inner_body.push_back(b.Assignment(abs_shift, shift_val));
+            inner_body.push_back(b.Assignment(abs_shift_val, shift_val));
+            inner_body.push_back(b.If(b.Lt(shift_val, b.i_idx(0, index_kind)), {
+                b.Assignment(shift_val, b.Add(shift_val, b.GetUBound(args[0], shifting_dim, index_kind))),
+                b.Assignment(abs_shift, b.Mul(abs_shift, b.i_idx(-1, index_kind)))
+            }, {}));
+            inner_body.push_back(b.Assignment(i, lb));
+            ASR::expr_t* sh_start = b.Add(lb, shift_val);
+            inner_body.push_back(b.DoLoop(j, sh_start,
+                b.GetUBound(args[0], shifting_dim, index_kind), {
+                    copy_element,
+                    b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                }, nullptr));
+            inner_body.push_back(b.DoLoop(j, lb,
+                b.Sub(sh_start, b.i_idx(1, index_kind)), {
+                    copy_element,
+                    b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+                }, nullptr));
+            inner_body.push_back(b.If(b.GtE(abs_shift_val, b.i_idx(0, index_kind)), {
+                b.Assignment(i, b.GetUBound(args[0], shifting_dim, index_kind)),
+                b.Assignment(i, b.Sub(i, abs_shift)),
+                b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+            }, {
+                b.Assignment(i, lb)
+            }));
+            inner_body.push_back(b.DoLoop(j, b.i_idx(1, index_kind), abs_shift, {
+                fill_element,
+                b.Assignment(i, b.Add(i, b.i_idx(1, index_kind)))
+            }, nullptr));
+            ASR::stmt_t* array_shift_loop = Cshift::build_cshift_array_shift_loop(al, loc,
+                do_loop_variables, inner_body, args[0], shifting_dim, index_kind, 0);
+            body.push_back(al, array_shift_loop);
+            body.push_back(al, b.Return());
+            ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
+                    body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
+            scope->add_symbol(fn_name, fn_sym);
+            Vec<ASR::call_arg_t> new_args; new_args.reserve(al, 3);
+            new_args.push_back(al, m_args[0]);
+            new_args.push_back(al, m_args[1]);
+            new_args.push_back(al, m_args[2]);
+            return b.Call(fn_sym, new_args, return_type, nullptr);
         }
 
         body.push_back(al, b.Assignment(shift_val, args[1]));


### PR DESCRIPTION
## Summary

Fixes #11585

Passing an array-valued `shift` argument to `CSHIFT` or `EOSHIFT` caused an internal compiler error. The intrinsic replacement pass treated `shift` as scalar throughout instantiation, eventually crashing in `ASRBuilder::Lt()` which only handles scalar expressions.

While the reported issue only mentions CSHIFT, the same bug exists in EOSHIFT. Both intrinsics share the same scalar-only assumption for the shift argument. This PR fixes both.

## What Changed

**Rank validation** in `create_Cshift` and `create_Eoshift`:
- Array-valued shift must have rank one less than `array`, per the Fortran standard
- Emits a clear semantic error instead of ICE

**Array-shift lowering** in `instantiate_Cshift` and `instantiate_Eoshift`:
- Added `build_cshift_array_shift_loop`, a generic recursive helper that generates a loop nest over all non-shifting dimensions, reused by both intrinsics
- For each slice, extracts the scalar shift via `ArrayItem` and generates the element-wise copy (with wrap-around for CSHIFT, with boundary fill for EOSHIFT)
- Scalar-shift path is completely unchanged, no regression risk for existing code

**Design choice**: The loop body logic (shift extraction, copy, fill) is constructed separately and passed into the generic loop builder, keeping concerns separated. The shared `build_cshift_array_shift_loop` helper handles only loop nesting, making it reusable and easier to maintain.

## Test Coverage

`intrinsics_464.f90` covers:
- CSHIFT rank-2 dim=1 (positive, zero, negative shifts)
- CSHIFT rank-2 dim=2
- CSHIFT zero-sized arrays (the original MRE from #11585)
- EOSHIFT rank-2 dim=1
- EOSHIFT rank-2 dim=2

Each test case uses element-wise assertions with unique error stop codes for easy failure diagnosis.

Existing CSHIFT/EOSHIFT tests (`intrinsics_44`, `intrinsics_384`, `intrinsics_457`) all pass with no regressions.

## Verification

```
$ ./build/src/bin/lfortran integration_tests/intrinsics_464.f90 && ./a.out
All tests passed.

$ ./build/src/bin/lfortran integration_tests/intrinsics_44.f90 && ./a.out
  ... (correct output)

$ ./build/src/bin/lfortran integration_tests/intrinsics_457.f90 && ./a.out
ok
```