### PR TITLE
fix: ICE for c_f_pointer with array pointer missing shape argument

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -6756,7 +6756,7 @@ public:
                 "shape argument not specified in c_f_pointer "
                 "even though fptr is an array.",
                 Level::Error, Stage::Semantic, {
-                    Label("",{shape->base.loc})
+                    Label("",{fptr->base.loc})
                 }));
             throw SemanticAbort();
         }

--- a/tests/errors/continue_compilation_2.f90
+++ b/tests/errors/continue_compilation_2.f90
@@ -254,8 +254,8 @@ program continue_compilation_2
     character(8) :: badfmt_s = '(a i0)'
     character(:), allocatable :: ax
     integer :: a_deferred(:)
-    
-
+    type(c_ptr) :: queries_3
+    integer, pointer :: cfp_y_3(:)
 
 
 
@@ -537,8 +537,8 @@ program continue_compilation_2
     print "(aai6)", a,"hi",15
     call sleep(1)
     a = cmplx(y = 2)
-    
-
+    ! c_f_pointer_03
+    call c_f_pointer(queries_3, cfp_y_3)    
 
 
 

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_2-a6145a1",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_2.f90",
-    "infile_hash": "4484372b6ed718f6b991ab6b9e7d8be1e0994e334afb82d0ab6e15fc",
+    "infile_hash": "d5b6a9d7147f307bf11923027d8838b001e9b4abc5fd3a60112c106b",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "f295a8de43dfa1f7c9d43145d479ff2515466778bfc13990be8b2336",
+    "stderr_hash": "8ecd840bb3fe130a084e393f35ea19bdf46595501bf86a46b623b415",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -1003,3 +1003,9 @@ semantic error: Missing actual argument 'x' in call to 'cmplx'
     |
 539 |     a = cmplx(y = 2)
     |         ^^^^^^^^^^^^ 
+
+semantic error: shape argument not specified in c_f_pointer even though fptr is an array.
+   --> tests/errors/continue_compilation_2.f90:541:33
+    |
+541 |     call c_f_pointer(queries_3, cfp_y_3)    
+    |                                 ^^^^^^^ 


### PR DESCRIPTION
fixes #11830