### PR TITLE
fix: internal write to strided character array sections

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3608,6 +3608,7 @@ RUN(NAME write_37 LABELS gfortran llvm)
 RUN(NAME write_38 LABELS gfortran llvm)
 RUN(NAME write_39 LABELS gfortran llvm)
 RUN(NAME write_40 LABELS gfortran llvm)
+RUN(NAME write_41 LABELS gfortran llvm)
 
 RUN(NAME write_fortran_01 LABELS gfortran llvm fortran)
 RUN(NAME write_fortran_02 LABELS gfortran llvm fortran)

--- a/integration_tests/write_41.f90
+++ b/integration_tests/write_41.f90
@@ -1,0 +1,21 @@
+program write_41
+    implicit none
+
+    character(2) :: c(5)
+
+    c = "??"
+    write(c(5:1:-2), "(A, I0)") "x", 2, "z"
+    if (c(1) /= "??") error stop
+    if (c(2) /= "??") error stop
+    if (c(3) /= "z ") error stop
+    if (c(4) /= "??") error stop
+    if (c(5) /= "x2") error stop
+
+    c = "??"
+    write(c(5:1:-2), "(A,A)") "x", "V", "z"
+    if (c(1) /= "??") error stop
+    if (c(2) /= "??") error stop
+    if (c(3) /= "z ") error stop
+    if (c(4) /= "??") error stop
+    if (c(5) /= "xV") error stop
+end program

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -722,27 +722,93 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
             if (step == nullptr) {
                 step = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, ikind, loc);
             }
-            for (size_t i = 0; i < fmt->n_args; i++) {
-                ASR::expr_t* offset = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, i, ikind, loc);
-                ASR::expr_t* scaled_offset = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                    al, loc, offset, ASR::binopType::Mul, step, int_type, nullptr));
-                ASR::expr_t* idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                    al, loc, lb_lhs, ASR::binopType::Add, scaled_offset, int_type, nullptr));
-                ASR::expr_t* unit_i = PassUtils::create_array_ref(unit, idx, al, current_scope);
 
