### PR TITLE
test: check for invalid types in substring start index and stride

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -485,10 +485,10 @@ program continue_compilation_1
 
     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [1.0, 2.0])
     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
-
+    print *, a(b'01':2)
     print *, count(1)
     print *, count([2])
-
+    print *, a(1:2:b'10')
     a_real = [logical::]
     print *,size(a_real)
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "1152101fab560eac88ef949257a00e60d18569983d864ac854cab2ec",
+    "infile_hash": "5c0cb66dfcbdf74306e2ef892b86a9ae3d8713066a341d5665fdf104",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2d895109555bd9ab407f8b8650eb5aaf4d82905d57bcf807e2702539",
+    "stderr_hash": "6f2d03c238964827e7b36302d2b630794a6a836a938bb5e85f96fcee",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1054,6 +1054,12 @@ semantic error: reshape accepts `order` array as a permutation of elements from 
 487 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
     |                                                          ^^^^^^ 
 
+semantic error: Substring start index must be of type integer
+   --> tests/errors/continue_compilation_1.f90:488:16
+    |
+488 |     print *, a(b'01':2)
+    |                ^^^^^ 
+
 semantic error: `mask` argument to `count` intrinsic must be a logical array
    --> tests/errors/continue_compilation_1.f90:489:20
     |
@@ -1065,6 +1071,12 @@ semantic error: `mask` argument to `count` intrinsic must be a logical array
     |
 490 |     print *, count([2])
     |                    ^^^ 
+
+semantic error: Substring stride must be of type integer
+   --> tests/errors/continue_compilation_1.f90:491:20
+    |
+491 |     print *, a(1:2:b'10')
+    |                    ^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
    --> tests/errors/continue_compilation_1.f90:492:5


### PR DESCRIPTION
resolves 
https://github.com/lfortran/lfortran/pull/11590/changes#r3278062641
https://github.com/lfortran/lfortran/pull/11590/changes#r3278062326