### PR TITLE
test: added test for out-of-order keyword arguments in procedure pointers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3705,6 +3705,7 @@ RUN(NAME procedure_50 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_abstract_02 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_keyword_01 LABELS gfortran llvm)
 RUN(NAME procedure_pointer_keyword_02 LABELS gfortran llvm)
+RUN(NAME procedure_pointer_keyword_03 LABELS gfortran llvm)
 
 RUN(NAME allocated_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME allocated_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/procedure_pointer_keyword_03.f90
+++ b/integration_tests/procedure_pointer_keyword_03.f90
@@ -1,0 +1,38 @@
+module procedure_pointer_keyword_03_mod
+  implicit none
+
+  type :: obj_type
+    integer :: val = 0
+    procedure(sub_iface), pointer :: compute => null()
+  end type
+
+  abstract interface
+    subroutine sub_iface(me, x, y)
+      import :: obj_type
+      class(obj_type), intent(inout) :: me
+      integer, intent(in) :: x, y
+    end subroutine
+  end interface
+
+contains
+
+  subroutine my_div(me, x, y)
+    class(obj_type), intent(inout) :: me
+    integer, intent(in) :: x, y
+    me%val = x / y
+  end subroutine
+
+end module
+
+program procedure_pointer_keyword_03
+  use procedure_pointer_keyword_03_mod
+  implicit none
+  type(obj_type) :: obj
+
+  ! Test: out of order keyword arguments with division
+  obj%compute => my_div
+  call obj%compute(y=10, x=100)
+  if (obj%val /= 10) error stop "Test failed"
+
+  print *, "All tests passed"
+end program


### PR DESCRIPTION
fixes #11790