### PR TITLE
fix: ICE and unallocated errors for nested array-returning intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2799,6 +2799,7 @@ RUN(NAME string_115 LABELS gfortran llvm)
 
 RUN(NAME substring_read LABELS gfortran llvm)
 
+RUN(NAME nested_array_intrinsics_01 LABELS gfortran llvm)
 RUN(NAME nested_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/nested_array_intrinsics_01.f90
+++ b/integration_tests/nested_array_intrinsics_01.f90
@@ -1,0 +1,21 @@
+program test_nested_array_intrinsics
+    implicit none
+
+    character(len=1), parameter :: tokens(1) = ["A"]
+
+    ! Test spread inside index and any with character arrays
+    if (.not. hit("A")) error stop 1
+    if (hit("B")) error stop 2
+
+    ! Test spread inside sum with integer arrays
+    if (sum(spread([1, 2], 1, 2)) /= 6) error stop 3
+
+contains
+
+    function hit(deferred_text) result(found)
+        character(*), intent(in) :: deferred_text
+        logical :: found
+        found = any(index(tokens, spread(deferred_text, 1, 1)) /= 0)
+    end function hit
+
+end program test_nested_array_intrinsics

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2560,6 +2560,34 @@ namespace Spread {
         ASR::ttype_t *type_ncopies = ASRUtils::type_get_past_allocatable_pointer(expr_type(ncopies));
         ASR::ttype_t *ret_type = ASRUtils::type_get_past_allocatable_pointer(expr_type(source));
 
+        // If the source is an assumed-length string (character(*)), the return
+        // type must not carry AssumedLength — that's only valid for dummy
+        // arguments and is invalid in ASR for a function return.  Convert to
+        // ExpressionLength with len = StringLen(source).
+        ASR::ttype_t* ret_elem = ASRUtils::extract_type(ret_type);
+        if( ASR::is_a<ASR::String_t>(*ret_elem) ) {
+            ASR::String_t* str_t = ASR::down_cast<ASR::String_t>(ret_elem);
+            if( str_t->m_len_kind == ASR::string_length_kindType::AssumedLength ) {
+                ASR::expr_t* source_for_len = args[0];
+                ASR::expr_t* len_expr = ASRUtils::EXPR(
+                    ASR::make_StringLen_t(al, loc, source_for_len,
+                        ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr));
+                ASR::ttype_t* new_str = ASRUtils::TYPE(ASR::make_String_t(
+                    al, loc, str_t->m_kind, len_expr,
+                    ASR::string_length_kindType::ExpressionLength,
+                    str_t->m_physical_type));
+                // Rebuild ret_type with the corrected element type
+                ASR::dimension_t* rdims = nullptr;
+                size_t rn = ASRUtils::extract_dimensions_from_ttype(ret_type, rdims);
+                if( rn > 0 ) {
+                    ret_type = ASRUtils::make_Array_t_util(al, loc, new_str,
+                        rdims, rn);
+                } else {
+                    ret_type = new_str;
+                }
+            }
+        }
+
         ASRBuilder b(al, loc);
         int overload_id = 2;
         if(ASR::is_a<ASR::Integer_t>(*type_source) || ASR::is_a<ASR::Real_t>(*type_source) ||
@@ -2676,6 +2704,10 @@ namespace Spread {
         }
         fill_func_arg("dim", arg_types[1]);
         fill_func_arg("ncopies", arg_types[2]);
+
+        // Save the original return type for the FunctionCall node (caller's scope).
+        ASR::ttype_t* caller_return_type = return_type;
+
         int64_t n_dims_return_type = ASRUtils::extract_n_dims_from_ttype(return_type);
         bool is_allocatable = ASRUtils::is_allocatable(return_type);
         Vec<ASR::dimension_t> empty_dims;
@@ -2687,10 +2719,38 @@ namespace Spread {
             empty_dim.m_length = nullptr;
             empty_dims.push_back(al, empty_dim);
         }
+
+        // For string element types with ExpressionLength, the length expression
+        // references the caller's variable (e.g. StringLen(deferred_text)).
+        // Inside this generated function, we must use StringLen(source_param)
+        // where source_param is the function's own source argument.
+        ASR::ttype_t* elem_type = ASRUtils::extract_type(return_type);
+        if( ASR::is_a<ASR::String_t>(*elem_type) ) {
+            ASR::String_t* str = ASR::down_cast<ASR::String_t>(elem_type);
+            if( str->m_len_kind == ASR::string_length_kindType::ExpressionLength ) {
+                ASR::expr_t* source_param = args[0]; // function's own source arg
+                ASR::expr_t* new_len = ASRUtils::EXPR(
+                    ASR::make_StringLen_t(al, loc, source_param,
+                        ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr));
+                elem_type = ASRUtils::TYPE(ASR::make_String_t(
+                    al, loc, str->m_kind, new_len,
+                    ASR::string_length_kindType::ExpressionLength,
+                    str->m_physical_type));
+            }
+        }
+
         return_type = ASRUtils::make_Array_t_util(al, loc,
-            ASRUtils::extract_type(return_type), empty_dims.p, empty_dims.size());
+            elem_type, empty_dims.p, empty_dims.size());
         if( is_allocatable ) {
             return_type = ASRUtils::TYPE(ASRUtils::make_Allocatable_t_util(al, loc, return_type));
+        }
+
+        // Also rebuild caller_return_type with empty dims for the FunctionCall node.
+        ASR::ttype_t* caller_elem = ASRUtils::extract_type(caller_return_type);
+        caller_return_type = ASRUtils::make_Array_t_util(al, loc,
+            caller_elem, empty_dims.p, empty_dims.size());
+        if( is_allocatable ) {
+            caller_return_type = ASRUtils::TYPE(ASRUtils::make_Allocatable_t_util(al, loc, caller_return_type));
         }
 
         diag::Diagnostics diag;
@@ -2716,7 +2776,7 @@ namespace Spread {
         ASR::symbol_t *fn_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
                 body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, fn_sym);
-        return b.Call(fn_sym, m_args, return_type, nullptr);
+        return b.Call(fn_sym, m_args, caller_return_type, nullptr);
     }
 
 } // namespace Spread

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -186,13 +186,15 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
     public:
     ASR::expr_t* result_var_; // Declared in array_struct_temporary
     SymbolTable* current_scope;
