### PR TITLE
fix: handle implicit procedure args in type-bound generics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2460,6 +2460,7 @@ RUN(NAME multi_file_member_access_01 LABELS gfortran llvm llvm_single_invocation
 RUN(NAME multi_file_member_access_02 LABELS gfortran llvm_single_invocation EXTRAFILES multi_file_member_access_02_mod.f90)
 RUN(NAME type_bound_generic_member_access_01 LABELS gfortran llvm)
 RUN(NAME type_bound_generic_member_access_02 LABELS gfortran llvm)
+RUN(NAME type_bound_generic_member_access_03 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME type_parameter_inquiry_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/type_bound_generic_member_access_03.f90
+++ b/integration_tests/type_bound_generic_member_access_03.f90
@@ -1,0 +1,33 @@
+module type_bound_generic_member_access_03_m
+  implicit none
+  logical :: called = .false.
+  type :: runner
+  contains
+    procedure :: run_a1
+    generic :: run => run_a1
+  end type
+contains
+  subroutine run_a1(this, a1, f)
+    class(runner), intent(inout) :: this
+    class(*), intent(in) :: a1
+    procedure() :: f
+    call f()
+  end subroutine
+end module
+
+program type_bound_generic_member_access_03
+  use type_bound_generic_member_access_03_m
+  implicit none
+  type(runner) :: br
+  interface
+    subroutine my_sub()
+    end subroutine
+  end interface
+  call br%run(1, my_sub)
+  if (.not. called) error stop 1
+end program
+
+subroutine my_sub()
+  use type_bound_generic_member_access_03_m, only: called
+  called = .true.
+end subroutine

--- a/integration_tests/type_bound_generic_member_access_03.f90
+++ b/integration_tests/type_bound_generic_member_access_03.f90
@@ -4,7 +4,8 @@ module type_bound_generic_member_access_03_m
   type :: runner
   contains
     procedure :: run_a1
-    generic :: run => run_a1
+    procedure :: run_a2
+    generic :: run => run_a1, run_a2
   end type
 contains
   subroutine run_a1(this, a1, f)
@@ -13,21 +14,35 @@ contains
     procedure() :: f
     call f()
   end subroutine
+
+  subroutine run_a2(this, a1, f2, arg)
+    class(runner), intent(inout) :: this
+    class(*), intent(in) :: a1
+    procedure() :: f2
+    integer, intent(in) :: arg
+    call f2(arg)
+  end subroutine
 end module
 
 program type_bound_generic_member_access_03
   use type_bound_generic_member_access_03_m
   implicit none
   type(runner) :: br
-  interface
-    subroutine my_sub()
-    end subroutine
-  end interface
+  logical :: called_with_arg = .false.
+
   call br%run(1, my_sub)
   if (.not. called) error stop 1
-end program
 
-subroutine my_sub()
-  use type_bound_generic_member_access_03_m, only: called
-  called = .true.
-end subroutine
+  call br%run(1, my_sub_with_arg, 42)
+  if (.not. called_with_arg) error stop 2
+
+contains
+  subroutine my_sub_with_arg(x)
+    integer, intent(in) :: x
+    if (x == 42) called_with_arg = .true.
+  end subroutine
+  subroutine my_sub()
+    use type_bound_generic_member_access_03_m, only: called
+    called = .true.
+  end subroutine
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2906,21 +2906,6 @@ bool is_op_overloaded(ASR::logicalbinopType op, std::string& intrinsic_op_name,
 template <typename T>
 bool argument_types_match(const Vec<ASR::call_arg_t>& args,
         const T &sub) {
-    auto is_implicit_procedure = [](ASR::symbol_t* sym) -> bool {
-        if (!sym) return false;
-        if (ASR::is_a<ASR::Variable_t>(*sym)) {
-            ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(sym);
-            if (v->m_type_declaration) {
-                ASR::symbol_t* type_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
-                if (ASR::is_a<ASR::Function_t>(*type_decl)) {
-                    std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
-                    return (decl_name.find("__") == 0 && decl_name.find("_iface_implicit") != std::string::npos);
-                }
-            }
-        }
-        return false;
-    };
-
     if (args.size() <= sub.n_args) {
         size_t i;
         for (i = 0; i < args.size(); i++) {
@@ -2941,6 +2926,28 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                 }
                 ASR::ttype_t *arg1 = ASRUtils::expr_type(args[i].m_value);
                 ASR::ttype_t *arg2 = v->m_type;
+
+                // Check if formal argument is an implicit interface procedure (e.g. procedure() :: f)
+                // If it is, it accepts any explicit interface procedure as actual argument.
+                if (v->m_type_declaration) {
+                    ASR::symbol_t* type_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
+                    if (ASR::is_a<ASR::Function_t>(*type_decl)) {
+                        std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
+                        if (decl_name.find("__") == 0 && decl_name.find("_iface_implicit") != std::string::npos) {
+                            continue;
+                        }
+                    }
+                }
+
+                // Check if actual argument is an implicit interface procedure (e.g. external :: f)
+                // If it is, it is compatible with any explicit interface formal argument.
+                if (ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                    ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
+                    if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
+                        continue;
+                    }
+                }
+
                 ASR::symbol_t* s1 = ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(args[i].m_value));
                 ASR::symbol_t* s2 = nullptr;
                 ASR::ttype_t* arg2_ext = ASRUtils::extract_type(arg2);
@@ -2971,28 +2978,7 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                         }
                     }
                 } else {
-                    // Implicit interface procedures (procedure() with no arg types)
-                    // are compatible with any explicit interface — skip types_equal.
-                    ASR::symbol_t* actual_sym = nullptr;
-                    if (args[i].m_value) {
-                        if (ASR::is_a<ASR::Var_t>(*args[i].m_value)) {
-                            actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v);
-                        } else if (ASR::is_a<ASR::StructInstanceMember_t>(*args[i].m_value)) {
-                            actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructInstanceMember_t>(args[i].m_value)->m_m);
-                        }
-                    }
-
-                    bool arg_is_implicit_procedure = is_implicit_procedure(sub_arg_sym) || is_implicit_procedure(actual_sym);
-                    
-                    if (!arg_is_implicit_procedure && ASR::is_a<ASR::FunctionType_t>(*arg1)) {
-                        ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
-                        if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
-                            arg_is_implicit_procedure = true;
-                        }
-                    }
-
-                    if (!arg_is_implicit_procedure &&
-                        !types_equal(arg1, arg2, args[i].m_value, sub.m_args[i], !ASRUtils::get_FunctionType(sub)->m_elemental)) {
+                    if (!types_equal(arg1, arg2, args[i].m_value, sub.m_args[i], !ASRUtils::get_FunctionType(sub)->m_elemental)) {
                         return false;
                     }
                 }
