### PR TITLE
fix duplicate _lcompilers_* symbols in separate compilation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4392,7 +4392,7 @@ RUN(NAME separate_compilation_46 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compilation_47a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compilation_48a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
-RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90)
+RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4392,6 +4392,7 @@ RUN(NAME separate_compilation_46 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compilation_47a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compilation_48a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_50.f90
+++ b/integration_tests/separate_compilation_50.f90
@@ -1,0 +1,12 @@
+program separate_compilation_50
+  use separate_compilation_50_mod_a
+  use separate_compilation_50_mod_b
+  real :: x, y
+  x = 1.0
+  y = 2.0
+  call sc50a(x)
+  call sc50b(y)
+  if (abs(x - 0.841470957) > 1.0e-5) error stop
+  if (abs(y - 0.909297407) > 1.0e-5) error stop
+  print *, x, y
+end program

--- a/integration_tests/separate_compilation_50a.f90
+++ b/integration_tests/separate_compilation_50a.f90
@@ -1,0 +1,7 @@
+module separate_compilation_50_mod_a
+contains
+  subroutine sc50a(x)
+    real, intent(inout) :: x
+    x = sin(x)
+  end subroutine
+end module

--- a/integration_tests/separate_compilation_50b.f90
+++ b/integration_tests/separate_compilation_50b.f90
@@ -1,0 +1,7 @@
+module separate_compilation_50_mod_b
+contains
+  subroutine sc50b(x)
+    real, intent(inout) :: x
+    x = sin(x)
+  end subroutine
+end module

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7949,8 +7949,11 @@ public:
             );
             if (llvm_symtab_fn_names.find(fn_name) == llvm_symtab_fn_names.end()) {
                 llvm_symtab_fn_names[fn_name] = h;
-                F = llvm::Function::Create(function_type,
-                    llvm::Function::ExternalLinkage, fn_name, module.get());
+                auto linkage = llvm::Function::ExternalLinkage;
+                if (fn_name.rfind("_lcompilers_", 0) == 0 || fn_name.rfind("__lcompilers", 0) == 0) {
+                    linkage = llvm::Function::LinkOnceODRLinkage;
+                }
+                F = llvm::Function::Create(function_type, linkage, fn_name, module.get());
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -7950,9 +7950,6 @@ public:
             if (llvm_symtab_fn_names.find(fn_name) == llvm_symtab_fn_names.end()) {
                 llvm_symtab_fn_names[fn_name] = h;
                 auto linkage = llvm::Function::ExternalLinkage;
-                if (fn_name.rfind("_lcompilers_", 0) == 0 || fn_name.rfind("__lcompilers", 0) == 0) {
-                    linkage = llvm::Function::LinkOnceODRLinkage;
-                }
                 F = llvm::Function::Create(function_type, linkage, fn_name, module.get());
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
@@ -8457,8 +8454,15 @@ public:
                 for (size_t i=0; i<x.n_body; i++) {
                     this->visit_stmt(*x.m_body[i]);
                 }
-                
+
                 define_function_exit(x);
+
+                std::string fn_name = x.m_name;
+                if (!compiler_options.interactive &&
+                    (fn_name.rfind("_lcompilers_", 0) == 0 || fn_name.rfind("__lcompilers", 0) == 0)) {
+                    builder->GetInsertBlock()->getParent()->setLinkage(
+                        llvm::Function::LinkOnceODRLinkage);
+                }
             }
         } else if( ASRUtils::get_FunctionType(x)->m_abi == ASR::abiType::Intrinsic &&
                    ASRUtils::get_FunctionType(x)->m_deftype == ASR::deftypeType::Interface ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8458,7 +8458,7 @@ public:
                 define_function_exit(x);
 
                 std::string fn_name = x.m_name;
-                if (!compiler_options.interactive &&
+                if (compiler_options.separate_compilation &&
                     (fn_name.rfind("_lcompilers_", 0) == 0 || fn_name.rfind("__lcompilers", 0) == 0)) {
                     builder->GetInsertBlock()->getParent()->setLinkage(
                         llvm::Function::LinkOnceODRLinkage);


### PR DESCRIPTION
Fixes #11642

_lcompilers_* intrinsic helpers were emitted with ExternalLinkage,
causing duplicate symbol errors when linking separately compiled
objects that use the same intrinsic (e.g. sin).

Use LinkOnceODRLinkage so the linker merges identical copies across
translation units.