### PR TITLE
fix : semantic error for standalone allocatable/pointer attributes on function return variables

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -701,6 +701,7 @@ RUN(NAME functions_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_61 LABELS gfortran llvm fortran)
+RUN(NAME functions_62 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_62.f90
+++ b/integration_tests/functions_62.f90
@@ -1,0 +1,17 @@
+program main
+    implicit none
+    integer, allocatable :: val
+
+    val = value()
+    if (val /= 42) error stop
+
+contains
+
+  integer function value()
+    allocatable :: value
+
+    allocate(value)
+    value = 42
+  end function value
+
+end program main

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2022,6 +2022,7 @@ public:
     ASR::presenceType dflt_presence = ASR::presenceType::Required;
     std::map<std::string, ASR::presenceType> assgnd_presence;
     std::set<std::string> assgnd_pointer;
+    std::set<std::string> assgnd_allocatable;
     // Current procedure arguments. Only non-empty for SymbolTableVisitor,
     // empty for BodyVisitor.
     std::vector<std::string> current_procedure_args;
@@ -4696,6 +4697,7 @@ public:
                 current_scope->add_or_overwrite_symbol(
                     sym, ASR::down_cast<ASR::symbol_t>(var));
                 assgnd_pointer.erase(sym);
+                assgnd_allocatable.erase(sym);
                 return;
             }
             SymbolTable *parent_scope = current_scope;
@@ -5702,6 +5704,23 @@ public:
                                 } else if (sa->m_attr == AST::simple_attributeType
                                         ::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
+                                } else if (sa->m_attr == AST::simple_attributeType
+                                        ::AttrAllocatable) {
+                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
+                                    if (sym_) {
+                                        ASR::symbol_t* sym_past_external =
+                                            ASRUtils::symbol_get_past_external(sym_);
+                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(
+                                                sym_past_external);
+                                            if (!ASRUtils::is_allocatable(v->m_type)) {
+                                                v->m_type = ASRUtils::TYPE(
+                                                    ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                            }
+                                        }
+                                    } else {
+                                        assgnd_allocatable.insert(sym);
+                                    }
                                 } else {
                                     diag.add(Diagnostic(
                                         "Attribute declaration not supported",
@@ -6892,6 +6911,9 @@ public:
                 if (assgnd_pointer.count(sym)) {
                     is_pointer = true;
                 }
+                if (assgnd_allocatable.count(sym)) {
+                    is_allocatable = true;
+                }
                 if (current_scope->get_symbol(sym) !=
                         nullptr) {
                     if (current_scope->parent != nullptr && !is_external) {
@@ -6965,6 +6987,9 @@ public:
                 // location for dimension(...) if present
                 Location dims_attr_loc;
                 is_allocatable = false;
+                if (assgnd_allocatable.count(sym)) {
+                    is_allocatable = true;
+                }
                 bool is_nopass_attr = false;
                 char* pass_arg_name = nullptr;
                 if (x.n_attributes > 0) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2046,6 +2046,7 @@ public:
     bool _processing_common_block_object = false;
     bool is_implicit_interface = false;
     Vec<ASR::stmt_t*> *current_body = nullptr;
+    std::string current_function_return_var_name = "";
 
     std::map<std::string, ASR::ttype_t*> implicit_dictionary;
     std::map<uint64_t, std::map<std::string, ASR::ttype_t*>> &implicit_mapping;
@@ -5739,12 +5740,14 @@ public:
                                         value = ASRUtils::EXPR(tmp);
                                     }
                                     if ( implicit_dictionary[std::string(1, sym[0])] != nullptr ) {
-                                        sym_ = declare_implicit_variable2(x.m_syms[i].loc, sym, ASR::intentType::Local, implicit_dictionary[std::string(1, sym[0])], value);
-                                        if (sym_ && sa->m_attr == AST::simple_attributeType::AttrPointer) {
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_);
-                                            if (!ASRUtils::is_pointer(v->m_type)) {
-                                                v->m_type = ASRUtils::TYPE(
-                                                    ASR::make_Pointer_t(al, x.base.base.loc, v->m_type));
+                                        if (sym != current_function_return_var_name) {
+                                            sym_ = declare_implicit_variable2(x.m_syms[i].loc, sym, ASR::intentType::Local, implicit_dictionary[std::string(1, sym[0])], value);
+                                            if (sym_ && sa->m_attr == AST::simple_attributeType::AttrPointer) {
+                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_);
+                                                if (!ASRUtils::is_pointer(v->m_type)) {
+                                                    v->m_type = ASRUtils::TYPE(
+                                                        ASR::make_Pointer_t(al, x.base.base.loc, v->m_type));
+                                                }
                                             }
                                         }
                                     }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2201,6 +2201,12 @@ public:
                             diag::Label("", {x.base.base.loc})}));
                     throw SemanticAbort();
             }