@@ -3006,33 +2992,19 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                 ASR::ttype_t *arg1 = ASRUtils::expr_type(args[i].m_value);
                 ASR::ttype_t *arg2 = f->m_function_signature;
 
-                // Check if actual argument is an implicit interface procedure
-                // (e.g. procedure() dummy passed down).
-                // Implicit interfaces are compatible with any explicit interface
-                // - actual compatibility is checked at call site.
-                ASR::symbol_t* actual_sym = nullptr;
-                if (args[i].m_value) {
-                    if (ASR::is_a<ASR::Var_t>(*args[i].m_value)) {
-                        actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v);
-                    } else if (ASR::is_a<ASR::StructInstanceMember_t>(*args[i].m_value)) {
-                        actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructInstanceMember_t>(args[i].m_value)->m_m);
-                    }
-                }
-                bool arg1_is_implicit = is_implicit_procedure(actual_sym);
-
-                if (!arg1_is_implicit && ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                // Check if actual argument is an implicit interface procedure (e.g. external :: f)
+                // If it is, it is compatible with any explicit interface formal argument.
+                if (ASR::is_a<ASR::FunctionType_t>(*arg1)) {
                     ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
                     if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
-                        arg1_is_implicit = true;
+                        continue;
                     }
                 }
 
-                if (!arg1_is_implicit) {
-                    Allocator al(512);
-                    if (!types_equal(arg1, arg2, args[i].m_value,
-                        ASRUtils::get_expr_from_sym(al, &f->base), false)) {
-                        return false;
-                    }
+                Allocator al(512);
+                if (!types_equal(arg1, arg2, args[i].m_value,
+                    ASRUtils::get_expr_from_sym(al, &f->base), false)) {
+                    return false;
                 }
             }
         }

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2955,8 +2955,26 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                             return false;
                         }
                     }