+    bool was_temp_created;
 
     ReplaceFunctionCallReturningArray(Allocator& al_, Vec<ASR::stmt_t*>& pass_result_,
     std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions>& func2intrinsicid_) :
     al(al_), pass_result(pass_result_), result_counter(0),
     func2intrinsicid(func2intrinsicid_),
     result_var_(nullptr),
-    current_scope(nullptr) {}
+    current_scope(nullptr),
+    was_temp_created(false) {}
 
     // Not called from anywhere but kept for future use.
     // Especially if we don't find alternatives to allocatables
@@ -293,10 +295,114 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             return;
         }
 
-        if( !this->result_var_ ) {
-            // No result variable (e.g., parameter initialization);
-            // the value is compile-time constant, skip replacement.
-            return;
+        ASR::expr_t* effective_result_var = this->result_var_;
+        // Check if result_var_ is usable: it must be set AND its type must
+        // be compatible (i.e., it must be an array of the same element type).
+        // When the intrinsic is nested (e.g., index(tokens, spread(...))),
+        // result_var_ points to the outer assignment target which has an
+        // incompatible type.
+        bool need_temp = !effective_result_var;
+        if( effective_result_var ) {
+            ASR::ttype_t* res_type = ASRUtils::expr_type(effective_result_var);
+            ASR::ttype_t* call_type = x->m_type;
+            if( !ASRUtils::is_array(res_type) || !ASRUtils::is_array(call_type) ||
+                !ASRUtils::types_equal(
+                    ASRUtils::extract_type(res_type),
+                    ASRUtils::extract_type(call_type), nullptr, nullptr, true) ) {
+                need_temp = true;
+                effective_result_var = nullptr;
+            }
+        }
+        if( need_temp && !effective_result_var ) {
+            this->was_temp_created = true;
+            // No result variable from an assignment context. This happens
+            // when an array-returning intrinsic is used as a nested argument
+            // (e.g., index(tokens, spread(text, 1, 1))). Create a temporary
+            // allocatable variable to hold the result.
+            ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable(x->m_type);
+            // AssumedLength strings are only valid for dummy variables;
+            // convert to DeferredLength for the temporary.
+            ASR::ttype_t* element_type = ASRUtils::extract_type(base_type);
+            if( ASR::is_a<ASR::String_t>(*element_type) ) {
+                ASR::String_t* str_t = ASR::down_cast<ASR::String_t>(element_type);
+                if( str_t->m_len_kind == ASR::string_length_kindType::AssumedLength ) {
+                    element_type = ASRUtils::TYPE(ASR::make_String_t(
+                        al, x->base.base.loc, str_t->m_kind, nullptr,
+                        ASR::string_length_kindType::DeferredLength,
+                        str_t->m_physical_type));
+                    ASR::dimension_t* dims = nullptr;
+                    size_t n_dims = ASRUtils::extract_dimensions_from_ttype(base_type, dims);
+                    if( n_dims > 0 ) {
+                        base_type = ASRUtils::make_Array_t_util(al, x->base.base.loc,
+                            element_type, dims, n_dims);
+                    } else {
+                        base_type = element_type;
+                    }
+                }
+            }
+            ASR::ttype_t* tmp_type = ASRUtils::TYPE(ASR::make_Allocatable_t(
+                al, x->base.base.loc, base_type));
+            effective_result_var = PassUtils::create_var(result_counter,
+                "_intrinsic_array_tmp_", x->base.base.loc, tmp_type,
+                al, current_scope);
+
+            // Allocate the temp variable with dimensions from the return type.
+            ASR::dimension_t* ret_dims = nullptr;
+            size_t ret_n_dims = ASRUtils::extract_dimensions_from_ttype(
+                ASRUtils::type_get_past_allocatable(x->m_type), ret_dims);
+            ASR::alloc_arg_t alloc_arg;
+            // For deferred-length strings, provide the string length
+            // from the source argument (first arg of spread).
+            if( ASR::is_a<ASR::String_t>(*element_type) &&
+                ASR::down_cast<ASR::String_t>(element_type)->m_len_kind ==
+                    ASR::string_length_kindType::DeferredLength &&
+                x->n_args > 0 && x->m_args[0].m_value ) {
+                alloc_arg.m_len_expr = ASRUtils::EXPR(ASR::make_StringLen_t(
+                    al, x->base.base.loc, x->m_args[0].m_value,
+                    ASRUtils::TYPE(ASR::make_Integer_t(al, x->base.base.loc, 4)),
+                    nullptr));
+            } else {
+                alloc_arg.m_len_expr = nullptr;
+            }
+            alloc_arg.m_type = nullptr;
+            alloc_arg.loc = x->base.base.loc;
+            alloc_arg.m_a = effective_result_var;
+            alloc_arg.m_sym_subclass = nullptr;
+            Vec<ASR::dimension_t> alloc_dims;
+            alloc_dims.reserve(al, ret_n_dims);
+            ASR::ttype_t* i32_type = ASRUtils::TYPE(
+                ASR::make_Integer_t(al, x->base.base.loc, 4));
+            for( size_t d = 0; d < ret_n_dims; d++ ) {
+                ASR::dimension_t adim;
+                adim.loc = x->base.base.loc;
+                adim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                    al, x->base.base.loc, 1, i32_type));
+                // Use the dimension from the original return type if available,
+                // otherwise use ArraySize to compute at runtime.
+                if( ret_dims[d].m_length ) {
+                    adim.m_length = ret_dims[d].m_length;
+                } else if( x->n_args > 0 && x->m_args[0].m_value ) {
+                    // Fallback: use ArraySize of the first arg for that dimension
+                    adim.m_length = ASRUtils::EXPR(
+                        ASRUtils::make_ArraySize_t_util(al, x->base.base.loc,
+                            x->m_args[0].m_value,
+                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                al, x->base.base.loc, d + 1, i32_type)),
+                            i32_type, nullptr));
+                } else {
+                    adim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                        al, x->base.base.loc, 1, i32_type));
+                }
+                alloc_dims.push_back(al, adim);
+            }
+            alloc_arg.m_dims = alloc_dims.p;
+            alloc_arg.n_dims = alloc_dims.size();
+            Vec<ASR::alloc_arg_t> alloc_args;
+            alloc_args.reserve(al, 1);
+            alloc_args.push_back(al, alloc_arg);
+            pass_result.push_back(al, ASRUtils::STMT(ASR::make_Allocate_t(
+                al, x->base.base.loc, alloc_args.p, alloc_args.size(),
+                nullptr, nullptr, nullptr)));
         }
 
         Vec<ASR::call_arg_t> new_args;
