### PR TITLE
Fix ICE caused by optional dummy arguments in bind(c) procedure

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1492,6 +1492,18 @@ public:
                 }
             }
             ASR::symbol_t *var = current_scope->get_symbol(arg_s);
+            if (current_procedure_abi_type == ASR::abiType::BindC && ASR::is_a<ASR::Variable_t>(*var)) {
+                ASR::Variable_t *var_sym = ASR::down_cast<ASR::Variable_t>(var);
+                if (var_sym->m_value_attr && var_sym->m_presence == ASR::presenceType::Optional) {
+                    diag.add(diag::Diagnostic(
+                        "Variable `" + arg_s + "` cannot have both the OPTIONAL and VALUE attribute"
+                        " because procedure `" + std::string(x.m_name) + "` is BIND(C)",
+                        diag::Level::Error, diag::Stage::Semantic, {diag::Label("", {x.m_args[i].loc})}));
+                    if (!compiler_options.continue_compilation){
+                        throw SemanticAbort();
+                    }
+                }
+            }
             args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                 var)));
         }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -745,4 +745,8 @@ program continue_compilation_1
         case (:[2])
         end select
     end subroutine
+    subroutine bindc_optional_value(a) bind(c)
+        implicit none
+        integer, optional, value :: a
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "b2ad5a959a1b1eb7e5ad0b0ca7f4be6beba4598589d988334086b1ee",
+    "infile_hash": "4a96cc79b5b9724b98d84d260eb720b4d8cd231170b7dfacd97c3355",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "337f33d1c8288f1b20d4ec031f25e0fa0244554924195f22a0aa1ed2",
+    "stderr_hash": "24f01211d8aee66b0ccea4ae478f082102f2316423858818092e8c97",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -481,6 +481,16 @@ semantic error: COMMON block array bounds must be constant expressions
 736 |         integer :: arr(1:n)
     |                    ^^^^^^^^ 
 
+semantic error: Variable `a` cannot have both the OPTIONAL and VALUE attribute because procedure `bindc_optional_value` is BIND(C)
+   --> tests/errors/continue_compilation_1.f90:748:5 - 751:18
+    |
+748 |        subroutine bindc_optional_value(a) bind(c)
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
+...
+    |
+751 |        end subroutine
+    | ...^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |


### PR DESCRIPTION
fixes #11080