### PR TITLE
Support standalone allocatable attribute declarations

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -702,6 +702,7 @@ RUN(NAME functions_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_61 LABELS gfortran llvm fortran)
+RUN(NAME functions_62 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_62.f90
+++ b/integration_tests/functions_62.f90
@@ -1,0 +1,9 @@
+﻿program main
+  print *, value()
+contains
+  integer function value()
+    allocatable :: value
+    allocate(value)
+    value = 42
+  end function value
+end program main

--- a/integration_tests/functions_62.f90
+++ b/integration_tests/functions_62.f90
@@ -1,5 +1,4 @@
 ﻿program main
-  print *, value()
 contains
   integer function value()
     allocatable :: value

--- a/integration_tests/functions_62.f90
+++ b/integration_tests/functions_62.f90
@@ -1,8 +1,17 @@
-﻿program main
+program main
+    implicit none
+    integer, allocatable :: val
+
+    val = value()
+    if (val /= 42) error stop
+
 contains
+
   integer function value()
     allocatable :: value
+
     allocate(value)
     value = 42
   end function value
+
 end program main

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5813,16 +5813,30 @@ public:
                                         assgnd_pointer.insert(sym);
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
-                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
+                                    // Use resolve_symbol to find the function in parent scopes if necessary
+                                    ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
                                     if (sym_) {
                                         ASR::symbol_t* sym_past_external =
                                             ASRUtils::symbol_get_past_external(sym_);
+                                        
                                         if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
+                                            // Standard variable case
                                             ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(
                                                 sym_past_external);
                                             if (!ASRUtils::is_allocatable(v->m_type)) {
                                                 v->m_type = ASRUtils::TYPE(
                                                     ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                            }
+                                        } else if (ASR::is_a<ASR::Function_t>(*sym_past_external)) {
+                                            // Function result case: grab the internal return variable
+                                            ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past_external);
+                                            if (f->m_return_var) {
+                                                ASR::symbol_t* ret_sym = ASR::down_cast<ASR::Var_t>(f->m_return_var)->m_v;
+                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_sym);
+                                                if (!ASRUtils::is_allocatable(v->m_type)) {
+                                                    v->m_type = ASRUtils::TYPE(
+                                                        ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                                }
                                             }
                                         }
                                     } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5813,45 +5813,13 @@ public:
                                         assgnd_pointer.insert(sym);
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
-                                    ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
+                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
                                     if (sym_) {
-                                        ASR::symbol_t* sym_past = ASRUtils::symbol_get_past_external(sym_);
-                                        
-                                        // Case 1: Symbol resolved to the local Variable
-                                        if (ASR::is_a<ASR::Variable_t>(*sym_past)) {
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past);
+                                        ASR::symbol_t* sym_past_external = ASRUtils::symbol_get_past_external(sym_);
+                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past_external);
                                             if (!ASRUtils::is_allocatable(v->m_type)) {
                                                 v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
-                                            }
-                                            
-                                            // Prevent reverting: update the function signature if this is the return variable!
-                                            if (current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner)) {
-                                                ASR::symbol_t* owner_sym = ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner);
-                                                if (ASR::is_a<ASR::Function_t>(*owner_sym)) {
-                                                    ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(owner_sym);
-                                                    if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
-                                                        ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
-                                                        if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
-                                                            f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        } 
-                                        // Case 2: Symbol resolved directly to the Function (from parent scope)
-                                        else if (ASR::is_a<ASR::Function_t>(*sym_past)) {
-                                            ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past);
-                                            if (f->m_return_var) {
-                                                ASR::symbol_t* ret_sym = ASR::down_cast<ASR::Var_t>(f->m_return_var)->m_v;
-                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_sym);
-                                                if (!ASRUtils::is_allocatable(v->m_type)) {
-                                                    v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
-                                                }
-                                            }
-                                            // Prevent reverting here too
-                                            ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
-                                            if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
-                                                f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
                                             }
                                         }
                                     } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5813,30 +5813,42 @@ public:
                                         assgnd_pointer.insert(sym);
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
-                                    // Use resolve_symbol to find the function in parent scopes if necessary
                                     ASR::symbol_t* sym_ = current_scope->resolve_symbol(sym);
                                     if (sym_) {
-                                        ASR::symbol_t* sym_past_external =
-                                            ASRUtils::symbol_get_past_external(sym_);
+                                        ASR::symbol_t* sym_past = ASRUtils::symbol_get_past_external(sym_);
                                         
-                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
-                                            // Standard variable case
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(
-                                                sym_past_external);
+                                        // Case 1: Symbol resolved to the local Variable
+                                        if (ASR::is_a<ASR::Variable_t>(*sym_past)) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past);
                                             if (!ASRUtils::is_allocatable(v->m_type)) {
-                                                v->m_type = ASRUtils::TYPE(
-                                                    ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                                v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
                                             }
-                                        } else if (ASR::is_a<ASR::Function_t>(*sym_past_external)) {
-                                            // Function result case: grab the internal return variable
-                                            ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past_external);
+                                            
+                                            // Prevent reverting: update the function signature if this is the return variable!
+                                            if (current_scope->asr_owner && ASR::is_a<ASR::Function_t>(*current_scope->asr_owner)) {
+                                                ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(current_scope->asr_owner);
+                                                if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
+                                                    ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
+                                                    if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
+                                                        f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
+                                                    }
+                                                }
+                                            }
+                                        } 
+                                        // Case 2: Symbol resolved directly to the Function (from parent scope)
+                                        else if (ASR::is_a<ASR::Function_t>(*sym_past)) {
+                                            ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past);
                                             if (f->m_return_var) {
                                                 ASR::symbol_t* ret_sym = ASR::down_cast<ASR::Var_t>(f->m_return_var)->m_v;
                                                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_sym);
                                                 if (!ASRUtils::is_allocatable(v->m_type)) {
-                                                    v->m_type = ASRUtils::TYPE(
-                                                        ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                                    v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
                                                 }
+                                            }
+                                            // Prevent reverting here too
+                                            ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);
+                                            if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
+                                                f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
                                             }
                                         }
                                     } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5824,15 +5824,12 @@ public:
                                                 v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
                                             }
                                             
