### PR TITLE
fix: accept cpp macro definitions with equals

### DIFF
--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -423,6 +423,17 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                 interval_end_type_0(lm, output.size(), cur-string_start);
                 continue;
             }
+            "#" whitespace? "define" whitespace @t1 name @t2 @t3 "=" [^\n\x00]* @t4 newline  {
+                if (!branch_enabled) continue;
+                std::string macro_name = token(t1, t2),
+                        macro_subs = token(t3, t4);
+                CPPMacro fn;
+                fn.expansion = macro_subs;
+                macro_definitions[macro_name] = fn;
+
+                interval_end_type_0(lm, output.size(), cur-string_start);
+                continue;
+            }
             "#" whitespace? "define" whitespace @t1 name @t2 '(' whitespace? ')' whitespace @t3 [^\n\x00]* @t4 newline  {
                 if (!branch_enabled) continue;
                 std::string macro_name = token(t1, t2),

--- a/tests/preprocessor24.F90
+++ b/tests/preprocessor24.F90
@@ -1,0 +1,4 @@
+module wrapped
+#define WRAPPED=1
+#include "preprocessor24_generic.F90"
+end module wrapped

--- a/tests/preprocessor24_generic.F90
+++ b/tests/preprocessor24_generic.F90
@@ -1,0 +1,8 @@
+#ifndef WRAPPED
+module generic
+#endif
+implicit none
+integer, parameter :: value = 1
+#ifndef WRAPPED
+end module generic
+#endif

--- a/tests/reference/asr_preprocess-preprocessor24-b3e4f89.json
+++ b/tests/reference/asr_preprocess-preprocessor24-b3e4f89.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr_preprocess-preprocessor24-b3e4f89",
+    "cmd": "lfortran --cpp --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/preprocessor24.F90",
+    "infile_hash": "2edcfb7185b802889c935505a0dfd5f4abfffff021c9a0951fc4d068",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr_preprocess-preprocessor24-b3e4f89.stdout",
+    "stdout_hash": "f39f6461c6776b12c428f9bae3f17965abff209e124348adfa654c32",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr_preprocess-preprocessor24-b3e4f89.stdout
+++ b/tests/reference/asr_preprocess-preprocessor24-b3e4f89.stdout
@@ -1,0 +1,44 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            wrapped:
+                (Module
+                    (SymbolTable
+                        2
+                        {
+                            value:
+                                (Variable
+                                    2
+                                    value
+                                    []
+                                    Local
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    Parameter
+                                    (Integer 4)
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                    NotMethod
+                                    ()
+                                    []
+                                )
+                        })
+                    wrapped
+                    ()
+                    []
+                    .false.
+                    .false.
+                    .false.
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -640,6 +640,11 @@ filename = "preprocessor23.f90"
 asr_preprocess = true
 
 [[test]]
+filename = "preprocessor24.F90"
+asr_preprocess = true
+cpp_infer = true
+
+[[test]]
 filename = "expr1.f90"
 interactive = true
 ast = true


### PR DESCRIPTION
## Summary
- Accept `#define NAME=...` as an object-like macro in the C preprocessor.
- Add a wrapper/include regression for `#ifndef NAME` after that define form.

Fixes #11612

## Why
Some Fortran packages include one guarded generic implementation into multiple wrapper modules. LFortran left `#define NAME=1` inactive, so scanners saw duplicate generated modules.

**Stage:** Preprocessor

## Changes
- [`src/lfortran/parser/preprocessor.re#L426-L436`](https://github.com/krystophny/lfortran/blob/1097dc5ee2d25289750b62bf2907ab652739d5ac/src/lfortran/parser/preprocessor.re#L426-L436): parse `#define NAME=...` as an object-like macro.
- [`tests/preprocessor24.F90#L1-L4`](https://github.com/krystophny/lfortran/blob/1097dc5ee2d25289750b62bf2907ab652739d5ac/tests/preprocessor24.F90#L1-L4): cover the wrapper module input.
- [`tests/preprocessor24_generic.F90#L1-L8`](https://github.com/krystophny/lfortran/blob/1097dc5ee2d25289750b62bf2907ab652739d5ac/tests/preprocessor24_generic.F90#L1-L8): cover the guarded generic include.

## Tests
- [`tests/preprocessor24.F90`](https://github.com/krystophny/lfortran/blob/1097dc5ee2d25289750b62bf2907ab652739d5ac/tests/preprocessor24.F90): verifies that `#ifndef WRAPPED` is skipped after `#define WRAPPED=1`.

## Verification

### Test fails on main
```console
$ git checkout upstream/main
$ lfortran --cpp -E wrapped.F90
! wrapped.F90
module wrapped
#define WRAPPED=1
! generic.F90
module generic
implicit none
integer, parameter :: value = 1
end module generic
end module wrapped
```

### Test passes after fix
```console
$ lfortran --cpp -E wrapped.F90
! wrapped.F90
module wrapped
! generic.F90
implicit none
integer, parameter :: value = 1
end module wrapped
```

```console
$ scripts/lf.sh update-ref -t preprocessor24 -s
START TEST: preprocessor24.F90
preprocessor24.F90 * asr_preprocess OK
TESTS PASSED
SUCCESS: Reference updated for preprocessor24
```

```console
$ scripts/lf.sh test -t 'preprocessor2[234]' -s
START TEST: preprocessor22.f90
preprocessor22.f90 * asr_preprocess OK
START TEST: preprocessor23.f90
preprocessor23.f90 * asr_preprocess OK
START TEST: preprocessor24.F90
preprocessor24.F90 * asr_preprocess OK
TESTS PASSED
```

```console
$ scripts/lf.sh check
PASSED: All checks OK.
```
