### PR TITLE
fix: LLVM verification errors for date_and_time and procedure pointers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2513,6 +2513,7 @@ RUN(NAME derived_types_150 LABELS gfortran llvm) # SEQUENCE char(len>1) inline +
 # Non-elemental defined assignment(=) with scalar dummies (F2023 10.2.1.3–4).
 # Free-interface case is a separate file: coexisting with type-bound
 # assignment(=) in one module breaks resolution under LFortran.
+RUN(NAME derived_types_151 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME defined_assignment_01 LABELS llvm flang)
 RUN(NAME defined_assignment_free_interface_01 LABELS gfortran llvm flang)
 

--- a/integration_tests/derived_types_151.f90
+++ b/integration_tests/derived_types_151.f90
@@ -1,0 +1,52 @@
+! Test: procedure pointer in struct constructor with implicit interface
+! and date_and_time with integer(8) values array.
+! Verifies two LLVM codegen fixes:
+! 1. Procedure pointer type mismatch in struct constructors (asr_to_llvm.cpp)
+! 2. i32 to i64 cast for date_and_time values array (intrinsic_subroutines.h)
+module m_compute_150
+    implicit none
+contains
+    subroutine compute(n)
+        class(*), intent(in) :: n
+        select type(n)
+        type is (integer)
+            if (n /= 42) error stop
+        end select
+    end subroutine
+end module
+module m_150
+    implicit none
+    type :: method
+        integer :: nargs = 0
+        procedure(), nopass, pointer :: f => null()
+    end type
+    interface method
+        module procedure :: method_create
+    end interface
+contains
+    function method_create(f, a1) result(that)
+        procedure() :: f
+        class(*), intent(in) :: a1
+        type(method) :: that
+        that%f => f
+        that%nargs = 1
+    end function
+end module
+program derived_types_150
+    use m_150
+    use m_compute_150
+    implicit none
+    integer, parameter :: i8 = selected_int_kind(18)
+    type(method) :: mtd
+    integer(i8) :: values(8)
+    ! Test 1: procedure pointer in struct constructor
+    mtd = method(compute, 42)
+    if (mtd%nargs /= 1) error stop
+    if (.not. associated(mtd%f)) error stop
+    ! Test 2: date_and_time with integer(8) values array
+    call date_and_time(values=values)
+    if (values(1) < 2000 .or. values(1) > 2100) error stop
+    if (values(2) < 1 .or. values(2) > 12) error stop
+    if (values(3) < 1 .or. values(3) > 31) error stop
+    print *, "PASS"
+end program

--- a/integration_tests/derived_types_151.f90
+++ b/integration_tests/derived_types_151.f90
@@ -1,9 +1,4 @@
-! Test: procedure pointer in struct constructor with implicit interface
-! and date_and_time with integer(8) values array.
-! Verifies two LLVM codegen fixes:
-! 1. Procedure pointer type mismatch in struct constructors (asr_to_llvm.cpp)
-! 2. i32 to i64 cast for date_and_time values array (intrinsic_subroutines.h)
-module m_compute_150
+module m_compute_151
     implicit none
 contains
     subroutine compute(n)
@@ -14,7 +9,7 @@ contains
         end select
     end subroutine
 end module
-module m_150
+module m_151
     implicit none
     type :: method
         integer :: nargs = 0
@@ -32,9 +27,9 @@ contains
         that%nargs = 1
     end function
 end module
-program derived_types_150
-    use m_150
-    use m_compute_150
+program derived_types_151
+    use m_151
+    use m_compute_151
     implicit none
     integer, parameter :: i8 = selected_int_kind(18)
     type(method) :: mtd

