### PR TITLE
fix: handle scalar field argument in unpack intrinsic

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1462,6 +1462,7 @@ RUN(NAME intrinsics_146 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) #
 RUN(NAME intrinsics_147 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # pack
 RUN(NAME intrinsics_148 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_FAST_MATH) # pack
 RUN(NAME intrinsics_149 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_FAST_MATH) # unpack
+RUN(NAME unpack_scalar_field_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME intrinsics_150 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskr
 RUN(NAME intrinsics_151 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl
 RUN(NAME intrinsics_152 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # selected_real_kind

--- a/integration_tests/unpack_scalar_field_01.f90
+++ b/integration_tests/unpack_scalar_field_01.f90
@@ -1,0 +1,37 @@
+program unpack_scalar_field_01
+    implicit none
+
+    ! Integer scalar field
+    integer :: a(5)
+    logical :: mask(5)
+    mask = [.true., .false., .true., .false., .true.]
+    a = unpack([100, 200, 300], mask, 0)
+    if (any(a /= [100, 0, 200, 0, 300])) error stop 1
+
+    ! Real scalar field
+    real :: b(4)
+    logical :: rmask(4)
+    rmask = [.false., .true., .false., .true.]
+    b = unpack([1.5, 2.5], rmask, -1.0)
+    if (any(abs(b - [-1.0, 1.5, -1.0, 2.5]) > 0.001)) error stop 2
+
+    ! Logical scalar field
+    logical :: c(3)
+    logical :: lmask(3)
+    lmask = [.true., .true., .false.]
+    c = unpack([.true., .false.], lmask, .true.)
+    if (c(1) .neqv. .true.) error stop 3
+    if (c(2) .neqv. .false.) error stop 4
+    if (c(3) .neqv. .true.) error stop 5
+
+    ! 2D mask with scalar field
+    integer :: d(2,2)
+    logical :: mask2d(2,2)
+    mask2d = reshape([.true., .false., .false., .true.], [2,2])
+    d = unpack([10, 20], mask2d, 99)
+    if (d(1,1) /= 10 .or. d(2,1) /= 99) error stop 6
+    if (d(1,2) /= 99 .or. d(2,2) /= 20) error stop 7
+
+    print *, "PASS"
+
+end program

--- a/integration_tests/unpack_scalar_field_01.f90
+++ b/integration_tests/unpack_scalar_field_01.f90
@@ -1,23 +1,26 @@
 program unpack_scalar_field_01
     implicit none
 
-    ! Integer scalar field
     integer :: a(5)
     logical :: mask(5)
+    real :: b(4)
+    logical :: rmask(4)
+    logical :: c(3)
+    logical :: lmask(3)
+    integer :: d(2,2)
+    logical :: mask2d(2,2)
+
+    ! Integer scalar field
     mask = [.true., .false., .true., .false., .true.]
     a = unpack([100, 200, 300], mask, 0)
     if (any(a /= [100, 0, 200, 0, 300])) error stop 1
 
     ! Real scalar field
-    real :: b(4)
-    logical :: rmask(4)
     rmask = [.false., .true., .false., .true.]
     b = unpack([1.5, 2.5], rmask, -1.0)
     if (any(abs(b - [-1.0, 1.5, -1.0, 2.5]) > 0.001)) error stop 2
 
     ! Logical scalar field
-    logical :: c(3)
-    logical :: lmask(3)
     lmask = [.true., .true., .false.]
     c = unpack([.true., .false.], lmask, .true.)
     if (c(1) .neqv. .true.) error stop 3
@@ -25,8 +28,6 @@ program unpack_scalar_field_01
     if (c(3) .neqv. .true.) error stop 5
 
     ! 2D mask with scalar field
-    integer :: d(2,2)
-    logical :: mask2d(2,2)
     mask2d = reshape([.true., .false., .false., .true.], [2,2])
     d = unpack([10, 20], mask2d, 99)
     if (d(1,1) /= 10 .or. d(2,1) /= 99) error stop 6

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -6411,6 +6411,11 @@ namespace Unpack {
         ASR::ttype_t *type_mask = ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(expr_type(mask)));
         ASR::ttype_t* type_a = ASRUtils::type_get_past_array(type_vector);
 
+        ASR::ttype_t *type_field = ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(expr_type(field)));
+        if (!ASRUtils::is_array(type_field)) {
+            return nullptr;
+        }
+
         int kind = ASRUtils::extract_kind_from_ttype_t(type_a);
         int dim_mask = ASRUtils::get_fixed_size_of_array(type_mask);
         int dim_vector = ASRUtils::get_fixed_size_of_array(type_vector);
@@ -6568,10 +6573,13 @@ namespace Unpack {
         int vector_rank = extract_dimensions_from_ttype(type_vector, vector_dims);
         int mask_rank = extract_dimensions_from_ttype(type_mask, mask_dims);
         int field_rank = extract_dimensions_from_ttype(type_field, field_dims);
+        bool field_is_scalar = (field_rank == 0);
         int vector_dim = -1, mask_dim = -1, field_dim = -1;
         extract_value(vector_dims[0].m_length, vector_dim);
         extract_value(mask_dims[0].m_length, mask_dim);
-        extract_value(field_dims[0].m_length, field_dim);
+        if (!field_is_scalar) {
+            extract_value(field_dims[0].m_length, field_dim);
+        }
         if (vector_rank != 1) {
             append_error(diag, "`unpack` accepts vector of rank 1 only, provided an array "
                 "with rank, " + std::to_string(vector_rank), vector->base.loc);
@@ -6580,12 +6588,12 @@ namespace Unpack {
         if (mask_rank == 0) {
             append_error(diag, "The argument `mask` in `unpack` must be an array and not a scalar", mask->base.loc);
         }
-        if (field_rank != mask_rank) {
+        if (!field_is_scalar && field_rank != mask_rank) {
             append_error(diag, "The argument `field` must be of rank " + std::to_string(mask_rank) +
                 ", provided an array with rank, " + std::to_string(field_rank), mask->base.loc);
             return nullptr;
         }
-        if (!dimension_expr_equal(field_dims[0].m_length,
+        if (!field_is_scalar && !dimension_expr_equal(field_dims[0].m_length,
                 mask_dims[0].m_length)) {
             append_error(diag, "The argument `field` must be of dimension "
                 + std::to_string(mask_dim) + ", provided an array "


### PR DESCRIPTION
fixes #11637

The `unpack` intrinsic segfaulted when the `field` argument was a scalar
(e.g. `unpack([100, 200, 300], mask, 0)`). The `create_Unpack` function
unconditionally dereferenced `field_dims[0]` to extract dimension info,
which is invalid for scalar arguments (rank-0).

Added a `field_is_scalar` check to skip dimension extraction and
validation when `field` is rank-0. The scalar value broadcasts to the
mask shape at runtime. Compile-time evaluation via `eval_Unpack` is
skipped for scalar field (returns nullptr), letting the runtime path
handle it.

## Test plan
- [x] New integration test `unpack_scalar_field_01.f90` covering integer, real, logical scalar field and 2D mask
- [x] Existing `intrinsics_149` (array-field unpack) still passes