### PR TITLE
fix: ICE for alternate return arguments in intrinsic calls

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -12768,6 +12768,15 @@ public:
             args.push_back(al, nullptr);
         }
         for( size_t i = 0; i < x.n_args; i++ ) {
+            if (x.m_args[i].m_end == nullptr && x.m_args[i].m_label != 0) {
+                diag.add(diag::Diagnostic(
+                    "Alternate return arguments are not permitted in calls to the '" +
+                    intrinsic_name + "' intrinsic.",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
+            LCOMPILERS_ASSERT(x.m_args[i].m_end != nullptr);
             // Handle BOZ constants in real() function
             ASR::ttype_t* temp_current_variable_type = current_variable_type_;
             if (intrinsic_name == "real" && i == 0 && x.m_args[i].m_end && 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -749,4 +749,8 @@ program continue_compilation_1
         implicit none
         integer, optional, value :: a
     end subroutine
+    subroutine sub_alternate_return_intrinsic()
+        call cpu_time(*1)
+1       continue
+    end subroutine 
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "4a96cc79b5b9724b98d84d260eb720b4d8cd231170b7dfacd97c3355",
+    "infile_hash": "d1046713b17df9896067c8f29f62dafe5742842ae1d7ce36da2aaa54",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "24f01211d8aee66b0ccea4ae478f082102f2316423858818092e8c97",
+    "stderr_hash": "87e8bc0f42ba142a082580305e9f3c6d31ced973b4c9ed7f5b088fdf",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1602,3 +1602,9 @@ semantic error: case value must be scalar
     |
 745 |         case (:[2])
     |                ^^^ 
+
+semantic error: Alternate return arguments are not permitted in calls to the 'cpu_time' intrinsic.
+   --> tests/errors/continue_compilation_1.f90:753:9
+    |
+753 |         call cpu_time(*1)
+    |         ^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/11757