### PR TITLE
fix: avoid ASR size extraction aborts for function-call arrays and add StringConcat as a BinOp

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3376,6 +3376,7 @@ RUN(NAME implied_do_loops39 LABELS gfortran llvm)
 RUN(NAME implied_do_loops40 LABELS gfortran llvm)
 RUN(NAME implied_do_loops41 LABELS gfortran llvm)
 RUN(NAME implied_do_loops42 LABELS gfortran llvm)
+RUN(NAME implied_do_loops43 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops43.f90
+++ b/integration_tests/implied_do_loops43.f90
@@ -1,0 +1,29 @@
+module implied_do_loops43_mod
+    implicit none
+contains
+    function paragraph() result(res)
+        character(len=10), allocatable :: res(:)
+        allocate(res(1))
+        res(1) = 'def'
+    end function paragraph
+
+    function myfunc(name) result(textblock)
+        character(len=*), intent(in) :: name
+        character(len=256), allocatable :: textblock(:)
+        character(len=256), allocatable :: narrow(:)
+        
+        allocate(narrow(0))
+        narrow = [character(len=256) :: narrow, 'abc' // paragraph()]
+        
+        textblock = narrow 
+    end function myfunc
+end module implied_do_loops43_mod
+
+program implied_do_loops43
+    use implied_do_loops43_mod
+    implicit none
+    character(len=256), allocatable :: textblock(:)
+    textblock = myfunc('help')
+    if (size(textblock) /= 1) error stop 1
+    if (textblock(1) /= 'abcdef') error stop 2
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3876,10 +3876,14 @@ ASR::asr_t* make_ArraySize_t_util(
             }
         } else {
             if( a_dim == nullptr ) {
-                LCOMPILERS_ASSERT(m_dims[0].m_length);
+                if( n_dims == 0 || m_dims[0].m_length == nullptr ) {
+                    return ASR::make_ArraySize_t(al, a_loc, a_v, a_dim, a_type, a_value);
+                }
                 ASR::expr_t* result = m_dims[0].m_length;
                 for( size_t i = 1; i < n_dims; i++ ) {
-                    LCOMPILERS_ASSERT(m_dims[i].m_length);
+                    if( m_dims[i].m_length == nullptr ) {
+                        return ASR::make_ArraySize_t(al, a_loc, a_v, a_dim, a_type, a_value);
+                    }
                     result = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, a_loc,
                         result, ASR::binopType::Mul, m_dims[i].m_length, a_type, nullptr));
                 }
@@ -3930,8 +3934,7 @@ ASR::asr_t* make_ArraySize_t_util(
         ASR::IntrinsicElementalFunction_t* elemental = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(a_v);
         for( size_t i = 0; i < elemental->n_args; i++ ) {
             if( ASRUtils::is_array(ASRUtils::expr_type(elemental->m_args[i])) ) {
-                a_v = elemental->m_args[i];
-                break;
+                return make_ArraySize_t_util(al, a_loc, elemental->m_args[i], a_dim, a_type, a_value, for_type);
             }
         }
     }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3610,7 +3610,8 @@ static inline bool is_binop_expr(ASR::expr_t* x) {
         case ASR::exprType::ComplexCompare:
         case ASR::exprType::LogicalCompare:
         case ASR::exprType::UnsignedIntegerCompare:
-        case ASR::exprType::StringCompare: {
+        case ASR::exprType::StringCompare:
+        case ASR::exprType::StringConcat: {
             return true;
         }
         default: {
@@ -3674,6 +3675,7 @@ static inline ASR::expr_t* extract_member_from_binop(ASR::expr_t* x, int8_t memb
         BINOP_MEMBER_CASE(LogicalCompare, LogicalCompare_t)
         BINOP_MEMBER_CASE(UnsignedIntegerCompare, UnsignedIntegerCompare_t)
         BINOP_MEMBER_CASE(StringCompare, StringCompare_t)
+        BINOP_MEMBER_CASE(StringConcat, StringConcat_t)
         default: {
             LCOMPILERS_ASSERT(false)
         }


### PR DESCRIPTION
Fixes #11723
