### PR TITLE
fix(runtime): preserve writes when reopening SCRATCH unit as named file

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2937,6 +2937,7 @@ RUN(NAME file_69 LABELS gfortran llvm)
 RUN(NAME file_70 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
 RUN(NAME file_71 LABELS gfortran llvm)
 RUN(NAME file_72 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
+RUN(NAME file_73 LABELS gfortran llvm)
 
 RUN(NAME file_close_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME file_close_02 LABELS gfortran llvm)

--- a/integration_tests/file_73.f90
+++ b/integration_tests/file_73.f90
@@ -1,0 +1,26 @@
+program test_reopen
+    implicit none
+    integer, parameter :: lun = 10
+    integer :: ios, nlines
+    character(len=80) :: line
+    
+    open(unit=lun, status='scratch')
+    
+    open(unit=lun, file='test_mre3', action='write')
+    
+    write(lun, '(A)') 'hello'
+    
+    close(lun)
+    
+    open(unit=lun, file='test_mre3', action='read')
+    nlines = 0
+    do
+        read(lun, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        nlines = nlines + 1
+    end do
+    close(lun)
+    
+    ! print *, "Lines read:", nlines
+    if (nlines /= 1) error stop
+end program

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -6220,6 +6220,16 @@ _lfortran_open(int32_t unit_num,
         // since f_name_c is the copy we'll use going forward
         internal_free(f_name);
     }
+
+    if (already_open) {
+        bool existing_bin;
+        char* existing_filename = get_file_name_from_unit(unit_num, &existing_bin);
+        if (ini_file && (!existing_filename || !streql(existing_filename, f_name_c))) {
+            _lfortran_close(unit_num, NULL, 0, NULL);
+            already_open = NULL;
+        }
+    }
+
     char* status_c = to_c_string((const fchar*)status, status_len);
     char* form_c = to_c_string((const fchar*)form, form_len);
     char* action_c = to_c_string((const fchar*)action, action_len);


### PR DESCRIPTION
Fixes #11751 