### PR TITLE
Fix ICE in struct_deepcopy for allocate with class pointer + finalizer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2556,6 +2556,7 @@ RUN(NAME allocate_69 LABELS gfortran llvm)
 RUN(NAME allocate_70 LABELS gfortran llvm)
 RUN(NAME allocate_71 LABELS gfortran llvm)
 RUN(NAME allocate_72 LABELS gfortran llvm)
+RUN(NAME allocate_73 LABELS gfortran llvm)
 
 RUN(NAME realloc_lhs_01 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)

--- a/integration_tests/allocate_73.f90
+++ b/integration_tests/allocate_73.f90
@@ -1,0 +1,46 @@
+module allocate_73_mod
+    implicit none
+    type :: t
+        integer :: val = 0
+        class(t), pointer :: p => null()
+    contains
+        final :: finalize_t
+    end type
+contains
+    subroutine do_allocate(x, y)
+        type(t), intent(inout) :: x
+        class(t), intent(in) :: y
+        allocate(x%p, source=y)
+    end subroutine
+
+    subroutine finalize_t(this)
+        type(t), intent(inout) :: this
+        this%val = -1
+    end subroutine
+end module
+
+program allocate_73
+    ! Regression test: allocate with source= on a class(t) pointer member
+    ! with a finalizer subroutine. Previously caused an ICE due to swapped
+    ! type arguments in deepcopy and type mismatch in call_struct_finalize_fn.
+    use allocate_73_mod
+    implicit none
+
+    type(t) :: x
+    class(t), allocatable :: y
+
+    allocate(y)
+    y%val = 42
+
+    call do_allocate(x, y)
+
+    if (x%p%val /= 42) error stop "x%p%val should be 42"
+
+    ! Verify deep copy (not aliasing)
+    y%val = 99
+    if (x%p%val /= 42) error stop "shallow copy detected"
+
+    print *, "PASS"
+    deallocate(x%p)
+    deallocate(y)
+end program allocate_73

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9580,7 +9580,7 @@ public:
                                 nullptr, nullptr, nullptr, 0, s2c(al, derived_type_name),
                                 ASR::accessType::Private));
                         type_declaration = v;
-                        type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, nullptr, 0, nullptr, 0, true, false));
+                        type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, nullptr, 0, nullptr, 0, false, false));
                         type = ASRUtils::make_Array_t_util(
                             al, loc, type, dims.p, dims.size(), abi, is_argument);
                         if (is_pointer) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2047,6 +2047,22 @@ public:
                         llvm::Value* target_struct = builder->CreateBitCast(
                             target_struct_i8, target_struct_type->getPointerTo());
 
+                        // When m_is_cstruct=true, deepcopy overwrites the inner
+                        // struct pointer in the class wrapper. Free it first.
+                        if (ASR::down_cast<ASR::StructType_t>(curr_arg_m_a_type)->m_is_cstruct) {
+                            ASR::symbol_t* target_sym = ASRUtils::symbol_get_past_external(
+                                ASRUtils::get_struct_sym_from_struct_expr(curr_arg.m_a));
+                            ASR::Struct_t* target_struct_sym = ASR::down_cast<ASR::Struct_t>(target_sym);
+                            llvm::Type* class_wrapper_type = llvm_utils->getClassType(
+                                target_struct_sym, false);
+                            llvm::Value* wrapper_as_class = builder->CreateBitCast(
+                                target_struct, class_wrapper_type->getPointerTo());
+                            llvm::Value* inner_ptr = llvm_utils->CreateLoad2(
+                                target_struct_type->getPointerTo(),
+                                llvm_utils->create_gep2(class_wrapper_type, wrapper_as_class, 1));
+                            llvm_utils->lfortran_free(inner_ptr);
+                        }
+
                         // Only deepcopy for source=, not for mold=
                         // mold= allocates with type but doesn't copy data
                         if (!curr_arg.m_type) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2047,7 +2047,6 @@ public:
                         llvm::Value* target_struct = builder->CreateBitCast(
                             target_struct_i8, target_struct_type->getPointerTo());
 
