### PR TITLE
 fix: preserve assumed-size arrays in nested var contexts

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -414,6 +414,7 @@ RUN(NAME program_cmake_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 
 RUN(NAME program_cmake_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)
 
 RUN(NAME internal_subr_host_vars_01 LABELS gfortran llvm)
+RUN(NAME internal_subr_assumed_size_01 LABELS gfortran llvm)
 RUN(NAME nested_callback_arrays LABELS gfortran llvm)
 RUN(NAME nested_callback_interface_01 LABELS gfortran llvm)
 

--- a/integration_tests/internal_subr_assumed_size_01.f90
+++ b/integration_tests/internal_subr_assumed_size_01.f90
@@ -1,0 +1,34 @@
+program internal_subr_assumed_size_01
+implicit none
+
+real :: x(4)
+real :: total
+
+x = [1.0, 2.0, 3.0, 4.0]
+call sub(x, 4, total)
+
+if (abs(total - 10.0) > 1.e-6) error stop
+
+end program
+
+subroutine sub(a, n, total)
+implicit none
+
+real, intent(in) :: a(*)
+integer, intent(in) :: n
+real, intent(out) :: total
+
+total = 0.0
+call nested()
+
+contains
+
+    subroutine nested()
+    integer :: i
+
+    do i = 1, n
+        total = total + a(i)
+    end do
+    end subroutine
+
+end subroutine

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4291,6 +4291,11 @@ public:
                 // LLVM globals add a pointer level, so load to get data pointer
                 llvm::Type *array_type = llvm_utils->get_type_from_ttype_t_util(x.m_v, x_mv_type_, module.get());
                 array = llvm_utils->CreateLoad2(array_type, array);
+            } else if (array_t->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray &&
+                       !LLVM::is_llvm_pointer(*x_mv_type) &&
+                       llvm::isa<llvm::GlobalVariable>(array)) {
+                llvm::Type *array_type = llvm_utils->get_type_from_ttype_t_util(x.m_v, x_mv_type_, module.get());
+                array = llvm_utils->CreateLoad2(array_type, array);
             }
             if (compiler_options.po.bounds_checking && ASRUtils::is_allocatable(x_mv_type)) {
                 llvm::Value* is_allocated = arr_descr->get_is_allocated_flag(array, x.m_v);
@@ -10370,6 +10375,9 @@ public:
                             break;
                         }
                         case ASR::array_physical_typeType::PointerArray: {
+                            break;
+                        }
+                        case ASR::array_physical_typeType::UnboundedPointerArray: {
                             break;
                         }
                         default: {

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -71,6 +71,18 @@ static ASR::symbol_t *make_external_symbol(Allocator &al, SymbolTable *scope,
     return ext_sym;
 }
 
+static ASR::ttype_t *duplicate_type_for_nested_context(Allocator &al,
+        ASR::ttype_t *var_type) {
+    ASR::ttype_t *array_type = ASRUtils::type_get_past_allocatable_pointer(var_type);
+    if (ASR::is_a<ASR::Array_t>(*array_type) &&
+            ASR::down_cast<ASR::Array_t>(array_type)->m_physical_type ==
+                ASR::array_physical_typeType::UnboundedPointerArray) {
+        return ASRUtils::duplicate_type_with_empty_dims(al, var_type,
+            ASR::array_physical_typeType::UnboundedPointerArray, true);
+    }
+    return ASRUtils::duplicate_type_with_empty_dims(al, var_type);
+}
+
 /*
 
 This pass captures the global variables that are used by the
@@ -607,10 +619,13 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                     }
                 }
                 if( (ASRUtils::is_array(var_type) && !is_pointer) ) {
-                    var_type = ASRUtils::duplicate_type_with_empty_dims(al, var_type);
+                    bool is_unbounded_pointer_array =
+                        ASRUtils::extract_physical_type(var_type) ==
+                            ASR::array_physical_typeType::UnboundedPointerArray;
+                    var_type = duplicate_type_for_nested_context(al, var_type);
                     if (is_allocatable) {
                         var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, var_type->base.loc, var_type));
-                    } else {
+                    } else if (!is_unbounded_pointer_array) {
                         var_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, var_type->base.loc,
                             ASRUtils::type_get_past_allocatable(var_type)));
                     }


### PR DESCRIPTION
fixes #11229
nested_vars converted captured assumed-size dummy arrays into descriptor-style nested context variables. That lost the UnboundedPointerArray representation and led LLVM codegen either to build descriptors with invalid bounds or hit pointer-depth assertions when indexing the captured array from an internal procedure.

Preserve UnboundedPointerArray for captured assumed-size arrays in nested contexts, avoid adding an extra pointer wrapper for that representation, and extend LLVM’s existing pointer-to-data handling to cover unbounded pointer arrays. Add an integration test for an internal procedure accessing a host-associated assumed-size array.