-                                            // Prevent reverting: update the function signature and Var_t expression if this is the return variable!
+                                            // Prevent reverting: update the function signature if this is the return variable!
                                             if (current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner)) {
                                                 ASR::symbol_t* owner_sym = ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner);
                                                 if (ASR::is_a<ASR::Function_t>(*owner_sym)) {
                                                     ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(owner_sym);
                                                     if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
-                                                        ASR::Var_t *ret_var_expr = ASR::down_cast<ASR::Var_t>(fn->m_return_var);
-                                                        ret_var_expr->m_type = v->m_type; 
-                                                        
                                                         ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
                                                         if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
                                                             f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
@@ -5845,11 +5842,10 @@ public:
                                         else if (ASR::is_a<ASR::Function_t>(*sym_past)) {
                                             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past);
                                             if (f->m_return_var) {
-                                                ASR::Var_t *ret_var_expr = ASR::down_cast<ASR::Var_t>(f->m_return_var);
-                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_var_expr->m_v);
+                                                ASR::symbol_t* ret_sym = ASR::down_cast<ASR::Var_t>(f->m_return_var)->m_v;
+                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_sym);
                                                 if (!ASRUtils::is_allocatable(v->m_type)) {
                                                     v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
-                                                    ret_var_expr->m_type = v->m_type; 
                                                 }
                                             }
                                             // Prevent reverting here too

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5869,7 +5869,7 @@ public:
                             }
                         }
                     }
-             // enable sole `dimension` attribute
+		    // enable sole `dimension` attribute
         } else if (AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])) {
             for (size_t i=0;i<x.n_syms;++i) { // symbols for line only
                 AST::var_sym_t &s = x.m_syms[i];

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5825,12 +5825,15 @@ public:
                                             }
                                             
                                             // Prevent reverting: update the function signature if this is the return variable!
-                                            if (current_scope->asr_owner && ASR::is_a<ASR::Function_t>(*current_scope->asr_owner)) {
-                                                ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(current_scope->asr_owner);
-                                                if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
-                                                    ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
-                                                    if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
-                                                        f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
+                                            if (current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner)) {
+                                                ASR::symbol_t* owner_sym = ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner);
+                                                if (ASR::is_a<ASR::Function_t>(*owner_sym)) {
+                                                    ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(owner_sym);
+                                                    if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
+                                                        ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
+                                                        if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
+                                                            f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
+                                                        }
                                                     }
                                                 }
                                             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5869,7 +5869,7 @@ public:
                             }
                         }
                     }
