### PR TITLE
fix: ICE in struct implied do loop IO expansion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3323,6 +3323,7 @@ RUN(NAME implied_do_loops36 LABELS gfortran llvm)
 
 RUN(NAME implied_do_loops37 LABELS gfortran llvm)
 RUN(NAME implied_do_loops38 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
+RUN(NAME implied_do_loops39 LABELS gfortran llvm)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops39.f90
+++ b/integration_tests/implied_do_loops39.f90
@@ -1,0 +1,61 @@
+! Test: implied do loop with struct-typed array elements in read/write.
+! Regression test for ICE: visit_ImpliedDoLoop() not implemented
+! when struct members were incorrectly wrapped around ImpliedDoLoop
+! instead of being expanded inside the loop values.
+program implied_do_loops39
+    implicit none
+
+    type :: point_t
+        real(8) :: x, y, z
+    end type
+
+    type(point_t) :: pts(3)
+    integer :: i, n
+
+    ! --- Test 1: constant-bound implied do loop write/read with struct ---
+    pts(1) = point_t(1.0d0, 2.0d0, 3.0d0)
+    pts(2) = point_t(4.0d0, 5.0d0, 6.0d0)
+    pts(3) = point_t(7.0d0, 8.0d0, 9.0d0)
+
+    open(10, status="scratch", form="formatted")
+    write(10, *) (pts(i), i = 1, 3)
+    rewind(10)
+
+    pts = point_t(0.0d0, 0.0d0, 0.0d0)
+    read(10, *) (pts(i), i = 1, 3)
+    close(10)
+
+    if (abs(pts(1)%x - 1.0d0) > 1.0d-10) error stop "Test 1 failed: pts(1)%x"
+    if (abs(pts(1)%y - 2.0d0) > 1.0d-10) error stop "Test 1 failed: pts(1)%y"
+    if (abs(pts(1)%z - 3.0d0) > 1.0d-10) error stop "Test 1 failed: pts(1)%z"
+    if (abs(pts(2)%x - 4.0d0) > 1.0d-10) error stop "Test 1 failed: pts(2)%x"
+    if (abs(pts(2)%y - 5.0d0) > 1.0d-10) error stop "Test 1 failed: pts(2)%y"
+    if (abs(pts(2)%z - 6.0d0) > 1.0d-10) error stop "Test 1 failed: pts(2)%z"
+    if (abs(pts(3)%x - 7.0d0) > 1.0d-10) error stop "Test 1 failed: pts(3)%x"
+    if (abs(pts(3)%y - 8.0d0) > 1.0d-10) error stop "Test 1 failed: pts(3)%y"
+    if (abs(pts(3)%z - 9.0d0) > 1.0d-10) error stop "Test 1 failed: pts(3)%z"
+
+    ! --- Test 2: variable-bound implied do loop write/read with struct ---
+    ! This is the case that triggered the original ICE.
+    pts(1) = point_t(10.0d0, 20.0d0, 30.0d0)
+    pts(2) = point_t(40.0d0, 50.0d0, 60.0d0)
+
+    n = 2
+    open(10, status="scratch", form="formatted")
+    write(10, *) (pts(i), i = 1, n)
+    rewind(10)
+
+    pts(1) = point_t(0.0d0, 0.0d0, 0.0d0)
+    pts(2) = point_t(0.0d0, 0.0d0, 0.0d0)
+    read(10, *) (pts(i), i = 1, n)
+    close(10)
+
+    if (abs(pts(1)%x - 10.0d0) > 1.0d-10) error stop "Test 2 failed: pts(1)%x"
+    if (abs(pts(1)%y - 20.0d0) > 1.0d-10) error stop "Test 2 failed: pts(1)%y"
+    if (abs(pts(1)%z - 30.0d0) > 1.0d-10) error stop "Test 2 failed: pts(1)%z"
+    if (abs(pts(2)%x - 40.0d0) > 1.0d-10) error stop "Test 2 failed: pts(2)%x"
+    if (abs(pts(2)%y - 50.0d0) > 1.0d-10) error stop "Test 2 failed: pts(2)%y"
+    if (abs(pts(2)%z - 60.0d0) > 1.0d-10) error stop "Test 2 failed: pts(2)%z"
+
+    print *, "All tests passed."
+end program implied_do_loops39

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2283,23 +2283,32 @@ public:
                     })) {
                 overloaded_stmt = ASRUtils::STMT(asr);
             }
