### PR TITLE
fix: handle location intrinsics in array temporary sizing

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1786,6 +1786,7 @@ RUN(NAME intrinsics_463 LABELS llvm) # get_command (optional keyword arguments) 
 RUN(NAME intrinsics_464 LABELS gfortran llvm) # cshift with array shift
 RUN(NAME intrinsics_465 LABELS gfortran llvm) # index() must not read past declared length of deferred-length string
 RUN(NAME intrinsics_466 LABELS gfortran llvm) # eoshift with array-valued shift
+RUN(NAME intrinsics_467 LABELS gfortran llvm) # array temporary sizes for maxloc, minloc, findloc, product, iparity
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME la_constants LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # LAPACK constants

--- a/integration_tests/intrinsics_467.f90
+++ b/integration_tests/intrinsics_467.f90
@@ -1,0 +1,63 @@
+program intrinsics_468
+  implicit none
+
+  integer, allocatable :: a(:, :)
+  integer, allocatable :: b(:)
+
+  allocate(a(2, 3))
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  ! a is:
+  ! 1  2  3
+  ! 4  6  5
+
+  ! maxloc
+  a(1, :) = maxloc(a, dim=1)
+  if (any(a(1, :) /= [2, 2, 2])) error stop 1
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  a(:, 1) = maxloc(a, dim=2)
+  if (any(a(:, 1) /= [3, 2])) error stop 2
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  allocate(b(2))
+  b = maxloc(a)
+  if (any(b /= [2, 2])) error stop 3
+
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+
+  ! minloc
+  a(1, :) = minloc(a, dim=1)
+  if (any(a(1, :) /= [1, 1, 1])) error stop 4
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  a(:, 1) = minloc(a, dim=2)
+  if (any(a(:, 1) /= [1, 1])) error stop 5
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  b = minloc(a)
+  if (any(b /= [1, 1])) error stop 6
+
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+
+  ! findloc
+  a(1, :) = findloc(a, 6, dim=1)
+  if (any(a(1, :) /= [0, 2, 0])) error stop 7
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  a(:, 1) = findloc(a, 6, dim=2)
+  if (any(a(:, 1) /= [0, 2])) error stop 8
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  b = findloc(a, 6)
+  if (any(b /= [2, 2])) error stop 9
+
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+
+  ! product
+  a(1, :) = product(a, dim=1)
+  if (any(a(1, :) /= [4, 12, 15])) error stop 10
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+  a(:, 1) = product(a, dim=2)
+  if (any(a(:, 1) /= [6, 120])) error stop 11
+
+  a = reshape([1, 4, 2, 6, 3, 5], [2, 3])
+
+  ! iparity
+  a(1, :) = iparity(a, dim=1)
+  if (any(a(1, :) /= [5, 4, 6])) error stop 12
+
+end program

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -657,8 +657,10 @@ bool set_allocation_size(
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Count):
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Parity):
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Sum):
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Product):
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::MaxVal):
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::MinVal):
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Iparity):
                 case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::Norm2): {
                     size_t n_dims = ASRUtils::extract_n_dims_from_ttype(
                         intrinsic_array_function->m_type);
@@ -688,6 +690,69 @@ bool set_allocation_size(
                             al, loc, static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::Merge),
                             merge_i_args.p, merge_i_args.size(), 0, ASRUtils::expr_type(int32_one), nullptr));
                         allocate_dim.m_length = merge_i;
+                        allocate_dims.push_back(al, allocate_dim);
+                    }
+                    break;
+                }
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::MaxLoc):
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::MinLoc):
+                case static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::FindLoc): {
+                    size_t n_dims = ASRUtils::extract_n_dims_from_ttype(
+                        intrinsic_array_function->m_type);
+                    allocate_dims.reserve(al, n_dims);
+
+                    ASR::expr_t* dim_arg = nullptr;
+                    if (intrinsic_array_function->m_arr_intrinsic_id == static_cast<int64_t>(ASRUtils::IntrinsicArrayFunctions::FindLoc)) {
+                        dim_arg = intrinsic_array_function->m_args[2];
+                    } else {
+                        dim_arg = intrinsic_array_function->m_args[1];
+                    }
+                    bool has_dim = false;
+                    if (dim_arg && ASR::is_a<ASR::IntegerConstant_t>(*dim_arg)) {
+                        if (ASR::down_cast<ASR::IntegerConstant_t>(dim_arg)->m_n != -1) {
+                            has_dim = true;
+                        }
+                    } else if (dim_arg) {
+                        has_dim = true;
+                    }
+
+                    if (has_dim) {
+                        for( size_t i = 0; i < n_dims; i++ ) {
+                            ASR::dimension_t allocate_dim;
+                            allocate_dim.loc = loc;
+                            allocate_dim.m_start = int32_one;
+                            ASR::expr_t* size_i_1 = ASRUtils::EXPR(ASR::make_ArraySize_t(
+                                al, loc, ASRUtils::get_past_array_physical_cast(intrinsic_array_function->m_args[0]),
+                                ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                    al, loc, i + 1, ASRUtils::expr_type(int32_one))),
+                                ASRUtils::expr_type(int32_one), nullptr));
+                            ASR::expr_t* size_i_2 = ASRUtils::EXPR(ASR::make_ArraySize_t(
+                                al, loc, ASRUtils::get_past_array_physical_cast(intrinsic_array_function->m_args[0]),
+                                ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                    al, loc, i + 2, ASRUtils::expr_type(int32_one))),
+                                ASRUtils::expr_type(int32_one), nullptr));
+                            Vec<ASR::expr_t*> merge_i_args; merge_i_args.reserve(al, 3);
+                            merge_i_args.push_back(al, size_i_1); merge_i_args.push_back(al, size_i_2);
+                            merge_i_args.push_back(al, ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc,
+                                ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                                    al, loc, i + 1, ASRUtils::expr_type(int32_one))), ASR::cmpopType::Lt,
+                                    dim_arg,
+                                    ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr)));
+                            ASR::expr_t* merge_i = ASRUtils::EXPR(ASRUtils::make_IntrinsicElementalFunction_t_util(
+                                al, loc, static_cast<int64_t>(ASRUtils::IntrinsicElementalFunctions::Merge),
+                                merge_i_args.p, merge_i_args.size(), 0, ASRUtils::expr_type(int32_one), nullptr));
+                            allocate_dim.m_length = merge_i;
+                            allocate_dims.push_back(al, allocate_dim);
+                        }
+                    } else {
+                        LCOMPILERS_ASSERT(n_dims == 1);
+                        size_t array_rank = ASRUtils::extract_n_dims_from_ttype(
+                            ASRUtils::expr_type(intrinsic_array_function->m_args[0]));
+                        ASR::dimension_t allocate_dim;
+                        allocate_dim.loc = loc;
+                        allocate_dim.m_start = int32_one;
+                        allocate_dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                            al, loc, array_rank, ASRUtils::expr_type(int32_one)));
                         allocate_dims.push_back(al, allocate_dim);
                     }
                     break;


### PR DESCRIPTION
fixes #11695

Array temporary creation did not know how to determine the result shape
for maxloc, minloc, and findloc. Assignments such as:

    a(1, :) = maxloc(a, dim=1)

therefore reached set_allocation_size without a supported intrinsic case
and failed with:

    IntrinsicArrayFunctions::MaxLoc not handled yet in set_allocation_size

Handle these intrinsics by deriving the temporary shape from the source
array and the optional dim argument. Also cover product and iparity in the
existing dim-reduction path.