-            // enable sole `dimension` attribute
+           // enable sole `dimension` attribute
         } else if (AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])) {
             for (size_t i=0;i<x.n_syms;++i) { // symbols for line only
                 AST::var_sym_t &s = x.m_syms[i];

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5824,12 +5824,15 @@ public:
                                                 v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
                                             }
                                             
-                                            // Prevent reverting: update the function signature if this is the return variable!
+                                            // Prevent reverting: update the function signature and Var_t expression if this is the return variable!
                                             if (current_scope->asr_owner && ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner)) {
                                                 ASR::symbol_t* owner_sym = ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner);
                                                 if (ASR::is_a<ASR::Function_t>(*owner_sym)) {
                                                     ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(owner_sym);
                                                     if (fn->m_return_var && ASR::down_cast<ASR::Var_t>(fn->m_return_var)->m_v == sym_past) {
+                                                        ASR::Var_t *ret_var_expr = ASR::down_cast<ASR::Var_t>(fn->m_return_var);
+                                                        ret_var_expr->m_type = v->m_type; 
+                                                        
                                                         ASR::FunctionType_t *f_type = ASR::down_cast<ASR::FunctionType_t>(fn->m_function_signature);
                                                         if (f_type->m_return_var_type && !ASRUtils::is_allocatable(f_type->m_return_var_type)) {
                                                             f_type->m_return_var_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, f_type->m_return_var_type));
@@ -5842,10 +5845,11 @@ public:
                                         else if (ASR::is_a<ASR::Function_t>(*sym_past)) {
                                             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(sym_past);
                                             if (f->m_return_var) {
-                                                ASR::symbol_t* ret_sym = ASR::down_cast<ASR::Var_t>(f->m_return_var)->m_v;
-                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_sym);
+                                                ASR::Var_t *ret_var_expr = ASR::down_cast<ASR::Var_t>(f->m_return_var);
+                                                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(ret_var_expr->m_v);
                                                 if (!ASRUtils::is_allocatable(v->m_type)) {
                                                     v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                                    ret_var_expr->m_type = v->m_type; 
                                                 }
                                             }
                                             // Prevent reverting here too
@@ -5857,8 +5861,7 @@ public:
                                     } else {
                                         assgnd_allocatable.insert(sym);
                                     }
-                                } else if (sa->m_attr == AST::simple_attributeType
-                                        ::AttrAsynchronous) {
+                                } else if (sa->m_attr == AST::simple_attributeType::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
                                 } else {
                                     diag.add(Diagnostic(

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5869,7 +5869,7 @@ public:
                             }
                         }
                     }
-           // enable sole `dimension` attribute
+             // enable sole `dimension` attribute
         } else if (AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])) {
             for (size_t i=0;i<x.n_syms;++i) { // symbols for line only
                 AST::var_sym_t &s = x.m_syms[i];

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5823,7 +5823,7 @@ public:
                                             }
                                         }
                                     } else {
-                                        assgnd_allocatable.insert(sym);
+                                        assgnd_allocatable.insert(to_lower(sym));
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
@@ -7017,9 +7017,6 @@ public:
                 bool is_pointer = false;
                 if (assgnd_pointer.count(sym)) {
                     is_pointer = true;
-                }
-                if (assgnd_allocatable.count(sym)) {
-                    is_allocatable = true;
                 }
                 if (current_scope->get_symbol(sym) !=
                         nullptr) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2081,6 +2081,7 @@ public:
     ASR::presenceType dflt_presence = ASR::presenceType::Required;
     std::map<std::string, ASR::presenceType> assgnd_presence;
     std::set<std::string> assgnd_pointer;
+    std::set<std::string> assgnd_allocatable;
     // Current procedure arguments. Only non-empty for SymbolTableVisitor,
     // empty for BodyVisitor.
     std::vector<std::string> current_procedure_args;
@@ -5811,6 +5812,22 @@ public:
                                     } else {
                                         assgnd_pointer.insert(sym);
                                     }
