### PR TITLE
Fix :segfault by adding missing Structure Constructor fallback for generic interfaces

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2466,6 +2466,7 @@ RUN(NAME derived_types_143 LABELS gfortran llvm
     EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME derived_types_144 LABELS gfortran llvm)
 RUN(NAME derived_types_145 LABELS llvm)
+RUN(NAME derived_types_146 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_146.f90
+++ b/integration_tests/derived_types_146.f90
@@ -1,0 +1,41 @@
+module derived_types_146_mod
+    implicit none
+
+    type :: workflow
+        integer :: dummy
+    end type
+
+    type :: compiler
+        integer :: id
+        character(20) :: name
+    end type
+
+    interface compiler
+        module procedure compiler_new
+    end interface
+
+contains
+
+    function compiler_new() result(step)
+        type(workflow) :: step
+    end function
+
+    subroutine build_compilerinfo()
+        type(compiler) :: info
+
+        select case (1)
+        case (1)
+            info = compiler(1, 'UNKNOWN')
+        end select
+        
+        if (info%id /= 1) error stop
+        if (trim(info%name) /= 'UNKNOWN') error stop
+    end subroutine
+end module
+
+program derived_types_146
+    use derived_types_146_mod
+    implicit none
+    call build_compilerinfo()
+    print *, "OK"
+end program

--- a/integration_tests/derived_types_146.f90
+++ b/integration_tests/derived_types_146.f90
@@ -18,10 +18,15 @@ contains
 
     function compiler_new() result(step)
         type(workflow) :: step
+        step%dummy = 100
     end function
 
     subroutine build_compilerinfo()
         type(compiler) :: info
+        type(workflow) :: wf
+
+        wf = compiler()
+        if (wf%dummy /= 100) error stop
 
         select case (1)
         case (1)

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11414,6 +11414,12 @@ public:
                         },
                     false);
             if( idx == -1 ) {
+                ASR::symbol_t* tmp_v = current_scope->resolve_symbol(std::string(x.m_func));
+                if (tmp_v && ASR::is_a<ASR::Struct_t>(*ASRUtils::symbol_get_past_external(tmp_v))) {
+                    return create_DerivedTypeConstructor(x.base.base.loc, x.m_args, x.n_args,
+                        x.m_keywords, x.n_keywords, tmp_v);
+                }
+
                 bool is_function = true;
                 v = intrinsic_as_node(x, is_function);
                 if( !is_function ) {


### PR DESCRIPTION
fixes #11793
When a derived type is defined with the same name as a generic interface (valid Fortran for extending types), LFortran should fall back to checking if an unresolved generic procedure call matches a structure constructor. 

Previously in `create_GenericProcedureWithASTNode`, this fallback was completely missing. When generic procedure resolution failed (`idx == -1`), the compiler incorrectly fell through to checking for an intrinsic function (`intrinsic_as_node`) without attempting to build a `DerivedTypeConstructor`. This resulted in returning a null pointer to `create_FunctionCall`, which subsequently dereferenced it and triggered a Segmentation Fault 

This commit resolves the issue by adding the missing structure constructor fallback logic in `create_GenericProcedureWithASTNode` immediately after generic procedure resolution fails, properly handling derived types that share a name with a generic interface.
