### PR TITLE
Fix : Free heap-allocated array descriptors to prevent memory leaks

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2695,7 +2695,6 @@ public:
             ASR::symbol_t* curr_obj = nullptr;
             ASR::abiType abt = ASR::abiType::Source;
             
-            // --- FIX: Track address for nullification ---
             llvm::Value* address_to_nullify = nullptr;
 
             if( ASR::is_a<ASR::Var_t>(*tmp_expr) ) {
@@ -2806,6 +2805,7 @@ public:
                         tmp = llvm_utils->CreateLoad2(typ, tmp);
                     }
                     if (ASRUtils::is_class_type(ASRUtils::extract_type(cur_type))) {
+                        // If it is a class type, we need to get the pointer to the struct
                         llvm::Type* class_type = llvm_utils->get_type_from_ttype_t_util(
                             tmp_expr,
                             ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(cur_type)),
@@ -2825,6 +2825,7 @@ public:
                             llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()),
                             llvm::Type::getInt64Ty(context)) );
                     llvm_utils->create_if_else(cond, [=]() {
+                        // Call user-defined FINAL procedures (Fortran 2018 §7.5.6.3)
                         if (struct_sym != nullptr && struct_sym->n_member_functions > 0) {
                             for (size_t fi = 0; fi < struct_sym->n_member_functions; fi++) {
                                 std::string final_proc_name = struct_sym->m_member_functions[fi];
@@ -2834,6 +2835,9 @@ public:
                                     uint32_t fh = get_hash((ASR::asr_t*)final_sym);
                                     if (llvm_symtab_fn.find(fh) != llvm_symtab_fn.end()) {
                                         llvm::Function* final_fn = llvm_symtab_fn[fh];
+                                        // Finalizers take type(T), not class(T). For class
+                                        // variables, load the concrete data pointer (field 1)
+                                        // from the class wrapper {vptr, data*}.
                                         llvm::Value* final_arg = tmp;
                                         if (ASRUtils::is_class_type(ASRUtils::extract_type(cur_type))) {
                                             llvm::Value* data_field = llvm_utils->create_gep2(llvm_data_type, tmp, 1);
@@ -2883,7 +2887,7 @@ public:
                             call_lfortran_free(free_fn, typ,  llvm_data_type);
                         }
 
-                        // --- FIX: Only free the descriptor if it is an IMPLICIT deallocate ---
+                      
                         // Explicit deallocates should keep the descriptor for reuse.
                         bool is_implicit_dealloc = false;
                         if constexpr (std::is_same_v<T, ASR::ImplicitDeallocate_t>) {
@@ -9381,7 +9385,7 @@ public:
             // Allocate descriptor on the heap so it survives after this
             // function returns (the caller holds a pointer).
             
-            // --- FIX: Prevent pointer reassignment leak (Guarded for Structs only) ---
+           
             bool is_struct_member = ASR::is_a<ASR::StructInstanceMember_t>(*target_section->m_v);
             llvm::Value* old_desc = llvm_utils->CreateLoad2(
                 target_type_llvm->getPointerTo(), target_desc);
@@ -9405,7 +9409,6 @@ public:
                     builder->CreateCall(free_fn, {allocator, desc_i8});
                 }
             }, [](){});
-            // -----------------------------------------------------
 
             new_desc = arr_descr->allocate_descriptor_on_heap(
                 target_type_llvm);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2694,6 +2694,10 @@ public:
             ASR::expr_t* tmp_expr = x.m_vars[i];
             ASR::symbol_t* curr_obj = nullptr;
             ASR::abiType abt = ASR::abiType::Source;
+            
+            // --- FIX: Track address for nullification ---
+            llvm::Value* address_to_nullify = nullptr;
+
             if( ASR::is_a<ASR::Var_t>(*tmp_expr) ) {
                 const ASR::Var_t* tmp_var = ASR::down_cast<ASR::Var_t>(tmp_expr);
                 curr_obj = tmp_var->m_v;
@@ -2718,6 +2722,9 @@ public:
                 this->visit_expr_wrapper(sm->m_v, ASRUtils::is_class_type(ASRUtils::extract_type(caller_type)));
                 ptr_loads = ptr_loads_copy;
                 llvm::Value* dt = tmp;
+                
+                address_to_nullify = dt; 
+
                 ASR::symbol_t *struct_sym = nullptr;
                 llvm::Type* dt_type = llvm_utils->getStructType(
                     ASR::down_cast<ASR::Struct_t>(
@@ -2731,6 +2738,7 @@ public:
                         module.get());
                     llvm::Value* dt_ptr = llvm_utils->create_gep2(dt_type_poly, dt, 1);
                     dt = llvm_utils->CreateLoad2(dt_type->getPointerTo(), dt_ptr);
+                    address_to_nullify = dt_ptr;
                 } else if (ASR::is_a<ASR::StructInstanceMember_t>(*sm->m_v) &&
                            ASRUtils::is_allocatable_or_pointer(ASRUtils::expr_type(sm->m_v))) {
                     dt = llvm_utils->CreateLoad2(dt_type->getPointerTo(), dt);
@@ -2759,6 +2767,7 @@ public:
                 LCOMPILERS_ASSERT(dt->getType()->isPointerTy());
                 llvm::Value* dt_1 = builder->CreateGEP(name2dertype[curr_struct], dt, idx_vars);
                 tmp = dt_1;
+                address_to_nullify = dt_1;
             } else {
                 throw CodeGenError("Cannot deallocate variables in expression " +
                                     ASRUtils::type_to_str_python_expr(ASRUtils::expr_type(tmp_expr), tmp_expr),
@@ -2874,7 +2883,7 @@ public:
                         } else {
                             call_lfortran_free(free_fn, typ,  llvm_data_type);
                         }
-                        if (in_struct) {
+                        if (in_struct && address_to_nullify) {
 #if LLVM_VERSION_MAJOR < 15
                             llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
 #else
@@ -2884,7 +2893,7 @@ public:
                             llvm::Type* desc_ptr_type = tmp->getType();
                             builder->CreateStore(
                                 llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(desc_ptr_type)),
-                                saved_ptr_to_descriptor
+                                address_to_nullify
                             );
                         }
                     }, [](){});
@@ -2892,7 +2901,7 @@ public:
             }
         }
     }
