### PR TITLE
Add runtime test for array shape mismatch assignment

### DIFF
--- a/tests/errors/array_shape_06.f90
+++ b/tests/errors/array_shape_06.f90
@@ -1,0 +1,25 @@
+module m_array_shape_06
+    use, intrinsic :: iso_fortran_env, only: real32
+    implicit none
+contains
+    subroutine write_partial(upstream_grad, output)
+        real(real32), dimension(:,:), intent(in) :: upstream_grad
+        real(real32), dimension(:,:), intent(out) :: output
+        output = upstream_grad * 2.0_real32
+    end subroutine write_partial
+end module m_array_shape_06
+
+program array_shape_06
+    use, intrinsic :: iso_fortran_env, only: real32
+    use m_array_shape_06
+    implicit none
+
+    real(real32) :: ug(8, 1)
+    real(real32), allocatable :: out(:,:)
+
+    allocate(out(1, 1))
+    ug = 1.0_real32
+    out = 0.0_real32
+
+    call write_partial(ug, out)
+end program array_shape_06

--- a/tests/reference/run-array_shape_06-53f4e72.json
+++ b/tests/reference/run-array_shape_06-53f4e72.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-array_shape_06-53f4e72",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/errors/array_shape_06.f90",
+    "infile_hash": "d4490ff091dac24964ae48c22563cdc2a4f76a0de8b1e175b9ade57a",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "run-array_shape_06-53f4e72.stderr",
+    "stderr_hash": "baf3202926a50bbbe272c4e0982b225f26b7405d17c04f7cd76c2e1b",
+    "returncode": 1
+}

--- a/tests/reference/run-array_shape_06-53f4e72.stderr
+++ b/tests/reference/run-array_shape_06-53f4e72.stderr
@@ -1,0 +1,8 @@
+runtime error: Array shape mismatch in assignment to 'output'. Tried to match size 1 of dimension 1 of LHS with size 8 of dimension 1 of RHS.
+ --> tests/errors/array_shape_06.f90:8:9
+  |
+8 |         output = upstream_grad * 2.0_real32
+  |         ^^^^^^ LHS size is 1
+  |
+8 |         output = upstream_grad * 2.0_real32
+  |                  ^^^^^^^^^^^^^ RHS size is 8

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4867,6 +4867,10 @@ filename = "errors/array_shape_05.f90"
 run = true
 
 [[test]]
+filename = "errors/array_shape_06.f90"
+run = true
+
+[[test]]
 filename = "function_call1.f90"
 asr = true
 lookup_name = true


### PR DESCRIPTION
Addresses: https://github.com/lfortran/lfortran/pull/11569#issuecomment-4491345227