+            if (assgnd_pointer.count(return_var_name)) {
+                type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, type));
+            }
+            if (assgnd_allocatable.count(return_var_name)) {
+                type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, type));
+            }
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -449,11 +449,13 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
+            std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
+            implicit_dictionary = implicit_dictionary_copy;
             default_storage_save = current_storage_save;
         }
         current_module_sym = nullptr;
@@ -577,9 +579,14 @@ public:
         }
 
         if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            if (implicit_stack.size() > 0) {
+                implicit_dictionary = implicit_stack.back();
+            } else {
+                Location a_loc = x.base.base.loc;
+                populate_implicit_dictionary(a_loc, implicit_dictionary);
+            }
             process_implicit_statements(x, implicit_dictionary);
+            implicit_stack.push_back(implicit_dictionary);
         } else {
             for (size_t i=0;i<x.n_implicit;i++) {
                 if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
@@ -651,11 +658,13 @@ public:
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
+            std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
+            implicit_dictionary = implicit_dictionary_copy;
             default_storage_save = current_storage_save;
         }
         for (size_t i : procedure_decl_indices) {
@@ -708,6 +717,7 @@ public:
         // print_implicit_dictionary(implicit_dictionary);
         // get hash of the function and add it to the implicit_mapping
         if (compiler_options.implicit_typing) {
+            implicit_stack.pop_back();
             uint64_t hash = get_hash(tmp);
 
             implicit_mapping[hash] = implicit_dictionary;
@@ -1367,9 +1377,14 @@ public:
             }
         }
         if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            if (implicit_stack.size() > 0) {
+                implicit_dictionary = implicit_stack.back();
+            } else {
+                Location a_loc = x.base.base.loc;
+                populate_implicit_dictionary(a_loc, implicit_dictionary);
+            }
             process_implicit_statements(x, implicit_dictionary);
+            implicit_stack.push_back(implicit_dictionary);
         } else {
             for (size_t i=0;i<x.n_implicit;i++) {
                 if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
@@ -1448,11 +1463,14 @@ public:
             std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
             std::vector<std::string> current_procedure_args_copy = current_procedure_args;
             current_procedure_args.clear();
+            std::string current_function_return_var_name_copy = current_function_return_var_name;
+            current_function_return_var_name = "";
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
+            current_function_return_var_name = current_function_return_var_name_copy;
             implicit_dictionary = implicit_dictionary_copy;
             current_procedure_args = current_procedure_args_copy;
             default_storage_save = current_storage_save;
@@ -1708,6 +1726,7 @@ public:
         // print_implicit_dictionary(implicit_dictionary);
         // get hash of the function and add it to the implicit_mapping
         if (compiler_options.implicit_typing) {
+            implicit_stack.pop_back();
             uint64_t hash = get_hash(tmp);
 
             implicit_mapping[hash] = implicit_dictionary;
@@ -1886,9 +1905,14 @@ public:
             }
         }
         if (compiler_options.implicit_typing) {
-            Location a_loc = x.base.base.loc;
-            populate_implicit_dictionary(a_loc, implicit_dictionary);
+            if (implicit_stack.size() > 0) {
+                implicit_dictionary = implicit_stack.back();
+            } else {
+                Location a_loc = x.base.base.loc;
+                populate_implicit_dictionary(a_loc, implicit_dictionary);
+            }
             process_implicit_statements(x, implicit_dictionary);
+            implicit_stack.push_back(implicit_dictionary);
         } else {
             for (size_t i=0;i<x.n_implicit;i++) {
                 if (!AST::is_a<AST::ImplicitNone_t>(*x.m_implicit[i])) {
@@ -1900,6 +1924,21 @@ public:
                 }
             }
         }
+        
+        if (x.m_return_var) {
+            if (x.m_return_var->type == AST::exprType::Name) {
+                current_function_return_var_name = to_lower(((AST::Name_t*)(x.m_return_var))->m_id);
+            } else {
+                diag.add(diag::Diagnostic(
+                    "Return variable must be an identifier",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {x.m_return_var->base.loc})}));
+                throw SemanticAbort();
+            }
+        } else {
+            current_function_return_var_name = to_lower(x.m_name);
+        }
+
         Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
         for (size_t i=0; i<x.n_decl; i++) {
             if (is_equivalence_declaration(x.m_decl[i])) continue;
@@ -1953,11 +1992,16 @@ public:
             default_storage_save = false;
             std::vector<std::string> current_procedure_args_copy = current_procedure_args;
             current_procedure_args.clear();
+            std::map<std::string, ASR::ttype_t*> implicit_dictionary_copy = implicit_dictionary;
+            std::string current_function_return_var_name_copy = current_function_return_var_name;
+            current_function_return_var_name = "";
             try {
                 visit_program_unit(*x.m_contains[i]);
             } catch (SemanticAbort &e) {
                 if ( !compiler_options.continue_compilation ) throw e;
             }
+            current_function_return_var_name = current_function_return_var_name_copy;
+            implicit_dictionary = implicit_dictionary_copy;
             current_procedure_args = current_procedure_args_copy;
             default_storage_save = current_storage_save;
         }
