### PR TITLE
fix : ICE when polymorphic string length is derived from a struct member

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2801,6 +2801,7 @@ RUN(NAME string_112 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_113 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_114 LABELS gfortran llvm)
 RUN(NAME string_115 LABELS gfortran llvm)
+RUN(NAME string_116 LABELS gfortran llvm)
 
 RUN(NAME substring_read LABELS gfortran llvm)
 

--- a/integration_tests/string_116.f90
+++ b/integration_tests/string_116.f90
@@ -45,26 +45,20 @@ contains
         me%buf_size = original_size  ! restore
     end subroutine test_modify_mid_sub
 
-end module string_116_mod
+    ! Test: character(len=n) where n is a normal variable (not a struct member)
+    subroutine test_normal_variable(n)
+        implicit none
+        integer, intent(in) :: n
+        character(len=n) :: buf
+        buf = "hello world"
+        if (len(buf) /= n) error stop
+    end subroutine test_normal_variable
 
-! Test: character(len=n) where n is a normal variable (not a struct member)
-subroutine test_normal_variable(n)
-    implicit none
-    integer, intent(in) :: n
-    character(len=n) :: buf
-    buf = "hello world"
-    if (len(buf) /= n) error stop
-end subroutine test_normal_variable
+end module string_116_mod
 
 program string_116
     use string_116_mod
     implicit none
-
-    interface
-        subroutine test_normal_variable(n)
-            integer, intent(in) :: n
-        end subroutine test_normal_variable
-    end interface
 
     type(buffer_type) :: obj
     type(buffer_type) :: obj2

--- a/integration_tests/string_116.f90
+++ b/integration_tests/string_116.f90
@@ -11,6 +11,7 @@ module string_116_mod
     contains
         procedure :: fill_buffer
         procedure :: get_greeting
+        procedure :: test_modify_mid_sub
     end type buffer_type
 
 contains
@@ -29,11 +30,41 @@ contains
         res = "greetings!"
     end function get_greeting
 
+    ! Test: modifying buf_size mid-subroutine should NOT change len(buf)
+    ! The character length is frozen at subroutine entry.
+    subroutine test_modify_mid_sub(me)
+        class(buffer_type), intent(inout) :: me
+        character(len=me%buf_size) :: buf
+        integer :: original_size
+        original_size = me%buf_size
+        buf = "hello"
+        if (len(buf) /= original_size) error stop
+        me%buf_size = 3
+        ! len(buf) must still reflect the original value, not 3
+        if (len(buf) /= original_size) error stop
+        me%buf_size = original_size  ! restore
+    end subroutine test_modify_mid_sub
+
 end module string_116_mod
+
+! Test: character(len=n) where n is a normal variable (not a struct member)
+subroutine test_normal_variable(n)
+    implicit none
+    integer, intent(in) :: n
+    character(len=n) :: buf
+    buf = "hello world"
+    if (len(buf) /= n) error stop
+end subroutine test_normal_variable
 
 program string_116
     use string_116_mod
     implicit none
+
+    interface
+        subroutine test_normal_variable(n)
+            integer, intent(in) :: n
+        end subroutine test_normal_variable
+    end interface
 
     type(buffer_type) :: obj
     type(buffer_type) :: obj2
@@ -49,6 +80,18 @@ program string_116
     ! Test 3: function returning character(len=me%buf_size)
     result = obj%get_greeting()
     if (result /= "greetings!") error stop
+
+    ! Test 4: modifying buf_size mid-subroutine (length should be frozen)
+    obj%buf_size = 10
+    call obj%test_modify_mid_sub()
+
+    ! Test 5: after modification, next call should use new value
+    obj2%buf_size = 7
+    call obj2%fill_buffer()
+
+    ! Test 6: character(len=n) with a normal variable
+    call test_normal_variable(10)
+    call test_normal_variable(5)
 
     print *, "All tests passed."
 end program string_116

