### PR TITLE
Unify shared codegen predicate into codegen_asr_utils.h (prep for Liric backend)

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -66,6 +66,7 @@
 #include <libasr/codegen/asr_to_metal.h>
 #include <libasr/codegen/asr_to_cuda.h>
 #include <libasr/codegen/gpu_utils.h>
+#include <libasr/codegen/codegen_asr_utils.h>
 namespace LCompilers {
 
 using ASR::is_a;
@@ -82,21 +83,12 @@ using ASRUtils::determine_module_dependencies;
 using ASRUtils::is_arg_dummy;
 using ASRUtils::is_argument_of_type_CPtr;
 
+// Backend-neutral ASR classification now lives in codegen_asr_utils.h so
+// the Liric backend can share one definition.
+using CodeGen::is_external_interface_function;
+
 // Helper functions for LLVM function name mangling
 namespace {
-
-/**
- * Check if a function is an external interface function.
- * External interface functions are functions with:
- * - Interface deftype
- * - Not intrinsic ABI
- * - Not in a module
- */
-static inline bool is_external_interface_function(ASR::FunctionType_t* ftype) {
-    return ftype->m_deftype == ASR::deftypeType::Interface &&
-           ftype->m_abi != ASR::abiType::Intrinsic &&
-           !ftype->m_module;
-}
 
 /**
  * Compute the final mangled LLVM function name.

--- a/src/libasr/codegen/codegen_asr_utils.h
+++ b/src/libasr/codegen/codegen_asr_utils.h
@@ -1,0 +1,30 @@
+#ifndef LFORTRAN_CODEGEN_ASR_UTILS_H
+#define LFORTRAN_CODEGEN_ASR_UTILS_H
+
+#include <libasr/asr.h>
+
+// Backend-neutral ASR classification shared by the code generators.
+// These are pure queries over ASR with no backend (LLVM, Liric, Wasm,
+// x86) types in their signatures, so every backend can share one
+// definition instead of repeating the rule.
+
+namespace LCompilers {
+namespace CodeGen {
+
+/**
+ * Check if a function is an external interface function.
+ * External interface functions are functions with:
+ * - Interface deftype
+ * - Not intrinsic ABI
+ * - Not in a module
+ */
+inline bool is_external_interface_function(ASR::FunctionType_t* ftype) {
+    return ftype->m_deftype == ASR::deftypeType::Interface &&
+           ftype->m_abi != ASR::abiType::Intrinsic &&
+           !ftype->m_module;
+}
+
+} // namespace CodeGen
+} // namespace LCompilers
+
+#endif // LFORTRAN_CODEGEN_ASR_UTILS_H


### PR DESCRIPTION
## Unify a shared codegen predicate, ahead of the Liric backend

Small, behavior-preserving extraction. Move the pure ASR predicate `is_external_interface_function` out of the anonymous namespace in `asr_to_llvm.cpp` into a new backend-neutral header `src/libasr/codegen/codegen_asr_utils.h` (`namespace LCompilers::CodeGen`).

### Why

The predicate is pure ASR classification with no backend types in its signature. A second code generator, the direct Liric backend ([#11702](https://github.com/lfortran/lfortran/pull/11702)), needs the same check and currently reimplements it inline. Hoisting it to a shared header lets both share one definition instead of drifting apart. This is the first of the shared-policy extractions for that work, done on its own merit as deduplication.

### Changes

- New `src/libasr/codegen/codegen_asr_utils.h`: `is_external_interface_function`.
- `asr_to_llvm.cpp`: drop the local definition, use the shared one through a using-declaration. Call sites are unchanged.

### Verification

Behavior-preserving: same function body, relocated. The LLVM backend builds (LLVM 11) and runs:

```
$ ./build/src/bin/lfortran integration_tests/expr_02.f90 -o /tmp/e && /tmp/e; echo $?
0
```

Context: the full direct Liric backend reaches 100% integration-test pass on the integration branch, https://github.com/krystophny/lfortran/tree/liric-showcase , and #11702 is its first reviewable slice.
