### PR TITLE
fix : list-directed character read from standard input

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1108,6 +1108,8 @@ RUN(NAME nested_namelist_01 LABELS gfortran llvm)
 
 RUN(NAME format_quotes_01 LABELS gfortran llvm)
 
+RUN(NAME list_directed_stdin_eof_01 LABELS gfortran llvm COPY_TO_BIN list_directed_stdin_eof_01_data.txt)
+
 RUN(NAME format_01 LABELS gfortran llvm fortran)
 RUN(NAME format_02 LABELS gfortran llvm fortran)
 RUN(NAME format_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/list_directed_stdin_eof_01.f90
+++ b/integration_tests/list_directed_stdin_eof_01.f90
@@ -1,0 +1,29 @@
+program list_directed_stdin_eof_01
+    implicit none
+    character(len=1) :: key
+    character(len=10) :: word
+    integer :: ios, u
+
+    u = 20
+    open(u, file="list_directed_stdin_eof_01_data.txt", status="old")
+
+    ! Test 1: Read a single character via list-directed I/O
+    read(u, *) key
+    if (key /= "A") error stop "Test 1 failed: expected 'A'"
+
+    ! Test 2: Read another character (should skip the newline properly)
+    read(u, *) key
+    if (key /= "B") error stop "Test 2 failed: expected 'B'"
+
+    ! Test 3: Read a word
+    read(u, *) word
+    if (trim(word) /= "Hello") error stop "Test 3 failed: expected 'Hello'"
+
+    ! Test 4: Read past end-of-file with iostat
+    read(u, *, iostat=ios) key
+    if (ios >= 0) error stop "Test 4 failed: expected EOF (negative iostat)"
+
+    close(u)
+
+    print *, "All list-directed character read tests passed."
+end program

--- a/integration_tests/list_directed_stdin_eof_01_data.txt
+++ b/integration_tests/list_directed_stdin_eof_01_data.txt
@@ -1,0 +1,3 @@
+A
+B
+Hello

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -8572,27 +8572,23 @@ LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num,
 {
     if (iostat) *iostat = 0;
 
+    bool unit_file_bin;
+    int access_id = 0;
+    bool read_access = true, write_access = false;
+    int delim_value = 0;
+    FILE *filep;
+
     if (unit_num == -1) {
-        if (!fgets(*p, p_len + 1, stdin)) {
-            if (iostat) { *iostat = -1; return; }
-            printf("Runtime error: End of file!\n");
+        filep = stdin;
+        unit_file_bin = false;
+    } else {
+        filep = get_file_pointer_from_unit(unit_num, &unit_file_bin,
+                                           &access_id, &read_access, &write_access, &delim_value, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        if (!filep) {
+            if (iostat) { *iostat = 1; return; }
+            printf("No file found with given unit\n");
             exit(1);
         }
-        size_t len = strcspn(*p, "\n");
-        pad_with_spaces(*p, len, p_len);
-        return;
-    }
-
-    bool unit_file_bin;
-    int access_id;
-    bool read_access, write_access;
-    int delim_value;
-    FILE *filep = get_file_pointer_from_unit(unit_num, &unit_file_bin,
-                                             &access_id, &read_access, &write_access, &delim_value, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    if (!filep) {
-        if (iostat) { *iostat = 1; return; }
-        printf("No file found with given unit\n");
-        exit(1);
     }
 
     if (unit_file_bin) {


### PR DESCRIPTION
fixes #11604


This commit fixes a bug in the runtime I/O library where reading a
character from standard input (`read(*, *)`) left a trailing newline 
in the input buffer. 

Previously, `_lfortran_read_char` hardcoded the use of `fgets` for 
`unit_num == -1` (stdin). This bypassed the list-directed token 
parsing logic used by other standard file units, causing subsequent 
reads to inadvertently consume leftover newlines (`\n`) as empty lines 
rather than waiting for user input.

The fix maps `unit_num == -1` directly to `stdin` and routes it 
through the regular list-directed parser block (`list_directed_check_null_repeat`). 
This ensures that list-directed character input behaves consistently with 
other data types, correctly skipping leading whitespace, identifying tokens, 
and properly handling EOF.