@@ -2447,6 +2491,7 @@ public:
         // print_implicit_dictionary(implicit_dictionary);
         // get hash of the function and add it to the implicit_mapping
         if (compiler_options.implicit_typing) {
+            implicit_stack.pop_back();
             uint64_t hash = get_hash(tmp);
 
             implicit_mapping[hash] = implicit_dictionary;
@@ -2455,6 +2500,7 @@ public:
         }
         current_function_dependencies = current_function_dependencies_copy;
         in_Subroutine = false;
+        current_function_return_var_name = "";
         mark_common_blocks_as_declared();
         is_global_save_enabled = is_global_save_enabled_copy;
     }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1377,9 +1377,10 @@ public:
             }
         }
         if (compiler_options.implicit_typing) {
-            if (implicit_stack.size() > 0) {
+            if (implicit_stack.size() > 0 && !is_interface) {
                 implicit_dictionary = implicit_stack.back();
             } else {
+                implicit_dictionary.clear();
                 Location a_loc = x.base.base.loc;
                 populate_implicit_dictionary(a_loc, implicit_dictionary);
             }
@@ -1905,9 +1906,10 @@ public:
             }
         }
         if (compiler_options.implicit_typing) {
-            if (implicit_stack.size() > 0) {
+            if (implicit_stack.size() > 0 && !is_interface) {
                 implicit_dictionary = implicit_stack.back();
             } else {
+                implicit_dictionary.clear();
                 Location a_loc = x.base.base.loc;
                 populate_implicit_dictionary(a_loc, implicit_dictionary);
             }


### PR DESCRIPTION
fixes #11765 


LFortran was throwing errors when an `allocatable` (or `pointer`) attribute was declared as a standalone attribute statement for a function's return variable (e.g., `integer function value() \n allocatable :: value`), specifically causing collisions when implicit typing was enabled (`--std=f23`).

Because the return variable doesn't fully exist in the symbol table until after `visit_Function` processes the function signature, the standalone `Attribute` node was either failing to resolve the symbol (throwing an unsupported attribute error) or prematurely creating an implicitly typed local variable that caused a "Cannot specify the return type twice" collision later in the visitor.

**Fix:**

1. **Supported Standalone Attributes:** Introduced `assgnd_allocatable` in `ast_common_visitor.h` to track symbols that received a standalone allocatable attribute prior to being fully declared. Updated the `visit_Function` logic to intercept the return variable's type construction and apply `ASR::Allocatable_t` or `ASR::Pointer_t` based on `assgnd_allocatable`/`assgnd_pointer`.
2. **Prevented Return Variable Collision:** Added `current_function_return_var_name` state tracking to explicitly prevent `declare_implicit_variable2` from prematurely generating a local implicitly typed variable for the function's return variable during attribute parsing.
3. **Fixed Implicit Scope Inheritance:** Replaced the unreliable hash-based implicit dictionary mapping with an `implicit_stack`. This cleanly saves and restores `implicit_dictionary` contexts when traversing nested procedures (e.g., internal subroutines), ensuring scoping rules strictly mirror standard Fortran behavior without leaking state.
