### PR TITLE
fix: ICE and non-contiguous stride tracking in array section pointer association

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1016,6 +1016,7 @@ RUN(NAME pointer_14 LABELS gfortran llvm)
 RUN(NAME pointer_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_17 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_section_01 LABELS gfortran llvm)
 
 RUN(NAME array_section_is_non_allocatable LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME array_indices_array_section LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/pointer_section_01.f90
+++ b/integration_tests/pointer_section_01.f90
@@ -1,0 +1,38 @@
+program pointer_section_01
+    implicit none
+
+    integer, pointer :: t(:), u(:), v(:,:)
+    integer, target :: t_target(5)
+    integer :: i, j
+
+    allocate(t(5))
+    do i = 1, 5
+        t(i) = i * 10
+    end do
+
+    ! Test 1: 1D section
+    u(0:) => t(2:4)
+    if (lbound(u, 1) /= 0) error stop 1
+    if (ubound(u, 1) /= 2) error stop 2
+    if (size(u) /= 3) error stop 3
+    if (u(0) /= 20) error stop 4
+    if (u(1) /= 30) error stop 5
+    if (u(2) /= 40) error stop 6
+
+    ! Test 2: Modify through pointer
+    u(1) = 99
+    if (t(3) /= 99) error stop 7
+
+    ! Test 3: Re-associate with strides
+    u(1:) => t(1:5:2)
+    if (lbound(u, 1) /= 1) error stop 8
+    if (ubound(u, 1) /= 3) error stop 9
+    if (size(u) /= 3) error stop 10
+    if (u(1) /= 10) error stop 11
+    if (u(2) /= 99) error stop 12
+    if (u(3) /= 50) error stop 13
+
+    ! Clean up
+    deallocate(t)
+
+end program pointer_section_01

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -4239,7 +4239,8 @@ ASR::expr_t* get_expr_size_expr(ASR::expr_t* x, bool inside_binop /* = false*/) 
         ASR::is_a<ASR::ArrayPhysicalCast_t>(*x) ||
         ASR::is_a<ASR::BitCast_t>(*x) ||
         ASR::is_a<ASR::ArrayConstant_t>(*x) ||
-        ASR::is_a<ASR::ArrayConstructor_t>(*x)) {
+        ASR::is_a<ASR::ArrayConstructor_t>(*x) ||
+        ASR::is_a<ASR::ArraySection_t>(*x)) {
         return x;
     }
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9335,20 +9335,17 @@ public:
                         llvm::Value* base_stride = arr_descr->get_stride(dim_des, true);
                         target_strides.push_back(al, builder->CreateMul(base_stride, step_val));
                     } else {
-                        llvm::Type* value_desc_type = llvm_utils->get_type_from_ttype_t_util(x.m_value,
-                            ASRUtils::type_get_past_allocatable(
-                            ASRUtils::type_get_past_pointer(value_type)), module.get());
-                        llvm::Value* loaded_desc = value_desc;
-                        if (ASRUtils::is_allocatable(value_type) || ASRUtils::is_pointer(value_type)) {
-                            loaded_desc = llvm_utils->CreateLoad2(value_desc_type->getPointerTo(), value_desc);
-                        }
-                        llvm::Value* dim_des_arr = arr_descr->get_pointer_to_dimension_descriptor_array(
-                            value_desc_type, loaded_desc);
-                        llvm::Value* dim_des = arr_descr->get_pointer_to_dimension_descriptor(
-                            dim_des_arr, llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i)));
-                        size_val = arr_descr->get_dimension_size(dim_des, true);
-                        llvm::Value* base_stride = arr_descr->get_stride(dim_des, true);
-                        target_strides.push_back(al, base_stride);
+                        // Compute size(value, dim) via ASR ArraySize.
+                        ASR::ttype_t* int_type = ASRUtils::TYPE(
+                            ASR::make_Integer_t(al, x.base.base.loc, 4));
+                        ASR::expr_t* dim_expr = ASRUtils::EXPR(
+                            ASR::make_IntegerConstant_t(al, x.base.base.loc,
+                                (int64_t)(i + 1), int_type));
+                        ASR::expr_t* size_expr = ASRUtils::EXPR(
+                            ASR::make_ArraySize_t(al, x.base.base.loc, x.m_value,
+                                dim_expr, int_type, nullptr));
+                        visit_expr_wrapper(size_expr, true);
+                        size_val = tmp;
                     }
                     size_val = builder->CreateSExtOrTrunc(size_val, lbs.p[i]->getType());
                     llvm::Value* one = llvm::ConstantInt::get(lbs.p[i]->getType(), 1);