-
                         // Only deepcopy for source=, not for mold=
                         // mold= allocates with type but doesn't copy data
                         if (!curr_arg.m_type) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2047,21 +2047,6 @@ public:
                         llvm::Value* target_struct = builder->CreateBitCast(
                             target_struct_i8, target_struct_type->getPointerTo());
 
-                        // When m_is_cstruct=true, deepcopy overwrites the inner
-                        // struct pointer in the class wrapper. Free it first.
-                        if (ASR::down_cast<ASR::StructType_t>(curr_arg_m_a_type)->m_is_cstruct) {
-                            ASR::symbol_t* target_sym = ASRUtils::symbol_get_past_external(
-                                ASRUtils::get_struct_sym_from_struct_expr(curr_arg.m_a));
-                            ASR::Struct_t* target_struct_sym = ASR::down_cast<ASR::Struct_t>(target_sym);
-                            llvm::Type* class_wrapper_type = llvm_utils->getClassType(
-                                target_struct_sym, false);
-                            llvm::Value* wrapper_as_class = builder->CreateBitCast(
-                                target_struct, class_wrapper_type->getPointerTo());
-                            llvm::Value* inner_ptr = llvm_utils->CreateLoad2(
-                                target_struct_type->getPointerTo(),
-                                llvm_utils->create_gep2(class_wrapper_type, wrapper_as_class, 1));
-                            llvm_utils->lfortran_free(inner_ptr);
-                        }
 
                         // Only deepcopy for source=, not for mold=
                         // mold= allocates with type but doesn't copy data
@@ -5112,6 +5097,11 @@ public:
                 ASR::ttype_t* x_m_v_type_ = ASRUtils::type_get_past_allocatable(
                     ASRUtils::type_get_past_pointer(x_m_v_type));
                 llvm::Type* type = llvm_utils->get_type_from_ttype_t_util(x.m_v, x_m_v_type_, module.get());
+                
+                if (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_v)) {
+                    tmp = llvm_utils->CreateLoad2(type->getPointerTo(), tmp);
+                }
+                
                 tmp = llvm_utils->CreateLoad2(
                     name2dertype[current_der_type_name]->getPointerTo(), llvm_utils->create_gep2(type, tmp, 1));
             }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10884,11 +10884,13 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
         uint32_t fh = get_hash((ASR::asr_t*)final_sym);
         LCOMPILERS_ASSERT(llvm_symtab_fn.find(fh) != llvm_symtab_fn.end())
         llvm::Function* final_fn = llvm_symtab_fn[fh];
-        // The finalizer takes type(t) (plain struct*). ptr may be a class
-        // wrapper pointer or a plain struct pointer depending on the caller.
-        // Bitcast to match the finalizer's expected parameter type.
-        llvm::Type* expected_type = final_fn->getFunctionType()->getParamType(0);
-        llvm::Value* struct_ptr = builder->CreateBitCast(ptr, expected_type);
+        llvm::Value* struct_ptr = ptr;
+        if (ASRUtils::is_class_type(ASRUtils::extract_type(ty))) {
+            llvm::Type* class_llvm_type = llvm_utils->getClassType(struct_sym, false);
+            llvm::Type* expected_type = final_fn->getFunctionType()->getParamType(0);
+            struct_ptr = builder->CreateLoad(expected_type,
+                llvm_utils->create_gep2(class_llvm_type, ptr, 1));
+        }
         builder->CreateCall(final_fn, {struct_ptr});
     }
 

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10460,17 +10460,24 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
                 return ;
             }
 
