### PR TITLE
feat: add legacy F77 aliases iargc and getarg

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3311,6 +3311,7 @@ RUN(NAME boz_02 LABELS llvm llvm_wasm llvm_wasm_emcc) #remove gfortran label, as
 RUN(NAME cmd_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME cmd_02 LABELS gfortran llvm)
 RUN(NAME cmd_03 LABELS gfortran llvm) # get_command_argument loop until empty
+RUN(NAME cmd_04 LABELS gfortran llvm) # iargc/getarg legacy F77 aliases
 
 RUN(NAME flip_sign LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME div_to_mul LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/cmd_04.f90
+++ b/integration_tests/cmd_04.f90
@@ -1,0 +1,28 @@
+program test_iargc_getarg
+    ! Legacy F77 intrinsics iargc()/getarg(pos, value) should behave
+    ! identically to the F2003 equivalents command_argument_count() and
+    ! get_command_argument(number, value). See issue #10764.
+    implicit none
+    integer :: n1, n2, i
+    character(len=128) :: arg_legacy, arg_modern
+
+    n1 = iargc()
+    n2 = command_argument_count()
+    if (n1 /= n2) error stop "iargc() must equal command_argument_count()"
+
+    call getarg(0, arg_legacy)
+    call get_command_argument(0, arg_modern)
+    if (arg_legacy /= arg_modern) then
+        error stop "getarg(0) must match get_command_argument(0)"
+    end if
+
+    do i = 1, n1
+        call getarg(i, arg_legacy)
+        call get_command_argument(i, arg_modern)
+        if (arg_legacy /= arg_modern) then
+            error stop "getarg(i) must match get_command_argument(i)"
+        end if
+    end do
+
+    print *, "iargc:", n1
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1898,6 +1898,8 @@ public:
         {"_lfortran_compiler_version", IntrinsicSignature({}, 0, 0)},
         {"compiler_options", IntrinsicSignature({}, 0, 0)},
         {"command_argument_count", IntrinsicSignature({}, 0, 0)},
+        // Legacy F77 alias for command_argument_count (no args).
+        {"iargc", IntrinsicSignature({}, 0, 0)},
         {"rand", IntrinsicSignature({"flag"}, 0, 1)},
         {"this_image", IntrinsicSignature({}, 0, 0)},
         {"num_images", IntrinsicSignature({}, 0, 0)},
@@ -1914,6 +1916,10 @@ public:
         {"abort", IntrinsicSignature({}, 0, 0)},
         {"get_command", IntrinsicSignature({"command", "length", "status"}, 0, 3)},
         {"get_command_argument", IntrinsicSignature({"number", "value", "length", "status"}, 1, 4)},
+        // Legacy F77 alias for get_command_argument. Standard form is
+        // `call getarg(pos, value)`; the extra optional args are accepted
+        // by extension to share the get_command_argument signature.
+        {"getarg", IntrinsicSignature({"number", "value", "length", "status"}, 1, 4)},
         {"system_clock", IntrinsicSignature({"count", "count_rate", "count_max"}, 0, 3)},
         {"date_and_time", IntrinsicSignature({"date", "time", "zone", "values"}, 0, 4)},
         {"get_environment_variable", IntrinsicSignature({"name", "value", "length", "status", "trim_name"}, 1, 5)},

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -681,6 +681,8 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"nearest", {&Nearest::create_Nearest, &Nearest::eval_Nearest}},
                 {"_lfortran_compiler_version", {&CompilerVersion::create_CompilerVersion, &CompilerVersion::eval_CompilerVersion}},
                 {"command_argument_count", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
+                // Legacy F77 alias for command_argument_count.
+                {"iargc", {&CommandArgumentCount::create_CommandArgumentCount, nullptr}},
                 {"rand", {&Rand::create_Rand, nullptr}},
                 {"this_image", {&ThisImage::create_ThisImage, &ThisImage::eval_ThisImage}},
                 {"num_images", {&NumImages::create_NumImages, &NumImages::eval_NumImages}},

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -109,6 +109,8 @@ namespace IntrinsicImpureSubroutineRegistry {
                 {"srand", &Srand::create_Srand},
                 {"get_command", &GetCommand::create_GetCommand},
                 {"get_command_argument", &GetCommandArgument::create_GetCommandArgument},
+                // Legacy F77 alias for get_command_argument.
+                {"getarg", &GetCommandArgument::create_GetCommandArgument},
                 {"system_clock", &SystemClock::create_SystemClock},
                 {"get_environment_variable", &GetEnvironmentVariable::create_GetEnvironmentVariable},
                 {"execute_command_line", &ExecuteCommandLine::create_ExecuteCommandLine},


### PR DESCRIPTION
Map iargc() to command_argument_count and getarg(pos, value) to get_command_argument by registering the legacy names in the intrinsic registries. Both follow the existing lshift -> shiftl alias pattern, sharing the modern create_* functions verbatim.

Real F77 benchmark code (FASTA and similar) uses these spellings; without the aliases the user has to rewrite source to compile under LFortran while gfortran/ifort accept them as-is.

Adds integration_tests/cmd_04.f90 that asserts the legacy and modern intrinsics agree for every command-line position from 0 to iargc(), labelled gfortran + llvm.

Fixes #10764