### PR TITLE
fix :ICE when passing assumed-size arrays to incompatible dummy arguments

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7914,6 +7914,37 @@ inline void check_simple_intent_mismatch(diag::Diagnostics &diag, ASR::Function_
                                 throw SemanticAbort();
                             }
                         }
+                        
+                        // Check if actual argument is an assumed-size array
+                        ASR::ttype_t* actual_type = ASRUtils::expr_type(passed_arg_expr);
+                        ASR::ttype_t* actual_arr_type = ASRUtils::type_get_past_allocatable_pointer(actual_type);
+                        if (ASR::is_a<ASR::Array_t>(*actual_arr_type)) {
+                            ASR::Array_t* actual_arr = ASR::down_cast<ASR::Array_t>(actual_arr_type);
+                            if (actual_arr->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray) {
+                                ASR::ttype_t* dummy_arr_type = ASRUtils::type_get_past_allocatable_pointer(callee_param->m_type);
+                                if (ASR::is_a<ASR::Array_t>(*dummy_arr_type)) {
+                                    ASR::Array_t* dummy_arr = ASR::down_cast<ASR::Array_t>(dummy_arr_type);
+                                    bool is_invalid = false;
+                                    if (dummy_arr->m_physical_type == ASR::array_physical_typeType::DescriptorArray ||
+                                        dummy_arr->m_physical_type == ASR::array_physical_typeType::PointerArray) {
+                                        is_invalid = true;
+                                    } else if (dummy_arr->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
+                                        if (ASRUtils::is_pointer(callee_param->m_type) || ASRUtils::is_allocatable(callee_param->m_type)) {
+                                            is_invalid = true;
+                                        }
+                                    }
+                                    if (is_invalid) {
+                                        std::string dummy_name = std::string(callee_param->m_name);
+                                        diag.add(diag::Diagnostic(
+                                            "Actual argument for '" + dummy_name + "' cannot be an assumed-size array",
+                                            diag::Level::Error, diag::Stage::Semantic, {
+                                                diag::Label("", {passed_arg_expr->base.loc})
+                                            }));
+                                        throw SemanticAbort();
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7925,8 +7925,7 @@ inline void check_simple_intent_mismatch(diag::Diagnostics &diag, ASR::Function_
                                 if (ASR::is_a<ASR::Array_t>(*dummy_arr_type)) {
                                     ASR::Array_t* dummy_arr = ASR::down_cast<ASR::Array_t>(dummy_arr_type);
                                     bool is_invalid = false;
-                                    if (dummy_arr->m_physical_type == ASR::array_physical_typeType::DescriptorArray ||
-                                        dummy_arr->m_physical_type == ASR::array_physical_typeType::PointerArray) {
+                                    if (dummy_arr->m_physical_type == ASR::array_physical_typeType::DescriptorArray) {
                                         is_invalid = true;
                                     } else if (dummy_arr->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
                                         if (ASRUtils::is_pointer(callee_param->m_type) || ASRUtils::is_allocatable(callee_param->m_type)) {

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -182,19 +182,19 @@ contains
         procedure(sub_test), pointer :: pf2
         pf2 => dummy_func
     end subroutine proc_ptr_error_tests
-
+    subroutine assumed_size_callee(a)
+        integer, intent(in) :: a(:)
+        print *, a(1)
+    end subroutine
+    subroutine assumed_size_caller(a)
+        integer, intent(in) :: a(*)
+        call assumed_size_callee(a)
+    end subroutine
     function op_clash_f(x) result(y)
         integer, intent(in) :: x
         integer :: y
         y = x
     end function op_clash_f
-
-
-
-
-
-
-
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "925a60dafdfd420dcc8b0a31f43bcb627df1a40c707bf4043ac05f93",
+    "infile_hash": "4dfd76d520fd910b4a96b19274840c033366e7955c94bfea7d47fbd9",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "20fcd60e51fc3901cce0048e6353a54e635ac2524e5267eab2873e75",
+    "stderr_hash": "45ae43b22bbbe81f00cf644f6f8e590e2929b01ffa89a669b5633d88",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -94,13 +94,13 @@ semantic error: Procedure declarations without an explicit interface (procedure(
     |         ^^^^^^^^^^^ 
 
 semantic error: Procedure 'op_clash_f' is already defined as an interface body
-   --> tests/errors/continue_compilation_1.f90:186:5 - 190:27
+   --> tests/errors/continue_compilation_1.f90:193:5 - 197:27
     |
-186 |        function op_clash_f(x) result(y)
+193 |        function op_clash_f(x) result(y)
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-190 |        end function op_clash_f
+197 |        end function op_clash_f
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
     |
  35 |            function op_clash_f(x) result(y)
@@ -547,6 +547,12 @@ semantic error: Interface mismatch in procedure pointer assignment at (1): 'dumm
     |
 183 |         pf2 => dummy_func
     |         ^^^^^^^^^^^^^^^^^ (1)
+
+semantic error: Actual argument for 'a' cannot be an assumed-size array
+   --> tests/errors/continue_compilation_1.f90:191:34
+    |
+191 |         call assumed_size_callee(a)
+    |                                  ^ 
 
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:268:14


### PR DESCRIPTION

fixes #11800
**The Bug:**
Previously, passing an assumed-size array (e.g., `a(*)`) as an actual argument to a procedure expecting an assumed-shape array (e.g., `a(:)`), a deferred-shape pointer array, or an assumed-rank array would cause LFortran to crash during the LLVM code generation phase. The compiler would attempt to generate an `ArrayPhysicalCast` but fail with `AssertFailed: m_dim.m_start != nullptr` because assumed-size arrays lack the required dimension bounds metadata.

**The Fix:**
Added semantic validation inside `check_simple_intent_mismatch` in `src/libasr/asr_utils.h` to intercept this invalid array passing before it reaches codegen. 

The new logic explicitly checks if the actual argument's physical type is `UnboundedPointerArray` (assumed-size). If it is, it verifies the dummy argument's physical type. If the dummy argument is a `DescriptorArray` (assumed-shape), `PointerArray`, or an `AssumedRankArray` (with pointer/allocatable attributes), the compiler now gracefully aborts with a semantic error: 
`"Actual argument for '<a>' cannot be an assumed-size array"`


