### PR TITLE
fix : polymorphic method dispatch and allocation checks on unallocated receivers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3117,6 +3117,7 @@ RUN(NAME class_146 LABELS gfortran llvm)
 RUN(NAME class_147 LABELS gfortran llvm)
 RUN(NAME class_148 LABELS gfortran llvm)
 RUN(NAME class_149 LABELS gfortran llvm)
+RUN(NAME class_150 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 

--- a/integration_tests/class_150.f90
+++ b/integration_tests/class_150.f90
@@ -1,0 +1,66 @@
+module class_150_mod
+   implicit none
+
+   integer :: animal_calls = 0
+   integer :: dog_calls = 0
+   integer :: cat_calls = 0
+
+   type :: animal_t
+   contains
+      procedure :: speak => animal_speak
+   end type
+
+   type, extends(animal_t) :: dog_t
+   contains
+      procedure :: speak => dog_speak
+   end type
+
+   type, extends(animal_t) :: cat_t
+   contains
+      procedure :: speak => cat_speak
+   end type
+
+contains
+
+   subroutine animal_speak(self)
+      class(animal_t), intent(in) :: self
+      animal_calls = animal_calls + 1
+   end subroutine
+
+   subroutine dog_speak(self)
+      class(dog_t), intent(in) :: self
+      dog_calls = dog_calls + 1
+   end subroutine
+
+   subroutine cat_speak(self)
+      class(cat_t), intent(in) :: self
+      cat_calls = cat_calls + 1
+   end subroutine
+
+end module
+
+program class_150
+   use class_150_mod
+   implicit none
+
+   integer :: i
+
+   type :: animal_wrapper_t
+      class(animal_t), allocatable :: ref
+   end type
+
+   type(animal_wrapper_t), allocatable :: animals(:)
+
+   allocate(animals(3))
+   allocate(cat_t :: animals(1)%ref)
+   allocate(dog_t :: animals(2)%ref)
+
+   do i = 1, size(animals)
+      call animals(i)%ref%speak()
+   end do
+
+   if (cat_calls /= 1) error stop 1
+   if (dog_calls /= 1) error stop 2
+   if (animal_calls /= 1) error stop 3
+   if (allocated(animals(3)%ref)) error stop 4
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -25581,8 +25581,8 @@ public:
         llvm::BasicBlock *vtable_dispatchBB = nullptr;
         llvm::BasicBlock *mergeBB = nullptr;
         llvm::Value* ret_val_ptr = nullptr;
+        llvm::Type* ret_llvm_ty = nullptr;
         if (use_declared_binding_for_unallocated) {
-            llvm::Type* ret_llvm_ty = nullptr;
             if (func->m_return_var) {
                 ASR::ttype_t* ret_ty = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
                 if (ASR::is_a<ASR::Complex_t>(*ret_ty)) {
@@ -25672,7 +25672,7 @@ public:
             builder->CreateBr(mergeBB);
             start_new_block(mergeBB);
             if (ret_val_ptr) {
-                tmp = llvm_utils->CreateLoad2(ret_val_ptr->getType()->getPointerElementType(), ret_val_ptr);
+                tmp = llvm_utils->CreateLoad2(ret_llvm_ty, ret_val_ptr);
             }
         }
         return;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -24901,8 +24901,12 @@ public:
                     ASR::FunctionType_t *ft = ASRUtils::get_FunctionType(function);
                     ASR::Variable_t *func_arg_variable = ASRUtils::expr_to_variable_or_null(function->m_args[i]);
                     LCOMPILERS_ASSERT(func_arg_variable != nullptr);
+                    bool is_type_bound_receiver = x.m_dt &&
+                        i == 0 &&
+                        x.m_dt == alloc_check_expr;
                     if (!ASRUtils::is_allocatable(ft->m_arg_types[i]) &&
-                        ASRUtils::symbol_intent((ASR::symbol_t *)func_arg_variable) != ASRUtils::intent_out) {
+                        ASRUtils::symbol_intent((ASR::symbol_t *)func_arg_variable) != ASRUtils::intent_out &&
+                        !is_type_bound_receiver) {
                         llvm::Value* is_unallocated = expr_is_unallocated(alloc_check_expr);
                         llvm::Value* arg_number = llvm::ConstantInt::get(llvm_utils->getIntType(4), llvm::APInt(32, i + 1));
                         llvm::Value* subroutine_name = LCompilers::create_global_string_ptr(
@@ -25455,6 +25459,39 @@ public:
         std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass /* skip_self */);
         args.insert(args.end(), args2.begin(), args2.end());
 
+        bool use_declared_binding_for_unallocated = ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_dt));
+        llvm::BasicBlock *vtable_dispatchBB = nullptr;
+        llvm::BasicBlock *mergeBB = nullptr;
+        if (use_declared_binding_for_unallocated) {
+            llvm::Function *current_fn = builder->GetInsertBlock()->getParent();
+            llvm::Value* is_unallocated = builder->CreateICmpEQ(
+                builder->CreatePtrToInt(llvm_dt, llvm::Type::getInt64Ty(context)),
+                builder->CreatePtrToInt(
+                    llvm::ConstantPointerNull::get(
+                        llvm::cast<llvm::PointerType>(llvm_dt->getType())),
+                    llvm::Type::getInt64Ty(context)));
+            llvm::BasicBlock *declared_bindingBB = llvm::BasicBlock::Create(
+                context, "declared_binding", current_fn);
+            vtable_dispatchBB = llvm::BasicBlock::Create(context, "vtable_dispatch");
+            mergeBB = llvm::BasicBlock::Create(context, "method_dispatch_cont");
+            builder->CreateCondBr(is_unallocated, declared_bindingBB, vtable_dispatchBB);
+
+            builder->SetInsertPoint(declared_bindingBB);
+            uint32_t h = get_hash((ASR::asr_t*)func_sym);
+            if (!class_proc->m_is_deferred && llvm_symtab_fn.find(h) != llvm_symtab_fn.end()) {
+                builder->CreateCall(llvm_symtab_fn[h], args);
+            } else {
+                llvm_utils->generate_runtime_error(
+                    llvm::ConstantInt::get(llvm::Type::getInt1Ty(context), 1),
+                    "Cannot call deferred method on unallocated polymorphic variable",
+                    {LLVMUtils::RuntimeLabel("unallocated receiver", {x.base.base.loc})},
+                    infile, location_manager);
+            }
+            builder->CreateBr(mergeBB);
+
+            start_new_block(vtable_dispatchBB);
+        }
+
         // Get VTable pointer
         if (ASR::is_a<ASR::ArrayItem_t>(*x.m_dt)) {
             ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(x.m_dt);
@@ -25481,6 +25518,10 @@ public:
             vtable_ptr, struct_api->struct_vtab_function_offset[struct_sym][proc_sym_name]));
         fn = llvm_utils->CreateLoad2(fnPtrTy, fn);
         builder->CreateCall(fnTy, fn, args);
+        if (use_declared_binding_for_unallocated) {
+            builder->CreateBr(mergeBB);
+            start_new_block(mergeBB);
+        }
         return;
     }
 