-                Vec<ASR::expr_t*> fmt_args; fmt_args.reserve(al, 1);
-                fmt_args.push_back(al, fmt->m_args[i]);
-                ASR::expr_t* fmt_i = ASRUtils::EXPR(ASRUtils::make_StringFormat_t_util(
-                    al, loc, fmt->m_fmt, fmt_args.p, 1, fmt->m_kind, fmt->m_type, fmt->m_value));
-                Vec<ASR::expr_t*> inner_vals; inner_vals.reserve(al, 1);
-                inner_vals.push_back(al, fmt_i);
-                pass_result.push_back(al, ASRUtils::STMT(ASR::make_FileWrite_t(
-                    al, loc, x.m_label, unit_i,
-                    x.m_iomsg, x.m_iostat, x.m_id,
-                    inner_vals.p, 1,
-                    x.m_separator, x.m_end, x.m_overloaded,
-                    x.m_is_formatted, x.m_nml, x.m_rec, x.m_pos, x.m_asynchronous)));
-            }
+            // Compute section size: abs((end - start) / step) + 1
+            ASR::expr_t* diff = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, ub_lhs, ASR::binopType::Sub, lb_lhs, int_type, nullptr));
+            ASR::expr_t* quot = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, diff, ASR::binopType::Div, step, int_type, nullptr));
+            ASR::expr_t* one = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, ikind, loc);
+            ASR::expr_t* section_size = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, quot, ASR::binopType::Add, one, int_type, nullptr));
+
+            // Create a temporary contiguous array: character(len) :: temp(section_size)
+            ASR::ttype_t* base_str_type = ASRUtils::type_get_past_array(
+                ASRUtils::expr_type(x.m_unit));
+            ASR::dimension_t* temp_dim = al.allocate<ASR::dimension_t>(1);
+            temp_dim->loc = loc;
+            temp_dim->m_start = one;
+            temp_dim->m_length = section_size;
+            ASR::ttype_t* temp_arr_type = ASRUtils::TYPE(ASR::make_Array_t(
+                al, loc, base_str_type, temp_dim, 1,
+                ASR::array_physical_typeType::DescriptorArray));
+            std::string tmp_name = current_scope->get_unique_name("__fw_temp_");
+            ASR::symbol_t* tmp_sym = ASR::down_cast<ASR::symbol_t>(
+                ASRUtils::make_Variable_t_util(
+                    al, loc, current_scope, s2c(al, tmp_name), nullptr, 0,
+                    ASR::intentType::Local, nullptr, nullptr,
+                    ASR::storage_typeType::Default, temp_arr_type, nullptr,
+                    ASR::abiType::Source, ASR::accessType::Public,
+                    ASR::presenceType::Required, false));
+            current_scope->add_symbol(tmp_name, tmp_sym);
+            ASR::expr_t* temp_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, tmp_sym));
+
+
+            // Setup loop index for copy-in and copy-out
+            Vec<ASR::expr_t*> idx_vars;
+            idx_vars.reserve(al, 1);
+            PassUtils::create_idx_vars(idx_vars, 1, loc, al, current_scope, "_fwcopy", ikind);
+            ASR::expr_t* loop_var = idx_vars[0];
+            ASR::expr_t* zero = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 0, ikind, loc);
+            ASR::expr_t* loop_end = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, section_size, ASR::binopType::Sub, one, int_type, nullptr));
+
+            // Original array index: start + loop_var * step
+            ASR::expr_t* scaled = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, loop_var, ASR::binopType::Mul, step, int_type, nullptr));
+            ASR::expr_t* orig_idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, lb_lhs, ASR::binopType::Add, scaled, int_type, nullptr));
+            ASR::expr_t* orig_elem = PassUtils::create_array_ref(unit, orig_idx, al, current_scope);
+
+            // Temp array index: loop_var + 1
+            ASR::expr_t* temp_idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                al, loc, loop_var, ASR::binopType::Add, one, int_type, nullptr));
+            ASR::expr_t* temp_elem = PassUtils::create_array_ref(temp_var, temp_idx, al, current_scope);
+
+            // Copy in: do i = 0, section_size - 1
+            //   temp(i + 1) = c(start + i*step)
+            ASR::stmt_t* copy_in_stmt = ASRUtils::STMT(
+                ASRUtils::make_Assignment_t_util(
+                    al, loc, temp_elem, orig_elem, nullptr, false, false));
+            Vec<ASR::stmt_t*> loop_in_body; loop_in_body.reserve(al, 1);
+            loop_in_body.push_back(al, copy_in_stmt);
+            ASR::do_loop_head_t head_in;
+            head_in.m_v = loop_var; head_in.m_start = zero; head_in.m_end = loop_end;
+            head_in.m_increment = nullptr; head_in.loc = loc;
+            pass_result.push_back(al, ASRUtils::STMT(ASR::make_DoLoop_t(
+                al, loc, nullptr, head_in, loop_in_body.p, 1, nullptr, 0)));
+
+            // Use temp_var directly as the write unit
+            pass_result.push_back(al, ASRUtils::STMT(ASR::make_FileWrite_t(
+                al, loc, x.m_label, temp_var,
+                x.m_iomsg, x.m_iostat, x.m_id,
+                x.m_values, x.n_values,
+                x.m_separator, x.m_end, x.m_overloaded,
+                x.m_is_formatted, x.m_nml, x.m_rec, x.m_pos, x.m_asynchronous)));
+
+            // Copy back: do i = 0, section_size - 1
+            //   c(start + i*step) = temp(i + 1)
+            ASR::stmt_t* copy_stmt = ASRUtils::STMT(
+                ASRUtils::make_Assignment_t_util(
+                    al, loc, orig_elem, temp_elem, nullptr, false, false));
+            Vec<ASR::stmt_t*> loop_body; loop_body.reserve(al, 1);
+            loop_body.push_back(al, copy_stmt);
+            ASR::do_loop_head_t head;
+            head.m_v = loop_var; head.m_start = zero; head.m_end = loop_end;
+            head.m_increment = nullptr; head.loc = loc;
+            pass_result.push_back(al, ASRUtils::STMT(ASR::make_DoLoop_t(
+                al, loc, nullptr, head, loop_body.p, 1, nullptr, 0)));
+
             remove_original_stmt = true;
             return;
         }

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -666,20 +666,10 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
         if (fmt->n_args == 0) return;
         ASR::expr_t* val_arg = fmt->m_args[0];
         bool is_do_loop = ASR::is_a<ASR::ImpliedDoLoop_t>(*val_arg);
