### PR TITLE
fix :Keyword argument resolution for type-bound procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3680,6 +3680,7 @@ RUN(NAME procedure_49 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME procedure_50 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_abstract_02 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_keyword_01 LABELS gfortran llvm)
+RUN(NAME procedure_pointer_keyword_02 LABELS gfortran llvm)
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_pointer_keyword_02.f90
+++ b/integration_tests/procedure_pointer_keyword_02.f90
@@ -1,0 +1,57 @@
+module procedure_pointer_keyword_02_mod
+  implicit none
+
+  type :: obj_type
+    integer :: val = 0
+    procedure(sub_iface), pointer :: compute => null()
+  end type
+
+  abstract interface
+    subroutine sub_iface(me, x, y)
+      import :: obj_type
+      class(obj_type), intent(inout) :: me
+      integer, intent(in) :: x, y
+    end subroutine
+  end interface
+
+contains
+
+  subroutine my_add(me, x, y)
+    class(obj_type), intent(inout) :: me
+    integer, intent(in) :: x, y
+    me%val = x + y
+  end subroutine
+
+  subroutine my_mul(me, x, y)
+    class(obj_type), intent(inout) :: me
+    integer, intent(in) :: x, y
+    me%val = x * y
+  end subroutine
+
+end module
+
+program procedure_pointer_keyword_02
+  use procedure_pointer_keyword_02_mod
+  implicit none
+  type(obj_type) :: obj
+
+  ! Test 1: positional + keyword with pass (default)
+  obj%compute => my_add
+  call obj%compute(1, y=2)
+  if (obj%val /= 3) error stop "Test 1 failed"
+
+  ! Test 2: all keyword args with pass
+  call obj%compute(x=10, y=20)
+  if (obj%val /= 30) error stop "Test 2 failed"
+
+  ! Test 3: different procedure pointer target
+  obj%compute => my_mul
+  call obj%compute(3, y=4)
+  if (obj%val /= 12) error stop "Test 3 failed"
+
+  ! Test 4: all keyword args with my_mul
+  call obj%compute(x=5, y=6)
+  if (obj%val /= 30) error stop "Test 4 failed"
+
+  print *, "All tests passed"
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7132,20 +7132,21 @@ public:
 
         // we handle kwargs here
         if (x.n_keywords > 0) {
-            bool is_proc_pointer_var = false;
+            bool is_nopass = false;
             if (ASR::is_a<ASR::Variable_t>(*f2)) {
                 ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(f2);
                 [[maybe_unused]] ASR::ttype_t* v_type = ASRUtils::type_get_past_pointer(v->m_type);
                 LCOMPILERS_ASSERT(ASR::is_a<ASR::FunctionType_t>(*v_type));
                 f2 = ASRUtils::symbol_get_past_external(v->m_type_declaration);
-                is_proc_pointer_var = true;
+                is_nopass = (v->m_pass_attr == ASR::pass_attrType::NoPass ||
+                             v->m_pass_attr == ASR::pass_attrType::NotMethod);
             }
             if (ASR::is_a<ASR::Function_t>(*f2)) {
                 ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(f2);
                 diag::Diagnostics diags;
                 visit_kwargs(args, x.m_keywords, x.n_keywords,
                              f->m_args, f->n_args, x.base.base.loc, f,
-                             diags, x.n_member, is_proc_pointer_var);
+                             diags, x.n_member, is_nopass);
                 if (diags.has_error()) {
                     diag.diagnostics.insert(diag.diagnostics.end(),
                                             diags.diagnostics.begin(), diags.diagnostics.end());


### PR DESCRIPTION
fixes #11730
Keyword argument resolution was broken for type-bound procedure
pointers using the default pass attribute. The bug was in
process_call_args_and_kwargs where is_proc_pointer_var (always true
for any procedure pointer variable) was passed as the is_nopass
argument to visit_kwargs. This incorrectly treated all procedure
pointer variables as nopass, causing the implicit self argument
passed via % to be counted as an explicit argument. For example,
call me%compute_function(1, y=2) would fail with "1-th argument
not specified for func" because the compiler expected 3 explicit
arguments instead of 2.

Fixed by checking the Variable_t's actual m_pass_attr field to
determine whether the procedure pointer is nopass, instead of
assuming all procedure pointer variables are nopass.