@@ -25536,6 +25577,62 @@ public:
         std::vector<llvm::Value *> args2 = convert_call_args(x, !class_proc->m_is_nopass /* skip_self */);
         args.insert(args.end(), args2.begin(), args2.end());
 
+        bool use_declared_binding_for_unallocated = ASRUtils::is_allocatable(ASRUtils::expr_type(x.m_dt));
+        llvm::BasicBlock *vtable_dispatchBB = nullptr;
+        llvm::BasicBlock *mergeBB = nullptr;
+        llvm::Value* ret_val_ptr = nullptr;
+        if (use_declared_binding_for_unallocated) {
+            llvm::Type* ret_llvm_ty = nullptr;
+            if (func->m_return_var) {
+                ASR::ttype_t* ret_ty = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
+                if (ASR::is_a<ASR::Complex_t>(*ret_ty)) {
+                    ret_llvm_ty = llvm_utils->get_type_from_ttype_t_util(x.m_dt, ret_ty, module.get());
+                } else {
+                    ret_llvm_ty = fnTy->getReturnType();
+                }
+                if (ret_llvm_ty && !ret_llvm_ty->isVoidTy()) {
+                    ret_val_ptr = llvm_utils->CreateAlloca(*builder, ret_llvm_ty);
+                }
+            }
+
+            llvm::Function *current_fn = builder->GetInsertBlock()->getParent();
+            llvm::Value* is_unallocated = builder->CreateICmpEQ(
+                builder->CreatePtrToInt(llvm_dt, llvm::Type::getInt64Ty(context)),
+                builder->CreatePtrToInt(
+                    llvm::ConstantPointerNull::get(
+                        llvm::cast<llvm::PointerType>(llvm_dt->getType())),
+                    llvm::Type::getInt64Ty(context)));
+            llvm::BasicBlock *declared_bindingBB = llvm::BasicBlock::Create(
+                context, "declared_binding", current_fn);
+            vtable_dispatchBB = llvm::BasicBlock::Create(context, "vtable_dispatch");
+            mergeBB = llvm::BasicBlock::Create(context, "method_dispatch_cont");
+            builder->CreateCondBr(is_unallocated, declared_bindingBB, vtable_dispatchBB);
+
+            builder->SetInsertPoint(declared_bindingBB);
+            uint32_t h = get_hash((ASR::asr_t*)func_sym);
+            if (!class_proc->m_is_deferred && llvm_symtab_fn.find(h) != llvm_symtab_fn.end()) {
+                tmp = builder->CreateCall(llvm_symtab_fn[h], args);
+                if (func->m_return_var) {
+                    ASR::ttype_t* ret_ty = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
+                    if (ASR::is_a<ASR::Complex_t>(*ret_ty)) {
+                        tmp = llvm_utils->complex_function_return_abi_to_internal(tmp, ret_ty);
+                    }
+                }
+                if (ret_val_ptr) {
+                    builder->CreateStore(tmp, ret_val_ptr);
+                }
+            } else {
+                llvm_utils->generate_runtime_error(
+                    llvm::ConstantInt::get(llvm::Type::getInt1Ty(context), 1),
+                    "Cannot call deferred method on unallocated polymorphic variable",
+                    {LLVMUtils::RuntimeLabel("unallocated receiver", {x.base.base.loc})},
+                    infile, location_manager);
+            }
+            builder->CreateBr(mergeBB);
+
+            start_new_block(vtable_dispatchBB);
+        }
+
         // Get Runtime VTable Pointer
         if (ASR::is_a<ASR::ArrayItem_t>(*x.m_dt)) {
             ASR::ArrayItem_t* array_item = ASR::down_cast<ASR::ArrayItem_t>(x.m_dt);
@@ -25566,6 +25663,16 @@ public:
             ASR::ttype_t* ret_ty = ASRUtils::EXPR2VAR(func->m_return_var)->m_type;
             if (ASR::is_a<ASR::Complex_t>(*ret_ty)) {
                 tmp = llvm_utils->complex_function_return_abi_to_internal(tmp, ret_ty);
+            }
+        }
+        if (use_declared_binding_for_unallocated) {
+            if (ret_val_ptr) {
+                builder->CreateStore(tmp, ret_val_ptr);
+            }
+            builder->CreateBr(mergeBB);
+            start_new_block(mergeBB);
+            if (ret_val_ptr) {
+                tmp = llvm_utils->CreateLoad2(ret_val_ptr->getType()->getPointerElementType(), ret_val_ptr);
             }
         }
         return;

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "e8650db0dd50f9530a86249aeb840c737cec2bff9f68f89f3bab7bea",
+    "stdout_hash": "4b9492c05ad30f1b95d30c46f176617a9b0a0b4224fa45345bccb38b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -22,10 +22,6 @@ target datalayout = "..."
 @5 = private unnamed_addr constant [63 x i8] c"tests/../integration_tests/call_subroutine_without_type_01.f90\00", align 1
 @6 = private unnamed_addr constant [22 x i8] c"'%s' unallocated here\00", align 1
 @7 = private unnamed_addr constant [52 x i8] c"Tried to access member of unallocated variable '%s'\00", align 1
