### PR TITLE
Add CI for building JupyterLite deployment

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -696,3 +696,73 @@ jobs:
           context: .
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.image-tags.outputs.tags }}
+
+  build_xlfortran_jupyterlite:
+    name: Build xlfortran JupyterLite WASM kernel
+    runs-on: ubuntu-24.04
+    if: >-
+      ${{ github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install build0 prerequisites
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ci/environment_linux.yml
+          init-shell: bash
+          environment-name: lf
+
+      - name: Generate parser/ASR headers (build0.sh)
+        run: ./build0.sh
+
+      - name: Install WASM build environment
+        run: micromamba create -f environment-wasm-build.yml -y
+
+      - name: Build WASM kernel
+        run: |
+          set -ex
+          micromamba create -f environment-wasm-host.yml -y \
+            --platform=emscripten-wasm32 \
+            -c https://prefix.dev/emscripten-forge-4x \
+            -c https://prefix.dev/conda-forge
+          export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-lfortran-wasm-host
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          micromamba run -n xeus-lfortran-wasm-build ./wasm-build1.sh
+
+      - name: Build JupyterLite site
+        run: |
+          set -ex
+          micromamba create -n xeus-lite-host jupyter_server jupyterlite-xeus -c conda-forge -y
+          micromamba run -n xeus-lite-host jupyter lite build \
+              --XeusAddon.prefix=${{ env.PREFIX }} \
+              --contents share/lfortran/nb/Demo1.ipynb \
+              --contents share/lfortran/nb/Demo2.ipynb \
+              --contents share/lfortran/nb/Variables.ipynb \
+              --output-dir dist
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy_jupyterlite:
+    name: Deploy JupyterLite to GitHub Pages
+    needs: build_xlfortran_jupyterlite
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I've added the CI for building the JupyterLite deployment in the exhaustive checks file. Hope that's correct.

Finally as I've mentioned it multiple times, we would need the github pages to be enabled !
On a PR level the build section of the CI would run & the deploy section of the CI would be **skipped** as seen [here](https://github.com/lfortran/lfortran/actions/runs/26702652659/job/78698900247?pr=11693)
The deployment only happens works for commits that go into main.

- So the build section at a PR level would confirm that the build is correct considering the new changes on the PR
- And then once we take the PR in, the deploy section at the main level would just host the artifacts i.e xlfortran.js/wasm on github pages.

So we would be seeing this error on main
```
Fetching artifact metadata for "github-pages" in this workflow run
Found 1 artifact(s)
Creating Pages deployment with payload:
{
    "artifact_id": 7308734146,
    "pages_build_version": "380db30371c4abaf7b89631c043da12bed711578",
    "oidc_token": "***"
}
Error: Creating Pages deployment failed
Error: HttpError: Not Found
    at /home/runner/work/_actions/actions/deploy-pages/v4/node_modules/@octokit/request/dist-node/index.js:124:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at createPagesDeployment (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/api-client.js:125:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v4/src/internal/deployment.js:74:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v4/src/index.js:30:1)
Error: Error: Failed to create deployment (status: 404) with build version 380db30371c4abaf7b89631c043da12bed711578. Request ID 3018:32C252:6113267:172AA3B2:6A1AF29D Ensure GitHub Pages has been enabled: https://github.com/lfortran/lfortran/settings/pages
```

Unless we have github pages enabled.

This is how you enable it 
- Open Settings → Pages https://github.com/lfortran/lfortran/settings/pages
- Under Build and deployment → Source, select GitHub Actions

I don't have rights to enable it.