-                } else if (!types_equal(arg1, arg2, args[i].m_value, sub.m_args[i], !ASRUtils::get_FunctionType(sub)->m_elemental)) {
-                    return false;
+                } else {
+                    // Implicit interface procedures (procedure() with no arg types)
+                    // are compatible with any explicit interface — skip types_equal.
+                    bool arg_is_implicit_procedure = false;
+                    if (ASR::is_a<ASR::FunctionType_t>(*arg1) &&
+                        ASR::is_a<ASR::FunctionType_t>(*arg2)) {
+                        ASR::FunctionType_t* arg1_func_type =
+                            ASR::down_cast<ASR::FunctionType_t>(arg1);
+                        ASR::FunctionType_t* arg2_func_type =
+                            ASR::down_cast<ASR::FunctionType_t>(arg2);
+                        arg_is_implicit_procedure =
+                            (arg1_func_type->n_arg_types == 0 &&
+                             arg1_func_type->m_deftype == ASR::deftypeType::Interface) ||
+                            (arg2_func_type->n_arg_types == 0 &&
+                             arg2_func_type->m_deftype == ASR::deftypeType::Interface);
+                    }
+                    if (!arg_is_implicit_procedure &&
+                        !types_equal(arg1, arg2, args[i].m_value, sub.m_args[i], !ASRUtils::get_FunctionType(sub)->m_elemental)) {
+                        return false;
+                    }
                 }
             } else if (ASR::is_a<ASR::Function_t>(*sub_arg_sym)) {
                 if (args[i].m_value == nullptr) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -2906,6 +2906,21 @@ bool is_op_overloaded(ASR::logicalbinopType op, std::string& intrinsic_op_name,
 template <typename T>
 bool argument_types_match(const Vec<ASR::call_arg_t>& args,
         const T &sub) {
+    auto is_implicit_procedure = [](ASR::symbol_t* sym) -> bool {
+        if (!sym) return false;
+        if (ASR::is_a<ASR::Variable_t>(*sym)) {
+            ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(sym);
+            if (v->m_type_declaration) {
+                ASR::symbol_t* type_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
+                if (ASR::is_a<ASR::Function_t>(*type_decl)) {
+                    std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
+                    return (decl_name.find("__") == 0 && decl_name.find("_iface_implicit") != std::string::npos);
+                }
+            }
+        }
+        return false;
+    };
+
     if (args.size() <= sub.n_args) {
         size_t i;
         for (i = 0; i < args.size(); i++) {
@@ -2958,19 +2973,24 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                 } else {
                     // Implicit interface procedures (procedure() with no arg types)
                     // are compatible with any explicit interface — skip types_equal.
-                    bool arg_is_implicit_procedure = false;
-                    if (ASR::is_a<ASR::FunctionType_t>(*arg1) &&
-                        ASR::is_a<ASR::FunctionType_t>(*arg2)) {
-                        ASR::FunctionType_t* arg1_func_type =
-                            ASR::down_cast<ASR::FunctionType_t>(arg1);
-                        ASR::FunctionType_t* arg2_func_type =
-                            ASR::down_cast<ASR::FunctionType_t>(arg2);
-                        arg_is_implicit_procedure =
-                            (arg1_func_type->n_arg_types == 0 &&
-                             arg1_func_type->m_deftype == ASR::deftypeType::Interface) ||
-                            (arg2_func_type->n_arg_types == 0 &&
-                             arg2_func_type->m_deftype == ASR::deftypeType::Interface);
+                    ASR::symbol_t* actual_sym = nullptr;
+                    if (args[i].m_value) {
+                        if (ASR::is_a<ASR::Var_t>(*args[i].m_value)) {
+                            actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v);
+                        } else if (ASR::is_a<ASR::StructInstanceMember_t>(*args[i].m_value)) {
+                            actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructInstanceMember_t>(args[i].m_value)->m_m);
+                        }
                     }
+
+                    bool arg_is_implicit_procedure = is_implicit_procedure(sub_arg_sym) || is_implicit_procedure(actual_sym);
+                    
+                    if (!arg_is_implicit_procedure && ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                        ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
+                        if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
+                            arg_is_implicit_procedure = true;
+                        }
+                    }
+
                     if (!arg_is_implicit_procedure &&
                         !types_equal(arg1, arg2, args[i].m_value, sub.m_args[i], !ASRUtils::get_FunctionType(sub)->m_elemental)) {
                         return false;
@@ -2987,14 +3007,24 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
                 ASR::ttype_t *arg2 = f->m_function_signature;
 
                 // Check if actual argument is an implicit interface procedure
-                // (FunctionType with no arg types and Interface deftype).
+                // (e.g. procedure() dummy passed down).
                 // Implicit interfaces are compatible with any explicit interface
                 // - actual compatibility is checked at call site.
-                bool arg1_is_implicit = false;
-                if (ASR::is_a<ASR::FunctionType_t>(*arg1)) {
-                    ASR::FunctionType_t* ft = ASR::down_cast<ASR::FunctionType_t>(arg1);
-                    arg1_is_implicit = (ft->n_arg_types == 0 &&
-                        ft->m_deftype == ASR::deftypeType::Interface);
+                ASR::symbol_t* actual_sym = nullptr;
+                if (args[i].m_value) {
+                    if (ASR::is_a<ASR::Var_t>(*args[i].m_value)) {
+                        actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v);
+                    } else if (ASR::is_a<ASR::StructInstanceMember_t>(*args[i].m_value)) {
+                        actual_sym = ASRUtils::symbol_get_past_external(ASR::down_cast<ASR::StructInstanceMember_t>(args[i].m_value)->m_m);
+                    }
+                }
+                bool arg1_is_implicit = is_implicit_procedure(actual_sym);
+
+                if (!arg1_is_implicit && ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                    ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
+                    if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
+                        arg1_is_implicit = true;
+                    }
                 }
 
                 if (!arg1_is_implicit) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22754,13 +22754,12 @@ public:
                     if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Implementation) {
                         LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
                         tmp = llvm_symtab_fn[h];
-                    } else if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface) {
-                        if (llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end()) {
-                            tmp = llvm_symtab_fn_arg[h];
-                        } else {
-                            LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
-                            tmp = llvm_symtab_fn[h];
-                        }
+                    } else if (llvm_symtab_fn_arg.find(h) == llvm_symtab_fn_arg.end() &&
+                                ASR::is_a<ASR::Function_t>(*var_sym) &&
+                                ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface ) {
+                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
+                        tmp = llvm_symtab_fn[h];
+                        LCOMPILERS_ASSERT(tmp != nullptr)
                     } else {
                         // Must be an argument/chained procedure pass
                         LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7927,13 +7927,23 @@ public:
         } else {
             llvm::FunctionType* function_type = llvm_utils->get_function_type(x, module.get());
             if( ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface && !ASRUtils::get_FunctionType(x)->m_module ) {
-                ASR::FunctionType_t* asr_function_type = ASRUtils::get_FunctionType(x);
-                for( size_t i = 0; i < asr_function_type->n_arg_types; i++ ) {
-                    if( ASRUtils::is_class_type(asr_function_type->m_arg_types[i]) ) {
-                        if (compiler_options.emit_debug_info) {
-                            debug_current_scope = debug_current_scope_copy;
+                // Skip pre-declaration only for submodule interfaces with class(*) args,
+                // not for program-scoped interfaces (where m_module is also false).
+                bool parent_is_program = false;
+                if (x.m_symtab->parent && x.m_symtab->parent->asr_owner &&
+                        x.m_symtab->parent->asr_owner->type == ASR::asrType::symbol) {
+                    parent_is_program = ASR::is_a<ASR::Program_t>(
+                        *ASR::down_cast<ASR::symbol_t>(x.m_symtab->parent->asr_owner));
+                }
+                if (!parent_is_program) {
+                    ASR::FunctionType_t* asr_function_type = ASRUtils::get_FunctionType(x);
+                    for( size_t i = 0; i < asr_function_type->n_arg_types; i++ ) {
+                        if( ASRUtils::is_class_type(asr_function_type->m_arg_types[i]) ) {
+                            if (compiler_options.emit_debug_info) {
+                                debug_current_scope = debug_current_scope_copy;
+                            }
+                            return ;
                         }
-                        return ;
                     }
                 }
             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22747,7 +22747,24 @@ public:
                     } else if (llvm_symtab_fn_arg.find(h) == llvm_symtab_fn_arg.end() &&
                                 ASR::is_a<ASR::Function_t>(*var_sym) &&
                                 ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface ) {
-                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
+                        if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
+                            llvm::FunctionType* function_type =
+                                llvm_utils->get_function_type(*fn, module.get());
+                            ASR::FunctionType_t* ftype = ASRUtils::get_FunctionType(fn);
+                            std::string fn_name = compute_llvm_function_name(
+                                fn->m_name, ftype, compiler_options, mangle_prefix,
+                                parent_function);
+                            if (llvm_symtab_fn_names.find(fn_name) ==
+                                    llvm_symtab_fn_names.end()) {
+                                llvm_symtab_fn_names[fn_name] = h;
+                                llvm_symtab_fn[h] = llvm::Function::Create(
+                                    function_type, llvm::Function::ExternalLinkage,
+                                    fn_name, module.get());
+                            } else {
+                                uint32_t old_h = llvm_symtab_fn_names[fn_name];
+                                llvm_symtab_fn[h] = llvm_symtab_fn[old_h];
+                            }
+                        }
                         tmp = llvm_symtab_fn[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     } else {
@@ -22755,6 +22772,27 @@ public:
                         LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());
                         tmp = llvm_symtab_fn_arg[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
+                    }
+                    bool orig_arg_is_implicit_procedure = false;
+                    if (orig_arg &&
+                            ASR::is_a<ASR::FunctionType_t>(*orig_arg->m_type)) {
+                        ASR::FunctionType_t* orig_arg_ft =
+                            ASR::down_cast<ASR::FunctionType_t>(orig_arg->m_type);
+                        orig_arg_is_implicit_procedure =
+                            orig_arg_ft->n_arg_types == 0 &&
+                            orig_arg_ft->m_deftype == ASR::deftypeType::Interface;
+                    }
+                    if (orig_arg_is_implicit_procedure &&
+                            ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface &&
+                            orig_arg_intent != ASR::intentType::InOut &&
+                            orig_arg_intent != ASR::intentType::Out &&
+                            !ASRUtils::is_pointer(orig_arg->m_type)) {
+                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
+                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
+                            orig_arg->m_type, module.get());
+                        if (tmp->getType() != expected_type) {
+                            tmp = builder->CreateBitCast(tmp, expected_type);
+                        }
                     }
                     // If the target parameter is a procedure pointer,
                     // wrap the function pointer in an alloca

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22745,8 +22745,12 @@ public:
                         LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
                         tmp = llvm_symtab_fn[h];
                     } else if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface) {
-                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
-                        tmp = llvm_symtab_fn[h];
+                        if (llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end()) {
+                            tmp = llvm_symtab_fn_arg[h];
+                        } else {
+                            LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
+                            tmp = llvm_symtab_fn[h];
+                        }
                     } else {
                         // Must be an argument/chained procedure pass
                         LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22744,29 +22744,9 @@ public:
                     if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Implementation) {
                         LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
                         tmp = llvm_symtab_fn[h];
-                    } else if (llvm_symtab_fn_arg.find(h) == llvm_symtab_fn_arg.end() &&
-                                ASR::is_a<ASR::Function_t>(*var_sym) &&
-                                ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface ) {
-                        if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
-                            llvm::FunctionType* function_type =
-                                llvm_utils->get_function_type(*fn, module.get());
-                            ASR::FunctionType_t* ftype = ASRUtils::get_FunctionType(fn);
-                            std::string fn_name = compute_llvm_function_name(
-                                fn->m_name, ftype, compiler_options, mangle_prefix,
-                                parent_function);
-                            if (llvm_symtab_fn_names.find(fn_name) ==
-                                    llvm_symtab_fn_names.end()) {
-                                llvm_symtab_fn_names[fn_name] = h;
-                                llvm_symtab_fn[h] = llvm::Function::Create(
-                                    function_type, llvm::Function::ExternalLinkage,
-                                    fn_name, module.get());
-                            } else {
-                                uint32_t old_h = llvm_symtab_fn_names[fn_name];
-                                llvm_symtab_fn[h] = llvm_symtab_fn[old_h];
-                            }
-                        }
+                    } else if (ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface) {
+                        LCOMPILERS_ASSERT(llvm_symtab_fn.find(h) != llvm_symtab_fn.end());
                         tmp = llvm_symtab_fn[h];
-                        LCOMPILERS_ASSERT(tmp != nullptr)
                     } else {
                         // Must be an argument/chained procedure pass
                         LCOMPILERS_ASSERT(llvm_symtab_fn_arg.find(h) != llvm_symtab_fn_arg.end());

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22774,13 +22774,14 @@ public:
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }
                     bool orig_arg_is_implicit_procedure = false;
-                    if (orig_arg &&
-                            ASR::is_a<ASR::FunctionType_t>(*orig_arg->m_type)) {
-                        ASR::FunctionType_t* orig_arg_ft =
-                            ASR::down_cast<ASR::FunctionType_t>(orig_arg->m_type);
-                        orig_arg_is_implicit_procedure =
-                            orig_arg_ft->n_arg_types == 0 &&
-                            orig_arg_ft->m_deftype == ASR::deftypeType::Interface;
+                    if (orig_arg && orig_arg->m_type_declaration) {
+                        ASR::symbol_t *type_decl = ASRUtils::symbol_get_past_external(orig_arg->m_type_declaration);
+                        if (ASR::is_a<ASR::Function_t>(*type_decl)) {
+                            std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
+                            if (decl_name.find("__") == 0 && decl_name.find("_iface_implicit") != std::string::npos) {
+                                orig_arg_is_implicit_procedure = true;
+                            }
+                        }
                     }
                     if (orig_arg_is_implicit_procedure &&
                             ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface &&

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -22773,28 +22773,6 @@ public:
                         tmp = llvm_symtab_fn_arg[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }
-                    bool orig_arg_is_implicit_procedure = false;
-                    if (orig_arg && orig_arg->m_type_declaration) {
-                        ASR::symbol_t *type_decl = ASRUtils::symbol_get_past_external(orig_arg->m_type_declaration);
-                        if (ASR::is_a<ASR::Function_t>(*type_decl)) {
-                            std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
-                            if (decl_name.find("__") == 0 && decl_name.find("_iface_implicit") != std::string::npos) {
-                                orig_arg_is_implicit_procedure = true;
-                            }
-                        }
-                    }
-                    if (orig_arg_is_implicit_procedure &&
-                            ASRUtils::get_FunctionType(fn)->m_deftype == ASR::deftypeType::Interface &&
-                            orig_arg_intent != ASR::intentType::InOut &&
-                            orig_arg_intent != ASR::intentType::Out &&
-                            !ASRUtils::is_pointer(orig_arg->m_type)) {
-                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
-                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
-                            orig_arg->m_type, module.get());
-                        if (tmp->getType() != expected_type) {
-                            tmp = builder->CreateBitCast(tmp, expected_type);
-                        }
-                    }
                     // If the target parameter is a procedure pointer,
                     // wrap the function pointer in an alloca
                     if (orig_arg &&


### PR DESCRIPTION
fixes #11624
This PR fixes the semantic error "Arguments do not match for any generic procedure" that occurs when calling a type-bound generic procedure where the formal argument is declared as `procedure() :: f `(implicit interface).

Changes
`src/libasr/asr_utils.cpp`

Updated `argument_types_match` to recognize implicit interface procedures (`procedure() :: f `and `external :: f`) as compatible with explicit interface actual arguments during generic dispatch resolution.
For the `Variable_t `branch: if the formal argument's type declaration is an implicit interface (identified by `_iface_implicit` in the name), skip strict type matching.
For the `Function_t` branch: if the actual argument is an implicit interface procedure (FunctionType with 0 arg types and Interface deftype), skip strict type matching — actual compatibility is checked at the call site.

`src/libasr/codegen/asr_to_llvm.cpp`

Fixed instantiate_function to only skip pre-declaration of Interface functions with class(*) args for submodule cases, not for program-scoped interfaces. The existing condition !m_module is false for both submodules and programs; added a parent scope check to exclude Program_t.
integration_tests/type_bound_generic_member_access_03.f90

New integration test covering generic dispatch with procedure() dummy arguments, including multiple overloads and internal procedures passed as actual arguments.
