### PR TITLE
fix: avoid env variable buffer overrun

### DIFF
--- a/integration_tests/intrinsics_367.f90
+++ b/integration_tests/intrinsics_367.f90
@@ -1,6 +1,8 @@
 PROGRAM intrinsics_367
 CHARACTER(len=255) :: test_env_var
+character(len=5) :: short_env_var
 integer :: stat
+integer :: len
 
 CALL get_environment_variable("LFORTRAN_TEST_ENV_VAR", test_env_var)
 WRITE (*,*) TRIM(test_env_var)
@@ -23,5 +25,11 @@ if (stat /= 0) error stop
 
 call get_environment_variable("LFORTRAN_TEST_ENV_VAR_MISSING", status=stat)
 if (stat == 0) error stop
+
+short_env_var = ""
+call get_environment_variable("LFORTRAN_TEST_ENV_VAR", short_env_var, length=len, status=stat)
+if (short_env_var /= "STATU") error stop
+if (len /= 10) error stop
+if (stat /= -1) error stop
 
 END PROGRAM

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -1054,19 +1054,18 @@ namespace GetEnvironmentVariable {
             }
             if (has_status) {
                 fill_func_arg_sub("status", arg_types[arg_idx], Out);
-                // Declare interface `_lfortran_get_environment_variable_status`
-                std::string status_func_name = "_lfortran_get_environment_variable_status";
+                std::string status_func_name = "_lfortran_get_environment_variable_status_value";
                 ASR::symbol_t *_lfortran_get_environment_variable_status = b.create_c_func_subroutines_with_return_type(
-                    status_func_name, fn_symtab, 2,
+                    status_func_name, fn_symtab, 3,
                     {b.UnboundedArray(b.String(b.i32(1), ASR::ExpressionLength, ASR::CChar), 1),
-                     int32},
+                     int32, int32},
                     arg_types[arg_idx]);
                 fn_symtab->add_symbol(status_func_name, _lfortran_get_environment_variable_status);
                 dep.push_back(al, s2c(al, status_func_name));
-                // Call the status function and assign result
-                Vec<ASR::expr_t*> status_call_args; status_call_args.reserve(al, 2);
+                Vec<ASR::expr_t*> status_call_args; status_call_args.reserve(al, 3);
                 status_call_args.push_back(al, ASRUtils::create_string_physical_cast(al, args[0], ASR::CChar));
                 status_call_args.push_back(al, b.StringLen(args[0] /* name */));