@@ -308,9 +414,8 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             new_args.push_back(al, new_arg);
         }
         ASR::call_arg_t new_arg;
-        LCOMPILERS_ASSERT(this->result_var_)
-        new_arg.loc = this->result_var_->base.loc;
-        new_arg.m_value = this->result_var_;
+        new_arg.loc = effective_result_var->base.loc;
+        new_arg.m_value = effective_result_var;
         new_args.push_back(al, new_arg);
 
 
@@ -318,6 +423,11 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             al, x->base.base.loc, x->m_name, x->m_original_name, new_args.p,
             new_args.size(), x->m_dt, nullptr, false));
         pass_result.push_back(al, subrout_call);
+        if( need_temp ) {
+            // For nested intrinsic calls, replace the FunctionCall expression
+            // with the temp variable so the parent expression uses it.
+            *current_expr = effective_result_var;
+        }
     }
 };
 
@@ -359,6 +469,7 @@ class ReplaceFunctionCallReturningArrayVisitor : public ASR::CallReplacerOnExpre
             for (size_t i=0; i<n_body; i++) {
                 pass_result.n = 0;
                 pass_result.reserve(al, 1);
+                replacer.was_temp_created = false;
                 Vec<ASR::stmt_t*>* parent_body_copy = parent_body;
                 parent_body = &body;
                 visit_stmt(*m_body[i]);
@@ -366,6 +477,9 @@ class ReplaceFunctionCallReturningArrayVisitor : public ASR::CallReplacerOnExpre
                 if( pass_result.size() > 0 ) {
                     for (size_t j=0; j < pass_result.size(); j++) {
                         body.push_back(al, pass_result[j]);
+                    }
+                    if( replacer.was_temp_created ) {
+                        body.push_back(al, m_body[i]);
                     }
                 } else {
                     body.push_back(al, m_body[i]);

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -186,15 +186,13 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
     public:
     ASR::expr_t* result_var_; // Declared in array_struct_temporary
     SymbolTable* current_scope;
-    bool was_temp_created;
 
     ReplaceFunctionCallReturningArray(Allocator& al_, Vec<ASR::stmt_t*>& pass_result_,
     std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions>& func2intrinsicid_) :
     al(al_), pass_result(pass_result_), result_counter(0),
     func2intrinsicid(func2intrinsicid_),
     result_var_(nullptr),
-    current_scope(nullptr),
-    was_temp_created(false) {}
+    current_scope(nullptr) {}
 
     // Not called from anywhere but kept for future use.
     // Especially if we don't find alternatives to allocatables
@@ -295,82 +293,10 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             return;
         }
 
-        ASR::expr_t* effective_result_var = this->result_var_;
-        // Check if result_var_ is usable: it must be set AND its type must
-        // be compatible (i.e., it must be an array of the same element type).
-        // When the intrinsic is nested (e.g., index(tokens, spread(...))),
-        // result_var_ points to the outer assignment target which has an
-        // incompatible type.
-        bool need_temp = !effective_result_var;
-        if( effective_result_var ) {
-            ASR::ttype_t* res_type = ASRUtils::expr_type(effective_result_var);
-            ASR::ttype_t* call_type = x->m_type;
-            if( !ASRUtils::is_array(res_type) || !ASRUtils::is_array(call_type) ||
-                !ASRUtils::types_equal(
-                    ASRUtils::extract_type(res_type),
-                    ASRUtils::extract_type(call_type), nullptr, nullptr, true) ) {
-                need_temp = true;
-                effective_result_var = nullptr;
-            }
-        }
-        if( need_temp && !effective_result_var ) {
-            this->was_temp_created = true;
-            // No result variable from an assignment context. This happens
-            // when an array-returning intrinsic is used as a nested argument
-            // (e.g., index(tokens, spread(text, 1, 1))). Create a temporary
-            // allocatable variable to hold the result.
-            ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable(x->m_type);
-            ASR::ttype_t* tmp_type = ASRUtils::TYPE(ASR::make_Allocatable_t(
-                al, x->base.base.loc, base_type));
-            effective_result_var = PassUtils::create_var(result_counter,
-                "_intrinsic_array_tmp_", x->base.base.loc, tmp_type,
-                al, current_scope);
-
-            // Allocate the temp variable with dimensions from the return type.
-            ASR::dimension_t* ret_dims = nullptr;
-            size_t ret_n_dims = ASRUtils::extract_dimensions_from_ttype(
-                ASRUtils::type_get_past_allocatable(x->m_type), ret_dims);
-            ASR::alloc_arg_t alloc_arg;
-            alloc_arg.m_len_expr = nullptr;
-            alloc_arg.m_type = nullptr;
-            alloc_arg.loc = x->base.base.loc;
-            alloc_arg.m_a = effective_result_var;
-            alloc_arg.m_sym_subclass = nullptr;
-            Vec<ASR::dimension_t> alloc_dims;
-            alloc_dims.reserve(al, ret_n_dims);
-            ASR::ttype_t* i32_type = ASRUtils::TYPE(
-                ASR::make_Integer_t(al, x->base.base.loc, 4));
-            for( size_t d = 0; d < ret_n_dims; d++ ) {
-                ASR::dimension_t adim;
-                adim.loc = x->base.base.loc;
-                adim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                    al, x->base.base.loc, 1, i32_type));
-                // Use the dimension from the original return type if available,
-                // otherwise use ArraySize to compute at runtime.
-                if( ret_dims[d].m_length ) {
-                    adim.m_length = ret_dims[d].m_length;
-                } else if( x->n_args > 0 && x->m_args[0].m_value ) {
-                    // Fallback: use ArraySize of the first arg for that dimension
-                    adim.m_length = ASRUtils::EXPR(
-                        ASRUtils::make_ArraySize_t_util(al, x->base.base.loc,
-                            x->m_args[0].m_value,
-                            ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                                al, x->base.base.loc, d + 1, i32_type)),
-                            i32_type, nullptr));
-                } else {
-                    adim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x->base.base.loc, 1, i32_type));
-                }
-                alloc_dims.push_back(al, adim);
-            }
-            alloc_arg.m_dims = alloc_dims.p;
-            alloc_arg.n_dims = alloc_dims.size();
-            Vec<ASR::alloc_arg_t> alloc_args;
-            alloc_args.reserve(al, 1);
-            alloc_args.push_back(al, alloc_arg);
-            pass_result.push_back(al, ASRUtils::STMT(ASR::make_Allocate_t(
-                al, x->base.base.loc, alloc_args.p, alloc_args.size(),
-                nullptr, nullptr, nullptr)));
+        if( !this->result_var_ ) {
+            // No result variable (e.g., parameter initialization);
+            // the value is compile-time constant, skip replacement.
+            return;
         }
 
         Vec<ASR::call_arg_t> new_args;
