### PR TITLE
parser: dispatch STMT_NAME by stmt type instead of casting to If_t*

### DIFF
--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -65,6 +65,25 @@ static inline char* name2char(const ast_t *n)
     return down_cast2<Name_t>(n)->m_id;
 }
 
+static inline void set_stmt_name(stmt_t &stmt, char *name) {
+    switch (stmt.type) {
+        case stmtType::If:                ((If_t&)stmt).m_stmt_name = name; break;
+        case stmtType::DoLoop:            ((DoLoop_t&)stmt).m_stmt_name = name; break;
+        case stmtType::Block:             ((Block_t&)stmt).m_stmt_name = name; break;
+        case stmtType::AssociateBlock:    ((AssociateBlock_t&)stmt).m_stmt_name = name; break;
+        case stmtType::Critical:          ((Critical_t&)stmt).m_stmt_name = name; break;
+        case stmtType::WhileLoop:         ((WhileLoop_t&)stmt).m_stmt_name = name; break;
+        case stmtType::ChangeTeam:        ((ChangeTeam_t&)stmt).m_stmt_name = name; break;
+        case stmtType::ForAll:            ((ForAll_t&)stmt).m_stmt_name = name; break;
+        case stmtType::Select:            ((Select_t&)stmt).m_stmt_name = name; break;
+        case stmtType::SelectRank:        ((SelectRank_t&)stmt).m_stmt_name = name; break;
+        case stmtType::SelectType:        ((SelectType_t&)stmt).m_stmt_name = name; break;
+        case stmtType::Where:             ((Where_t&)stmt).m_stmt_name = name; break;
+        case stmtType::DoConcurrentLoop:  ((DoConcurrentLoop_t&)stmt).m_stmt_name = name; break;
+        default: LCOMPILERS_ASSERT_MSG(false, "Unknown statement type in set_stmt_name"); break;
+    }
+}
+
 static inline bool streql(const char *s1, const char *s2)
 {
 #if defined(_MSC_VER)
@@ -1817,7 +1836,7 @@ return make_Program_t(al, a_loc,
 
 #define STMT_NAME(id_first, id_last, stmt) \
         stmt; \
-        ((If_t*)stmt)->m_stmt_name = name2char(id_first); \
+        set_stmt_name(*(stmt_t*)(stmt), name2char(id_first)); \
         std::string first = name2char(id_first), \
                     last  = name2char(id_last); \
         if (LCompilers::to_lower(first) != LCompilers::to_lower(last)) { \


### PR DESCRIPTION
STMT_NAME wrote the construct name through ((If_t*)stmt)->m_stmt_name regardless of the actual node type. This only worked because If_t, DoLoop_t, Block_t, Select_t, Where_t and the other named multi-line constructs currently share an identical memory layout up to m_stmt_name; any future layout change would silently write the name at the wrong offset and corrupt the AST.

Replace the cast with a set_stmt_name() helper that switches on stmt.type and writes through the correct concrete type for each named multi-line construct.