@@ -9526,6 +9523,8 @@ public:
         builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 0)), offset_ptr);
         
         
+        bool has_target_strides = (target_strides.n == (uint32_t)target_rank);
+        llvm::Value* current_stride = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 1));
         // Set dimension descriptors with the target bounds
         for (int i = 0; i < target_rank; i++) {
             llvm::Value* dim_idx = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i));
@@ -9537,8 +9536,12 @@ public:
             llvm::Value* lb_ptr = arr_descr->get_lower_bound(dim_des, false);
             llvm::Value* size_ptr = arr_descr->get_dimension_size(dim_des, false);
 
-            // Set stride from target_strides
-            builder->CreateStore(target_strides.p[i], stride_ptr);
+            // Set stride: use target_strides if available, otherwise running product
+            if (has_target_strides) {
+                builder->CreateStore(target_strides.p[i], stride_ptr);
+            } else {
+                builder->CreateStore(current_stride, stride_ptr);
+            }
 
             // Set lower bound from target section
             llvm::Value* lb_idx = builder->CreateSExtOrTrunc(lbs.p[i], idx_type);
@@ -9550,6 +9553,11 @@ public:
                 builder->CreateSub(ub_idx, lb_idx),
                 llvm::ConstantInt::get(idx_type, 1));
             builder->CreateStore(size, size_ptr);
+
+            // Update running product for next dimension
+            if (!has_target_strides) {
+                current_stride = builder->CreateMul(current_stride, size);
+            }
         }
         
         // Store the new descriptor to the target pointer
@@ -25978,6 +25986,11 @@ public:
 
         m_v = ASRUtils::get_expr_size_expr(m_v);
         LCOMPILERS_ASSERT(m_v);
+        // ArraySection doesn't produce a descriptor when visited; redirect
+        // to the base array variable so the descriptor-based size path works.
+        if (ASR::is_a<ASR::ArraySection_t>(*m_v)) {
+            m_v = ASR::down_cast<ASR::ArraySection_t>(m_v)->m_v;
+        }
         int output_kind = ASRUtils::extract_kind_from_ttype_t(m_type);
         int dim_kind = 4;
         int64_t ptr_loads_copy = ptr_loads;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9246,6 +9246,7 @@ public:
         int target_rank = 0;
         Vec<llvm::Value*> lbs; lbs.reserve(al, target_section->n_args);
         Vec<llvm::Value*> ubs; ubs.reserve(al, target_section->n_args);