@@ -382,8 +308,9 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             new_args.push_back(al, new_arg);
         }
         ASR::call_arg_t new_arg;
-        new_arg.loc = effective_result_var->base.loc;
-        new_arg.m_value = effective_result_var;
+        LCOMPILERS_ASSERT(this->result_var_)
+        new_arg.loc = this->result_var_->base.loc;
+        new_arg.m_value = this->result_var_;
         new_args.push_back(al, new_arg);
 
 
@@ -391,11 +318,6 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             al, x->base.base.loc, x->m_name, x->m_original_name, new_args.p,
             new_args.size(), x->m_dt, nullptr, false));
         pass_result.push_back(al, subrout_call);
-        if( need_temp ) {
-            // For nested intrinsic calls, replace the FunctionCall expression
-            // with the temp variable so the parent expression uses it.
-            *current_expr = effective_result_var;
-        }
     }
 };
 
@@ -437,7 +359,6 @@ class ReplaceFunctionCallReturningArrayVisitor : public ASR::CallReplacerOnExpre
             for (size_t i=0; i<n_body; i++) {
                 pass_result.n = 0;
                 pass_result.reserve(al, 1);
-                replacer.was_temp_created = false;
                 Vec<ASR::stmt_t*>* parent_body_copy = parent_body;
                 parent_body = &body;
                 visit_stmt(*m_body[i]);
@@ -445,9 +366,6 @@ class ReplaceFunctionCallReturningArrayVisitor : public ASR::CallReplacerOnExpre
                 if( pass_result.size() > 0 ) {
                     for (size_t j=0; j < pass_result.size(); j++) {
                         body.push_back(al, pass_result[j]);
-                    }
-                    if( replacer.was_temp_created ) {
-                        body.push_back(al, m_body[i]);
                     }
                 } else {
                     body.push_back(al, m_body[i]);

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -320,26 +320,6 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             // (e.g., index(tokens, spread(text, 1, 1))). Create a temporary
             // allocatable variable to hold the result.
             ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable(x->m_type);
-            // AssumedLength strings are only valid for dummy variables;
-            // convert to DeferredLength for the temporary.
-            ASR::ttype_t* element_type = ASRUtils::extract_type(base_type);
-            if( ASR::is_a<ASR::String_t>(*element_type) ) {
-                ASR::String_t* str_t = ASR::down_cast<ASR::String_t>(element_type);
-                if( str_t->m_len_kind == ASR::string_length_kindType::AssumedLength ) {
-                    element_type = ASRUtils::TYPE(ASR::make_String_t(
-                        al, x->base.base.loc, str_t->m_kind, nullptr,
-                        ASR::string_length_kindType::DeferredLength,
-                        str_t->m_physical_type));
-                    ASR::dimension_t* dims = nullptr;
-                    size_t n_dims = ASRUtils::extract_dimensions_from_ttype(base_type, dims);
-                    if( n_dims > 0 ) {
-                        base_type = ASRUtils::make_Array_t_util(al, x->base.base.loc,
-                            element_type, dims, n_dims);
-                    } else {
-                        base_type = element_type;
-                    }
-                }
-            }
             ASR::ttype_t* tmp_type = ASRUtils::TYPE(ASR::make_Allocatable_t(
                 al, x->base.base.loc, base_type));
             effective_result_var = PassUtils::create_var(result_counter,
@@ -351,19 +331,7 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             size_t ret_n_dims = ASRUtils::extract_dimensions_from_ttype(
                 ASRUtils::type_get_past_allocatable(x->m_type), ret_dims);
             ASR::alloc_arg_t alloc_arg;
-            // For deferred-length strings, provide the string length
-            // from the source argument (first arg of spread).
-            if( ASR::is_a<ASR::String_t>(*element_type) &&
-                ASR::down_cast<ASR::String_t>(element_type)->m_len_kind ==
-                    ASR::string_length_kindType::DeferredLength &&
-                x->n_args > 0 && x->m_args[0].m_value ) {
-                alloc_arg.m_len_expr = ASRUtils::EXPR(ASR::make_StringLen_t(
-                    al, x->base.base.loc, x->m_args[0].m_value,
-                    ASRUtils::TYPE(ASR::make_Integer_t(al, x->base.base.loc, 4)),
-                    nullptr));
-            } else {
-                alloc_arg.m_len_expr = nullptr;
-            }
+            alloc_arg.m_len_expr = nullptr;
             alloc_arg.m_type = nullptr;
             alloc_arg.loc = x->base.base.loc;
             alloc_arg.m_a = effective_result_var;


### PR DESCRIPTION
fixes #11647

Root Cause: create_Spread was propagating the source argument's AssumedLength string type directly into the IntrinsicArrayFunction's return type via duplicate_type. character(*) (AssumedLength) is only valid for dummy arguments — it is invalid ASR for a function return type. This caused downstream passes to fail when trying to create temporaries or allocate variables for the result.

Fix: In create_Spread (intrinsic_array_function_registry.h), when the source is an assumed-length string, convert the return type's element type from AssumedLength to ExpressionLength with len = StringLen(source). This produces a semantically correct return type that the existing array_struct_temporary pass can handle properly when creating temporaries for nested intrinsic calls.

In instantiate_Spread, remap the string length expression to reference the generated function's own source parameter (instead of the caller's variable) to avoid cross-scope symbol table references.

No changes to intrinsic_function.cpp are needed — the array_struct_temporary pass already unwraps nested intrinsics into temp = intrinsicCall statements with proper types.