### PR TITLE
fix : ICE for internal read from equivalenced character array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4069,6 +4069,7 @@ RUN(NAME equivalence_33 LABELS gfortran llvm)
 RUN(NAME equivalence_34 LABELS gfortran llvm)
 RUN(NAME equivalence_35 LABELS gfortran llvm)
 RUN(NAME equivalence_36 LABELS gfortran llvm)
+RUN(NAME equivalence_37 LABELS gfortran llvm)
 
 RUN(NAME fortran_primes_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/equivalence_37.f90
+++ b/integration_tests/equivalence_37.f90
@@ -1,0 +1,14 @@
+program equivalence_37
+  implicit none
+
+  character(len=4) :: x(8) = (/ &
+      "abcd", "efgh", "ijkl", "mnop", &
+      "qrst", "uvwx", "yz01", "2345" /)
+  character(len=4) :: y(2, 4)
+  character(len=8) :: z
+
+  equivalence (x, y)
+
+  read(y, "(a8)") z
+  if (z /= "abcd    ") error stop
+end program

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -142,6 +142,18 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
             Vec<ASR::stmt_t*> body;
             body.reserve(al, n_body);
 
+            // Collect leading CPtrToPointer statements from the existing body
+            // first (e.g. equivalence pointer setup). These must execute before
+            // any init-expr assignments that index into the pointer arrays.
+            size_t i = 0;
+            for (; i < n_body; i++) {
+                if (ASR::is_a<ASR::CPtrToPointer_t>(*m_body[i])) {
+                    body.push_back(al, m_body[i]);
+                } else {
+                    break;
+                }
+            }
+
             if( symtab2decls.find(current_scope) != symtab2decls.end() ) {
                 Vec<ASR::stmt_t*>& decls = symtab2decls[current_scope];
                 for (size_t j = 0; j < decls.size(); j++) {
@@ -150,7 +162,7 @@ class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVis
                 symtab2decls.erase(current_scope);
             }
 
-            for (size_t i = 0; i < n_body; i++) {
+            for (; i < n_body; i++) {
                 body.push_back(al, m_body[i]);
             }
             m_body = body.p;

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1643,18 +1643,24 @@ namespace LCompilers {
             bool perform_cast, ASR::cast_kindType cast_kind, ASR::ttype_t* casted_type) {
             const Location& loc = arr_var->base.loc;
             ASRUtils::ASRBuilder b(al, loc);
-            int arr_n_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(arr_var));
-            ASR::dimension_t* x_dims;
-            int x_n_dims = ASRUtils::extract_dimensions_from_ttype(x->m_type, x_dims);
-            LCOMPILERS_ASSERT(arr_n_dims == x_n_dims);
-            int n_dims = x_n_dims;
+            ASR::dimension_t* m_dims;
+            int n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(arr_var), m_dims);
+            // For pointer/equivalence variables the variable type may have empty
+            // dimensions (e.g. [(() ())]).  In that case fall back to the
+            // ArrayConstant's own type which carries concrete bounds.
+            bool use_x_dims = (n_dims > 0 && (m_dims[0].m_length == nullptr));
+            if( use_x_dims ) {
+                n_dims = ASRUtils::extract_dimensions_from_ttype(x->m_type, m_dims);
+            }
             Vec<int> strides;
             strides.resize(al, n_dims);
             // compute stride vars for each dimension in column major order
             strides.p[0] = 1;
             for( int i = 1; i < n_dims; i++ ) {
                 int64_t dim_size = 1;
-                LCOMPILERS_ASSERT(ASRUtils::extract_value(x_dims[i - 1].m_length, dim_size));
+                if( m_dims[i - 1].m_length != nullptr ) {
+                    ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i - 1].m_length), dim_size);
+                }
                 strides.p[i] = strides[i - 1] * dim_size;
             }
 
@@ -1662,8 +1668,8 @@ namespace LCompilers {
             lower_bounds_values.resize(al, n_dims);
             for( int i = 0; i < n_dims; i++ ) {
                 int64_t dim_size = 1;
-                if( x_dims[i].m_start != nullptr ) {
-                    ASRUtils::extract_value(x_dims[i].m_start, dim_size);
+                if( m_dims[i].m_start != nullptr ) {
+                    ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i].m_start), dim_size);
                 }
                 lower_bounds_values.p[i] = dim_size;
             }

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -1643,23 +1643,28 @@ namespace LCompilers {
             bool perform_cast, ASR::cast_kindType cast_kind, ASR::ttype_t* casted_type) {
             const Location& loc = arr_var->base.loc;
             ASRUtils::ASRBuilder b(al, loc);
-            ASR::dimension_t* m_dims;
-            int n_dims = ASRUtils::extract_dimensions_from_ttype(ASRUtils::expr_type(arr_var), m_dims);
+            int arr_n_dims = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(arr_var));
+            ASR::dimension_t* x_dims;
+            int x_n_dims = ASRUtils::extract_dimensions_from_ttype(x->m_type, x_dims);
+            LCOMPILERS_ASSERT(arr_n_dims == x_n_dims);
+            int n_dims = x_n_dims;
             Vec<int> strides;
             strides.resize(al, n_dims);
             // compute stride vars for each dimension in column major order
             strides.p[0] = 1;
             for( int i = 1; i < n_dims; i++ ) {
-                int64_t dim_size = -1;
-                ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i - 1].m_length), dim_size);
+                int64_t dim_size = 1;
+                LCOMPILERS_ASSERT(ASRUtils::extract_value(x_dims[i - 1].m_length, dim_size));
                 strides.p[i] = strides[i - 1] * dim_size;
             }
 
             Vec<int64_t> lower_bounds_values;
             lower_bounds_values.resize(al, n_dims);
             for( int i = 0; i < n_dims; i++ ) {
-                int64_t dim_size = -1;
-                ASRUtils::extract_value(ASRUtils::expr_value(m_dims[i].m_start), dim_size);
+                int64_t dim_size = 1;
+                if( x_dims[i].m_start != nullptr ) {
+                    ASRUtils::extract_value(x_dims[i].m_start, dim_size);
+                }
                 lower_bounds_values.p[i] = dim_size;
             }
 


### PR DESCRIPTION
fixes #11705


Bug 
1. The init_expr pass prepended initializer assignments (x(1)="abcd",
   x(2)="efgh", ...) before the CPtrToPointer statement that sets up
   the equivalence pointer. At that point x's descriptor had size=0,
   so bounds checks failed and the program segfaulted.

2. In visit_ArrayConstant (pass_utils.cpp), extracting dimension info
   via expr_value(m_dims[i].m_length) crashed for pointer/equivalence
   variables whose type carries empty descriptor dims [(() ())].

Fix:
- init_expr.cpp: hoist leading CPtrToPointer statements before the
  generated init assignments, so equivalence pointers are set up
  before any indexing into them.
- pass_utils.cpp: use arr_var's dimensions as primary source (needed
  for multi-dim data statements like ABC(2,3,4,5)), but fall back to
  the ArrayConstant's own type when arr_var's dims are null (pointer/
  equivalence variables).