--- a/src/lfortran/semantics/asr_implicit_cast_rules.h
+++ b/src/lfortran/semantics/asr_implicit_cast_rules.h
@@ -114,10 +114,23 @@ public:
                                   ASR::ttype_t *source_type,
                                   ASR::ttype_t *dest_type, diag::Diagnostics &diag) {
       if ((ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(source_type))
-           || ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(dest_type)))
-          || ((ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(source_type))
-               || ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(dest_type))))) {
-          // No casting supported currently for `StructType` and `FunctionType`
+           || ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(dest_type)))) {
+          // No casting supported currently for `StructType`
+          return;
+      }
+
+      if (ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(source_type))
+          && ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(dest_type))) {
+          // FunctionType-to-FunctionType reconciliation is handled in
+          // Call_t_body for call arguments.  Do not insert a cast here
+          // because structural comparison of polymorphic class arguments
+          // can give false negatives (anonymous struct vs named class type),
+          // leading to spurious casts and LLVM type mismatches.
+          return;
+      }
+
+      if ((ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(source_type))
+           || ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(dest_type)))) {
           return;
       }
       if (ASRUtils::types_equal(source_type, dest_type, nullptr, nullptr, true)) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4878,22 +4878,19 @@ public:
             } else if (compiler_options.implicit_typing) {
                 type = implicit_dictionary[std::string(1,sym[0])];
                 if (!type) {
-                    // There exists an `implicit none` statement, here compiler has
-                    // no information about type of symbol hence keeping it real*4.
-                    type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 4));
+                    is_subroutine = true;
                 }
             } else {
-                // Here compiler has no information about type of symbol hence keeping it real*4.
-                type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 4));
+                is_subroutine = true;
             }
             // add return var
             std::string return_var_name = sym + "_return_var_name";
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
-            ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
             ASR::asr_t *return_var = nullptr;
             ASR::expr_t *to_return = nullptr;
             if (!is_subroutine) {
+                ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
                 return_var = ASRUtils::make_Variable_t_util(al, loc,
                     current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
                     variable_dependencies_vec.size(), ASRUtils::intent_return_var,
@@ -7527,7 +7524,27 @@ public:
                     LCOMPILERS_ASSERT( sym_ != nullptr );
                     // set function return type as `type`
                     ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_);
-                    ASRUtils::EXPR2VAR(f->m_return_var)->m_type = type;
+                    if (f->m_return_var == nullptr) {
+                        std::string return_var_name = sym + "_return_var_name";
+                        SetChar variable_dependencies_vec;
+                        variable_dependencies_vec.reserve(al, 1);
+                        ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
+                        ASR::asr_t *return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
+                            current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
+                            variable_dependencies_vec.size(), ASRUtils::intent_return_var,
+                            nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
+                            ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required,
+                            false);
+                        current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
+                        f->m_return_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
+                            ASR::down_cast<ASR::symbol_t>(return_var)));
+                        ASR::FunctionType_t *ft = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                        ft->m_return_var_type = type;
+                    } else {
+                        ASRUtils::EXPR2VAR(f->m_return_var)->m_type = type;
+                        ASR::FunctionType_t *ft = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                        ft->m_return_var_type = type;
+                    }
                 }
                 current_variable_type_ = type;
                 if (is_argument && current_scope->asr_owner
@@ -16845,13 +16862,30 @@ public:
                 // We need to create an interface and add the Function into
                 // the symbol table.
                 // Currently using real*8 as the return type.
-                ASR::ttype_t* type = external_sym ? ASRUtils::symbol_type(external_sym) :
-                                    ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 8));
+                ASR::ttype_t* type = nullptr;
+                bool is_subrout = false;
+                if (external_sym) {
+                    ASR::symbol_t* target = ASRUtils::symbol_get_past_external(external_sym);
+                    if (ASR::is_a<ASR::Function_t>(*target)) {
+                        ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(target);
+                        if (!fn->m_return_var) {
+                            is_subrout = true;
+                        }
+                    }
+                    if (!is_subrout) {
+                        type = ASRUtils::symbol_type(external_sym);
+                    }
+                }
+                
                 std::string var_name_first_letter = to_lower(std::string(1, var_name[0]));
                 implicit_dictionary = implicit_mapping[get_hash(current_scope->asr_owner)];
-                if ( !external_sym && compiler_options.implicit_typing &&
-                     implicit_dictionary.find(var_name_first_letter) != implicit_dictionary.end() ) {
+                if ( (!external_sym || is_subrout) && compiler_options.implicit_typing &&
+                     implicit_dictionary.find(var_name_first_letter) != implicit_dictionary.end() &&
+                     implicit_dictionary[var_name_first_letter] != nullptr ) {
                     type = implicit_dictionary[var_name_first_letter];
+                }
+                if (!type) {
+                    type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 4));
                 }
                 create_implicit_interface_function(x, var_name, true, type);
                 v = current_scope->resolve_symbol(var_name);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9979,19 +9979,11 @@ public:
         } else if (sym_type->m_type == AST::decl_typeType::TypeProcedure) {
             if (!sym_type->m_name) {
                 if (compiler_options.implicit_interface) {
+                    // procedure() with no explicit interface is completely
+                    // opaque — we don't know the return type (or whether it's
+                    // a function or subroutine).  Use nullptr (void) so the
+                    // LLVM backend emits a generic void()* function pointer.
                     ASR::ttype_t *return_type = nullptr;
-                    std::string first_letter = std::string(1, sym[0]);
-                    if (implicit_dictionary.find(first_letter) != implicit_dictionary.end()
-                            && implicit_dictionary[first_letter] != nullptr) {
-                        return_type = implicit_dictionary[first_letter];
-                    } else {
-                        char first_char = sym[0];
-                        if (first_char >= 'i' && first_char <= 'n') {
-                            return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
-                        } else {
-                            return_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 4));
-                        }
-                    }
                     Location &attr_loc = sym_type->base.base.loc;
                     type = ASRUtils::TYPE(ASR::make_FunctionType_t(
                         al, loc,
@@ -16932,7 +16924,20 @@ public:
                     ASR::FunctionType_t* func_type = ASR::down_cast<ASR::FunctionType_t>(ptype);
                     ASR::ttype_t* return_type = func_type->m_return_var_type;
                     if (!return_type) {
-                        return_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 8));
+                        // Use implicit typing rules for the return type
+                        std::string first_letter = std::string(1, var_name[0]);
+                        if (compiler_options.implicit_typing &&
+                                implicit_dictionary.find(first_letter) != implicit_dictionary.end() &&
+                                implicit_dictionary[first_letter] != nullptr) {
+                            return_type = implicit_dictionary[first_letter];
+                        } else {
+                            char first_char = var_name[0];
+                            if (first_char >= 'i' && first_char <= 'n') {
+                                return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
+                            } else {
+                                return_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 4));
+                            }
+                        }
                     }
                     SymbolTable* parent_scope = current_scope->parent ? current_scope->parent : current_scope;
                     // Resolve arg types from the call arguments
