### PR TITLE
fix : support derived type component array sections in intrinsics and pointer association

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1784,6 +1784,7 @@ RUN(NAME intrinsics_463 LABELS llvm) # get_command (optional keyword arguments) 
 RUN(NAME intrinsics_464 LABELS gfortran llvm) # cshift with array shift
 RUN(NAME intrinsics_465 LABELS gfortran llvm) # index() must not read past declared length of deferred-length string
 RUN(NAME intrinsics_466 LABELS gfortran llvm) # eoshift with array-valued shift
+RUN(NAME intrinsics_467 LABELS gfortran llvm) # maxloc over derived-type array component section
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants

--- a/integration_tests/intrinsics_467.f90
+++ b/integration_tests/intrinsics_467.f90
@@ -1,0 +1,18 @@
+program intrinsics_467
+    implicit none
+
+    type :: point
+        real(8) :: x(2)
+    end type
+
+    type(point), allocatable :: top(:)
+    integer :: loc(1)
+
+    allocate(top(3))
+    top(1)%x = [0.0d0, 0.0d0]
+    top(2)%x = [1.0d0, 0.0d0]
+    top(3)%x = [2.0d0, 0.0d0]
+
+    loc = maxloc(top(:)%x(1), top(:)%x(1) < 1.5d0)
+    if (loc(1) /= 2) error stop
+end program intrinsics_467

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10291,6 +10291,20 @@ public:
                   final_type = ASRUtils::type_get_past_pointer(
                         ASRUtils::type_get_past_allocatable(type));
                 }
+                bool preserve_dt_array_dims = false;
+                if (v_expr && ASRUtils::is_array(ASRUtils::expr_type(v_expr)) &&
+                        !is_arg_array) {
+                    ASR::dimension_t* base_dims = nullptr;
+                    int base_n_dims = ASRUtils::extract_dimensions_from_ttype(
+                        ASRUtils::expr_type(v_expr), base_dims);
+                    Vec<ASR::dimension_t> base_dims_vec;
+                    base_dims_vec.from_pointer_n_copy(al, base_dims, base_n_dims);
+                    final_type = ASRUtils::duplicate_type(al,
+                        ASRUtils::extract_type(final_type),
+                        &base_dims_vec, ASRUtils::extract_physical_type(
+                            ASRUtils::expr_type(v_expr)), true);
+                    preserve_dt_array_dims = true;
+                }
                 if ( current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner) &&
                     !ASR::is_a<ASR::Block_t>(*ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner)) &&
                     !ASRUtils::is_array(ASRUtils::expr_type(v_Var))) {
@@ -10342,9 +10356,18 @@ public:
                         }
                     }
                 }
-                return (ASR::asr_t*) replace_with_common_block_variables(ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al, loc,
-                    v_Var, args.p, args.size(), final_type,
-                    ASR::arraystorageType::ColMajor, arr_ref_val)));
+                ASR::asr_t* array_item_node = nullptr;
+                if (preserve_dt_array_dims) {
+                    array_item_node = ASR::make_ArraySection_t(al, loc, v_Var,
+                        args.p, args.size(), ASRUtils::duplicate_type(al, final_type),
+                        arr_ref_val);
+                } else {
+                    array_item_node = ASRUtils::make_ArrayItem_t_util(al, loc,
+                        v_Var, args.p, args.size(), final_type,
+                        ASR::arraystorageType::ColMajor, arr_ref_val);
+                }
+                return (ASR::asr_t*) replace_with_common_block_variables(
+                    ASRUtils::EXPR(array_item_node));
             }
         } else {
             ASR::ttype_t *v_type = ASRUtils::symbol_type(v);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5183,9 +5183,7 @@ public:
                     }
                     tmp = llvm_utils->get_array_descriptor_ptr(tmp, array_type, false);
                     tmp = llvm_utils->create_gep2(array_type, tmp, 0);
-                    if (tmp->getType()->isPointerTy() && tmp->getType()->getPointerElementType()->isPointerTy()) {
-                        tmp = llvm_utils->CreateLoad2(tmp->getType()->getPointerElementType(), tmp);
-                    }
+                    tmp = llvm_utils->load_pointer_element(tmp, array_type);
                     base_t = elem_t;
                 }
             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5172,11 +5172,20 @@ public:
             base_t = ASRUtils::type_get_past_allocatable(base_t);
             base_t = ASRUtils::type_get_past_pointer(base_t);
             if (ASRUtils::is_array(base_t)) {// If nested derived type
-                ASR::ttype_t *elem_t = ASRUtils::type_get_past_array(base_t);\
+                ASR::ttype_t *elem_t = ASRUtils::type_get_past_array(base_t);
                 if (ASRUtils::is_struct(*elem_t)){
                     llvm::Type *array_type = llvm_utils->get_type_from_ttype_t_util(
                         x.m_v, base_t, module.get());
+                    if (LLVM::is_llvm_pointer(*ASRUtils::expr_type(x.m_v)) &&
+                        !llvm::dyn_cast<llvm::AllocaInst>(tmp) &&
+                        !llvm::dyn_cast<llvm::GlobalVariable>(tmp)) {
+                        tmp = llvm_utils->CreateLoad2(array_type->getPointerTo(), tmp);
+                    }
+                    tmp = llvm_utils->get_array_descriptor_ptr(tmp, array_type, false);
                     tmp = llvm_utils->create_gep2(array_type, tmp, 0);
+                    if (tmp->getType()->isPointerTy() && tmp->getType()->getPointerElementType()->isPointerTy()) {
+                        tmp = llvm_utils->CreateLoad2(tmp->getType()->getPointerElementType(), tmp);
+                    }
                     base_t = elem_t;
                 }
             }
