### PR TITLE
Improve : Make lfortran reproducible-build friendly

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2090,11 +2090,10 @@ int link_executable(const std::vector<std::string> &infiles,
                 if (backend == Backend::llvm &&
                         compiler_options.po.enable_gpu_offloading &&
                         std::regex_match(s, std::regex(R"(.*\.tmp_\w+\.o)"))) {
-                    std::string file_path = std::filesystem::path(s.substr(0, s.size() - 2)).string();    // strip ".o" from end
-                    std::string mlir_tmp_o = std::filesystem::path(file_path).replace_extension(
-                        ".mlir.tmp_" + LCompilers::get_unique_ID(s) + ".o").string();
-                    compile_cmd += mlir_tmp_o + " ";
-                    mlir_temp_object_files.push_back(mlir_tmp_o);
+                        std::string obj_file_path = std::filesystem::path(s).string();// "do_concurrent_01.tmp_yDR0nDW17GGvAia86INkc2.o"
+                        obj_file_path.insert(obj_file_path.find('.'), ".mlir");
+                        compile_cmd += obj_file_path + " ";
+                        mlir_temp_object_files.push_back(obj_file_path);
                 }
             }
             if(!extra_library_flags.empty()) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -120,7 +120,6 @@ std::string LFORTRAN_TEMP_DIR = get_system_temp_dir();
 
 // The unique compilation ID for this invocation of the compiler.
 // Used in naming unique intermediate object files during both compilation modes.
