### PR TITLE
Initial support for remaining real128 intrinsics inquiry

### DIFF
--- a/integration_tests/real128_intrinsic_inquiry_01.f90
+++ b/integration_tests/real128_intrinsic_inquiry_01.f90
@@ -8,7 +8,15 @@ program real128_intrinsic_inquiry_01
     real(real128), parameter :: t = tiny(x)
     real(real128), parameter :: expected_tiny = &
         3.36210314311209350626267781732175260e-4932_real128
+    real(real128), parameter :: eps = epsilon(x)
+    real(real128), parameter :: expected_epsilon = &
+        1.92592994438723585305597794258492732e-34_real128
     integer, parameter :: d = digits(x)
+    integer, parameter :: p = precision(x)
+    integer, parameter :: r = range(x)
+    integer, parameter :: min_exp = minexponent(x)
+    integer, parameter :: max_exp = maxexponent(x)
+    integer, parameter :: bits = storage_size(x)
     integer, parameter :: real128_significant_digits = &
         int(log10(2.0_real128**digits(0.0_real128)))
 
@@ -33,4 +41,26 @@ program real128_intrinsic_inquiry_01
     e = digits(1.0_real128)
     if (e /= 113) error stop 6
 
+    if (p /= 33) error stop 7
+    if (precision(1.0_real128) /= 33) error stop 8
+
+    if (r /= 4931) error stop 9
+    if (range(1.0_real128) /= 4931) error stop 14
+
+    if (min_exp /= -16381) error stop 15
+    if (minexponent(1.0_real128) /= -16381) error stop 16
+
+    if (max_exp /= 16384) error stop 17
+    if (maxexponent(1.0_real128) /= 16384) error stop 18
+
+    if (kind(eps) /= real128) error stop 19
+    if (abs((eps - expected_epsilon) / expected_epsilon) > 1.0e-30_real128) error stop 20
+
+    z = epsilon(1.0_real128)
+    if (kind(z) /= real128) error stop 21
+
+    if (bits /= 128) error stop 22
+    if (storage_size(1.0_real128) /= 128) error stop 23
+    if (storage_size(cmplx(1.0_real128, 0.0_real128, kind=real128)) /= 256) error stop 24
+  print *, "All tests passed."
 end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1273,6 +1273,7 @@ namespace StorageSize {
             int64_t kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
             if (kind == 4) return make_ConstantWithType(make_IntegerConstant_t, 64, t1, loc);
             else if (kind == 8) return make_ConstantWithType(make_IntegerConstant_t, 128, t1, loc);
+            else if (kind == 16) return make_ConstantWithType(make_IntegerConstant_t, 256, t1, loc);
             else return make_ConstantWithType(make_IntegerConstant_t, -1, t1, loc);
         } else {
             int64_t kind = ASRUtils::extract_kind_from_ttype_t(arg_type);
@@ -1280,6 +1281,7 @@ namespace StorageSize {
             else if (kind == 2) return make_ConstantWithType(make_IntegerConstant_t, 16, t1, loc);
             else if (kind == 4) return make_ConstantWithType(make_IntegerConstant_t, 32, t1, loc);
             else if (kind == 8) return make_ConstantWithType(make_IntegerConstant_t, 64, t1, loc);
+            else if (kind == 16) return make_ConstantWithType(make_IntegerConstant_t, 128, t1, loc);
             else return make_ConstantWithType(make_IntegerConstant_t, -1, t1, loc);
         }
     }
@@ -1442,6 +1444,8 @@ namespace Range {
                     range_val = 37; break;
                 } case 8: {
                     range_val = 307; break;
+                } case 16: {
+                    range_val = 4931; break;
                 } default: {
                     break;
                 }
@@ -6926,6 +6930,8 @@ namespace MinExponent {
         int result;
         if (m_kind == 4) {
             result = std::numeric_limits<float>::min_exponent;
+        } else if (m_kind == 16) {
+            result = -16381;
         } else {
             result = std::numeric_limits<double>::min_exponent;
         }
@@ -6942,6 +6948,8 @@ namespace MaxExponent {
         int result;
         if (m_kind == 4) {
             result = std::numeric_limits<float>::max_exponent;
+        } else if (m_kind == 16) {
+            result = 16384;
         } else {
             result = std::numeric_limits<double>::max_exponent;
         }
@@ -7862,6 +7870,10 @@ namespace Epsilon {
                 epsilon_val = std::numeric_limits<float>::epsilon(); break;
             } case 8: {
                 epsilon_val = std::numeric_limits<double>::epsilon(); break;
+            } case 16: {
+                return ASRUtils::make_RealConstant_r16(al, loc,
+                    lf_float128_from_str("1.92592994438723585305597794258492732e-34"),
+                    arg_type);
             } default: {
                 break;
             }
@@ -7884,6 +7896,8 @@ namespace Precision {
                 precision_val = 6; break;
             } case 8: {
                 precision_val = 15; break;
+            } case 16: {
+                precision_val = 33; break;
             } default: {
                 append_error(diag, "Kind " + std::to_string(kind) + " is not supported yet", loc);
                 return nullptr;


### PR DESCRIPTION
add support for the following remaining inquiry:

-`precision`
-`range`
-`minexponent`
-`maxexponent`
-`epsilon`
-`storage_size`