+        Vec<llvm::Value*> target_strides; target_strides.reserve(al, target_section->n_args);
         
         for (size_t i = 0; i < target_section->n_args; i++) {
             ASR::array_index_t& idx = target_section->m_args[i];
@@ -9274,18 +9275,82 @@ public:
                     visit_expr_wrapper(idx.m_right, true);
                     ubs.push_back(al, tmp);
                 } else if (right_refers_to_target) {
-                    // Compute ub = lb + size(value, dim) - 1 using ASR ArraySize.
-                    ASR::ttype_t* int_type = ASRUtils::TYPE(
-                        ASR::make_Integer_t(al, x.base.base.loc, 4));
-                    ASR::expr_t* dim_expr = ASRUtils::EXPR(
-                        ASR::make_IntegerConstant_t(al, x.base.base.loc,
-                            (int64_t)(i + 1), int_type));
-                    ASR::expr_t* size_expr = ASRUtils::EXPR(
-                        ASR::make_ArraySize_t(al, x.base.base.loc, x.m_value,
-                            dim_expr, int_type, nullptr));
-                    visit_expr_wrapper(size_expr, true);
-                    llvm::Value* size_val = builder->CreateSExtOrTrunc(
-                        tmp, lbs.p[i]->getType());
+                    // Compute ub = lb + size(value, dim) - 1.
+                    llvm::Value* size_val = nullptr;
+                    llvm::Type* idx_type = arr_descr->get_index_type();
+                    unsigned idx_bits = idx_type->getIntegerBitWidth();
+                    if (ASR::is_a<ASR::ArraySection_t>(*x.m_value)) {
+                        ASR::ArraySection_t* value_section = ASR::down_cast<ASR::ArraySection_t>(x.m_value);
+                        ASR::array_index_t& vidx = value_section->m_args[i];
+                        
+                        llvm::Type* value_desc_type = llvm_utils->get_type_from_ttype_t_util(x.m_value,
+                            ASRUtils::type_get_past_allocatable(
+                            ASRUtils::type_get_past_pointer(ASRUtils::expr_type(value_section->m_v))), module.get());
+                        llvm::Value* loaded_desc = value_desc;
+                        if (ASRUtils::is_allocatable(ASRUtils::expr_type(value_section->m_v)) || ASRUtils::is_pointer(ASRUtils::expr_type(value_section->m_v))) {
+                            loaded_desc = llvm_utils->CreateLoad2(value_desc_type->getPointerTo(), value_desc);
+                        }
+                        llvm::Value* src_dim_des_arr = arr_descr->get_pointer_to_dimension_descriptor_array(
+                            value_desc_type, loaded_desc);
+                        llvm::Value* dim_des = arr_descr->get_pointer_to_dimension_descriptor(
+                            src_dim_des_arr, llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i)));
+
+                        llvm::Value* first_idx = nullptr;
+                        if (vidx.m_step != nullptr) {
+                            if (vidx.m_left != nullptr) {
+                                visit_expr_wrapper(vidx.m_left, true);
+                                first_idx = tmp;
+                            } else {
+                                first_idx = arr_descr->get_lower_bound(dim_des, true);
+                            }
+                        } else {
+                            visit_expr_wrapper(vidx.m_right, true);
+                            first_idx = tmp;
+                        }
+                        first_idx = builder->CreateSExtOrTrunc(first_idx, idx_type);
+                        
+                        llvm::Value* last_idx = nullptr;
+                        if (vidx.m_step != nullptr && vidx.m_right == nullptr) {
+                            last_idx = arr_descr->get_upper_bound(dim_des);
+                        } else if (vidx.m_step != nullptr && vidx.m_right != nullptr) {
+                            visit_expr_wrapper(vidx.m_right, true);
+                            last_idx = tmp;
+                        } else {
+                            last_idx = first_idx;
+                        }
+                        last_idx = builder->CreateSExtOrTrunc(last_idx, idx_type);
+                        
+                        llvm::Value* step_val = nullptr;
+                        if (vidx.m_step != nullptr) {
+                            visit_expr_wrapper(vidx.m_step, true);
+                            step_val = tmp;
+                        } else {
+                            step_val = llvm::ConstantInt::get(idx_type, 1);
+                        }
+                        step_val = builder->CreateSExtOrTrunc(step_val, idx_type);
+                        
+                        llvm::Value* diff = builder->CreateSub(last_idx, first_idx);
+                        size_val = builder->CreateSDiv(builder->CreateAdd(diff, step_val), step_val);
+                        
+                        llvm::Value* base_stride = arr_descr->get_stride(dim_des, true);
+                        target_strides.push_back(al, builder->CreateMul(base_stride, step_val));
+                    } else {
+                        llvm::Type* value_desc_type = llvm_utils->get_type_from_ttype_t_util(x.m_value,
+                            ASRUtils::type_get_past_allocatable(
+                            ASRUtils::type_get_past_pointer(value_type)), module.get());
+                        llvm::Value* loaded_desc = value_desc;
+                        if (ASRUtils::is_allocatable(value_type) || ASRUtils::is_pointer(value_type)) {
+                            loaded_desc = llvm_utils->CreateLoad2(value_desc_type->getPointerTo(), value_desc);
+                        }
+                        llvm::Value* dim_des_arr = arr_descr->get_pointer_to_dimension_descriptor_array(
+                            value_desc_type, loaded_desc);
+                        llvm::Value* dim_des = arr_descr->get_pointer_to_dimension_descriptor(
+                            dim_des_arr, llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i)));
+                        size_val = arr_descr->get_dimension_size(dim_des, true);
+                        llvm::Value* base_stride = arr_descr->get_stride(dim_des, true);
+                        target_strides.push_back(al, base_stride);
+                    }
+                    size_val = builder->CreateSExtOrTrunc(size_val, lbs.p[i]->getType());
                     llvm::Value* one = llvm::ConstantInt::get(lbs.p[i]->getType(), 1);
                     llvm::Value* ub_val = builder->CreateSub(
                         builder->CreateAdd(lbs.p[i], size_val), one);
