### PR TITLE
fix: compile-time eval of unpack with scalar field

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1468,7 +1468,7 @@ RUN(NAME intrinsics_147 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # pack
 RUN(NAME intrinsics_148 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_FAST_MATH) # pack
 RUN(NAME intrinsics_149 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_FAST_MATH) # unpack
 RUN(NAME unpack_scalar_field_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
-RUN(NAME unpack_scalar_field_02 LABELS llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME unpack_scalar_field_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME intrinsics_150 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskr
 RUN(NAME intrinsics_151 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl
 RUN(NAME intrinsics_152 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # selected_real_kind

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1468,6 +1468,7 @@ RUN(NAME intrinsics_147 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # pack
 RUN(NAME intrinsics_148 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc NO_FAST_MATH) # pack
 RUN(NAME intrinsics_149 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran NO_FAST_MATH) # unpack
 RUN(NAME unpack_scalar_field_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME unpack_scalar_field_02 LABELS llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME intrinsics_150 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskr
 RUN(NAME intrinsics_151 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maskl
 RUN(NAME intrinsics_152 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # selected_real_kind

--- a/integration_tests/unpack_scalar_field_02.f90
+++ b/integration_tests/unpack_scalar_field_02.f90
@@ -6,25 +6,19 @@ program unpack_scalar_field_02
     logical, parameter :: mask3(3) = [.true., .true., .false.]
     logical, parameter :: mask4(4) = [.true., .false., .true., .false.]
 
-    ! Integer scalar field in parameter context
     integer, parameter :: a(5) = unpack([100, 200, 300], mask1, 0)
-    if (a(1) /= 100 .or. a(2) /= 0 .or. a(3) /= 200 .or. a(4) /= 0 .or. a(5) /= 300) error stop 1
-
-    ! Real scalar field in parameter context
     real, parameter :: b(4) = unpack([1.5, 2.5], mask2, -1.0)
+    logical, parameter :: c(3) = unpack([.true., .false.], mask3, .true.)
+    complex, parameter :: d(4) = unpack([(1.0, 2.0), (3.0, 4.0)], mask4, (0.0, -1.0))
+
+    if (a(1) /= 100 .or. a(2) /= 0 .or. a(3) /= 200 .or. a(4) /= 0 .or. a(5) /= 300) error stop 1
     if (abs(b(1) - (-1.0)) > 0.001) error stop 2
     if (abs(b(2) - 1.5) > 0.001) error stop 3
     if (abs(b(3) - (-1.0)) > 0.001) error stop 4
     if (abs(b(4) - 2.5) > 0.001) error stop 5
-
-    ! Logical scalar field in parameter context
-    logical, parameter :: c(3) = unpack([.true., .false.], mask3, .true.)
     if (c(1) .neqv. .true.) error stop 6
     if (c(2) .neqv. .false.) error stop 7
     if (c(3) .neqv. .true.) error stop 8
-
-    ! Complex scalar field in parameter context
-    complex, parameter :: d(4) = unpack([(1.0, 2.0), (3.0, 4.0)], mask4, (0.0, -1.0))
     if (abs(real(d(1)) - 1.0) > 0.001) error stop 9
     if (abs(aimag(d(1)) - 2.0) > 0.001) error stop 10
     if (abs(real(d(2)) - 0.0) > 0.001) error stop 11

--- a/integration_tests/unpack_scalar_field_02.f90
+++ b/integration_tests/unpack_scalar_field_02.f90
@@ -1,0 +1,39 @@
+program unpack_scalar_field_02
+    implicit none
+
+    logical, parameter :: mask1(5) = [.true., .false., .true., .false., .true.]
+    logical, parameter :: mask2(4) = [.false., .true., .false., .true.]
+    logical, parameter :: mask3(3) = [.true., .true., .false.]
+    logical, parameter :: mask4(4) = [.true., .false., .true., .false.]
+
+    ! Integer scalar field in parameter context
+    integer, parameter :: a(5) = unpack([100, 200, 300], mask1, 0)
+    if (a(1) /= 100 .or. a(2) /= 0 .or. a(3) /= 200 .or. a(4) /= 0 .or. a(5) /= 300) error stop 1
+
+    ! Real scalar field in parameter context
+    real, parameter :: b(4) = unpack([1.5, 2.5], mask2, -1.0)
+    if (abs(b(1) - (-1.0)) > 0.001) error stop 2
+    if (abs(b(2) - 1.5) > 0.001) error stop 3
+    if (abs(b(3) - (-1.0)) > 0.001) error stop 4
+    if (abs(b(4) - 2.5) > 0.001) error stop 5
+
+    ! Logical scalar field in parameter context
+    logical, parameter :: c(3) = unpack([.true., .false.], mask3, .true.)
+    if (c(1) .neqv. .true.) error stop 6
+    if (c(2) .neqv. .false.) error stop 7
+    if (c(3) .neqv. .true.) error stop 8
+
+    ! Complex scalar field in parameter context
+    complex, parameter :: d(4) = unpack([(1.0, 2.0), (3.0, 4.0)], mask4, (0.0, -1.0))
+    if (abs(real(d(1)) - 1.0) > 0.001) error stop 9
+    if (abs(aimag(d(1)) - 2.0) > 0.001) error stop 10
+    if (abs(real(d(2)) - 0.0) > 0.001) error stop 11
+    if (abs(aimag(d(2)) - (-1.0)) > 0.001) error stop 12
+    if (abs(real(d(3)) - 3.0) > 0.001) error stop 13
+    if (abs(aimag(d(3)) - 4.0) > 0.001) error stop 14
+    if (abs(real(d(4)) - 0.0) > 0.001) error stop 15
+    if (abs(aimag(d(4)) - (-1.0)) > 0.001) error stop 16
+
+    print *, "PASS"
+
+end program

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -6436,12 +6436,15 @@ namespace Unpack {
             vector_a = ASR::down_cast<ASR::ArrayPhysicalCast_t>(vector_a)->m_arg;
         }
         vector_a = ASRUtils::expr_value(vector_a);
-        LCOMPILERS_ASSERT(ASR::is_a<ASR::ArrayConstant_t>(*vector_a));
-        ASR::ArrayConstant_t *a_const = ASR::down_cast<ASR::ArrayConstant_t>(vector_a);
-
+        LCOMPILERS_ASSERT(ASRUtils::is_value_constant(vector_a));
         for (int i = 0; i < dim; i++) {
-            ASR::expr_t* arg_a = ASRUtils::fetch_ArrayConstant_value(al, a_const, i);
-
+            ASR::expr_t* arg_a {};
+            if (ASR::is_a<ASR::ArrayConstant_t>(*vector_a)) {
+                ASR::ArrayConstant_t *a_const = ASR::down_cast<ASR::ArrayConstant_t>(vector_a);
+                arg_a = ASRUtils::fetch_ArrayConstant_value(al, a_const, i);
+            } else {
+                arg_a = vector_a;
+            }
             if (ASR::is_a<ASR::IntegerConstant_t>(*arg_a)) {
                 a[i] = ASR::down_cast<ASR::IntegerConstant_t>(arg_a)->m_n;
             } else if (ASR::is_a<ASR::RealConstant_t>(*arg_a)) {
@@ -6461,12 +6464,15 @@ namespace Unpack {
             vector_a = ASR::down_cast<ASR::ArrayPhysicalCast_t>(vector_a)->m_arg;
         }
         vector_a = ASRUtils::expr_value(vector_a);
-        LCOMPILERS_ASSERT(ASR::is_a<ASR::ArrayConstant_t>(*vector_a));
-        ASR::ArrayConstant_t *a_const = ASR::down_cast<ASR::ArrayConstant_t>(vector_a);
-
+        LCOMPILERS_ASSERT(ASRUtils::is_value_constant(vector_a));
         for (int i = 0; i < dim; i++) {
-            ASR::expr_t* arg_a = ASRUtils::fetch_ArrayConstant_value(al, a_const, i);
-
+            ASR::expr_t* arg_a {};
+            if (ASR::is_a<ASR::ArrayConstant_t>(*vector_a)) {
+                ASR::ArrayConstant_t *a_const = ASR::down_cast<ASR::ArrayConstant_t>(vector_a);
+                arg_a = ASRUtils::fetch_ArrayConstant_value(al, a_const, i);
+            } else {
+                arg_a = vector_a;
+            }
             if (ASR::is_a<ASR::ComplexConstructor_t>(*arg_a)) {
                 arg_a = ASR::down_cast<ASR::ComplexConstructor_t>(arg_a)->m_value;
             }
@@ -6485,11 +6491,6 @@ namespace Unpack {
         ASR::ttype_t *type_vector = ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(expr_type(vector)));
         ASR::ttype_t *type_mask = ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(expr_type(mask)));
         ASR::ttype_t* type_a = ASRUtils::type_get_past_array(type_vector);
-
-        ASR::ttype_t *type_field = ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(expr_type(field)));
-        if (!ASRUtils::is_array(type_field)) {
-            return nullptr;
-        }
 
         int kind = ASRUtils::extract_kind_from_ttype_t(type_a);
         int dim_mask = ASRUtils::get_fixed_size_of_array(type_mask);


### PR DESCRIPTION
fixes #11775

The `unpack` intrinsic failed to evaluate at compile time when `field`
was a scalar (e.g. `unpack([100, 200, 300], mask, 0)` in a `parameter`
declaration). `eval_Unpack` returned nullptr for scalar field, which
works at runtime but breaks constant folding.

The fix makes `populate_vector` and `populate_vector_complex` handle
scalar constants by broadcasting the value across the output vector,
instead of asserting `ArrayConstant_t`. The early `return nullptr` in
`eval_Unpack` is removed since scalars are now handled downstream.