### PR TITLE
fix: correctly apply integer-type-spec to all loop variables in do concurrent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4080,6 +4080,7 @@ RUN(NAME do_concurrent_10 LABELS llvm_omp)
 RUN(NAME do_concurrent_11 LABELS llvm_omp llvm) # every other `do_concurrent` test can work with llvm, the only reason
 RUN(NAME do_concurrent_12 LABELS llvm_omp llvm NO_FAST_MATH) # to not include is that we do a `omp_set_num_threads(xx)` call
 RUN(NAME do_concurrent_13 LABELS llvm_omp llvm) # to not include is that we do a `omp_set_num_threads(xx)` call
+RUN(NAME do_concurrent_14 LABELS llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME transfer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/do_concurrent_14.f90
+++ b/integration_tests/do_concurrent_14.f90
@@ -1,0 +1,15 @@
+program do_concurrent_14
+    implicit none
+    integer :: a(10, 10)
+    integer :: j_test, k_test
+
+    do concurrent (integer :: j = 1:10, k = 1:10)
+        a(j, k) = j + k
+    end do
+
+    do j_test = 1, 10
+        do k_test = 1, 10
+            if (a(j_test, k_test) /= j_test + k_test) error stop
+        end do
+    end do
+end program do_concurrent_14

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8687,6 +8687,7 @@ public:
         all_loops_blocks_nesting += 1;
         Vec<ASR::do_loop_head_t> heads;  // Create a vector of loop heads
         heads.reserve(al,x.n_control);
+        AST::decl_attribute_t *current_type = nullptr;
         for(size_t i=0;i<x.n_control;i++) {
             AST::ConcurrentControl_t &h = *(AST::ConcurrentControl_t*) x.m_control[i];
             if (! h.m_var) {
@@ -8716,7 +8717,10 @@ public:
             std::string var_name = to_lower(h.m_var);
             ASR::expr_t *var = nullptr;
             if (h.m_type) {
-                AST::decl_attribute_t *decl_type = h.m_type;
+                current_type = h.m_type;
+            }
+            if (current_type) {
+                AST::decl_attribute_t *decl_type = current_type;
                 Vec<ASR::dimension_t> dims;
                 dims.reserve(al, 1);
                 ASR::symbol_t *type_declaration;


### PR DESCRIPTION
fixes #11627
* Bug: 
Fortran 2018 introduces the ability to declare loop variables inline using an 
`integer-type-spec` in a `concurrent-header` (e.g. `do concurrent(integer :: j=1:10, k=1:10)`).
Previously, LFortran's semantic analyzer (`ast_body_visitor.cpp`) only applied this 
type specifier to the *first* loop variable (`j`) in the `concurrent_control_list`. 
Subsequent variables (like `k`) were left un-typed, leading to a `semantic error: 
Variable 'k' is not declared` when `implicit none` was active.

* Fix: 
Modified `visit_DoConcurrentLoop` to cache the `m_type` attribute into a `current_type`
pointer while iterating over the `concurrent-control-list`. If a subsequent control element
has a null `m_type` (which happens because the parser associates the type-spec solely with 
the first element), it falls back to `current_type`. This ensures all loop variables 
in the header correctly inherit the inline type declaration.