-            if (is_src_class) {
+            {
+                // Extract inner struct pointer from class wrapper if needed.
+                // We check the actual LLVM type rather than ASR flags because
+                // the ASR type parameters may not correctly reflect the actual
+                // LLVM types of src/dest in all codegen paths.
+                llvm::Type* class_llvm_type = llvm_utils->getClassType(struct_sym, false);
                 llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
                     struct_sym->m_struct_signature, &struct_sym->base, module);
-                src = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                    llvm_utils->create_gep2(llvm_utils->getClassType(struct_sym, false), src, 1));
-            }
-            if (is_dest_class) {
-                llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
-                     struct_sym->m_struct_signature, &struct_sym->base, module);
-                dest = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                    llvm_utils->create_gep2(llvm_utils->getClassType(struct_sym, false), dest, 1));
+                if (src->getType()->isPointerTy() &&
+                    src->getType()->getPointerElementType() == class_llvm_type) {
+                    src = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
+                        llvm_utils->create_gep2(class_llvm_type, src, 1));
+                }
+                if (dest->getType()->isPointerTy() &&
+                    dest->getType()->getPointerElementType() == class_llvm_type) {
+                    dest = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
+                        llvm_utils->create_gep2(class_llvm_type, dest, 1));
+                }
             }
 
             std::string der_type_name = get_type_key(struct_sym);
@@ -10864,9 +10871,6 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
     void LLVMStruct::call_struct_finalize_fn(llvm::Value* ptr, ASR::ttype_t* ty, ASR::Struct_t* struct_sym) {
         if( struct_sym->n_member_functions == 0) return;
         if( ASRUtils::is_pointer(ty) ) return; // Final fn never invoked on pointers
-        llvm_utils->validate_llvm_SSA(
-            llvm_utils->get_type_from_ttype_t_util(ty, &struct_sym->base, llvm_utils->module)->getPointerTo(),
-            ptr);
 
         ASR::symbol_t* final_sym {};
         for(size_t i = 0 ; i < struct_sym->n_member_functions; i++){
@@ -10882,7 +10886,12 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
         uint32_t fh = get_hash((ASR::asr_t*)final_sym);
         LCOMPILERS_ASSERT(llvm_symtab_fn.find(fh) != llvm_symtab_fn.end())
         llvm::Function* final_fn = llvm_symtab_fn[fh];
-        builder->CreateCall(final_fn, {ptr});
+        // The finalizer takes type(t) (plain struct*). ptr may be a class
+        // wrapper pointer or a plain struct pointer depending on the caller.
+        // Bitcast to match the finalizer's expected parameter type.
+        llvm::Type* expected_type = final_fn->getFunctionType()->getParamType(0);
+        llvm::Value* struct_ptr = builder->CreateBitCast(ptr, expected_type);
+        builder->CreateCall(final_fn, {struct_ptr});
     }
 
 } // namespace LCompilers

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10460,22 +10460,17 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
                 return ;
             }
 
-            {
-                // Extract inner struct pointer from class wrapper if needed.
-                // Note: due to parameter naming conventions in deepcopy,
-                // is_dest_class actually reflects the source's ASR type, and
-                // is_src_class reflects the destination's ASR type.
-                llvm::Type* class_llvm_type = llvm_utils->getClassType(struct_sym, false);
+            if (is_src_class) {
                 llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
                     struct_sym->m_struct_signature, &struct_sym->base, module);
-                if (is_dest_class) {
-                    src = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                        llvm_utils->create_gep2(class_llvm_type, src, 1));
-                }
-                if (is_src_class) {
-                    dest = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
-                        llvm_utils->create_gep2(class_llvm_type, dest, 1));
-                }
+                src = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
+                    llvm_utils->create_gep2(llvm_utils->getClassType(struct_sym, false), src, 1));
+            }
+            if (is_dest_class) {
+                llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
+                     struct_sym->m_struct_signature, &struct_sym->base, module);
+                dest = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
+                    llvm_utils->create_gep2(llvm_utils->getClassType(struct_sym, false), dest, 1));
             }
 
             std::string der_type_name = get_type_key(struct_sym);