-@8 = private unnamed_addr constant [15 x i8] c"1_mytype_get_i\00", align 1
-@9 = private unnamed_addr constant [63 x i8] c"tests/../integration_tests/call_subroutine_without_type_01.f90\00", align 1
-@10 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
-@11 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
 
 define void @__module_module_call_subroutine_without_type_01_get_i(%module_call_subroutine_without_type_01.mytype.3_class* %self) {
 .entry:
@@ -216,56 +212,32 @@ ifcont:                                           ; preds = %.entry
   %36 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
   %37 = ptrtoint %module_call_subroutine_without_type_01.mytype.3_class* %36 to i64
   %38 = icmp eq i64 %37, 0
-  br i1 %38, label %then1, label %ifcont2
+  br i1 %38, label %declared_binding, label %vtable_dispatch
 
-then1:                                            ; preds = %ifcont
-  %39 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %40 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %41 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 0
-  store i8* getelementptr inbounds ([63 x i8], [63 x i8]* @9, i32 0, i32 0), i8** %42, align 8
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 1
-  store i32 28, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 2
-  store i32 5, i32* %44, align 4
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 3
-  store i32 28, i32* %45, align 4
-  %46 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 4
-  store i32 20, i32* %46, align 4
-  %47 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @10, i32 0, i32 0))
-  %48 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  %49 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 2
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 0
-  store i1 true, i1* %51, align 1
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 1
-  store i8* %47, i8** %52, align 8
-  store { i8*, i32, i32, i32, i32 }* %49, { i8*, i32, i32, i32, i32 }** %50, align 8
-  %53 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 3
-  store i32 1, i32* %53, align 4
-  %54 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @11, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @8, i32 0, i32 0))
-  call void @exit(i32 1)
-  unreachable
+declared_binding:                                 ; preds = %ifcont
+  call void @__module_module_call_subroutine_without_type_01_get_i(%module_call_subroutine_without_type_01.mytype.3_class* %36)
+  br label %method_dispatch_cont
 