-        bool is_array_section_unit_with_scalar_values =
-            ASR::is_a<ASR::ArraySection_t>(*x.m_unit) && fmt->n_args > 1;
-        if (is_array_section_unit_with_scalar_values) {
-            for (size_t i = 0; i < fmt->n_args; i++) {
-                if (ASR::is_a<ASR::ImpliedDoLoop_t>(*fmt->m_args[i]) ||
-                    ASRUtils::is_array(ASRUtils::expr_type(fmt->m_args[i]))) {
-                    is_array_section_unit_with_scalar_values = false;
-                    break;
-                }
-            }
-        }
+        bool is_array_section_unit = ASR::is_a<ASR::ArraySection_t>(*x.m_unit);
 
         if (!is_do_loop && !ASRUtils::is_array(ASRUtils::expr_type(val_arg)) &&
-            !is_array_section_unit_with_scalar_values) return;
+            !is_array_section_unit) return;
 
         // For formatted writes with plain array values whose format contains
         // a slash (/), skip the per-element loop transformation. The slash
@@ -715,24 +705,20 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
             }
         }
 
-        if (is_array_section_unit_with_scalar_values) {
+        if (is_array_section_unit) {
             ASR::ArraySection_t* sec = ASR::down_cast<ASR::ArraySection_t>(x.m_unit);
             if (sec->n_args != 1) return;
+
+            ASRUtils::ASRBuilder b(al, loc);
             ASR::expr_t* step = sec->m_args[0].m_step;
-            if (step == nullptr) {
-                step = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, ikind, loc);
-            }
+            if (!step) step = b.i_idx(1, ikind);
+            ASR::expr_t* one = b.i_idx(1, ikind);
+            ASR::expr_t* zero = b.i_idx(0, ikind);
 
-            // Compute section size: abs((end - start) / step) + 1
-            ASR::expr_t* diff = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, ub_lhs, ASR::binopType::Sub, lb_lhs, int_type, nullptr));
-            ASR::expr_t* quot = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, diff, ASR::binopType::Div, step, int_type, nullptr));
-            ASR::expr_t* one = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 1, ikind, loc);
-            ASR::expr_t* section_size = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, quot, ASR::binopType::Add, one, int_type, nullptr));
+            // section_size = (end - start) / step + 1
+            ASR::expr_t* section_size = b.Add(b.Div(b.Sub(ub_lhs, lb_lhs), step), one);
 
-            // Create a temporary contiguous array: character(len) :: temp(section_size)
+            // Create temporary contiguous array: character(len) :: temp(section_size)
             ASR::ttype_t* base_str_type = ASRUtils::type_get_past_array(
                 ASRUtils::expr_type(x.m_unit));
             ASR::dimension_t* temp_dim = al.allocate<ASR::dimension_t>(1);
@@ -743,52 +729,27 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
                 al, loc, base_str_type, temp_dim, 1,
                 ASR::array_physical_typeType::DescriptorArray));
             std::string tmp_name = current_scope->get_unique_name("__fw_temp_");
-            ASR::symbol_t* tmp_sym = ASR::down_cast<ASR::symbol_t>(
-                ASRUtils::make_Variable_t_util(
-                    al, loc, current_scope, s2c(al, tmp_name), nullptr, 0,
-                    ASR::intentType::Local, nullptr, nullptr,
-                    ASR::storage_typeType::Default, temp_arr_type, nullptr,
-                    ASR::abiType::Source, ASR::accessType::Public,
-                    ASR::presenceType::Required, false));
-            current_scope->add_symbol(tmp_name, tmp_sym);
-            ASR::expr_t* temp_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, tmp_sym));
+            ASR::expr_t* temp_var = b.Variable(current_scope, tmp_name,
+                temp_arr_type, ASR::intentType::Local);
 
-
-            // Setup loop index for copy-in and copy-out
+            // Loop index
             Vec<ASR::expr_t*> idx_vars;
             idx_vars.reserve(al, 1);
             PassUtils::create_idx_vars(idx_vars, 1, loc, al, current_scope, "_fwcopy", ikind);
             ASR::expr_t* loop_var = idx_vars[0];
-            ASR::expr_t* zero = make_ConstantWithKind(make_IntegerConstant_t, make_Integer_t, 0, ikind, loc);
-            ASR::expr_t* loop_end = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, section_size, ASR::binopType::Sub, one, int_type, nullptr));
+            ASR::expr_t* loop_end = b.Sub(section_size, one);
 
-            // Original array index: start + loop_var * step
-            ASR::expr_t* scaled = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, loop_var, ASR::binopType::Mul, step, int_type, nullptr));
-            ASR::expr_t* orig_idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, lb_lhs, ASR::binopType::Add, scaled, int_type, nullptr));
-            ASR::expr_t* orig_elem = PassUtils::create_array_ref(unit, orig_idx, al, current_scope);
+            // Element references: orig = c(start + i*step), temp = temp(i+1)
+            ASR::expr_t* orig_elem = PassUtils::create_array_ref(unit,
+                b.Add(lb_lhs, b.Mul(loop_var, step)), al, current_scope);
+            ASR::expr_t* temp_elem = PassUtils::create_array_ref(temp_var,
+                b.Add(loop_var, one), al, current_scope);
 