-const std::string LCOMPILERS_UNIQUE_ID = LCompilers::get_unique_ID();
 
 void print_one_component(std::string component) {
     std::istringstream ss(component);
@@ -1216,12 +1215,12 @@ int compile_src_to_object_file(const std::string &infile,
         compiler_options.po.intrinsic_symbols_mangling = true;
         compiler_options.po.intrinsic_module_name_mangling = true;
     }
+    lcompilers_unique_ID_separate_compilation = compiler_options.separate_compilation ? LCompilers::get_unique_ID(infile) : "";
     LCompilers::diag::Diagnostics diagnostics;
     t1 = std::chrono::high_resolution_clock::now();
     LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
         result = fe.get_asr2(input, lm, diagnostics);
     t2 = std::chrono::high_resolution_clock::now();
-    lcompilers_unique_ID_separate_compilation = compiler_options.separate_compilation ? LCOMPILERS_UNIQUE_ID : "";
 
     time_src_to_asr = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
     bool has_error_w_cc = compiler_options.continue_compilation && diagnostics.has_error();
@@ -1334,7 +1333,7 @@ int compile_src_to_object_file(const std::string &infile,
                 if (mlir_res.ok) {
                     mlir_res.result->mlir_to_llvm(*mlir_res.result->llvm_ctx);
                     std::string mlir_tmp_o = (std::filesystem::path(LFORTRAN_TEMP_DIR) / std::filesystem::path(infile)
-                        .filename().replace_extension(".mlir.tmp_" + LCOMPILERS_UNIQUE_ID + ".o")).string();
+                        .filename().replace_extension(".mlir.tmp_" + LCompilers::get_unique_ID(infile) + ".o")).string();
                     e.save_object_file(*(mlir_res.result->llvm_m), mlir_tmp_o);
                 } else {
                     LCOMPILERS_ASSERT(diagnostics.has_error())
@@ -2093,7 +2092,7 @@ int link_executable(const std::vector<std::string> &infiles,
                         std::regex_match(s, std::regex(R"(.*\.tmp_\w+\.o)"))) {
                     std::string file_path = std::filesystem::path(s.substr(0, s.size() - 2)).string();    // strip ".o" from end
                     std::string mlir_tmp_o = std::filesystem::path(file_path).replace_extension(
-                        ".mlir.tmp_" + LCOMPILERS_UNIQUE_ID + ".o").string();
+                        ".mlir.tmp_" + LCompilers::get_unique_ID(s) + ".o").string();
                     compile_cmd += mlir_tmp_o + " ";
                     mlir_temp_object_files.push_back(mlir_tmp_o);
                 }
@@ -2119,7 +2118,7 @@ int link_executable(const std::vector<std::string> &infiles,
                 std::string metal_runtime_src = runtime_library_dir
                     + "/../libasr/runtime/lfortran_gpu_metal.m";
                 std::string metal_runtime_obj = LFORTRAN_TEMP_DIR
-                    + "/lfortran_gpu_metal_" + LCOMPILERS_UNIQUE_ID + ".o";
+                    + "/lfortran_gpu_metal_" + LCompilers::get_unique_ID(metal_runtime_src) + ".o";
                 std::string metal_compile_cmd = "clang -c -O2 -fobjc-arc"
                     " -o " + metal_runtime_obj
                     + " " + metal_runtime_src;
@@ -2152,9 +2151,9 @@ int link_executable(const std::vector<std::string> &infiles,
 
                 // Write CUDA kernel source to a temp .cu file
                 std::string cuda_kernel_src = LFORTRAN_TEMP_DIR
-                    + "/lfortran_gpu_kernel_" + LCOMPILERS_UNIQUE_ID + ".cu";
+                    + "/lfortran_gpu_kernel_" + LCompilers::get_unique_ID(cuda_source) + ".cu";
                 std::string cuda_kernel_obj = LFORTRAN_TEMP_DIR
-                    + "/lfortran_gpu_kernel_" + LCOMPILERS_UNIQUE_ID + ".o";
+                    + "/lfortran_gpu_kernel_" + LCompilers::get_unique_ID(cuda_source) + ".o";
                 {
                     std::ofstream cu_out(cuda_kernel_src);
                     cu_out << cuda_source;
@@ -2174,7 +2173,7 @@ int link_executable(const std::vector<std::string> &infiles,
                 std::string cuda_runtime_src = runtime_library_dir
                     + "/../libasr/runtime/lfortran_gpu_cuda.cu";
                 std::string cuda_runtime_obj = LFORTRAN_TEMP_DIR
-                    + "/lfortran_gpu_cuda_" + LCOMPILERS_UNIQUE_ID + ".o";
+                    + "/lfortran_gpu_cuda_" + LCompilers::get_unique_ID(cuda_runtime_src) + ".o";
                 std::string cuda_rt_cmd = "nvcc -c -O2"
                     " -I" + runtime_library_dir + "/../libasr/runtime"
                     " -o " + cuda_runtime_obj
@@ -2568,7 +2567,6 @@ int main_app(int argc, char *argv[]) {
         }
     }
 
-    lcompilers_unique_ID_separate_compilation = ( parser.opts.compiler_options.separate_compilation || compiler_options.generate_code_for_global_procedures ) ? LCOMPILERS_UNIQUE_ID : "";
     if (parser.opts.compiler_options.separate_compilation) {
         compiler_options.po.intrinsic_symbols_mangling = true;
         compiler_options.po.intrinsic_module_name_mangling = true;
@@ -2896,7 +2894,7 @@ int main_app(int argc, char *argv[]) {
     for (const auto &arg_file : opts.arg_files) {
         int err = 0;
         std::string tmp_o = (std::filesystem::path(LFORTRAN_TEMP_DIR) / std::filesystem::path(arg_file)
-                                .filename().replace_extension(".tmp_" + LCOMPILERS_UNIQUE_ID + ".o")).string();
+                                .filename().replace_extension(".tmp_" + LCompilers::get_unique_ID(arg_file) + ".o")).string();
         temp_object_files.push_back(tmp_o);
         if (endswith(arg_file, ".f90") || endswith(arg_file, ".f") ||
             endswith(arg_file, ".F90") || endswith(arg_file, ".F")) {

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -5,7 +5,7 @@
 #include <libasr/asr_utils.h>
 #include <libasr/pass/pass_utils.h>
 
-std::string lcompilers_unique_ID_separate_compilation;
+std::string lcompilers_unique_ID_separate_compilation;// Unique ID per source file
 std::string lcompilers_commandline_options;
 
 namespace LCompilers  {

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -32,11 +32,6 @@ namespace LCompilers {
 
 using ASR::down_cast;
 
-uint64_t static inline get_hash(ASR::asr_t *node)
-{
-    return (uint64_t)node;
-}
-
 class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
     public:
     std::unordered_map<ASR::symbol_t*, std::string> sym_to_renamed;

--- a/src/libasr/pass/unique_symbols.cpp
+++ b/src/libasr/pass/unique_symbols.cpp
@@ -81,8 +81,7 @@ class SymbolRenameVisitor: public ASR::BaseWalkVisitor<SymbolRenameVisitor> {
             return curr_name;
         } else if (startswith(curr_name, "_lcompilers_") && current_scope) {
             // mangle intrinsic functions
-            uint64_t hash = get_hash(current_scope->asr_owner);
-            return module_name + curr_name + "_" + std::to_string(hash) + "_" + lcompilers_unique_ID_separate_compilation;
+            return module_name + curr_name + "_" + lcompilers_unique_ID_separate_compilation;
         } else if (parent_function_name.size() > 0) {
             // add parent function name to suffix
             std::string name = module_name + curr_name + "_";

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -21,7 +21,7 @@ enum Platform {
 std::string pf2s(Platform);
 Platform get_platform();
 
-std::string get_unique_ID();
+std::string get_unique_ID(const std::string &file_path);
 int visualize_json(std::string &astr_data_json, LCompilers::Platform os);
 std::string generate_visualize_html(std::string &astr_data_json);
 

--- a/src/libasr/utils2.cpp
+++ b/src/libasr/utils2.cpp
@@ -14,18 +14,13 @@
 #include <libasr/string_utils.h>
 
 namespace LCompilers {
-
-std::string get_unique_ID() {
-    static std::random_device dev;
-    static std::mt19937 rng(dev());
-    std::uniform_int_distribution<int> dist(0, 61);
-    const std::string v =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    std::string res;
-    for (int i = 0; i < 22; i++) {
-        res += v[dist(rng)];
-    }
-    return res;
+    
+// Get a unique ID for the given file path.
+// Used for separate compilation symbol mangling.
+// Makes sure symbol mangling is stable across different runs.
+// helpful for reproducible builds
+std::string get_unique_ID(const std::string &file_path) {
+    return std::to_string(std::hash<std::string>{}(file_path));
 }
 
 bool present(Vec<char*> &v, const char* name) {


### PR DESCRIPTION
fixes #11428
- Change `get_unique_id` which wass used to return a unique id per lfortran invokation (random), into a function that reutrn a unique id per source file path name (consistent from build-to-build with same env)
- now the rebuilds for the same file is consistent not random.