+                                } else if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
+                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
+                                    if (sym_) {
+                                        ASR::symbol_t* sym_past_external =
+                                            ASRUtils::symbol_get_past_external(sym_);
+                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(
+                                                sym_past_external);
+                                            if (!ASRUtils::is_allocatable(v->m_type)) {
+                                                v->m_type = ASRUtils::TYPE(
+                                                    ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                            }
+                                        }
+                                    } else {
+                                        assgnd_allocatable.insert(sym);
+                                    }
                                 } else if (sa->m_attr == AST::simple_attributeType
                                         ::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
@@ -5839,6 +5856,12 @@ public:
                                                 v->m_type = ASRUtils::TYPE(
                                                     ASR::make_Pointer_t(al, x.base.base.loc, v->m_type));
                                             }
+                                        } else if (sym_ && sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_);
+                                            if (!ASRUtils::is_allocatable(v->m_type)) {
+                                                v->m_type = ASRUtils::TYPE(
+                                                    ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
+                                            }
                                         }
                                     }
                                 }
@@ -5850,30 +5873,25 @@ public:
                             }
                         }
                     }
-		    // enable sole `dimension` attribute
+            // enable sole `dimension` attribute
         } else if (AST::is_a<AST::AttrDimension_t>(*x.m_attributes[i])) {
             for (size_t i=0;i<x.n_syms;++i) { // symbols for line only
                 AST::var_sym_t &s = x.m_syms[i];
                 dimension_variable(s, x.base.base.loc);
             }
-		} else if (AST::is_a<AST::AttrCommon_t>(*x.m_attributes[i])) {
-		    AST::AttrCommon_t const & common_stmt =
-			*AST::down_cast<AST::AttrCommon_t>(x.m_attributes[i]);
-		    constexpr char BLANK_BLOCK[] = "blank#block";
-		    std::string common_block_name;
-		    /* Local dictionary to aggregate objects into:
-		       "COMMON A /B1/ B, // C", will put "A" and "C"
-		       in the blank block.  This should be done for
-		       the entire declaration-construct. */
-		    common_block_varsyms objs_by_blk;
-		    for (size_t bi = 0; bi < common_stmt.n_blks; ++bi) {
-			AST::common_block_t const &cb = common_stmt.m_blks[bi];
-			if (cb.m_name) {
-			    common_block_name = to_lower(cb.m_name);
-			} else {
-			    common_block_name = BLANK_BLOCK;
-			}
-
+        } else if (AST::is_a<AST::AttrCommon_t>(*x.m_attributes[i])) {
+            AST::AttrCommon_t const & common_stmt =
+            *AST::down_cast<AST::AttrCommon_t>(x.m_attributes[i]);
+            constexpr char BLANK_BLOCK[] = "blank#block";
+            std::string common_block_name;
+            common_block_varsyms objs_by_blk;
+            for (size_t bi = 0; bi < common_stmt.n_blks; ++bi) {
+            AST::common_block_t const &cb = common_stmt.m_blks[bi];
+            if (cb.m_name) {
+                common_block_name = to_lower(cb.m_name);
+            } else {
+                common_block_name = BLANK_BLOCK;
+            }
 			// Aggregate the objects into their named common blocks
 			for (size_t oi = 0; oi < cb.n_objects; ++oi) {
 			    AST::var_sym_t const & vs = cb.m_objects[oi];
@@ -7003,6 +7021,9 @@ public:
                 bool is_pointer = false;
                 if (assgnd_pointer.count(sym)) {
                     is_pointer = true;
+                }
+                if (assgnd_allocatable.count(sym)) {
+                    is_allocatable = true;
                 }
                 if (current_scope->get_symbol(sym) !=
                         nullptr) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2257,6 +2257,7 @@ public:
             bool is_ptr_standalone = assgnd_pointer.count(return_var_name);
 
             if (return_type && !(x.n_attributes == 0 && compiler_options.implicit_typing && compiler_options.implicit_interface)) {
+                // Bypass the strict F23 guard if the duplicate was just caused by a standalone attribute
                 if (!is_alloc_standalone && !is_ptr_standalone) {
                     diag.add(diag::Diagnostic(
                         "Cannot specify the return type twice",
@@ -2269,6 +2270,20 @@ public:
             return_var = (ASR::asr_t*) current_scope->get_symbol(return_var_name);
             ASR::Variable_t* return_variable = ASR::down_cast2<ASR::Variable_t>(return_var);
             return_variable->m_intent = ASRUtils::intent_return_var;
+
+            if (return_type && (is_alloc_standalone || is_ptr_standalone)) {
+                Vec<ASR::dimension_t> dummy_dims;
+                dummy_dims.reserve(al, 0);
+                ASR::symbol_t* dummy_type_decl = nullptr;
+                return_variable->m_type = determine_type(x.base.base.loc, return_var_name, (AST::decl_attribute_t*)return_type, false, false, dummy_dims, nullptr, dummy_type_decl, current_procedure_abi_type);
+            }
+
+            if (is_alloc_standalone && !ASRUtils::is_allocatable(return_variable->m_type)) {
+                return_variable->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, return_variable->m_type));
+            }
+            if (is_ptr_standalone && !ASRUtils::is_pointer(return_variable->m_type)) {
+                return_variable->m_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, return_variable->m_type));
+            }
 
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2175,9 +2175,9 @@ public:
                             dims.reserve(al, 0);
                             std::string sym = "";
                             ASR::ttype_t *contained_type = determine_type(x.base.base.loc, sym, 
-                                                                        return_attr_type->m_attr, false, 
-                                                                        false, dims, nullptr /*TODO : pass var_sym of return*/,
-                                                                        type_declaration, current_procedure_abi_type);
+                                                                return_attr_type->m_attr, false, 
+                                                                false, dims, nullptr /*TODO : pass var_sym of return*/,
+                                                                type_declaration, current_procedure_abi_type);
 
                             type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, contained_type));
                             break;
@@ -2249,7 +2249,6 @@ public:
 
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
-          
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
             // Add it as a local variable:
             return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2175,9 +2175,9 @@ public:
                             dims.reserve(al, 0);
                             std::string sym = "";
                             ASR::ttype_t *contained_type = determine_type(x.base.base.loc, sym, 
-                                                                return_attr_type->m_attr, false, 
-                                                                false, dims, nullptr /*TODO : pass var_sym of return*/,
-                                                                type_declaration, current_procedure_abi_type);
+                                                                        return_attr_type->m_attr, false, 
+                                                                        false, dims, nullptr /*TODO : pass var_sym of return*/,
+                                                                        type_declaration, current_procedure_abi_type);
 
                             type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, contained_type));
                             break;