-            // Temp array index: loop_var + 1
-            ASR::expr_t* temp_idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                al, loc, loop_var, ASR::binopType::Add, one, int_type, nullptr));
-            ASR::expr_t* temp_elem = PassUtils::create_array_ref(temp_var, temp_idx, al, current_scope);
+            // Copy in: do i = 0, section_size-1; temp(i+1) = c(start+i*step)
+            pass_result.push_back(al, b.DoLoop(loop_var, zero, loop_end,
+                {b.Assignment(temp_elem, orig_elem)}));
 
-            // Copy in: do i = 0, section_size - 1
-            //   temp(i + 1) = c(start + i*step)
-            ASR::stmt_t* copy_in_stmt = ASRUtils::STMT(
-                ASRUtils::make_Assignment_t_util(
-                    al, loc, temp_elem, orig_elem, nullptr, false, false));
-            Vec<ASR::stmt_t*> loop_in_body; loop_in_body.reserve(al, 1);
-            loop_in_body.push_back(al, copy_in_stmt);
-            ASR::do_loop_head_t head_in;
-            head_in.m_v = loop_var; head_in.m_start = zero; head_in.m_end = loop_end;
-            head_in.m_increment = nullptr; head_in.loc = loc;
-            pass_result.push_back(al, ASRUtils::STMT(ASR::make_DoLoop_t(
-                al, loc, nullptr, head_in, loop_in_body.p, 1, nullptr, 0)));
-
-            // Use temp_var directly as the write unit
+            // Write to contiguous temp
             pass_result.push_back(al, ASRUtils::STMT(ASR::make_FileWrite_t(
                 al, loc, x.m_label, temp_var,
                 x.m_iomsg, x.m_iostat, x.m_id,
@@ -796,18 +757,9 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
                 x.m_separator, x.m_end, x.m_overloaded,
                 x.m_is_formatted, x.m_nml, x.m_rec, x.m_pos, x.m_asynchronous)));
 
-            // Copy back: do i = 0, section_size - 1
-            //   c(start + i*step) = temp(i + 1)
-            ASR::stmt_t* copy_stmt = ASRUtils::STMT(
-                ASRUtils::make_Assignment_t_util(
-                    al, loc, orig_elem, temp_elem, nullptr, false, false));
-            Vec<ASR::stmt_t*> loop_body; loop_body.reserve(al, 1);
-            loop_body.push_back(al, copy_stmt);
-            ASR::do_loop_head_t head;
-            head.m_v = loop_var; head.m_start = zero; head.m_end = loop_end;
-            head.m_increment = nullptr; head.loc = loc;
-            pass_result.push_back(al, ASRUtils::STMT(ASR::make_DoLoop_t(
-                al, loc, nullptr, head, loop_body.p, 1, nullptr, 0)));
+            // Copy back: do i = 0, section_size-1; c(start+i*step) = temp(i+1)
+            pass_result.push_back(al, b.DoLoop(loop_var, zero, loop_end,
+                {b.Assignment(orig_elem, temp_elem)}));
 
             remove_original_stmt = true;
             return;

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -11930,15 +11930,8 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
                 start = end + 1;
             }
 
-            // For remaining records, pad with spaces.
-            while (rec < array_size) {
-                _lfortran_copy_str_and_pad(
-                    (*str_holder) + rec * (*len),
-                    *len,
-                    "",
-                    0);
-                rec++;
-            }
+            // Remaining records (beyond the output list) are left
+            // unchanged, per the Fortran standard.
         } else {
             _lfortran_copy_str_and_pad(*str_holder, *len, str, str_len);
         }


### PR DESCRIPTION
fixes #11735

Two bugs caused incorrect output for writes like
`write(c(5:1:-2), "(A,I0)") "x", 2, "z"`:

1. The array_op pass split format args one-per-element, creating
   separate writes like `write(c(5),"(A,I0)") "x"` for each arg.
   This is wrong for multi-item formats like (A,I0) where the format
   engine must group multiple args into a single record.

   Fix: materialize a contiguous temporary array, copy-in the original
   values, perform the write to the temp (letting the format engine
   handle record grouping), then copy-out back to the strided positions.

2. The runtime `_lfortran_string_write` padded all remaining array
   records with spaces after writing, even those beyond the output
   list. Per the Fortran standard, untouched records must remain
   unchanged.

   Fix: remove the remaining-record padding loop.
