### PR TITLE
fix: handle elemental intrinsics on allocatable arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2577,6 +2577,8 @@ RUN(NAME realloc_lhs_22 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME realloc_lhs_23 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME realloc_lhs_24 LABELS gfortran llvm
+    EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME automatic_allocation_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)
 RUN(NAME automatic_allocation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --std=f23)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1784,6 +1784,7 @@ RUN(NAME intrinsics_463 LABELS llvm) # get_command (optional keyword arguments) 
 RUN(NAME intrinsics_464 LABELS gfortran llvm) # cshift with array shift
 RUN(NAME intrinsics_465 LABELS gfortran llvm) # index() must not read past declared length of deferred-length string
 RUN(NAME intrinsics_466 LABELS gfortran llvm) # eoshift with array-valued shift
+RUN(NAME intrinsics_467 LABELS gfortran llvm) # elemental intrinsics over allocatable arrays in array constructors
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants

--- a/integration_tests/intrinsics_467.f90
+++ b/integration_tests/intrinsics_467.f90
@@ -1,0 +1,18 @@
+program intrinsics_467
+  implicit none
+
+  real(8), allocatable :: data(:,:)
+  integer :: expected(6)
+
+  allocate(data(2,3))
+
+  data(1,:) = [1.0d0, -5.0d0, 3.0d2]
+  data(2,:) = [4.0d0, 2.0d0, 6.0d0]
+  expected = [1, 4, -5, 2, 300, 6]
+
+  if (.not. all([nint(data)] == expected)) error stop
+  if (.not. all([nint(data, 8)] == int(expected, 8))) error stop
+  if (.not. all(abs([anint(data)] - real(expected, 8)) < 1.0d-12)) error stop
+
+  print *, "pass"
+end program intrinsics_467