@@ -9468,6 +9477,127 @@ public:
     void handle_array_section_association_to_pointer(const ASR::Associate_t& x) {
         ASR::ArraySection_t* array_section = ASR::down_cast<ASR::ArraySection_t>(x.m_value);
         ASR::ttype_t* value_array_type = ASRUtils::expr_type(array_section->m_v);
+
+        if (ASR::is_a<ASR::StructInstanceMember_t>(*array_section->m_v)) {
+            ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(array_section->m_v);
+            if (ASRUtils::is_array(ASRUtils::expr_type(sim->m_v))) {
+                int64_t ptr_loads_copy = ptr_loads;
+                ptr_loads = 0;
+                visit_expr(*sim->m_v);
+                llvm::Value* base_desc = tmp;
+                ptr_loads = ptr_loads_copy;
+
+                ptr_loads = 0;
+                visit_expr_wrapper(array_section->m_v);
+                llvm::Value* value_desc = tmp;
+                ptr_loads = ptr_loads_copy;
+
+                ptr_loads = 0;
+                visit_expr(*x.m_target);
+                llvm::Value* target_desc = tmp;
+                ptr_loads = ptr_loads_copy;
+
+                ASR::ttype_t* target_desc_type = ASRUtils::duplicate_type_with_empty_dims(al,
+                    ASRUtils::type_get_past_allocatable(
+                        ASRUtils::type_get_past_pointer(ASRUtils::expr_type(x.m_target))),
+                     ASR::array_physical_typeType::DescriptorArray, true);
+                llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, target_desc_type, module.get());
+
+                llvm::Value *target = arr_descr->create_descriptor_alloca(
+                    target_type, "array_section_descriptor");
+
+                int value_rank = array_section->n_args;
+                std::vector<llvm::Value*> section_first_indices;
+                for (int i = 0; i < value_rank; i++) {
+                    visit_expr_wrapper(array_section->m_args[i].m_right, true);
+                    section_first_indices.push_back(tmp);
+                }
+
+                ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(
+                    symbol_get_past_external(sim->m_m));
+                ASR::ttype_t* member_type = member_var->m_type;
+                ASR::dimension_t* m_dims = nullptr;
+                int member_dims_count = ASRUtils::extract_dimensions_from_ttype(member_type, m_dims);
+
+                std::vector<llvm::Value*> llvm_diminfo;
+                for (int idim = 0; idim < member_dims_count; idim++) {
+                    llvm::Value* dim_start = nullptr;
+                    if (m_dims[idim].m_start) {
+                        ptr_loads = 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(m_dims[idim].m_start));
+                        visit_expr_wrapper(m_dims[idim].m_start, true);
+                        dim_start = tmp;
+                    } else {
+                        llvm::Type* idx_type = arr_descr->get_index_type();
+                        unsigned idx_bits = idx_type->getIntegerBitWidth();
+                        dim_start = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 1));
+                    }
+                    llvm::Value* dim_size = nullptr;
+                    if (m_dims[idim].m_length) {
+                        ptr_loads = 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(m_dims[idim].m_length));
+                        visit_expr_wrapper(m_dims[idim].m_length, true);
+                        dim_size = tmp;
+                    } else {
+                        llvm::Type* idx_type = arr_descr->get_index_type();
+                        unsigned idx_bits = idx_type->getIntegerBitWidth();
+                        dim_size = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 0));
+                    }
+                    llvm_diminfo.push_back(dim_start);
+                    llvm_diminfo.push_back(dim_size);
+                }
+                ptr_loads = ptr_loads_copy;
+
+                llvm::Type* member_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                    sim->m_v, member_type, module.get());
+
+                value_desc = arr_descr->get_single_element(
+                    member_llvm_type, value_desc, section_first_indices, value_rank,
+                    member_type, array_section->m_v,
+                    location_manager, nullptr, true, true, llvm_diminfo.data(),
+                    false, nullptr, false, false, "", infile);
+
+                builder->CreateStore(value_desc, arr_descr->get_pointer_to_data(target_type, target));
+
+                unsigned index_bit_width = arr_descr->get_index_type()->getIntegerBitWidth();
+                builder->CreateStore(
+                    llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0)),
+                    arr_descr->get_offset(target_type, target, false));
+
+                int target_rank = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(sim->m_v));
+                arr_descr->fill_dimension_descriptor(target_type, target, target_rank);
+
+                llvm::Type* base_desc_type = llvm_utils->get_type_from_ttype_t_util(sim->m_v, ASRUtils::expr_type(sim->m_v), module.get());
+                base_desc = llvm_utils->get_array_descriptor_ptr(base_desc, base_desc_type, false);
+                llvm::Value* base_dim_des_array = arr_descr->get_pointer_to_dimension_descriptor_array(base_desc_type, base_desc);
+                llvm::Value* target_dim_des_array = arr_descr->get_pointer_to_dimension_descriptor_array(target_type, target);
+                
+                llvm::Type* dim_des = arr_descr->get_dimension_descriptor_type(false);
+                llvm::Type* base_el_type = llvm_utils->get_el_type(sim->m_v,
+                    ASRUtils::extract_type(ASRUtils::expr_type(sim->m_v)), module.get());
+                llvm::Type* target_el_type = llvm_utils->get_el_type(x.m_target,
+                    ASRUtils::extract_type(ASRUtils::expr_type(x.m_target)), module.get());
+                llvm::DataLayout data_layout(module->getDataLayout());
+                uint64_t base_size = data_layout.getTypeAllocSize(base_el_type);
+                uint64_t target_size = data_layout.getTypeAllocSize(target_el_type);
+
+                for (int r = 0; r < target_rank; r++) {
+                    llvm::Value* src_dim_val = llvm_utils->create_ptr_gep2(dim_des, base_dim_des_array, r);
+                    llvm::Value* dst_dim_val = llvm_utils->create_ptr_gep2(dim_des, target_dim_des_array, r);
+                    builder->CreateMemCpy(dst_dim_val, llvm::MaybeAlign(), src_dim_val, llvm::MaybeAlign(),
+                        llvm::ConstantInt::get(context, llvm::APInt(32, data_layout.getTypeAllocSize(dim_des))));
+                    
+                    llvm::Value* dst_stride_ptr = llvm_utils->create_gep2(dim_des, dst_dim_val, 2);
+                    llvm::Value* src_stride = llvm_utils->CreateLoad2(arr_descr->get_index_type(), dst_stride_ptr);
+                    llvm::Value* scaled_stride = builder->CreateMul(src_stride,
+                        llvm::ConstantInt::get(arr_descr->get_index_type(), base_size));
+                    scaled_stride = builder->CreateUDiv(scaled_stride,
+                        llvm::ConstantInt::get(arr_descr->get_index_type(), target_size));
+                    builder->CreateStore(scaled_stride, dst_stride_ptr);
+                }
+
+                builder->CreateStore(target, target_desc);
+                return;
+            }
+        }
 
         int64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 1 - !LLVM::is_llvm_pointer(*value_array_type);

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1956,6 +1956,11 @@ namespace LCompilers {
 #endif
     }
 