@@ -17014,7 +17019,20 @@ public:
                 ASR::FunctionType_t* func_type = ASR::down_cast<ASR::FunctionType_t>(ptype);
                 ASR::ttype_t* return_type = func_type->m_return_var_type;
                 if (!return_type) {
-                    return_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 8));
+                    // Use implicit typing rules for the return type
+                    std::string first_letter = std::string(1, var_name[0]);
+                    if (compiler_options.implicit_typing &&
+                            implicit_dictionary.find(first_letter) != implicit_dictionary.end() &&
+                            implicit_dictionary[first_letter] != nullptr) {
+                        return_type = implicit_dictionary[first_letter];
+                    } else {
+                        char first_char = var_name[0];
+                        if (first_char >= 'i' && first_char <= 'n') {
+                            return_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, 4));
+                        } else {
+                            return_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 4));
+                        }
+                    }
                 }
                 bool needs_update = false;
                 if (proc_var->m_type_declaration != nullptr) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -823,10 +823,6 @@ const ASR::Function_t* get_function_from_expr(ASR::expr_t* expr) {
             // associated with it, so we return nullptr.
             return nullptr;
         }
-        case ASR::exprType::Cast: {
-            ASR::Cast_t* cast = ASR::down_cast<ASR::Cast_t>(expr);
-            return get_function_from_expr(cast->m_arg);
-        }
         default:
             throw LCompilersException("get_function_from_expr() not implemented for "
                                 + std::to_string(expr->type));

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3021,7 +3021,7 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
 
                 // Check if formal argument is an implicit interface procedure (e.g. procedure() :: f)
                 // If it is, it accepts any explicit interface procedure as actual argument.
