### PR TITLE
fix : ICE when allocatable/pointer derived-type member is used as string length

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2808,6 +2808,7 @@ RUN(NAME string_113 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_114 LABELS gfortran llvm)
 RUN(NAME string_115 LABELS gfortran llvm)
 RUN(NAME string_116 LABELS gfortran llvm)
+RUN(NAME string_117 LABELS gfortran llvm)
 
 RUN(NAME substring_read LABELS gfortran llvm)
 

--- a/integration_tests/string_117.f90
+++ b/integration_tests/string_117.f90
@@ -1,0 +1,31 @@
+module string_117_module
+    implicit none
+
+    type :: TestType
+        integer, allocatable :: buf_size
+    end type TestType
+
+contains
+
+    subroutine do_work(me)
+        class(TestType), intent(in) :: me
+        character(len=me%buf_size) :: buf
+        
+        if (len(buf) /= 8) error stop
+        buf = '12345678'
+        if (buf /= '12345678') error stop
+        print *, len(buf)
+    end subroutine do_work
+
+end module string_117_module
+
+program string_117
+    use string_117_module
+    implicit none
+    type(TestType) :: obj
+    
+    allocate(obj%buf_size)
+    obj%buf_size = 8
+    
+    call do_work(obj)
+end program string_117

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1164,6 +1164,14 @@ public:
             case ASR::ExpressionLength:{
                 LCOMPILERS_ASSERT(len);
                 visit_expr_load_wrapper(len, 2 - !LLVM::is_llvm_pointer(*ASRUtils::expr_type(len)), true);
+                if (ASRUtils::is_allocatable_or_pointer(ASRUtils::expr_type(len)) &&
+                    (ASR::is_a<ASR::StructInstanceMember_t>(*len) ||
+                     ASR::is_a<ASR::ArrayItem_t>(*len) ||
+                     ASR::is_a<ASR::ArraySection_t>(*len))) {
+                    llvm::Type* t = llvm_utils->get_type_from_ttype_t_util(
+                        len, ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(len)), module.get());
+                    tmp = llvm_utils->CreateLoad2(t, tmp);
+                }
                 tmp = llvm_utils->convert_kind(tmp, llvm::Type::getInt64Ty(context));
                 llvm::Value* len_ptr = llvm_utils->get_string_length(str_type, str, true);
                 builder->CreateStore(tmp, len_ptr);


### PR DESCRIPTION

fixes #11773
When setting up character string lengths, `setup_string_length` uses 
`visit_expr_load_wrapper` to evaluate the length expression. For simple variables,
this correctly unwraps the allocatable descriptor entirely to yield the
integer value. However, for reference expressions (like `StructInstanceMember`,
`ArrayItem`, or `ArraySection`), the visitor intentionally omits the final 
logical load, returning a pointer to the value rather than the value itself.

This commit adds a targeted check in `setup_string_length`: if the length 
expression is an allocatable or pointer type *and* a reference expression, 
we perform the final `CreateLoad2` to extract the integer length value. 
This prevents `convert_kind` from asserting on an unexpected pointer type,
while avoiding a double-load regression for ordinary allocatable variables.