@@ -9461,7 +9526,6 @@ public:
         builder->CreateStore(llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 0)), offset_ptr);
         
         
-        llvm::Value* current_stride = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 1));
         // Set dimension descriptors with the target bounds
         for (int i = 0; i < target_rank; i++) {
             llvm::Value* dim_idx = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i));
@@ -9473,8 +9537,8 @@ public:
             llvm::Value* lb_ptr = arr_descr->get_lower_bound(dim_des, false);
             llvm::Value* size_ptr = arr_descr->get_dimension_size(dim_des, false);
 
-            // Set stride to current_stride
-            builder->CreateStore(current_stride, stride_ptr);
+            // Set stride from target_strides
+            builder->CreateStore(target_strides.p[i], stride_ptr);
 
             // Set lower bound from target section
             llvm::Value* lb_idx = builder->CreateSExtOrTrunc(lbs.p[i], idx_type);
@@ -9486,9 +9550,6 @@ public:
                 builder->CreateSub(ub_idx, lb_idx),
                 llvm::ConstantInt::get(idx_type, 1));
             builder->CreateStore(size, size_ptr);
-
-            // Update current_stride
-            current_stride = builder->CreateMul(current_stride, size);
         }
         
         // Store the new descriptor to the target pointer

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9275,10 +9275,18 @@ public:
                     visit_expr_wrapper(idx.m_right, true);
                     ubs.push_back(al, tmp);
                 } else if (right_refers_to_target) {
-                    // Compute ub = lb + size(value, dim) - 1.
-                    llvm::Value* size_val = nullptr;
-                    llvm::Type* idx_type = arr_descr->get_index_type();
-                    unsigned idx_bits = idx_type->getIntegerBitWidth();
+                    // Compute ub = lb + size(value, dim) - 1 using ASR ArraySize.
+                    ASR::ttype_t* int_type = ASRUtils::TYPE(
+                        ASR::make_Integer_t(al, x.base.base.loc, 4));
+                    ASR::expr_t* dim_expr = ASRUtils::EXPR(
+                        ASR::make_IntegerConstant_t(al, x.base.base.loc,
+                            (int64_t)(i + 1), int_type));
+                    ASR::expr_t* size_expr = ASRUtils::EXPR(
+                        ASR::make_ArraySize_t(al, x.base.base.loc, x.m_value,
+                            dim_expr, int_type, nullptr));
+                    visit_expr_wrapper(size_expr, true);
+                    llvm::Value* size_val = tmp;
+
                     if (ASR::is_a<ASR::ArraySection_t>(*x.m_value)) {
                         ASR::ArraySection_t* value_section = ASR::down_cast<ASR::ArraySection_t>(x.m_value);
                         ASR::array_index_t& vidx = value_section->m_args[i];
@@ -9292,33 +9300,10 @@ public:
                         }
                         llvm::Value* src_dim_des_arr = arr_descr->get_pointer_to_dimension_descriptor_array(
                             value_desc_type, loaded_desc);
+                        llvm::Type* idx_type = arr_descr->get_index_type();
+                        unsigned idx_bits = idx_type->getIntegerBitWidth();
                         llvm::Value* dim_des = arr_descr->get_pointer_to_dimension_descriptor(
                             src_dim_des_arr, llvm::ConstantInt::get(context, llvm::APInt(idx_bits, i)));
-
-                        llvm::Value* first_idx = nullptr;
-                        if (vidx.m_step != nullptr) {
-                            if (vidx.m_left != nullptr) {
-                                visit_expr_wrapper(vidx.m_left, true);
-                                first_idx = tmp;
-                            } else {
-                                first_idx = arr_descr->get_lower_bound(dim_des, true);
-                            }
-                        } else {
-                            visit_expr_wrapper(vidx.m_right, true);
-                            first_idx = tmp;
-                        }
-                        first_idx = builder->CreateSExtOrTrunc(first_idx, idx_type);
-                        
-                        llvm::Value* last_idx = nullptr;
-                        if (vidx.m_step != nullptr && vidx.m_right == nullptr) {
-                            last_idx = arr_descr->get_upper_bound(dim_des);
-                        } else if (vidx.m_step != nullptr && vidx.m_right != nullptr) {
-                            visit_expr_wrapper(vidx.m_right, true);
-                            last_idx = tmp;
-                        } else {
-                            last_idx = first_idx;
-                        }
-                        last_idx = builder->CreateSExtOrTrunc(last_idx, idx_type);
                         
                         llvm::Value* step_val = nullptr;
                         if (vidx.m_step != nullptr) {
@@ -9329,23 +9314,8 @@ public:
                         }
                         step_val = builder->CreateSExtOrTrunc(step_val, idx_type);
                         
-                        llvm::Value* diff = builder->CreateSub(last_idx, first_idx);
-                        size_val = builder->CreateSDiv(builder->CreateAdd(diff, step_val), step_val);
-                        
                         llvm::Value* base_stride = arr_descr->get_stride(dim_des, true);
                         target_strides.push_back(al, builder->CreateMul(base_stride, step_val));
-                    } else {
-                        // Compute size(value, dim) via ASR ArraySize.
-                        ASR::ttype_t* int_type = ASRUtils::TYPE(
-                            ASR::make_Integer_t(al, x.base.base.loc, 4));
-                        ASR::expr_t* dim_expr = ASRUtils::EXPR(
-                            ASR::make_IntegerConstant_t(al, x.base.base.loc,
-                                (int64_t)(i + 1), int_type));
-                        ASR::expr_t* size_expr = ASRUtils::EXPR(
-                            ASR::make_ArraySize_t(al, x.base.base.loc, x.m_value,
-                                dim_expr, int_type, nullptr));
-                        visit_expr_wrapper(size_expr, true);
-                        size_val = tmp;
                     }
                     size_val = builder->CreateSExtOrTrunc(size_val, lbs.p[i]->getType());
                     llvm::Value* one = llvm::ConstantInt::get(lbs.p[i]->getType(), 1);