-                if (v->m_type_declaration) {
+                if (v->m_type_declaration && ASR::is_a<ASR::FunctionType_t>(*arg1)) {
                     ASR::symbol_t* type_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
                     if (ASR::is_a<ASR::Function_t>(*type_decl)) {
                         std::string decl_name = ASR::down_cast<ASR::Function_t>(type_decl)->m_name;
@@ -3033,7 +3033,7 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
 
                 // Check if actual argument is an implicit interface procedure (e.g. external :: f)
                 // If it is, it is compatible with any explicit interface formal argument.
-                if (ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                if (ASR::is_a<ASR::FunctionType_t>(*arg1) && ASR::is_a<ASR::FunctionType_t>(*arg2)) {
                     ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
                     if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
                         continue;
@@ -3086,7 +3086,7 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
 
                 // Check if actual argument is an implicit interface procedure (e.g. external :: f)
                 // If it is, it is compatible with any explicit interface formal argument.
-                if (ASR::is_a<ASR::FunctionType_t>(*arg1)) {
+                if (ASR::is_a<ASR::FunctionType_t>(*arg1) && ASR::is_a<ASR::FunctionType_t>(*arg2)) {
                     ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
                     if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
                         continue;

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -823,6 +823,10 @@ const ASR::Function_t* get_function_from_expr(ASR::expr_t* expr) {
             // associated with it, so we return nullptr.
             return nullptr;
         }
+        case ASR::exprType::Cast: {
+            ASR::Cast_t* cast = ASR::down_cast<ASR::Cast_t>(expr);
+            return get_function_from_expr(cast->m_arg);
+        }
         default:
             throw LCompilersException("get_function_from_expr() not implemented for "
                                 + std::to_string(expr->type));
@@ -3033,9 +3037,12 @@ bool argument_types_match(const Vec<ASR::call_arg_t>& args,
 
                 // Check if actual argument is an implicit interface procedure (e.g. external :: f)
                 // If it is, it is compatible with any explicit interface formal argument.
+                // Similarly, if formal argument is an implicit interface, it accepts an explicit interface actual argument.
                 if (ASR::is_a<ASR::FunctionType_t>(*arg1) && ASR::is_a<ASR::FunctionType_t>(*arg2)) {
                     ASR::FunctionType_t* arg1_func_type = ASR::down_cast<ASR::FunctionType_t>(arg1);
-                    if (arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) {
+                    ASR::FunctionType_t* arg2_func_type = ASR::down_cast<ASR::FunctionType_t>(arg2);
+                    if ((arg1_func_type->n_arg_types == 0 && arg1_func_type->m_deftype == ASR::deftypeType::Interface) ||
+                        (arg2_func_type->n_arg_types == 0 && arg2_func_type->m_deftype == ASR::deftypeType::Interface)) {
                         continue;
                     }
                 }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4910,7 +4910,6 @@ inline bool types_equal(ASR::ttype_t *a, ASR::ttype_t *b, ASR::expr_t* a_expr, A
                     return false;
                 }
                 return true;
-
             }
             default : return false;
         }
@@ -8030,12 +8029,10 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
         ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
 
+
         if (ASR::is_a<ASR::FunctionType_t>(*arg_type) && ASR::is_a<ASR::FunctionType_t>(*orig_arg_type)) {
-            if (!ASRUtils::types_equal(arg_type, orig_arg_type, nullptr, nullptr, true)) {
-                arg = a_args[i].m_value = ASRUtils::EXPR(ASR::make_Cast_t(
-                    al, arg->base.loc, arg, ASR::cast_kindType::FunctionToFunction,
-                    orig_arg_type, nullptr, nullptr));
-            }
+            // Implicit interface reconciliation is handled at the LLVM codegen level.
+            // No ASR-level cast is needed for procedure arguments.
             continue;
         }
         // cast string source based on the dest

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4910,6 +4910,7 @@ inline bool types_equal(ASR::ttype_t *a, ASR::ttype_t *b, ASR::expr_t* a_expr, A
                     return false;
                 }
                 return true;
+
             }
             default : return false;
         }
@@ -8028,6 +8029,15 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
         ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
+
+        if (ASR::is_a<ASR::FunctionType_t>(*arg_type) && ASR::is_a<ASR::FunctionType_t>(*orig_arg_type)) {
+            if (!ASRUtils::types_equal(arg_type, orig_arg_type, nullptr, nullptr, true)) {
+                arg = a_args[i].m_value = ASRUtils::EXPR(ASR::make_Cast_t(
+                    al, arg->base.loc, arg, ASR::cast_kindType::FunctionToFunction,
+                    orig_arg_type, nullptr, nullptr));
+            }
+            continue;
+        }
         // cast string source based on the dest
         if( ASRUtils::is_string_only(orig_arg_type) &&
             ASRUtils::is_string_only(arg_type) &&

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -23289,6 +23289,19 @@ public:
                         tmp = llvm_symtab_fn_arg[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }
+
+                    if (orig_arg && ASR::is_a<ASR::FunctionType_t>(*orig_arg->m_type) &&
+                            orig_arg_intent != ASR::intentType::InOut &&
+                            orig_arg_intent != ASR::intentType::Out &&
+                            !ASRUtils::is_pointer(orig_arg->m_type)) {
+                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
+                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
+                            orig_arg->m_type, module.get());
+                        if (tmp->getType() != expected_type) {
+                            tmp = builder->CreateBitCast(tmp, expected_type);
+                        }
+                    }
+
                     // If the target parameter is a procedure pointer,
                     // wrap the function pointer in an alloca
                     if (orig_arg &&

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16122,13 +16122,7 @@ public:
             return;
         }
         // Visit with appropriate load
-        if (x.m_kind == ASR::cast_kindType::FunctionToFunction) {
-            if (ASRUtils::is_pointer(expr_type(x.m_arg))) {
-                this->visit_expr_load_wrapper(x.m_arg, 1, true);
-            } else {
-                this->visit_expr_load_wrapper(x.m_arg, 0, true);
-            }
-        } else if (ASRUtils::is_string_only(expr_type(x.m_arg))) {
+        if (ASRUtils::is_string_only(expr_type(x.m_arg))) {
             this->visit_expr_load_wrapper(x.m_arg, 0);
         } else if(ASRUtils::is_pointer(expr_type(x.m_arg))){
             this->visit_expr_load_wrapper(x.m_arg, 2, true);
@@ -16471,12 +16465,7 @@ public:
                 }
                 break;
              }
-            case (ASR::cast_kindType::FunctionToFunction) : {
-                // The actual bitcast is handled in convert_call_args
-                // using proper orig_arg context for correct type lookup.
-                // Pointer loading logic is handled before the switch statement.
-                break;
-            }
+
             case (ASR::cast_kindType::RealToString) : {
                 /* Call Runtime Function `lfortran_float_to_str` */
                 llvm::Value* casted_float {}; // float -> string
@@ -23252,6 +23241,34 @@ public:
                             }
                         }
                     }
+#if LLVM_VERSION_MAJOR < 15
+                    // Bitcast procedure pointer if LLVM types don't match.
+                    // Handles implicit/explicit interfaces where LLVM generates
+                    // structurally equivalent but nominally different types
+                    // (e.g., named vs anonymous structs). When both actual and
+                    // formal are Pointer(FunctionType_t), tmp is at alloca
+                    // level (extra pointer), so compare at that level.
+                    if (orig_arg &&
+                            ASR::is_a<ASR::FunctionType_t>(
+                                *ASRUtils::type_get_past_pointer(arg->m_type)) &&
+                            ASR::is_a<ASR::FunctionType_t>(
+                                *ASRUtils::type_get_past_pointer(orig_arg->m_type))) {
+                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
+                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
+                            orig_arg->m_type, module.get());
+                        // When the variable is a procedure pointer stored in an
+                        // alloca, tmp has an extra pointer level. Match at that
+                        // level so we bitcast void({void*}*)** → void(%named*)**
+                        // rather than incorrectly casting void()** → void()*.
+                        if (ASRUtils::is_pointer(arg->m_type) &&
+                                ASRUtils::is_pointer(orig_arg->m_type)) {
+                            expected_type = expected_type->getPointerTo();
+                        }
+                        if (tmp->getType() != expected_type) {
+                            tmp = builder->CreateBitCast(tmp, expected_type);
+                        }
+                    }
+#endif
                     // When the formal is a pointer type but the actual is not,
                     // wrap the value with an extra pointer level. Skip this when
                     // the formal is a class type — convert_to_polymorphic_arg
@@ -23269,8 +23286,6 @@ public:
                         builder->CreateStore(tmp, ptr_to_tmp);
                         tmp = ptr_to_tmp;
                     }
-
-
                 } else if (ASR::is_a<ASR::Function_t>(*var_sym)) {
                     ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(var_sym);
                     uint32_t h = get_hash((ASR::asr_t*)fn);
@@ -23289,9 +23304,23 @@ public:
                         tmp = llvm_symtab_fn_arg[h];
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }
-
-
-
+#if LLVM_VERSION_MAJOR < 15
+                    // Bitcast function pointer if LLVM types don't match.
+                    // Handles implicit interfaces and typed-pointer LLVM
+                    // where named vs anonymous struct types may differ.
+                    // Must happen BEFORE alloca wrapping to preserve the
+                    // correct pointer indirection level.
+                    if (orig_arg && orig_arg->m_type_declaration &&
+                            ASR::is_a<ASR::FunctionType_t>(
+                            *ASRUtils::type_get_past_pointer(orig_arg->m_type))) {
+                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
+                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
+                            ASRUtils::type_get_past_pointer(orig_arg->m_type), module.get());
+                        if (tmp->getType() != expected_type) {
+                            tmp = builder->CreateBitCast(tmp, expected_type);
+                        }
+                    }
+#endif
                     // If the target parameter is a procedure pointer,
                     // wrap the function pointer in an alloca
                     if (orig_arg &&
@@ -23348,14 +23377,20 @@ public:
                     ASRUtils::type_get_past_allocatable(
                         ASRUtils::expr_type(x.m_args[i].m_value)))) ) {
                 this->visit_expr_wrapper(x.m_args[i].m_value, true);
-                if (orig_arg && ASR::is_a<ASR::FunctionType_t>(
+                if (orig_arg && orig_arg->m_type_declaration &&
+                        ASR::is_a<ASR::FunctionType_t>(
                         *ASRUtils::type_get_past_pointer(orig_arg->m_type))) {
+#if LLVM_VERSION_MAJOR < 15
+                    // Bitcast function pointer if LLVM types don't match.
+                    // Handles both implicit and explicit interfaces where
+                    // typed-pointer LLVM generates mismatching types.
                     llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
                         ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
-                        orig_arg->m_type, module.get());
+                        ASRUtils::type_get_past_pointer(orig_arg->m_type), module.get());
                     if (tmp->getType() != expected_type) {
                         tmp = builder->CreateBitCast(tmp, expected_type);
                     }
+#endif
                     if (ASRUtils::is_pointer(orig_arg->m_type)) {
                         llvm::AllocaInst *target = get_call_arg_alloca(tmp->getType());
                         builder->CreateStore(tmp, target);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16122,7 +16122,13 @@ public:
             return;
         }
         // Visit with appropriate load
-        if (ASRUtils::is_string_only(expr_type(x.m_arg))) {
+        if (x.m_kind == ASR::cast_kindType::FunctionToFunction) {
+            if (ASRUtils::is_pointer(expr_type(x.m_arg))) {
+                this->visit_expr_load_wrapper(x.m_arg, 1, true);
+            } else {
+                this->visit_expr_load_wrapper(x.m_arg, 0, true);
+            }
+        } else if (ASRUtils::is_string_only(expr_type(x.m_arg))) {
             this->visit_expr_load_wrapper(x.m_arg, 0);
         } else if(ASRUtils::is_pointer(expr_type(x.m_arg))){
             this->visit_expr_load_wrapper(x.m_arg, 2, true);
@@ -16465,6 +16471,12 @@ public:
                 }
                 break;
              }
+            case (ASR::cast_kindType::FunctionToFunction) : {
+                // The actual bitcast is handled in convert_call_args
+                // using proper orig_arg context for correct type lookup.
+                // Pointer loading logic is handled before the switch statement.
+                break;
+            }
             case (ASR::cast_kindType::RealToString) : {
                 /* Call Runtime Function `lfortran_float_to_str` */
                 llvm::Value* casted_float {}; // float -> string
@@ -23257,20 +23269,8 @@ public:
                         builder->CreateStore(tmp, ptr_to_tmp);
                         tmp = ptr_to_tmp;
                     }
-                    // Bitcast procedure pointer if types don't match (implicit interface)
-                    // Only for procedure values passed by value (not intent inout/out or pointer)
-                    if (orig_arg && ASR::is_a<ASR::FunctionType_t>(*arg->m_type) &&
-                            ASR::is_a<ASR::FunctionType_t>(*orig_arg->m_type) &&
-                            orig_arg_intent != ASR::intentType::InOut &&
-                            orig_arg_intent != ASR::intentType::Out &&
-                            !ASRUtils::is_pointer(orig_arg->m_type)) {
-                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
-                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
-                            orig_arg->m_type, module.get());
-                        if (tmp->getType() != expected_type) {
-                            tmp = builder->CreateBitCast(tmp, expected_type);
-                        }
-                    }
+
+
                 } else if (ASR::is_a<ASR::Function_t>(*var_sym)) {
                     ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(var_sym);
                     uint32_t h = get_hash((ASR::asr_t*)fn);
@@ -23290,17 +23290,7 @@ public:
                         LCOMPILERS_ASSERT(tmp != nullptr)
                     }
 