+                status_call_args.push_back(al, b.StringLen(args[1] /* value */));
                 body.push_back(al, b.Assignment(args[arg_idx], b.Call(_lfortran_get_environment_variable_status, status_call_args, arg_types[arg_idx])));
                 arg_idx++;
             }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -13313,13 +13313,11 @@ LFORTRAN_API void print_stacktrace_addresses(char *filename, bool use_colors) {
 LFORTRAN_API void _lfortran_get_environment_variable(fchar *name, int32_t name_len, char* receiver) {
     char* C_name = to_c_string(name , name_len);
     if (C_name == NULL || ! getenv(C_name)) {
-        receiver[0] = '\0';
         internal_free(C_name);
         return;
     }
     int32_t len = strlen(getenv(C_name));
     memcpy(receiver, getenv(C_name), len);
-    receiver[len] = '\0';
     internal_free(C_name);
 }
 
@@ -13332,6 +13330,23 @@ LFORTRAN_API int32_t _lfortran_get_environment_variable_status(fchar *name, int3
     internal_free(C_name);
     if (value == NULL) {
         return 1;
+    }
+    return 0;
+}
+
+LFORTRAN_API int32_t _lfortran_get_environment_variable_status_value(
+        fchar *name, int32_t name_len, int32_t value_len) {
+    char* C_name = to_c_string(name, name_len);
+    if (C_name == NULL) {
+        return 2;
+    }
+    char *value = getenv(C_name);
+    internal_free(C_name);
+    if (value == NULL) {
+        return 1;
+    }
+    if (value_len < (int32_t) strlen(value)) {
+        return -1;
     }
     return 0;
 }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -391,6 +391,7 @@ LFORTRAN_API void print_stacktrace_addresses(char *filename, bool use_colors);
 LFORTRAN_API char *_lfortran_get_env_variable(char *name);
 LFORTRAN_API void _lfortran_get_environment_variable(fchar *name, int32_t name_len, char* receiver);
 LFORTRAN_API int32_t _lfortran_get_environment_variable_status(fchar *name, int32_t name_len);
+LFORTRAN_API int32_t _lfortran_get_environment_variable_status_value(fchar *name, int32_t name_len, int32_t value_len);
 LFORTRAN_API int _lfortran_exec_command(fchar *cmd, int64_t len);
 LFORTRAN_API void _lfortran_get_command_command(char* receiver);
 LFORTRAN_API int32_t _lfortran_get_command_length();


### PR DESCRIPTION
## Summary

- Stop `_lfortran_get_environment_variable` from writing a C terminator into Fortran `VALUE` storage.
- Return `STATUS=-1` when `VALUE` is present but too short for the environment variable value.
- Extend the `get_environment_variable` integration test for fixed-length truncation.

Fixes #11700

Related: #6024, #7456, #8991, #9660, #9683, #9755, #9858, #280.

## Why

The generated caller allocates an exact-length Fortran character temporary before calling the runtime helper. The helper copied the environment value and then wrote `receiver[len] = '\0'`, which writes past that buffer. This is the root cause of the current LFortran-built fpm `--version` / `--help` malloc abort.

**Stage:** Runtime / intrinsic lowering

## Changes

- [`lfortran_intrinsics.c#L13313-L13354`](https://github.com/krystophny/lfortran/blob/7e08c1260f40e061bb61a584e635223347ff3321/src/libasr/runtime/lfortran_intrinsics.c#L13313-L13354): copy only Fortran character payload bytes and add a value-length-aware status helper.
- [`intrinsic_subroutines.h#L1054-L1071`](https://github.com/krystophny/lfortran/blob/7e08c1260f40e061bb61a584e635223347ff3321/src/libasr/pass/intrinsic_subroutines.h#L1054-L1071): use the new status helper when `VALUE` is present.
- [`intrinsics_367.f90#L29-L33`](https://github.com/krystophny/lfortran/blob/7e08c1260f40e061bb61a584e635223347ff3321/integration_tests/intrinsics_367.f90#L29-L33): check truncation to `character(len=5)` returns `STATUS=-1`.

## Tests

- [`integration_tests/intrinsics_367.f90`](https://github.com/krystophny/lfortran/blob/7e08c1260f40e061bb61a584e635223347ff3321/integration_tests/intrinsics_367.f90): existing env-var test plus fixed-length truncation.

## Verification

### Test fails on upstream/main

```console
$ /tmp/lfortran-bench-llvm/build/src/bin/lfortran /tmp/lfortran_env_overrun_mre.f90 -o /tmp/lfortran_env_overrun_main
$ LFORTRAN_TEST_ENV_VAR='STATUS OK!' valgrind --quiet --track-origins=yes --leak-check=no /tmp/lfortran_env_overrun_main
==289860== Invalid write of size 1
==289860==    at 0x48B9F6E: _lfortran_get_environment_variable (lfortran_intrinsics.c:13322)
==289860==  Address 0x4dbd1ba is 0 bytes after a block of size 10 alloc'd
10
```

```console
$ /tmp/lfortran-bench-llvm/build/src/bin/lfortran /tmp/lfortran_env_trunc_mre.f90 -o /tmp/lfortran_env_trunc_main
$ LFORTRAN_TEST_ENV_VAR='STATUS OK!' /tmp/lfortran_env_trunc_main
STATU
10
0
ERROR STOP
rc=1
```

### Test passes after fix

```console
$ LFORTRAN_SRC_DIR=/tmp/lfortran-fpm-llvm-fix LFORTRAN_BUILD_DIR=/tmp/lfortran-fpm-llvm-fix/build LFORTRAN_WITH_LIRIC=0 LFORTRAN_MAMBA_ENV=lf-llvm11 scripts/build.sh
=== BUILD COMPLETE ===
LFortran version: 0.63.0-653-g3cc3a7e21-dirty
Binary: /tmp/lfortran-fpm-llvm-fix/build/src/bin/lfortran
```

```console
$ scripts/lf.sh --liric-direct-dir /tmp/lfortran-fpm-llvm-fix/build itest -b llvm -t intrinsics_367
1/1 Test #1172: intrinsics_367 ...................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1
```

```console
$ scripts/lf.sh --liric-direct-dir /tmp/lfortran-fpm-llvm-fix/build itest -b gfortran -t intrinsics_367
1/1 Test #1183: intrinsics_367 ...................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1
```

```console
$ /tmp/lfortran-fpm-llvm-fix/build/src/bin/lfortran /tmp/lfortran_env_overrun_mre.f90 -o /tmp/lfortran_env_overrun_fixed
$ LFORTRAN_TEST_ENV_VAR='STATUS OK!' valgrind --quiet --track-origins=yes --leak-check=no /tmp/lfortran_env_overrun_fixed
10
```

```console
$ /tmp/lfortran-fpm-llvm-fix/build/src/bin/lfortran /tmp/lfortran_env_trunc_mre.f90 -o /tmp/lfortran_env_trunc_fixed
$ LFORTRAN_TEST_ENV_VAR='STATUS OK!' /tmp/lfortran_env_trunc_fixed
STATU
10
-1
rc=0
```

```console
$ timeout 1800 fpm build --compiler /tmp/lfortran-fpm-llvm-fix/build/src/bin/lfortran --flag '--separate-compilation --realloc-lhs-arrays'
[100%] Project compiled successfully.
elapsed=280.68

$ build/lfortran_1E84ECCC223D5B00/app/fpm --version
STOP
Version:     0.13.0, alpha
Program:     fpm(1)
Description: A Fortran package manager and build system
Home Page:   https://github.com/fortran-lang/fpm
License:     MIT
OS Type:     Linux

$ valgrind --quiet --track-origins=yes --leak-check=no build/lfortran_1E84ECCC223D5B00/app/fpm --version
STOP
Version:     0.13.0, alpha
Program:     fpm(1)
Description: A Fortran package manager and build system
Home Page:   https://github.com/fortran-lang/fpm
License:     MIT
OS Type:     Linux
```