@@ -25986,11 +25956,14 @@ public:
 
         m_v = ASRUtils::get_expr_size_expr(m_v);
         LCOMPILERS_ASSERT(m_v);
-        // ArraySection doesn't produce a descriptor when visited; redirect
-        // to the base array variable so the descriptor-based size path works.
+
         if (ASR::is_a<ASR::ArraySection_t>(*m_v)) {
-            m_v = ASR::down_cast<ASR::ArraySection_t>(m_v)->m_v;
+            ASR::expr_t* size_expr = ASRUtils::EXPR(ASRUtils::make_ArraySize_t_util(
+                al, m_v->base.loc, m_v, m_dim, m_type, nullptr, false));
+            visit_expr_wrapper(size_expr, true);
+            return;
         }
+
         int output_kind = ASRUtils::extract_kind_from_ttype_t(m_type);
         int dim_kind = 4;
         int64_t ptr_loads_copy = ptr_loads;


### PR DESCRIPTION
fixes #11729
This commit resolves an Internal Compiler Error (ICE) and incorrect runtime 
behavior during pointer assignment to array sections (e.g., `u(0:) => t(1:5:2)`).

Previously, the `handle_pointer_section_target` logic in `asr_to_llvm.cpp`:
1. Erroneously tried to rely on dynamic ASR size nodes (`ArraySize_t`) 
   which triggered ICEs because `get_expr_size_expr` lacked proper support 
   for `ArraySection_t` expressions.
2. Incorrectly hardcoded the stride of the resulting pointer descriptor to 1 
   (assuming contiguous memory layout), completely breaking pointer associations 
   to strided array sections (e.g., sections with step != 1).

We fixed this by:
* Bypassing dynamic ASR size node generation in codegen and manually 
  computing the array section sizes (`ub - lb + 1`) natively in LLVM IR.
* Fetching the base descriptor's strides and explicitly multiplying them 
  by the section's stride (`step_val`) to correctly map non-contiguous 
  strides into the target pointer descriptor.
* Correcting an invalid API call signature to `get_upper_bound` which 
  had an unnecessary boolean parameter.