-
+    
     void visit_ImplicitDeallocate(const ASR::ImplicitDeallocate_t& x) {
         visit_Deallocate(x);
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2776,7 +2776,7 @@ public:
                 struct_sym = ASR::down_cast<ASR::Struct_t>(sym);
             }
             int dims = ASRUtils::extract_n_dims_from_ttype(cur_type);
-            if(ASRUtils::is_character(*cur_type)) { // Handle Strings (array of strings or just string)
+            if(ASRUtils::is_character(*cur_type)) { 
                 tmp = LLVM::is_llvm_pointer(*cur_type) ?
                     builder->CreateLoad(llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get()), tmp)
                     : tmp ;
@@ -2797,7 +2797,6 @@ public:
                         tmp = llvm_utils->CreateLoad2(typ, tmp);
                     }
                     if (ASRUtils::is_class_type(ASRUtils::extract_type(cur_type))) {
-                        // If it is a class type, we need to get the pointer to the struct
                         llvm::Type* class_type = llvm_utils->get_type_from_ttype_t_util(
                             tmp_expr,
                             ASRUtils::type_get_past_pointer(ASRUtils::type_get_past_allocatable(cur_type)),
@@ -2817,7 +2816,6 @@ public:
                             llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()),
                             llvm::Type::getInt64Ty(context)) );
                     llvm_utils->create_if_else(cond, [=]() {
-                        // Call user-defined FINAL procedures (Fortran 2018 §7.5.6.3)
                         if (struct_sym != nullptr && struct_sym->n_member_functions > 0) {
                             for (size_t fi = 0; fi < struct_sym->n_member_functions; fi++) {
                                 std::string final_proc_name = struct_sym->m_member_functions[fi];
@@ -2827,9 +2825,6 @@ public:
                                     uint32_t fh = get_hash((ASR::asr_t*)final_sym);
                                     if (llvm_symtab_fn.find(fh) != llvm_symtab_fn.end()) {
                                         llvm::Function* final_fn = llvm_symtab_fn[fh];
-                                        // Finalizers take type(T), not class(T). For class
-                                        // variables, load the concrete data pointer (field 1)
-                                        // from the class wrapper {vptr, data*}.
                                         llvm::Value* final_arg = tmp;
                                         if (ASRUtils::is_class_type(ASRUtils::extract_type(cur_type))) {
                                             llvm::Value* data_field = llvm_utils->create_gep2(llvm_data_type, tmp, 1);
@@ -2842,9 +2837,8 @@ public:
                             }
                         }
                         llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
-                        // Deallocate data of class first
                         if( ASRUtils::is_pointer(cur_type) || 
-                            !ASR::is_a<ASR::StructType_t>(*ASRUtils::type_get_past_allocatable_pointer(cur_type)) ) { // TODO : Clean this by coordinating with `finalize_before_deallocate()`
+                            !ASR::is_a<ASR::StructType_t>(*ASRUtils::type_get_past_allocatable_pointer(cur_type)) ) {
                             if(ASRUtils::non_unlimited_polymorphic_class(ASRUtils::type_get_past_allocatable_pointer(cur_type)) && ASRUtils::is_pointer(cur_type) ){
                                 auto const inner_struct = llvm_utils->CreateLoad2(llvm_utils->getStructType(struct_sym, module.get(), true), llvm_utils->create_gep2(llvm_data_type, tmp, 1));
                                 llvm_utils->lfortran_free(inner_struct);
@@ -2855,13 +2849,10 @@ public:
                             builder->CreateCall(free_fn, args);
                         }
                         builder->CreateStore(
-                            llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()), tmp_); // Store NULL as identifier for deallocated variable.
+                            llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()), tmp_);
                     }, [](){});
                 } else {
-                    // --- FIX: Capture the pointer to the descriptor ---
                     llvm::Value* saved_ptr_to_descriptor = tmp; 
-                    // --------------------------------------------------
-
                     if( LLVM::is_llvm_pointer(*cur_type) ) {
                         llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
                         tmp = llvm_utils->CreateLoad2(typ, tmp);
@@ -2873,44 +2864,35 @@ public:
                     ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
                         ASRUtils::type_get_past_pointer(
                             ASRUtils::type_get_past_allocatable(cur_type)));
-                    // Use the array element *storage* type (e.g. logical arrays are i8-backed).
                     llvm::Type* llvm_data_type = llvm_utils->get_el_type(tmp_expr, element_type, module.get());
                     llvm::Value *cond = arr_descr->get_is_allocated_flag(tmp, tmp_expr);
                     
                     llvm_utils->create_if_else(cond, [=]() {
                         llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
-
                         if (ASRUtils::non_unlimited_polymorphic_class(element_type)) {
                             arr_descr->reset_is_allocated_flag(typ, tmp, llvm_data_type);
                         } else {
                             call_lfortran_free(free_fn, typ,  llvm_data_type);
                         }
-
-                        // --- FIX: Free the heap-allocated descriptor struct ---
                         if (in_struct) {
-                            // 1. Cast the descriptor pointer to i8* and free it
 #if LLVM_VERSION_MAJOR < 15
                             llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
 #else
-                            llvm::Value* desc_i8 = tmp; // Opaque pointers in LLVM 15+
+                            llvm::Value* desc_i8 = tmp;
 #endif
                             builder->CreateCall(free_fn, {allocator, desc_i8});
-
-                            // 2. Nullify the descriptor pointer inside the parent struct
                             llvm::Type* desc_ptr_type = tmp->getType();
                             builder->CreateStore(
                                 llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(desc_ptr_type)),
                                 saved_ptr_to_descriptor
                             );
                         }
-                        // -------------------------------------------------------------
-
                     }, [](){});
                 }
             }
         }
     }