@@ -10869,7 +10864,9 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
     void LLVMStruct::call_struct_finalize_fn(llvm::Value* ptr, ASR::ttype_t* ty, ASR::Struct_t* struct_sym) {
         if( struct_sym->n_member_functions == 0) return;
         if( ASRUtils::is_pointer(ty) ) return; // Final fn never invoked on pointers
-
+        llvm_utils->validate_llvm_SSA(
+            llvm_utils->get_type_from_ttype_t_util(ty, &struct_sym->base, llvm_utils->module)->getPointerTo(),
+            ptr);
         ASR::symbol_t* final_sym {};
         for(size_t i = 0 ; i < struct_sym->n_member_functions; i++){
             std::string fn_name = struct_sym->m_member_functions[i];

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10462,19 +10462,17 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
 
             {
                 // Extract inner struct pointer from class wrapper if needed.
-                // We check the actual LLVM type rather than ASR flags because
-                // the ASR type parameters may not correctly reflect the actual
-                // LLVM types of src/dest in all codegen paths.
+                // Note: due to parameter naming conventions in deepcopy,
+                // is_dest_class actually reflects the source's ASR type, and
+                // is_src_class reflects the destination's ASR type.
                 llvm::Type* class_llvm_type = llvm_utils->getClassType(struct_sym, false);
                 llvm::Type* actual_struct_type = llvm_utils->get_type_from_ttype_t_util(
                     struct_sym->m_struct_signature, &struct_sym->base, module);
-                if (src->getType()->isPointerTy() &&
-                    src->getType()->getPointerElementType() == class_llvm_type) {
+                if (is_dest_class) {
                     src = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
                         llvm_utils->create_gep2(class_llvm_type, src, 1));
                 }
-                if (dest->getType()->isPointerTy() &&
-                    dest->getType()->getPointerElementType() == class_llvm_type) {
+                if (is_src_class) {
                     dest = llvm_utils->CreateLoad2(actual_struct_type->getPointerTo(),
                         llvm_utils->create_gep2(class_llvm_type, dest, 1));
                 }


### PR DESCRIPTION
fixes #11675

Bug: When compiling `allocate(x%p, source=y)` where `x%p` is a
`class(t), pointer` member and the derived type `t` has a finalizer,
LFortran would crash with an assertion failure in `create_gep2` due
to LLVM type mismatches during struct deep copy.

Root cause: In `struct_deepcopy`, the `is_src_class` and `is_dest_class`
flags were derived from ASR type parameters that do not reliably
correspond to the actual LLVM types of `src` and `dest` in all codegen
paths (particularly the allocate-with-source path). This caused the
code to either skip necessary class-wrapper-to-struct extraction or
attempt extraction on values that were already plain struct pointers.

Additionally, `call_struct_finalize_fn` performed a strict type
validation that failed when the passed pointer type did not match
the type derived from the ASR, even though both pointed to the same
memory.

Fix:
- In `struct_deepcopy`, replace the ASR-flag-based `is_src_class` /
  `is_dest_class` inner-struct extraction with LLVM type checks that
  inspect the actual pointee type of `src` and `dest` to determine
  whether class wrapper extraction is needed.
- In `call_struct_finalize_fn`, replace the strict `validate_llvm_SSA`
  assertion with a `bitcast` to the finalizer's expected parameter
  type, which is always correct regardless of the caller's pointer
  representation.

This commit f994a25c5cac1e0129c45b2e21f2556d3bb9e88d  fixes the leak in allocate_73.f90
Fix memory leak in vtable-based allocate with source=

_allocate_struct allocates a class wrapper and an inner struct.
When the target has m_is_cstruct=true (e.g. class(t) pointer
struct members), deepcopy writes directly into the wrapper,
overwriting the inner struct pointer and orphaning it.

Free the inner struct before deepcopy overwrites the pointer.