--- a/integration_tests/realloc_lhs_24.f90
+++ b/integration_tests/realloc_lhs_24.f90
@@ -1,0 +1,20 @@
+program realloc_lhs_24
+  implicit none
+  integer, allocatable :: a(:)
+  allocate(a(2))
+  a(1) = 10
+  a(2) = 20
+  a = [f(), a(1:2)]
+
+  if (size(a) /= 5) error stop
+  if (a(1) /= 1) error stop
+  if (a(2) /= 2) error stop
+  if (a(3) /= 3) error stop
+  if (a(4) /= 10) error stop
+  if (a(5) /= 20) error stop
+contains
+  function f() result(r)
+    integer :: r(3)
+    r = [1, 2, 3]
+  end function f
+end program realloc_lhs_24

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -1609,8 +1609,8 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
                 // after collecting variables from RHS, we check whether
                 // there is any common variable
                 for (size_t i=0; i < array_vars.size(); i++) {
-                    ASR::Var_t* v = ASR::down_cast<ASR::Var_t>(array_vars[i]);
-                    if (v->m_v == v1->m_v) {
+                    ASR::symbol_t* sym = extract_symbol(array_vars[i]);
+                    if (sym && sym == v1->m_v) {
                         create_temp_var_for_rhs = true;
                     }
                 }

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -577,6 +577,30 @@ class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
     }
 
    void replace_ArrayConstructor(ASR::ArrayConstructor_t* x) {
+        // Skip ArrayConstructor replacement when any argument is a function
+        // call (FunctionCall or IntrinsicElementalFunction) returning an array.
+        // The implied_do_loop pass incorrectly expands these into do-loops,
+        // generating invalid code (e.g. lbound(Nint(data), ...) or calling
+        // functions multiple times). The downstream passes
+        // (array_struct_temporary + array_op) handle these cases properly.
+        for( size_t i = 0; i < x->n_args; i++ ) {
+            ASR::expr_t* arg = x->m_args[i];
+            if( arg == nullptr ) continue;
+            bool is_array_func_call = false;
+            if( ASR::is_a<ASR::FunctionCall_t>(*arg) &&
+                ASRUtils::is_array(ASRUtils::expr_type(arg)) ) {
+                is_array_func_call = true;
+            } else if( ASR::is_a<ASR::IntrinsicElementalFunction_t>(*arg) &&
+                       ASRUtils::is_array(ASRUtils::expr_type(arg)) ) {
+                is_array_func_call = true;
+            } else if( ASR::is_a<ASR::IntrinsicArrayFunction_t>(*arg) &&
+                       ASRUtils::is_array(ASRUtils::expr_type(arg)) ) {
+                is_array_func_call = true;
+            }
+            if( is_array_func_call ) {
+                return;
+            }
+        }
         const Location& loc = x->base.base.loc;
         ASR::expr_t* result_var_copy = result_var;
         bool is_result_var_fixed_size = false;

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -43,6 +43,64 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
         al(al_), global_scope(global_scope_), func2intrinsicid(func2intrinsicid_), in_debugcheck(in_debugcheck_), in_ttype(in_ttype_),
         index_kind(index_kind_) {}
 
+    void replace_ArrayItem(ASR::ArrayItem_t* x) {
+        if (!ASR::is_a<ASR::IntrinsicElementalFunction_t>(*x->m_v)) {
+            ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
+            return;
+        }
+
+        ASR::IntrinsicElementalFunction_t* intrinsic_func =
+            ASR::down_cast<ASR::IntrinsicElementalFunction_t>(x->m_v);
+        ASRUtils::impl_function instantiate_function =
+            ASRUtils::IntrinsicElementalFunctionRegistry::get_instantiate_function(
+                intrinsic_func->m_intrinsic_id);
+        if (instantiate_function == nullptr || (in_debugcheck && !in_ttype)) {
+            return;
+        }
+
+        bool has_array_arg = false;
+        Vec<ASR::call_arg_t> new_args; new_args.reserve(al, intrinsic_func->n_args);
+        Vec<ASR::ttype_t*> arg_types; arg_types.reserve(al, intrinsic_func->n_args);
+        for (size_t i = 0; i < intrinsic_func->n_args; i++) {
+            ASR::expr_t* arg = intrinsic_func->m_args[i];
+            ASR::ttype_t* arg_type = ASRUtils::expr_type(arg);
+            ASR::dimension_t* m_dims = nullptr;
+            size_t n_dims = ASRUtils::extract_dimensions_from_ttype(arg_type, m_dims);
+            if (n_dims > 0) {
+                if (n_dims != x->n_args) {
+                    ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
+                    return;
+                }
+                has_array_arg = true;
+                Vec<ASR::array_index_t> idx; idx.reserve(al, x->n_args);
+                for (size_t j = 0; j < x->n_args; j++) {
+                    idx.push_back(al, x->m_args[j]);
+                }
+                arg = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al,
+                    arg->base.loc, arg, idx.p, idx.n, arg_type,
+                    x->m_storage_format, nullptr));
+                arg_type = ASRUtils::expr_type(arg);
+            }
+
+            ASR::call_arg_t call_arg;
+            call_arg.loc = arg->base.loc;
+            call_arg.m_value = arg;
+            new_args.push_back(al, call_arg);
+            arg_types.push_back(al, arg_type);
+        }
+
+        if (!has_array_arg) {
+            ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
+            return;
+        }
+
+        ASR::expr_t* current_expr_ = instantiate_function(al, x->base.base.loc,
+            global_scope, arg_types, x->m_type, new_args,
+            intrinsic_func->m_overload_id, index_kind);
+        if (current_expr_) {
+            *current_expr = current_expr_;
+        }
+    }
 
     void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
         if (x->m_value) {

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -43,64 +43,6 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
         al(al_), global_scope(global_scope_), func2intrinsicid(func2intrinsicid_), in_debugcheck(in_debugcheck_), in_ttype(in_ttype_),
         index_kind(index_kind_) {}
 
-    void replace_ArrayItem(ASR::ArrayItem_t* x) {
-        if (!ASR::is_a<ASR::IntrinsicElementalFunction_t>(*x->m_v)) {
-            ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
-            return;
-        }
-
-        ASR::IntrinsicElementalFunction_t* intrinsic_func =
-            ASR::down_cast<ASR::IntrinsicElementalFunction_t>(x->m_v);
-        ASRUtils::impl_function instantiate_function =
-            ASRUtils::IntrinsicElementalFunctionRegistry::get_instantiate_function(
-                intrinsic_func->m_intrinsic_id);
-        if (instantiate_function == nullptr || (in_debugcheck && !in_ttype)) {
-            return;
-        }
-
-        bool has_array_arg = false;
-        Vec<ASR::call_arg_t> new_args; new_args.reserve(al, intrinsic_func->n_args);
-        Vec<ASR::ttype_t*> arg_types; arg_types.reserve(al, intrinsic_func->n_args);
-        for (size_t i = 0; i < intrinsic_func->n_args; i++) {
-            ASR::expr_t* arg = intrinsic_func->m_args[i];
-            ASR::ttype_t* arg_type = ASRUtils::expr_type(arg);
-            ASR::dimension_t* m_dims = nullptr;
-            size_t n_dims = ASRUtils::extract_dimensions_from_ttype(arg_type, m_dims);
-            if (n_dims > 0) {
-                if (n_dims != x->n_args) {
-                    ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
-                    return;
-                }
-                has_array_arg = true;
-                Vec<ASR::array_index_t> idx; idx.reserve(al, x->n_args);
-                for (size_t j = 0; j < x->n_args; j++) {
-                    idx.push_back(al, x->m_args[j]);
-                }
-                arg = ASRUtils::EXPR(ASRUtils::make_ArrayItem_t_util(al,
-                    arg->base.loc, arg, idx.p, idx.n, arg_type,
-                    x->m_storage_format, nullptr));
-                arg_type = ASRUtils::expr_type(arg);
-            }
-
-            ASR::call_arg_t call_arg;
-            call_arg.loc = arg->base.loc;
-            call_arg.m_value = arg;
-            new_args.push_back(al, call_arg);
-            arg_types.push_back(al, arg_type);
-        }
-
-        if (!has_array_arg) {
-            ASR::BaseExprReplacer<ReplaceIntrinsicFunctions>::replace_ArrayItem(x);
-            return;
-        }
-
-        ASR::expr_t* current_expr_ = instantiate_function(al, x->base.base.loc,
-            global_scope, arg_types, x->m_type, new_args,
-            intrinsic_func->m_overload_id, index_kind);
-        if (current_expr_) {
-            *current_expr = current_expr_;
-        }
-    }
 
     void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
         if (x->m_value) {


### PR DESCRIPTION
fixes #11678
Skip ArrayConstructor with array function calls in implied_do_loop pass

The implied_do_loop pass was incorrectly expanding ArrayConstructor
nodes containing function calls (FunctionCall, IntrinsicElementalFunction,
IntrinsicArrayFunction) returning arrays into do-loops. This generated
invalid code like `lbound(Nint(data), ...)` and caused functions to be
called multiple times instead of once.

The fix skips these cases in the implied_do_loop pass, letting the
downstream passes (array_struct_temporary + array_op) handle them
correctly. Also reverts the previous workaround in intrinsic_function.cpp
(replace_ArrayItem override) that was treating the symptom rather than
the root cause.