-    
+
     void visit_ImplicitDeallocate(const ASR::ImplicitDeallocate_t& x) {
         visit_Deallocate(x);
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2858,40 +2858,55 @@ public:
                             llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()), tmp_); // Store NULL as identifier for deallocated variable.
                     }, [](){});
                 } else {
-                    if( LLVM::is_llvm_pointer(*cur_type) ) {
-                        llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
-                        tmp = llvm_utils->CreateLoad2(typ, tmp);
-                    }
-                    llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr,
-                        ASRUtils::type_get_past_pointer(
-                            ASRUtils::type_get_past_allocatable(cur_type)),
-                    module.get(), abt);
-                    ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
-                        ASRUtils::type_get_past_pointer(
-                            ASRUtils::type_get_past_allocatable(cur_type)));
-                    // Use the array element *storage* type (e.g. logical arrays are i8-backed).
-                    llvm::Type* llvm_data_type = llvm_utils->get_el_type(tmp_expr, element_type, module.get());
-                    llvm::Value *cond = arr_descr->get_is_allocated_flag(tmp, tmp_expr);
-                    llvm_utils->create_if_else(cond, [=]() {
-                        llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
+                // --- ADDED: Capture the pointer to the descriptor ---
+                llvm::Value* saved_ptr_to_descriptor = tmp; 
+                // ----------------------------------------------------
 
-                        if (ASRUtils::non_unlimited_polymorphic_class(element_type)) {
-                            // Non-unlimited polymorphic class arrays use a single
-                            // wrapper {vptr, data*} stored as the descriptor's data
-                            // pointer. finalize_before_deallocate already frees the
-                            // per-element payloads, the consecutive struct block and
-                            // the wrapper itself, so skip call_lfortran_free to avoid
-                            // a double-free; just null the descriptor's data pointer.
-                            arr_descr->reset_is_allocated_flag(typ, tmp, llvm_data_type);
-                        } else {
-                            call_lfortran_free(free_fn, typ,  llvm_data_type);
-                        }
-                    }, [](){});
+                if( LLVM::is_llvm_pointer(*cur_type) ) {
+                    llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
+                    tmp = llvm_utils->CreateLoad2(typ, tmp);
                 }
