### PR TITLE
handle heterogeneous implied-do loops in unformatted write

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4468,6 +4468,7 @@ RUN(NAME proc_ptr_16 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME proc_ptr_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME proc_ptr_18 LABELS gfortran llvm)
 RUN(NAME write_substr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME write_implied_do_1 LABELS gfortran llvm)
 RUN(NAME move_alloc_derived_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_section_assign_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/write_implied_do_1.f90
+++ b/integration_tests/write_implied_do_1.f90
@@ -1,0 +1,15 @@
+program write_implied_do_1
+  implicit none
+  integer :: unit, medium, nmedia
+  integer :: n(2)
+  character(len=8) :: material(2)
+
+  nmedia = 2
+  n = [1, 2]
+  material = ['water   ', 'bottom  ']
+  unit = 20
+
+  open(unit=unit, file='out.dat', access='direct', recl=128, form='unformatted', status='replace')
+  write(unit, rec=1) (n(medium), material(medium), medium = 1, nmedia)
+  close(unit)
+end program

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -860,6 +860,11 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
         bool remove_original_statement, allocate_target = false;
         bool print = false, file_write = false;
         ASR::expr_t* m_unit = nullptr;
+        ASR::expr_t* m_rec = nullptr;
+        ASR::expr_t* m_iomsg = nullptr;
+        ASR::expr_t* m_iostat = nullptr;
+        ASR::expr_t* m_pos = nullptr;
+        bool m_is_formatted = true;
         ReplaceArrayConstant replacer;
         Vec<ASR::stmt_t*> pass_result;
         Vec<ASR::stmt_t*>* parent_body;
@@ -883,6 +888,11 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             pass_result.reserve(al, 0);
             print = false, file_write = false;
             m_unit = nullptr;
+            m_rec = nullptr;
+            m_iomsg = nullptr;
+            m_iostat = nullptr;
+            m_pos = nullptr;
+            m_is_formatted = true;
         }
 
         void visit_Variable(const ASR::Variable_t& /*x*/) {
@@ -1223,6 +1233,37 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             return do_loop;
         }
 
+        ASR::stmt_t* create_do_loop_unformatted_idl(ASR::ImpliedDoLoop_t* x) {
+            ASR::do_loop_head_t do_loop_head;
+            do_loop_head.loc = x->base.base.loc; do_loop_head.m_v = x->m_var;
+            do_loop_head.m_start = x->m_start; do_loop_head.m_end = x->m_end;
+            do_loop_head.m_increment = x->m_increment;
+
+            Vec<ASR::stmt_t*> do_loop_body; do_loop_body.reserve(al, 1);
+
+            Vec<ASR::expr_t*> args;
+            args.reserve(al, x->n_values);
+            for (size_t i = 0; i < x->n_values; i++ ) {
+                if ( ASR::is_a<ASR::ImpliedDoLoop_t>(*x->m_values[i]) ) {
+                    do_loop_body.push_back(al, create_do_loop_unformatted_idl(
+                        ASR::down_cast<ASR::ImpliedDoLoop_t>(x->m_values[i])));
+                } else {
+                    args.push_back(al, x->m_values[i]);
+                }
+            }
+
+            if (args.size() > 0) {
+                ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_FileWrite_t(al, x->base.base.loc,
+                    0, m_unit, m_iomsg, m_iostat, nullptr,
+                    args.p, args.size(), nullptr, nullptr, nullptr,
+                    m_is_formatted, nullptr, m_rec, m_pos, nullptr));
+                do_loop_body.push_back(al, stmt);
+            }
+
+            return ASRUtils::STMT(ASR::make_DoLoop_t(al, x->base.base.loc, nullptr,
+                do_loop_head, do_loop_body.p, do_loop_body.size(), nullptr, 0));
+        }
+
         void visit_Print(const ASR::Print_t &x) {
             print = true;
             /*
@@ -1432,6 +1473,11 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
         void visit_FileWrite(const ASR::FileWrite_t &x) {
             file_write = true;
             m_unit = x.m_unit;
+            m_rec = x.m_rec;
+            m_iomsg = x.m_iomsg;
+            m_iostat = x.m_iostat;
+            m_pos = x.m_pos;
+            m_is_formatted = x.m_is_formatted;
             if (x.m_overloaded) {
                 this->visit_stmt(*x.m_overloaded);
                 remove_original_statement = false;
@@ -1456,6 +1502,31 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             for(size_t i = 0; i < x.n_values; i++) {
                 ASR::expr_t* value = x.m_values[i];
                 if (ASR::is_a<ASR::ImpliedDoLoop_t>(*value)) {
+                    ASR::ImpliedDoLoop_t* idl = ASR::down_cast<ASR::ImpliedDoLoop_t>(value);
+                    if (ASR::is_a<ASR::Tuple_t>(*idl->m_type)) {
+                        Vec<ASR::expr_t*> expanded_values;
+                        expanded_values.reserve(al, 16);
+                        if (expand_implied_do_loop_flat(idl, expanded_values)) {
+                            Vec<ASR::expr_t*> new_values;
+                            new_values.reserve(al, x.n_values + expanded_values.size());
+                            for (size_t j = 0; j < i; j++) {
+                                new_values.push_back(al, x.m_values[j]);
+                            }
+                            for (size_t j = 0; j < expanded_values.size(); j++) {
+                                new_values.push_back(al, expanded_values.p[j]);
+                            }
+                            for (size_t j = i + 1; j < x.n_values; j++) {
+                                new_values.push_back(al, x.m_values[j]);
+                            }
+                            write_stmt->m_values = new_values.p;
+                            write_stmt->n_values = new_values.size();
+                            i = i + expanded_values.size() - 1;
+                            continue;
+                        }
+                        remove_original_statement = true;
+                        pass_result.push_back(al, create_do_loop_unformatted_idl(idl));
+                        continue;
+                    }
                     ASR::asr_t* array_constant = create_array_constant(x, value);
 
                     write_stmt->m_values[i] = ASRUtils::EXPR(array_constant);


### PR DESCRIPTION
Fixes #11660

Unformatted WRITE with an implied-do loop containing mixed types (e.g., Integer + String) crashed with an assertion in `llvm_utils.cpp:get_el_type()`. The `implied_do_loops` pass wrapped heterogeneous ImpliedDoLoop values in an ArrayConstructor with Tuple element type, which the codegen couldn't handle.

The fix detects Tuple-typed ImpliedDoLoop in `visit_FileWrite` and handles it via flat expansion (constant bounds) or a DoLoop with individual FileWrite statements (variable bounds), instead of wrapping in an ArrayConstructor.