### PR TITLE
fix: deserialization ICE for procedure pointer members across modules

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4339,6 +4339,9 @@ RUN(NAME separate_compilation_class_star_04 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME separate_compilation_external_symbol_01 LABELS gfortran llvm
     EXTRAFILES separate_compilation_external_symbol_01a.f90)
+RUN(NAME separate_compilation_external_symbol_02 LABELS gfortran llvm
+    EXTRAFILES separate_compilation_external_symbol_02a.f90
+    EXTRA_ARGS --implicit-interface)
 RUN(NAME class_star_pointer_01 LABELS gfortran llvm)
 
 RUN(NAME separate_compilation_14 LABELS gfortran llvm EXTRAFILES separate_compilation_14a.f90)

--- a/integration_tests/separate_compilation_external_symbol_02.f90
+++ b/integration_tests/separate_compilation_external_symbol_02.f90
@@ -1,0 +1,13 @@
+program test_sep_ext02
+    use sep_ext02_mod_runner
+    implicit none
+
+    type(runner) :: r
+    integer :: val
+
+    val = 10
+    call set_caller(r)
+    call r%caller(val)
+    if (val /= 11) error stop
+    print *, "PASS"
+end program

--- a/integration_tests/separate_compilation_external_symbol_02a.f90
+++ b/integration_tests/separate_compilation_external_symbol_02a.f90
@@ -1,0 +1,38 @@
+! Modules that reproduce an ICE during deserialization when a procedure
+! pointer member in a derived type references an implicit-interface
+! ExternalSymbol from a foreign module.  The body visitor must preserve
+! the ExternalSymbol wrapper on m_type_declaration so that the .mod
+! file serialises the correct (local) symbol-table ID.
+
+module sep_ext02_mod_method
+    implicit none
+
+    type :: method
+        procedure(), nopass, pointer :: caller => null()
+    end type method
+
+contains
+
+    subroutine caller(x)
+        integer, intent(inout) :: x
+        x = x + 1
+    end subroutine
+
+end module sep_ext02_mod_method
+
+module sep_ext02_mod_runner
+    use sep_ext02_mod_method, only: caller
+    implicit none
+
+    type :: runner
+        procedure(), nopass, pointer :: caller => null()
+    end type runner
+
+contains
+
+    subroutine set_caller(this)
+        type(runner), intent(inout) :: this
+        this%caller => caller
+    end subroutine
+
+end module sep_ext02_mod_runner

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2828,16 +2828,22 @@ public:
                         pnc->m_type = var->m_type;
                     }
                     if (ASR::is_a<ASR::Var_t>(*value)) {
-                        ASR::symbol_t *val_sym = ASRUtils::symbol_get_past_external(
-                            ASR::down_cast<ASR::Var_t>(value)->m_v);
+                        ASR::symbol_t *val_sym_raw = ASR::down_cast<ASR::Var_t>(value)->m_v;
+                        ASR::symbol_t *val_sym = ASRUtils::symbol_get_past_external(val_sym_raw);
                         if (ASR::is_a<ASR::Function_t>(*val_sym)) {
-                            var->m_type_declaration = val_sym;
+                            // Use the original symbol (which may be an
+                            // ExternalSymbol) so that m_type_declaration
+                            // stays within the current module boundary.
+                            var->m_type_declaration = val_sym_raw;
                         } else if (ASR::is_a<ASR::Variable_t>(*val_sym)) {
                             ASR::Variable_t *val_var = ASR::down_cast<ASR::Variable_t>(val_sym);
-                            ASR::symbol_t *val_type_decl = ASRUtils::symbol_get_past_external(
-                                val_var->m_type_declaration);
-                            if (val_type_decl && ASR::is_a<ASR::Function_t>(*val_type_decl)) {
-                                var->m_type_declaration = val_type_decl;
+                            if (val_var->m_type_declaration) {
+                                ASR::symbol_t *val_type_decl = ASRUtils::symbol_get_past_external(
+                                    val_var->m_type_declaration);
+                                if (val_type_decl && ASR::is_a<ASR::Function_t>(*val_type_decl)) {
+                                    // Preserve the ExternalSymbol wrapper if present.
+                                    var->m_type_declaration = val_var->m_type_declaration;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
fixes #11607

When a procedure pointer inside a struct was associated via `=>` in the
body visitor (visit_Associate), the code used symbol_get_past_external()
to unwrap the ExternalSymbol and assigned the underlying Function from
the foreign module directly to m_type_declaration. This caused the
serialized .mod file to reference the foreign module's symbol table ID,
which does not exist during deserialization in a different translation
unit, triggering:

  LCompilersException: Deserialization failed: symbol
  `__caller_iface_implicit`references symbol table with ID 2
  which has not been deserialized yet.

The fix preserves the ExternalSymbol wrapper when updating
m_type_declaration, so the reference stays within the current module's
symbol table boundary and survives serialization/deserialization.

