### PR TITLE
Fix : check derivedtypes properly when matching arguments against parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2171,6 +2171,7 @@ RUN(NAME operator_overloading_36 LABELS gfortran llvm_submodule EXTRAFILES
     operator_overloading_36_mod_base.f90 operator_overloading_36_mod_base_sub.f90)
 RUN(NAME operator_overloading_37 LABELS gfortran llvm)
 RUN(NAME operator_overloading_38 LABELS gfortran llvm)
+RUN(NAME operator_overloading_39 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME custom_unary_operator_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME custom_unary_operator_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/operator_overloading_39.f90
+++ b/integration_tests/operator_overloading_39.f90
@@ -1,0 +1,38 @@
+module operator_overloading_39_mod
+   implicit none
+   public :: string
+
+   type :: string
+      character(len=:), allocatable :: str
+   contains
+
+    procedure :: concat
+    generic :: operator(+) => concat
+   end type
+
+contains
+
+   function concat(self, value) result(other)
+      class(string), intent(in) :: self
+      class(*),      intent(in) :: value
+      type(string)              :: other
+      select type(value)
+         type is (string)
+            other%str = self%str // value%str
+      end select
+   end function
+
+end module 
+
+program operator_overloading_39
+  use operator_overloading_39_mod
+  implicit none
+  type(string) :: str1, str2, str3
+
+  str1%str = "Hello, "
+  str2%str = "world!"
+  str3 = str1 + str2
+  
+  print *, str3%str
+  if(str3%str /= "Hello, world!") error stop
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1672,7 +1672,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                 ASR::is_a<ASR::StructType_t>(*left_arg_type2)) {
                                 ASR::Struct_t* left_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[0])));
-                                if (!is_derived_type_similar(left_struct, left_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(left_struct, left_arg_sym /*param*/)) {
                                     break;
                                 }
                             }
@@ -1680,7 +1680,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                 ASR::is_a<ASR::StructType_t>(*right_arg_type2)) {
                                 ASR::Struct_t* right_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[1])));
-                                if (!is_derived_type_similar(right_struct, right_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(right_struct, right_arg_sym /*param*/)) {
                                     break;
                                 }
                             }
@@ -2466,7 +2466,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                 ASR::is_a<ASR::StructType_t>(*left_arg_type2)) {
                                 ASR::Struct_t* left_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[0])));
-                                if (!is_derived_type_similar(left_struct, left_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(left_struct, left_arg_sym)) {
                                     break;
                                 }
                             }
@@ -2474,7 +2474,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                 ASR::is_a<ASR::StructType_t>(*right_arg_type2)) {
                                 ASR::Struct_t* right_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[1])));
-                                if (!is_derived_type_similar(right_struct, right_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(right_struct, right_arg_sym)) {
                                     break;
                                 }
                             }
@@ -2683,7 +2683,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                         ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(left))));
                                 ASR::Struct_t* left_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[0]))));
-                                if (!is_derived_type_similar(left_sym, left_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(left_sym, left_arg_sym)) {
                                     break;
                                 }
                             }
@@ -2694,7 +2694,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                 ASR::Struct_t* right_arg_sym = ASR::down_cast<ASR::Struct_t>(
                                     ASRUtils::symbol_get_past_external(
                                         ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(func->m_args[1]))));
-                                if (!is_derived_type_similar(right_sym, right_arg_sym)) {
+                                if (!can_pass_derviedtype_arg_to_parameter(right_sym, right_arg_sym)) {
                                     break;
                                 }
                             }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -84,6 +84,7 @@ ASR::symbol_t* get_struct_sym_from_struct_expr(ASR::expr_t* expression);
 void set_struct_sym_to_struct_expr(ASR::expr_t* expression, ASR::symbol_t* struct_sym);
 
 ASR::symbol_t* get_union_sym_from_union_expr(ASR::expr_t* expression);
+static inline bool is_unlimited_polymorphic_type(ASR::Struct_t* st);
 
 static inline std::string extract_real(const char *s) {
     // TODO: this is inefficient. We should
@@ -4409,15 +4410,20 @@ inline bool is_parent(ASR::Struct_t* a, ASR::Struct_t* b) {
     }
     return false;
 }
-
+/**
+ * Check if two derived types are :
+ * 1) the same, or
+ * 2) one is parent of another, or
+ * 3) both are unlimited polymorphic types
+ */
 inline bool is_derived_type_similar(ASR::Struct_t* a, ASR::Struct_t* b) {
-    auto is_upoly = [](ASR::Struct_t* s) {
-        return s->m_struct_signature != nullptr &&
-            ASR::down_cast<ASR::StructType_t>(
-                s->m_struct_signature)->m_is_unlimited_polymorphic;
-    };
     return a == b || is_parent(a, b) || is_parent(b, a) ||
-        (is_upoly(a) && is_upoly(b));
+        (is_unlimited_polymorphic_type(a) && is_unlimited_polymorphic_type(b));
+}
+
+// Can we pass this ARGUMENT of this derivedtype --> to this PARAMETER of this derivedtype?
+inline bool can_pass_derviedtype_arg_to_parameter(ASR::Struct_t* arg, ASR::Struct_t* param) {
+    return arg == param || is_parent(param, arg) || is_unlimited_polymorphic_type(param);
 }
 
 // Helper: check if IntegerBinOp is identity (x+0, 0+x, x-0)


### PR DESCRIPTION
use `can_pass_derviedtype_arg_to_parameter()` instead of ` is_deriatved_type_similar()` to check if I can pass derivedtype argument to a functionparameter.
It should tolerate the idea of parameter being of type `class(*)`