@@ -2213,6 +2213,23 @@ public:
                             diag::Label("", {x.base.base.loc})}));
                     throw SemanticAbort();
             }
+
+            // Loop through function attributes to catch inline allocatable/pointer declarations
+            for (size_t i = 0; i < x.n_attributes; i++) {
+                if (AST::is_a<AST::SimpleAttribute_t>(*x.m_attributes[i])) {
+                    AST::SimpleAttribute_t *sa = AST::down_cast<AST::SimpleAttribute_t>(x.m_attributes[i]);
+                    if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
+                        if (!ASRUtils::is_allocatable(type)) {
+                            type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, type));
+                        }
+                    } else if (sa->m_attr == AST::simple_attributeType::AttrPointer) {
+                        if (!ASRUtils::is_pointer(type)) {
+                            type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, type));
+                        }
+                    }
+                }
+            }
+
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2230,8 +2230,26 @@ public:
                 }
             }
 
+            // Catch standalone declarations (e.g., `allocatable :: value`) parsed earlier in this pass
+            bool is_alloc_standalone = false;
+            bool is_ptr_standalone = false;
+            for (const auto& a_name : assgnd_allocatable) {
+                if (to_lower(a_name) == return_var_name) is_alloc_standalone = true;
+            }
+            for (const auto& p_name : assgnd_pointer) {
+                if (to_lower(p_name) == return_var_name) is_ptr_standalone = true;
+            }
+
+            if (is_alloc_standalone && !ASRUtils::is_allocatable(type)) {
+                type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, type));
+            }
+            if (is_ptr_standalone && !ASRUtils::is_pointer(type)) {
+                type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, type));
+            }
+
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
+          
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
             // Add it as a local variable:
             return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2231,8 +2231,8 @@ public:
             }
 
             // Catch standalone declarations (e.g., `allocatable :: value`) parsed earlier in this pass