-            // If no overload found and single struct value, then expand struct components
-            // (recursively for nested structs)
-            if (overloaded_stmt == nullptr &&
-                a_values_vec.size() == 1) {
-                ASR::expr_t* expr = a_values_vec[0];
-                ASR::ttype_t* type = ASRUtils::expr_type(expr);
-                type = ASRUtils::type_get_past_allocatable(
-                    ASRUtils::type_get_past_pointer(type));
-                if (ASR::is_a<ASR::StructType_t>(*type)) {
-                    a_values_vec.n = 0;
-                    std::function<void(ASR::expr_t*)> expand_struct_expr;
-                    expand_struct_expr = [&](ASR::expr_t* struct_expr) {
+            // If no overload found, expand any struct-typed values into their
+            // member components (recursively for nested structs).
+            if (overloaded_stmt == nullptr && a_values_vec.size() >= 1) {
+                // Check if any value has struct type
+                bool has_struct = false;
+                for (size_t vi = 0; vi < a_values_vec.size(); vi++) {
+                    ASR::ttype_t* vtype = ASRUtils::expr_type(a_values_vec[vi]);
+                    vtype = ASRUtils::type_get_past_allocatable(
+                        ASRUtils::type_get_past_pointer(vtype));
+                    if (ASR::is_a<ASR::StructType_t>(*vtype)) {
+                        has_struct = true;
+                        break;
+                    }
+                }
+                if (has_struct) {
+                    // Helper lambda: expand a struct expression into its member
+                    // expressions, recursively handling nested structs.
+                    // Appends the expanded (leaf) expressions to `expanded`.
+                    std::function<void(ASR::expr_t*, Vec<ASR::expr_t*>&)> expand_struct_expr;
+                    expand_struct_expr = [&](ASR::expr_t* struct_expr,
+                                             Vec<ASR::expr_t*>& expanded) {
                         ASR::ttype_t* stype = ASRUtils::expr_type(struct_expr);
                         stype = ASRUtils::type_get_past_allocatable(
                             ASRUtils::type_get_past_pointer(stype));
                         if (!ASR::is_a<ASR::StructType_t>(*stype)) {
-                            a_values_vec.push_back(al, struct_expr);
+                            expanded.push_back(al, struct_expr);
                             return;
                         }
                         ASR::symbol_t *struct_sym = ASRUtils::symbol_get_past_external(
@@ -2307,7 +2316,7 @@ public:
                         ASR::Struct_t *struct_def = ASR::down_cast<ASR::Struct_t>(struct_sym);
 
                         if (struct_def->n_members == 0) {
-                            a_values_vec.push_back(al, struct_expr);
+                            expanded.push_back(al, struct_expr);
                             return;
                         }
                         for (size_t j = 0; j < struct_def->n_members; j++) {
@@ -2322,10 +2331,48 @@ public:
                                     al, struct_expr->base.loc, struct_expr,
                                     member_sym, member_var->m_type, nullptr));
                             // Recursively expand if the member is itself a struct
-                            expand_struct_expr(member_expr);
+                            expand_struct_expr(member_expr, expanded);
                         }
                     };
-                    expand_struct_expr(expr);
+
+                    Vec<ASR::expr_t*> new_values_vec;
+                    new_values_vec.reserve(al, a_values_vec.size() * 4);
+                    for (size_t vi = 0; vi < a_values_vec.size(); vi++) {
+                        ASR::expr_t* expr = a_values_vec[vi];
+                        ASR::ttype_t* etype = ASRUtils::expr_type(expr);
+                        etype = ASRUtils::type_get_past_allocatable(
+                            ASRUtils::type_get_past_pointer(etype));
+                        if (!ASR::is_a<ASR::StructType_t>(*etype)) {
+                            // Non-struct value, keep as-is
+                            new_values_vec.push_back(al, expr);
+                        } else if (ASR::is_a<ASR::ImpliedDoLoop_t>(*expr)) {
+                            // For ImpliedDoLoop with struct values like:
+                            //   read(*, *) (recs(i), i = 1, n)
+                            // We expand struct members INSIDE the loop values.
+                            // Before: ImpliedDoLoop(values=[recs(i)], ...)
+                            // After:  ImpliedDoLoop(values=[recs(i)%x, recs(i)%y, ...], ...)
+                            ASR::ImpliedDoLoop_t* idl = ASR::down_cast<ASR::ImpliedDoLoop_t>(expr);
+                            Vec<ASR::expr_t*> idl_new_values;
+                            idl_new_values.reserve(al, idl->n_values * 4);
+                            for (size_t iv = 0; iv < idl->n_values; iv++) {
+                                expand_struct_expr(idl->m_values[iv], idl_new_values);
+                            }
+                            ASR::ttype_t* new_type = idl->m_type;
+                            if (idl_new_values.size() > 0) {
+                                new_type = ASRUtils::expr_type(idl_new_values[0]);
+                            }
+                            ASR::expr_t* new_idl = ASRUtils::EXPR(ASR::make_ImpliedDoLoop_t(
+                                al, idl->base.base.loc, idl_new_values.p, idl_new_values.size(),
+                                idl->m_var, idl->m_start, idl->m_end, idl->m_increment,
+                                new_type, idl->m_value));
+                            new_values_vec.push_back(al, new_idl);
+                        } else {
+                            // Direct struct value (e.g., pts(1) from constant-bound
+                            // implied do loop expansion): expand into members.
+                            expand_struct_expr(expr, new_values_vec);
+                        }
+                    }
+                    a_values_vec = new_values_vec;
                 }
             }
 


### PR DESCRIPTION
fixes #11659


The struct member expansion for IO statements (read/write) only
triggered when a_values_vec contained exactly one value. This caused
two bugs:

1. Variable-bound implied do loops like `read(*, *) (recs(i), i=1,n)`
   produced a single ImpliedDoLoop with StructType. The struct expansion
   then wrapped StructInstanceMember around the entire ImpliedDoLoop
   (producing the invalid `StructInstanceMember(ImpliedDoLoop(...))`),
   which hit the unimplemented visit_ImpliedDoLoop in LLVM codegen.

2. Constant-bound implied do loops like `read(*, *) (recs(i), i=1,3)`
   were expanded into multiple struct-typed ArrayItems (recs(1), recs(2),
   recs(3)). Since size > 1, struct expansion was skipped entirely,
   causing an assertion failure in codegen when it tried to generate a
   read function for StructType.

Fix: generalize the struct expansion to iterate over all IO values,
expanding struct members for each one. For ImpliedDoLoop values, struct
members are expanded inside the loop values (producing correct ASR like
`ImpliedDoLoop(values=[recs(i)%x, recs(i)%y, ...])`) instead of
wrapping outside.