-            }
-        }
-    }
+                llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr,
+                    ASRUtils::type_get_past_pointer(
+                        ASRUtils::type_get_past_allocatable(cur_type)),
+                module.get(), abt);
+                ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
+                    ASRUtils::type_get_past_pointer(
+                        ASRUtils::type_get_past_allocatable(cur_type)));
+                // Use the array element *storage* type (e.g. logical arrays are i8-backed).
+                llvm::Type* llvm_data_type = llvm_utils->get_el_type(tmp_expr, element_type, module.get());
+                llvm::Value *cond = arr_descr->get_is_allocated_flag(tmp, tmp_expr);
+                
+                llvm_utils->create_if_else(cond, [=]() {
+                    llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
 
+                    if (ASRUtils::non_unlimited_polymorphic_class(element_type)) {
+                        arr_descr->reset_is_allocated_flag(typ, tmp, llvm_data_type);
+                    } else {
+                        call_lfortran_free(free_fn, typ,  llvm_data_type);
+                    }
+
+                    // --- ADDED: Free the heap-allocated descriptor struct ---
+                    if (in_struct) {
+                        // 1. Cast the descriptor pointer to i8* and free it
+#if LLVM_VERSION_MAJOR < 15
+                        llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
+#else
+                        llvm::Value* desc_i8 = tmp; // Opaque pointers in LLVM 15+
+#endif
+                        builder->CreateCall(free_fn, {allocator, desc_i8});
+
+                        // 2. Nullify the descriptor pointer inside the parent struct
+                        llvm::Type* desc_ptr_type = tmp->getType();
+                        builder->CreateStore(
+                            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(desc_ptr_type)),
+                            saved_ptr_to_descriptor
+                        );
+                    }
+                    // -------------------------------------------------------------
+
+                }, [](){});
+            }
     void visit_ImplicitDeallocate(const ASR::ImplicitDeallocate_t& x) {
         visit_Deallocate(x);
     }
@@ -9363,6 +9378,29 @@ public:
         } else {
             // Allocate descriptor on the heap so it survives after this
             // function returns (the caller holds a pointer).
+            
+            // --- ADDED: Prevent pointer reassignment leak ---
+            llvm::Value* old_desc = llvm_utils->CreateLoad2(
+                target_type_llvm->getPointerTo(), target_desc);
+            
+            llvm::Value* is_not_null = builder->CreateICmpNE(
+                old_desc,
+                llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(target_type_llvm->getPointerTo()))
+            );
+            
+            llvm_utils->create_if_else(is_not_null, [&]() {
+                llvm::Function* free_fn = llvm_utils->_Deallocate();
+                llvm::Value* allocator = llvm_utils->get_allocator(module.get());
+                
+#if LLVM_VERSION_MAJOR < 15
+                llvm::Value* desc_i8 = builder->CreateBitCast(old_desc, llvm::Type::getInt8PtrTy(context));
+#else
+                llvm::Value* desc_i8 = old_desc; // Opaque pointers in LLVM 15+
+#endif
+                builder->CreateCall(free_fn, {allocator, desc_i8});
+            }, [](){});
+            // -----------------------------------------------------
+
             new_desc = arr_descr->allocate_descriptor_on_heap(
                 target_type_llvm);
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2882,11 +2882,19 @@ public:
                         } else {
                             call_lfortran_free(free_fn, typ,  llvm_data_type);
                         }