--- a/integration_tests/string_116.f90
+++ b/integration_tests/string_116.f90
@@ -1,0 +1,54 @@
+! Test: character variable with length from type-bound member via class argument
+! This tests the codegen path where a string's length is an ExpressionLength
+! derived from a StructInstanceMember (e.g., me%n) accessed through a
+! polymorphic class(*) self argument.
+
+module string_116_mod
+    implicit none
+
+    type :: buffer_type
+        integer :: buf_size = 10
+    contains
+        procedure :: fill_buffer
+        procedure :: get_greeting
+    end type buffer_type
+
+contains
+
+    subroutine fill_buffer(me)
+        class(buffer_type), intent(in) :: me
+        character(len=me%buf_size) :: buf
+        buf = "hello"
+        if (len(buf) /= me%buf_size) error stop
+        if (buf(1:5) /= "hello") error stop
+    end subroutine fill_buffer
+
+    function get_greeting(me) result(res)
+        class(buffer_type), intent(in) :: me
+        character(len=me%buf_size) :: res
+        res = "greetings!"
+    end function get_greeting
+
+end module string_116_mod
+
+program string_116
+    use string_116_mod
+    implicit none
+
+    type(buffer_type) :: obj
+    type(buffer_type) :: obj2
+    character(len=10) :: result
+
+    ! Test 1: default buf_size (10)
+    call obj%fill_buffer()
+
+    ! Test 2: custom buf_size
+    obj2%buf_size = 5
+    call obj2%fill_buffer()
+
+    ! Test 3: function returning character(len=me%buf_size)
+    result = obj%get_greeting()
+    if (result /= "greetings!") error stop
+
+    print *, "All tests passed."
+end program string_116

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1163,10 +1163,7 @@ public:
         switch(str_type->m_len_kind){
             case ASR::ExpressionLength:{
                 LCOMPILERS_ASSERT(len);
-                int ptr_load_cpy = ptr_loads;
-                ptr_loads = 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(len));
-                visit_expr(*len);
-                ptr_loads = ptr_load_cpy;
+                visit_expr_load_wrapper(len, 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(len)), true);
                 tmp = llvm_utils->convert_kind(tmp, llvm::Type::getInt64Ty(context));
                 llvm::Value* len_ptr = llvm_utils->get_string_length(str_type, str, true);
                 builder->CreateStore(tmp, len_ptr);


### PR DESCRIPTION

fixes #11749
**Issue:**
When a local character variable's length is defined using an expression derived from a polymorphic `class(*)` argument's struct member (e.g., `character(len=me%chunk_size)`), LFortran's codegen was encountering an Internal Compiler Error (ICE). The failure occurred in `setup_string_length` during the `convert_kind` call because `visit_expr` was returning an LLVM pointer to the integer member instead of loading the actual integer value, causing a type mismatch assertion failure `(val->getType()->isIntegerTy() && target_type->isIntegerTy())`.

**Root Cause:**
In `setup_string_length`, `visit_expr(*len)` was being called directly after adjusting `ptr_loads`. While this worked for simple variables, it failed for `StructInstanceMember` expressions. `visit_StructInstanceMember` evaluates to a pointer to the struct member, and the dereferencing (loading) of that pointer relies on `logical_load_val` which is only triggered properly if the expression is loaded via the wrapper functions.

**Fix:**
Replaced the direct `visit_expr(*len)` call and manual `ptr_loads` manipulation in `setup_string_length` with `visit_expr_load_wrapper(len, 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(len)), true)`. 
Using `visit_expr_load_wrapper` with `load_ref=true` ensures that if the length expression is a `StructInstanceMember` (or an array element), it properly dereferences the member pointer via `logical_load_val` to return the actual integer value, safely satisfying the LLVM `convert_kind` assertions.

**Testing:**
Added a new integration test `string_116.f90` covering polymorphic class structure members used in string length allocations.