+    llvm::Value* LLVMUtils::load_pointer_element(llvm::Value* tmp, llvm::Type* array_type) {
+        llvm::Type* loaded_type = llvm::cast<llvm::StructType>(array_type)->getElementType(0);
+        return CreateLoad2(loaded_type, tmp);
+    }
+
     llvm::Value* LLVMUtils::CreateBitCastForStore(llvm::Value* value, [[maybe_unused]] llvm::Value* target_ptr) {
 #if LLVM_VERSION_MAJOR < 15
         if (value->getType()->isPointerTy() && target_ptr->getType()->isPointerTy()) {

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -312,6 +312,7 @@ class ASRToLLVMVisitor;
             llvm::Value* create_ptr_gep2(llvm::Type* type, llvm::Value* ptr, llvm::Value* idx);
 
             llvm::Value* CreateLoad2(llvm::Type *t, llvm::Value *x, bool is_volatile = false);
+            llvm::Value* load_pointer_element(llvm::Value* tmp, llvm::Type* array_type);
             llvm::Value* CreateBitCastForStore(llvm::Value* value, llvm::Value* target_ptr);
             llvm::Value* get_array_descriptor_ptr(llvm::Value* value, llvm::Type* arr_type,
                                                   bool is_character_array);


### PR DESCRIPTION
fixes #11639

- Semantics (ast_common_visitor.h):
  When indexing a member of a derived-type array (e.g. `top(:)%x(1)`), return an `ArraySection_t` node instead of an `ArrayItem_t` node. Ensure that the dimensions and physical type of the base struct array are preserved and duplicated into the final type. This resolves the semantic error where component array sections were not recognized as arrays (e.g., `argument of MaxLoc must be an array`).

- Codegen (asr_to_llvm.cpp):
  - In `visit_StructInstanceMember`, load intermediate pointer-to-pointer temporaries representing descriptors (like dynamic `ArraySection` nodes) before performing GEP. This fixes GEP target type mismatches under LLVM 15+ (opaque pointers).
  - In `handle_array_section_association_to_pointer`, add support for derived-type component array sections. Since LFortran uses element-based strides, scale the stride of the target descriptor by:
    (base_stride * base_element_size) / target_element_size.
    This resolves runtime out-of-bounds indexing and incorrect mask evaluations during array slice operations.