-                        if (in_struct && address_to_nullify) {
+
+                        // --- FIX: Only free the descriptor if it is an IMPLICIT deallocate ---
+                        // Explicit deallocates should keep the descriptor for reuse.
+                        bool is_implicit_dealloc = false;
+                        if constexpr (std::is_same_v<T, ASR::ImplicitDeallocate_t>) {
+                            is_implicit_dealloc = true;
+                        }
+
+                        if (in_struct && address_to_nullify && is_implicit_dealloc) {
 #if LLVM_VERSION_MAJOR < 15
                             llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
 #else
-                            llvm::Value* desc_i8 = tmp;
+                            llvm::Value* desc_i8 = tmp; // Opaque pointers in LLVM 15+
 #endif
                             builder->CreateCall(free_fn, {allocator, desc_i8});
                             llvm::Type* desc_ptr_type = tmp->getType();
@@ -9373,7 +9381,8 @@ public:
             // Allocate descriptor on the heap so it survives after this
             // function returns (the caller holds a pointer).
             
-            // --- ADDED: Prevent pointer reassignment leak ---
+            // --- FIX: Prevent pointer reassignment leak (Guarded for Structs only) ---
+            bool is_struct_member = ASR::is_a<ASR::StructInstanceMember_t>(*target_section->m_v);
             llvm::Value* old_desc = llvm_utils->CreateLoad2(
                 target_type_llvm->getPointerTo(), target_desc);
             
@@ -9383,15 +9392,18 @@ public:
             );
             
             llvm_utils->create_if_else(is_not_null, [&]() {
-                llvm::Function* free_fn = llvm_utils->_Deallocate();
-                llvm::Value* allocator = llvm_utils->get_allocator(module.get());
-                
+                // Only free if it's a struct member to avoid freeing stack-allocated common block pointers
+                if (is_struct_member) {
+                    llvm::Function* free_fn = llvm_utils->_Deallocate();
+                    llvm::Value* allocator = llvm_utils->get_allocator(module.get());
+                    
 #if LLVM_VERSION_MAJOR < 15
-                llvm::Value* desc_i8 = builder->CreateBitCast(old_desc, llvm::Type::getInt8PtrTy(context));
+                    llvm::Value* desc_i8 = builder->CreateBitCast(old_desc, llvm::Type::getInt8PtrTy(context));
 #else
-                llvm::Value* desc_i8 = old_desc; // Opaque pointers in LLVM 15+
+                    llvm::Value* desc_i8 = old_desc; // Opaque pointers in LLVM 15+
 #endif
-                builder->CreateCall(free_fn, {allocator, desc_i8});
+                    builder->CreateCall(free_fn, {allocator, desc_i8});
+                }
             }, [](){});
             // -----------------------------------------------------
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2858,55 +2858,59 @@ public:
                             llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()), tmp_); // Store NULL as identifier for deallocated variable.
                     }, [](){});
                 } else {
-                // --- ADDED: Capture the pointer to the descriptor ---
-                llvm::Value* saved_ptr_to_descriptor = tmp; 
-                // ----------------------------------------------------
+                    // --- FIX: Capture the pointer to the descriptor ---
+                    llvm::Value* saved_ptr_to_descriptor = tmp; 
+                    // --------------------------------------------------
 
-                if( LLVM::is_llvm_pointer(*cur_type) ) {
-                    llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
-                    tmp = llvm_utils->CreateLoad2(typ, tmp);
-                }
-                llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr,
-                    ASRUtils::type_get_past_pointer(
-                        ASRUtils::type_get_past_allocatable(cur_type)),
-                module.get(), abt);
-                ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
-                    ASRUtils::type_get_past_pointer(
-                        ASRUtils::type_get_past_allocatable(cur_type)));
-                // Use the array element *storage* type (e.g. logical arrays are i8-backed).
-                llvm::Type* llvm_data_type = llvm_utils->get_el_type(tmp_expr, element_type, module.get());
-                llvm::Value *cond = arr_descr->get_is_allocated_flag(tmp, tmp_expr);
-                
-                llvm_utils->create_if_else(cond, [=]() {
-                    llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
-
-                    if (ASRUtils::non_unlimited_polymorphic_class(element_type)) {
-                        arr_descr->reset_is_allocated_flag(typ, tmp, llvm_data_type);
-                    } else {
-                        call_lfortran_free(free_fn, typ,  llvm_data_type);
+                    if( LLVM::is_llvm_pointer(*cur_type) ) {
+                        llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
+                        tmp = llvm_utils->CreateLoad2(typ, tmp);
                     }
+                    llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr,
+                        ASRUtils::type_get_past_pointer(
+                            ASRUtils::type_get_past_allocatable(cur_type)),
+                    module.get(), abt);
+                    ASR::ttype_t* element_type = ASRUtils::type_get_past_array(
+                        ASRUtils::type_get_past_pointer(
+                            ASRUtils::type_get_past_allocatable(cur_type)));
+                    // Use the array element *storage* type (e.g. logical arrays are i8-backed).
+                    llvm::Type* llvm_data_type = llvm_utils->get_el_type(tmp_expr, element_type, module.get());
+                    llvm::Value *cond = arr_descr->get_is_allocated_flag(tmp, tmp_expr);
+                    
+                    llvm_utils->create_if_else(cond, [=]() {
+                        llvm_symtab_finalizer.finalize_before_deallocate(tmp, cur_type, struct_sym, in_struct);
 
-                    // --- ADDED: Free the heap-allocated descriptor struct ---
-                    if (in_struct) {
-                        // 1. Cast the descriptor pointer to i8* and free it
+                        if (ASRUtils::non_unlimited_polymorphic_class(element_type)) {
+                            arr_descr->reset_is_allocated_flag(typ, tmp, llvm_data_type);
+                        } else {
+                            call_lfortran_free(free_fn, typ,  llvm_data_type);
+                        }
+
+                        // --- FIX: Free the heap-allocated descriptor struct ---
+                        if (in_struct) {
+                            // 1. Cast the descriptor pointer to i8* and free it
 #if LLVM_VERSION_MAJOR < 15
-                        llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
+                            llvm::Value* desc_i8 = builder->CreateBitCast(tmp, llvm::Type::getInt8PtrTy(context));
 #else
-                        llvm::Value* desc_i8 = tmp; // Opaque pointers in LLVM 15+
+                            llvm::Value* desc_i8 = tmp; // Opaque pointers in LLVM 15+
 #endif
-                        builder->CreateCall(free_fn, {allocator, desc_i8});
+                            builder->CreateCall(free_fn, {allocator, desc_i8});
 
-                        // 2. Nullify the descriptor pointer inside the parent struct
-                        llvm::Type* desc_ptr_type = tmp->getType();
-                        builder->CreateStore(
-                            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(desc_ptr_type)),
-                            saved_ptr_to_descriptor
-                        );
-                    }
-                    // -------------------------------------------------------------
+                            // 2. Nullify the descriptor pointer inside the parent struct
+                            llvm::Type* desc_ptr_type = tmp->getType();
+                            builder->CreateStore(
+                                llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(desc_ptr_type)),
+                                saved_ptr_to_descriptor
+                            );
+                        }
+                        // -------------------------------------------------------------
 
-                }, [](){});
+                    }, [](){});
+                }
             }