-            bool is_alloc_standalone = assgnd_allocatable.count(return_var_name) > 0;
-            bool is_ptr_standalone = assgnd_pointer.count(return_var_name) > 0;
+            bool is_alloc_standalone = assgnd_allocatable.count(return_var_name);
+            bool is_ptr_standalone = assgnd_pointer.count(return_var_name);
 
             if (is_alloc_standalone && !ASRUtils::is_allocatable(type)) {
                 type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, type));
@@ -2253,12 +2253,17 @@ public:
                 false);
             current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
         } else {
+            bool is_alloc_standalone = assgnd_allocatable.count(return_var_name);
+            bool is_ptr_standalone = assgnd_pointer.count(return_var_name);
+
             if (return_type && !(x.n_attributes == 0 && compiler_options.implicit_typing && compiler_options.implicit_interface)) {
-                diag.add(diag::Diagnostic(
-                    "Cannot specify the return type twice",
-                    diag::Level::Error, diag::Stage::Semantic, {
-                        diag::Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
+                if (!is_alloc_standalone && !is_ptr_standalone) {
+                    diag.add(diag::Diagnostic(
+                        "Cannot specify the return type twice",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {x.base.base.loc})}));
+                    throw SemanticAbort();
+                }
             }
             // Extract the variable from the local scope
             return_var = (ASR::asr_t*) current_scope->get_symbol(return_var_name);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2231,14 +2231,8 @@ public:
             }
 
             // Catch standalone declarations (e.g., `allocatable :: value`) parsed earlier in this pass
-            bool is_alloc_standalone = false;
-            bool is_ptr_standalone = false;
-            for (const auto& a_name : assgnd_allocatable) {
-                if (to_lower(a_name) == return_var_name) is_alloc_standalone = true;
-            }
-            for (const auto& p_name : assgnd_pointer) {
-                if (to_lower(p_name) == return_var_name) is_ptr_standalone = true;
-            }
+            bool is_alloc_standalone = assgnd_allocatable.count(return_var_name) > 0;
+            bool is_ptr_standalone = assgnd_pointer.count(return_var_name) > 0;
 
             if (is_alloc_standalone && !ASRUtils::is_allocatable(type)) {
                 type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, type));
@@ -2259,43 +2253,17 @@ public:
                 false);
             current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
         } else {
-            bool is_alloc_standalone = false;
-            bool is_ptr_standalone = false;
-            for (const auto& a_name : assgnd_allocatable) {
-                if (to_lower(a_name) == return_var_name) is_alloc_standalone = true;
-            }
-            for (const auto& p_name : assgnd_pointer) {
-                if (to_lower(p_name) == return_var_name) is_ptr_standalone = true;
-            }
-
             if (return_type && !(x.n_attributes == 0 && compiler_options.implicit_typing && compiler_options.implicit_interface)) {
-                if (!is_alloc_standalone && !is_ptr_standalone) {
-                    diag.add(diag::Diagnostic(
-                        "Cannot specify the return type twice",
-                        diag::Level::Error, diag::Stage::Semantic, {
-                            diag::Label("", {x.base.base.loc})}));
-                    throw SemanticAbort();
-                }
+                diag.add(diag::Diagnostic(
+                    "Cannot specify the return type twice",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
             }
             // Extract the variable from the local scope
             return_var = (ASR::asr_t*) current_scope->get_symbol(return_var_name);
             ASR::Variable_t* return_variable = ASR::down_cast2<ASR::Variable_t>(return_var);
             return_variable->m_intent = ASRUtils::intent_return_var;
-
-            if (return_type && (is_alloc_standalone || is_ptr_standalone)) {
-                Vec<ASR::dimension_t> dummy_dims;
-                dummy_dims.reserve(al, 0);
-                ASR::symbol_t* dummy_type_decl = nullptr;
-                return_variable->m_type = determine_type(x.base.base.loc, return_var_name, (AST::decl_attribute_t*)return_type, false, false, dummy_dims, nullptr, dummy_type_decl, current_procedure_abi_type);
-            }
-            
-            // Upgrade the implicitly typed variable to Allocatable or Pointer
-            if (is_alloc_standalone && !ASRUtils::is_allocatable(return_variable->m_type)) {
-                return_variable->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, return_variable->m_type));
-            }
-            if (is_ptr_standalone && !ASRUtils::is_pointer(return_variable->m_type)) {
-                return_variable->m_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, return_variable->m_type));
-            }
 
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2282,6 +2282,13 @@ public:
             return_var = (ASR::asr_t*) current_scope->get_symbol(return_var_name);
             ASR::Variable_t* return_variable = ASR::down_cast2<ASR::Variable_t>(return_var);
             return_variable->m_intent = ASRUtils::intent_return_var;