-                    if (orig_arg && ASR::is_a<ASR::FunctionType_t>(*orig_arg->m_type) &&
-                            orig_arg_intent != ASR::intentType::InOut &&
-                            orig_arg_intent != ASR::intentType::Out &&
-                            !ASRUtils::is_pointer(orig_arg->m_type)) {
-                        llvm::Type* expected_type = llvm_utils->get_type_from_ttype_t_util(
-                            ASRUtils::EXPR(ASR::make_Var_t(al, orig_arg->base.base.loc, &orig_arg->base)),
-                            orig_arg->m_type, module.get());
-                        if (tmp->getType() != expected_type) {
-                            tmp = builder->CreateBitCast(tmp, expected_type);
-                        }
-                    }
+
 
                     // If the target parameter is a procedure pointer,
                     // wrap the function pointer in an alloca
@@ -23330,6 +23320,7 @@ public:
                     tmp = convert_class_to_type(x.m_args[i].m_value, ASRUtils::EXPR(ASR::make_Var_t(
                         al, orig_arg->base.base.loc, &orig_arg->base)), orig_arg->m_type, tmp);
                 }
+
             } else if (ASR::is_a<ASR::Cast_t>(*x.m_args[i].m_value) &&
                         ASR::down_cast<ASR::Cast_t>(x.m_args[i].m_value)->m_kind ==
                             ASR::cast_kindType::ClassToIntrinsic) {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1438,7 +1438,12 @@ namespace LCompilers {
                     throw CodeGenError("Type not implemented " + ASRUtils::type_to_str_python_expr(return_var_type0, x.m_return_var));
             }
         } else {
-            return_type = llvm::Type::getVoidTy(context);
+            ASR::FunctionType_t *func_type = ASR::down_cast<ASR::FunctionType_t>(x.m_function_signature);
+            if (func_type->m_return_var_type != nullptr) {
+                return_type = get_type_from_ttype_t_util(nullptr, func_type->m_return_var_type, module);
+            } else {
+                return_type = llvm::Type::getVoidTy(context);
+            }
         }
         std::vector<llvm::Type*> args = convert_args(x, module);
         llvm::FunctionType *function_type = llvm::FunctionType::get(

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1438,12 +1438,7 @@ namespace LCompilers {
                     throw CodeGenError("Type not implemented " + ASRUtils::type_to_str_python_expr(return_var_type0, x.m_return_var));
             }
         } else {
-            ASR::FunctionType_t *func_type = ASR::down_cast<ASR::FunctionType_t>(x.m_function_signature);
-            if (func_type->m_return_var_type != nullptr) {
-                return_type = get_type_from_ttype_t_util(nullptr, func_type->m_return_var_type, module);
-            } else {
-                return_type = llvm::Type::getVoidTy(context);
-            }
+            return_type = llvm::Type::getVoidTy(context);
         }
         std::vector<llvm::Type*> args = convert_args(x, module);
         llvm::FunctionType *function_type = llvm::FunctionType::get(

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -911,12 +911,17 @@ namespace DateAndTime {
             ASR::symbol_t *s_4 = b.create_c_func_subroutines(c_func_name_4, fn_symtab, 1, int32);
             fn_symtab->add_symbol(c_func_name_4, s_4);
             dep.push_back(al, s2c(al, c_func_name_4));
+            ASR::ttype_t* element_type = ASRUtils::type_get_past_array(extract_type(arg_types[3]));
             for (int i = 0; i < 8; i++) {
                 Vec<ASR::expr_t*> call_args2; call_args2.reserve(al, 1);
                 call_args2.push_back(al, b.i32(i+1));
                 auto xx = declare("i_" + std::to_string(i), int32, Local);
                 body.push_back(al, b.Assignment(xx, b.Call(s_4, call_args2, int32)));
-                vals.push_back(xx);
+                ASR::expr_t* xx_casted = xx;
+                if (!ASRUtils::check_equal_type(ASRUtils::expr_type(xx), element_type, nullptr, nullptr, false)) {
+                    xx_casted = ASRUtils::EXPR(ASR::make_Cast_t(al, loc, xx, ASR::cast_kindType::IntegerToInteger, element_type, nullptr, nullptr));
+                }
+                vals.push_back(xx_casted);
             }
             body.push_back(al, b.Assignment(args[3], b.ArrayConstant(vals, extract_type(arg_types[3]), false)));
         } else {

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -1179,6 +1179,9 @@ public:
 
     bool value_is_nested_procedure(ASR::expr_t* value) {
         value = ASRUtils::get_past_array_physical_cast(value);
+        if (value && ASR::is_a<ASR::Cast_t>(*value)) {
+            value = ASR::down_cast<ASR::Cast_t>(value)->m_arg;
+        }
         if (value && ASR::is_a<ASR::Var_t>(*value)) {
             ASR::symbol_t* v = ASR::down_cast<ASR::Var_t>(value)->m_v;
             return is_nested_call_symbol(current_scope, v);
@@ -1202,6 +1205,9 @@ public:
         }
         if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*arg_expr)) {
             arg_expr = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr)->m_arg;
+        }
+        if (ASR::is_a<ASR::Cast_t>(*arg_expr)) {
+            arg_expr = ASR::down_cast<ASR::Cast_t>(arg_expr)->m_arg;
         }
         if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
             ASR::Var_t *var = ASR::down_cast<ASR::Var_t>(arg_expr);

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -1179,9 +1179,6 @@ public:
 
     bool value_is_nested_procedure(ASR::expr_t* value) {
         value = ASRUtils::get_past_array_physical_cast(value);
-        if (value && ASR::is_a<ASR::Cast_t>(*value)) {
-            value = ASR::down_cast<ASR::Cast_t>(value)->m_arg;
-        }
         if (value && ASR::is_a<ASR::Var_t>(*value)) {
             ASR::symbol_t* v = ASR::down_cast<ASR::Var_t>(value)->m_v;
             return is_nested_call_symbol(current_scope, v);
@@ -1206,9 +1203,7 @@ public:
         if (ASR::is_a<ASR::ArrayPhysicalCast_t>(*arg_expr)) {
             arg_expr = ASR::down_cast<ASR::ArrayPhysicalCast_t>(arg_expr)->m_arg;
         }
-        if (ASR::is_a<ASR::Cast_t>(*arg_expr)) {
-            arg_expr = ASR::down_cast<ASR::Cast_t>(arg_expr)->m_arg;
-        }
+
         if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
             ASR::Var_t *var = ASR::down_cast<ASR::Var_t>(arg_expr);
             if (is_nested_call_symbol(current_scope, var->m_v) ||

--- a/tests/reference/asr-allow_implicit_interface-68156ec.json
+++ b/tests/reference/asr-allow_implicit_interface-68156ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allow_implicit_interface-68156ec.stdout",
-    "stdout_hash": "c55c4b8209b7d07c8513bc148f3607c39088099455a7d3c736114dcb",
+    "stdout_hash": "adac2c154a5cbae043e6aa70b5dcf31fea5f19756372c136a4ed4f22",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allow_implicit_interface-68156ec.stdout
+++ b/tests/reference/asr-allow_implicit_interface-68156ec.stdout
@@ -69,7 +69,7 @@
                                                     ()
                                                     ()
                                                     Default
-                                                    (Real 8)
+                                                    (Real 4)
                                                     ()
                                                     BindC
                                                     Public
@@ -89,7 +89,7 @@
                                     (FunctionType
                                         [(Real 8)
                                         (Logical 4)]
-                                        (Real 8)
+                                        (Real 4)
                                         BindC
                                         Interface
                                         ()
@@ -538,14 +538,20 @@
                                 ()
                             )
                             Add
-                            (FunctionCall
-                                2 alnorm
-                                ()
-                                [((Var 2 x))
-                                ((LogicalConstant
-                                    .true.
-                                    (Logical 4)
-                                ))]
+                            (Cast
+                                (FunctionCall
+                                    2 alnorm
+                                    ()
+                                    [((Var 2 x))
+                                    ((LogicalConstant
+                                        .true.
+                                        (Logical 4)
+                                    ))]
+                                    (Real 4)
+                                    ()
+                                    ()
+                                )
+                                RealToReal
                                 (Real 8)
                                 ()
                                 ()

--- a/tests/reference/asr-external1-93d8653.json
+++ b/tests/reference/asr-external1-93d8653.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external1-93d8653.stdout",
-    "stdout_hash": "79f34918584e9e2d46b75fd9ab49832f1b9f98f26104d2adda6e2040",
+    "stdout_hash": "95c7b455721dec06161e5f3e42516951919ae95674b90b2085c1daa8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external1-93d8653.stdout
+++ b/tests/reference/asr-external1-93d8653.stdout
@@ -12,35 +12,12 @@
                                     (SymbolTable
                                         3
                                         {
-                                            matvect_return_var_name:
-                                                (Variable
-                                                    3
-                                                    matvect_return_var_name
-                                                    []
-                                                    ReturnVar
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Real 4)
-                                                    ()
-                                                    BindC
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                    .false.
-                                                    .false.
-                                                    ()
-                                                    .false.
-                                                    .false.
-                                                    NotMethod
-                                                    ()
-                                                    []
-                                                )
+                                            
                                         })
                                     matvect
                                     (FunctionType
                                         []
-                                        (Real 4)
+                                        ()
                                         BindC
                                         Interface
                                         ()
@@ -55,7 +32,7 @@
                                     []
                                     []
                                     []
-                                    (Var 3 matvect_return_var_name)
+                                    ()
                                     Public
                                     .false.
                                     .false.
@@ -66,7 +43,7 @@
                     (FunctionType
                         [(FunctionType
                             []
-                            (Real 4)
+                            ()
                             BindC
                             Interface
                             ()


### PR DESCRIPTION
fixes #11805

This commit resolves two distinct LLVM IR verification failures encountered when building `benchmark.f`:

1. Fix `date_and_time` intrinsic i32 to i64 type mismatch:
   - Bug: When the user provided an `integer(8)` (64-bit) array for the `values` argument, the generated LLVM IR attempted to directly store 32-bit integer values returned by the runtime into the 64-bit array constant, causing a `Stored value type does not match pointer operand type!` LLVM verification error.
   - Fix: Updated `instantiate_DateAndTime` in `src/libasr/pass/intrinsic_subroutines.h` to explicitly cast the runtime `i32` values to the target array's element type before populating the `ArrayConstant`.

2. Fix implicit-interface procedure pointer codegen:
   - Bug: When passing a procedure to a struct constructor containing an implicit-interface procedure pointer field, the generic resolution could select the wrong interface or generate a mismatched LLVM function type signature, resulting in a `Call parameter type does not match function signature!` error.
- fix : wip