+        }
+    }
+    
     void visit_ImplicitDeallocate(const ASR::ImplicitDeallocate_t& x) {
         visit_Deallocate(x);
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2861,7 +2861,6 @@ public:
                             llvm::ConstantPointerNull::get(llvm_data_type->getPointerTo()), tmp_);
                     }, [](){});
                 } else {
-                    llvm::Value* saved_ptr_to_descriptor = tmp; 
                     if( LLVM::is_llvm_pointer(*cur_type) ) {
                         llvm::Type* typ = llvm_utils->get_type_from_ttype_t_util(tmp_expr, cur_type, module.get());
                         tmp = llvm_utils->CreateLoad2(typ, tmp);
@@ -2901,7 +2900,7 @@ public:
             }
         }
     }
-    
+
     void visit_ImplicitDeallocate(const ASR::ImplicitDeallocate_t& x) {
         visit_Deallocate(x);
     }


### PR DESCRIPTION
Fixes#10759
This PR fixes the memory leak  where heap-allocated array descriptors were orphaned during variable deallocation and pointer reassignment. 
To resolve this, the LLVM IR generation in asr_to_llvm.cpp was updated to explicitly free these structs at their termination points. 

visit_Deallocate: Captures the descriptor pointer for struct members, frees the underlying array data and the descriptor struct itself, then safely nullifies the pointer.
handle_pointer_section_target: Adds a null-check for non-local pointers to explicitly free any existing heap-allocated descriptor before reassigning and allocating a new one.