+
+            if (return_type && (is_alloc_standalone || is_ptr_standalone)) {
+                Vec<ASR::dimension_t> dummy_dims;
+                dummy_dims.reserve(al, 0);
+                ASR::symbol_t* dummy_type_decl = nullptr;
+                return_variable->m_type = determine_type(x.base.base.loc, return_var_name, (AST::decl_attribute_t*)return_type, false, false, dummy_dims, nullptr, dummy_type_decl, current_procedure_abi_type);
+            }
             
             // Upgrade the implicitly typed variable to Allocatable or Pointer
             if (is_alloc_standalone && !ASRUtils::is_allocatable(return_variable->m_type)) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2260,17 +2260,37 @@ public:
                 false);
             current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
         } else {
+            bool is_alloc_standalone = false;
+            bool is_ptr_standalone = false;
+            for (const auto& a_name : assgnd_allocatable) {
+                if (to_lower(a_name) == return_var_name) is_alloc_standalone = true;
+            }
+            for (const auto& p_name : assgnd_pointer) {
+                if (to_lower(p_name) == return_var_name) is_ptr_standalone = true;
+            }
+
             if (return_type && !(x.n_attributes == 0 && compiler_options.implicit_typing && compiler_options.implicit_interface)) {
-                diag.add(diag::Diagnostic(
-                    "Cannot specify the return type twice",
-                    diag::Level::Error, diag::Stage::Semantic, {
-                        diag::Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
+                if (!is_alloc_standalone && !is_ptr_standalone) {
+                    diag.add(diag::Diagnostic(
+                        "Cannot specify the return type twice",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {x.base.base.loc})}));
+                    throw SemanticAbort();
+                }
             }
             // Extract the variable from the local scope
             return_var = (ASR::asr_t*) current_scope->get_symbol(return_var_name);
             ASR::Variable_t* return_variable = ASR::down_cast2<ASR::Variable_t>(return_var);
             return_variable->m_intent = ASRUtils::intent_return_var;
+            
+            // Upgrade the implicitly typed variable to Allocatable or Pointer
+            if (is_alloc_standalone && !ASRUtils::is_allocatable(return_variable->m_type)) {
+                return_variable->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, return_variable->m_type));
+            }
+            if (is_ptr_standalone && !ASRUtils::is_pointer(return_variable->m_type)) {
+                return_variable->m_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, return_variable->m_type));
+            }
+
             SetChar variable_dependencies_vec;
             variable_dependencies_vec.reserve(al, 1);
             ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, return_variable->m_type,
@@ -2278,7 +2298,6 @@ public:
             return_variable->m_dependencies = variable_dependencies_vec.p;
             return_variable->n_dependencies = variable_dependencies_vec.size();
         }
-
         ASR::asr_t *return_var_ref = ASR::make_Var_t(al, x.base.base.loc,
             ASR::down_cast<ASR::symbol_t>(return_var));
 


### PR DESCRIPTION
Fixes #11765 
This PR resolves semantic and implicit typing collisions (--std=f23) caused when an allocatable or pointer attribute is declared as a standalone statement for a function's return variable. Previously, because the return variable isn't fully registered in the symbol table until visit_Function processes the signature, these standalone attributes would either fail to resolve or trigger premature implicit variable creation, resulting in a "Cannot specify the return type twice" error. To fix this, assgnd_allocatable tracking was introduced in ast_common_visitor.h to properly apply Allocatable_t/Pointer_t wrappers during return type construction. Additionally, current_function_return_var_name state tracking was added to block premature implicit typing of the return variable, and the hash-based implicit dictionary was replaced with a robust implicit_stack to ensure clean, standard-compliant state restoration across nested procedures.