-ifcont2:                                          ; preds = %ifcont
-  %55 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %56 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %55 to void (%module_call_subroutine_without_type_01.mytype.3_class*)***
-  %57 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)**, void (%module_call_subroutine_without_type_01.mytype.3_class*)*** %56, align 8
-  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %57, i32 3
-  %59 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %58, align 8
-  call void %59(%module_call_subroutine_without_type_01.mytype.3_class* %55)
+vtable_dispatch:                                  ; preds = %ifcont
+  %39 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %36 to void (%module_call_subroutine_without_type_01.mytype.3_class*)***
+  %40 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)**, void (%module_call_subroutine_without_type_01.mytype.3_class*)*** %39, align 8
+  %41 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %40, i32 3
+  %42 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %41, align 8
+  call void %42(%module_call_subroutine_without_type_01.mytype.3_class* %36)
+  br label %method_dispatch_cont
+
+method_dispatch_cont:                             ; preds = %vtable_dispatch, %declared_binding
   br label %return
 
-return:                                           ; preds = %ifcont2
+return:                                           ; preds = %method_dispatch_cont
   br label %FINALIZE_SYMTABLE_call_subroutine_without_type_01
 
 FINALIZE_SYMTABLE_call_subroutine_without_type_01: ; preds = %return
   br label %Finalize_Variable_obj
 
 Finalize_Variable_obj:                            ; preds = %FINALIZE_SYMTABLE_call_subroutine_without_type_01
-  %60 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %60)
+  %43 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
+  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %43)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }


### PR DESCRIPTION
Towards #7629
* The Bug:
LFortran previously generated unconditional runtime allocation errors when 
an unallocated polymorphic allocatable variable was passed as a type-bound 
receiver. Bypassing this allocation check alone was insufficient because 
unallocated polymorphic objects possess a null VTable pointer, leading 
to runtime segmentation faults during dynamic dispatch. Furthermore, 
previous attempts to bypass VTable lookups caused code-generation crashes 
or linking errors (`undefined reference`) when dealing with deferred 
methods on abstract types.

* The Solution:
1. Allocation Check Bypass: Refined the condition in `visit_SubroutineCall` 
   to correctly identify type-bound receivers (`x.m_dt == alloc_check_expr`). 
   This safely bypasses the strict non-allocatable bounds check without 
   relying on brittle, post-resolution AST type assumptions.

2. F2008 Dynamic Type Fallback: Implemented dynamic type resolution logic in 
   both `visit_RuntimePolymorphicSubroutineCall` and `visit_RuntimePolymorphicFunctionCall`. 
   Because the dynamic type of an unallocated polymorphic object defaults to 
   its declared type, the code now generates an LLVM conditional branch to 
   safely dispatch to the statically declared binding when a null receiver 
   is detected.

3. Deferred Method Safety: Added a strict guard (`!class_proc->m_is_deferred`) 
   before attempting to dispatch to a declared binding. If a receiver is 
   unallocated and the method is deferred (abstract), the compiler now 
   emits a clean runtime abort instead of generating dead calls to abstract 
   interfaces that fail during linkage.

4. LLVM SSA Form Preservation: Introduced `Alloca` memory slots in 
   polymorphic function branches to safely store and load return values 
   across the divergent `vtable_dispatch` and `declared_binding` basic 
   blocks, satisfying LLVM's Static Single Assignment constraints.
