### PR TITLE
fix: add semantic checks for stat and errmsg arguments of sync all

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4580,6 +4580,7 @@ RUN(NAME allocatable_component_unnamed_unallocated_01 LABELS gfortran llvm EXTRA
 RUN(NAME allocatable_oob_01 FAIL LABELS gfortran llvm NO_FAST GFORTRAN_ARGS -fcheck=bounds)
 
 RUN(NAME sync_all_01 LABELS llvm)
+RUN(NAME sync_all_02 LABELS gfortran llvm GFORTRAN_ARGS -fcoarray=single)
 RUN(NAME sync_memory_01 LABELS llvm)
 
 RUN(NAME random_init_01 LABELS gfortran llvm)

--- a/integration_tests/sync_all_02.f90
+++ b/integration_tests/sync_all_02.f90
@@ -1,0 +1,10 @@
+program sync_all_02
+implicit none
+integer :: istat
+character(len=64) :: emsg
+istat = 0
+emsg = ""
+sync all (stat=istat, errmsg=emsg)
+if (istat /= 0) error stop
+print *, "ok"
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -9285,12 +9285,48 @@ public:
             AST::event_attribute_t *attr = x.m_stat[i];
             if (AST::is_a<AST::AttrStat_t>(*attr)) {
                 auto *s = AST::down_cast<AST::AttrStat_t>(attr);
-                ASR::symbol_t *sym = current_scope->resolve_symbol(s->m_variable);
-                stat = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, sym));
+                stat = ASRUtils::EXPR(resolve_variable(x.base.base.loc,
+                    to_lower(s->m_variable)));
+                ASR::ttype_t *stat_type = ASRUtils::expr_type(stat);
+                if (ASRUtils::is_array(stat_type)) {
+                    diag.add(Diagnostic(
+                        "`stat` argument of `sync all` must be scalar",
+                        Level::Error, Stage::Semantic, {
+                            Label("",{x.base.base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
+                if (!ASRUtils::is_integer(*stat_type)) {
+                    diag.add(Diagnostic(
+                        "`stat` argument of `sync all` must be of type integer, found "
+                        + ASRUtils::type_to_str_fortran_expr(stat_type, stat),
+                        Level::Error, Stage::Semantic, {
+                            Label("",{x.base.base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
             } else if (AST::is_a<AST::AttrErrmsg_t>(*attr)) {
                 auto *e = AST::down_cast<AST::AttrErrmsg_t>(attr);
-                ASR::symbol_t *sym = current_scope->resolve_symbol(e->m_variable);
-                errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, sym));
+                errmsg = ASRUtils::EXPR(resolve_variable(x.base.base.loc,
+                    to_lower(e->m_variable)));
+                ASR::ttype_t *errmsg_type = ASRUtils::expr_type(errmsg);
+                if (ASRUtils::is_array(errmsg_type)) {
+                    diag.add(Diagnostic(
+                        "`errmsg` argument of `sync all` must be scalar",
+                        Level::Error, Stage::Semantic, {
+                            Label("",{x.base.base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
+                if (!ASRUtils::is_character(*errmsg_type)) {
+                    diag.add(Diagnostic(
+                        "`errmsg` argument of `sync all` must be of type character, found "
+                        + ASRUtils::type_to_str_fortran_expr(errmsg_type, errmsg),
+                        Level::Error, Stage::Semantic, {
+                            Label("",{x.base.base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
             }
         }
         tmp = ASR::make_SyncAll_t(al, x.base.base.loc, stat, errmsg);

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1783,6 +1783,26 @@ public:
         BaseWalkVisitor<VerifyVisitor>::visit_Allocate(x);
     }
 
+    void visit_SyncAll(const SyncAll_t &x) {
+        if (x.m_stat) {
+            ASR::ttype_t *stat_type = ASRUtils::expr_type(x.m_stat);
+            require(!ASRUtils::is_array(stat_type),
+                "SyncAll::m_stat must be a scalar");
+            require(ASRUtils::is_integer(*stat_type),
+                "SyncAll::m_stat must be of integer type, found " +
+                std::string(ASRUtils::get_type_code(stat_type)));
+        }
+        if (x.m_errmsg) {
+            ASR::ttype_t *errmsg_type = ASRUtils::expr_type(x.m_errmsg);
+            require(!ASRUtils::is_array(errmsg_type),
+                "SyncAll::m_errmsg must be a scalar");
+            require(ASRUtils::is_character(*errmsg_type),
+                "SyncAll::m_errmsg must be of string type, found " +
+                std::string(ASRUtils::get_type_code(errmsg_type)));
+        }
+        BaseWalkVisitor<VerifyVisitor>::visit_SyncAll(x);
+    }
+
     void visit_DoConcurrentLoop(const DoConcurrentLoop_t &x) {
         for ( size_t i = 0; i < x.n_local; i++ ) {
             require(ASR::is_a<ASR::Var_t>(*x.m_local[i]),

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -753,4 +753,23 @@ program continue_compilation_1
         call cpu_time(*1)
 1       continue
     end subroutine 
+    subroutine sync_all_stat_wrong_type()
+        implicit none
+        character(len=10) :: cstat
+        sync all (stat=cstat)  ! {Error} `stat` argument of `sync all` must be of type integer
+    end subroutine
+    subroutine sync_all_errmsg_wrong_type()
+        implicit none
+        integer :: imsg
+        sync all (errmsg=imsg)  ! {Error} `errmsg` argument of `sync all` must be of type character
+    end subroutine
+    subroutine sync_all_stat_array()
+        implicit none
+        integer :: astat(3)
+        sync all (stat=astat)  ! {Error} `stat` argument of `sync all` must be scalar
+    end subroutine
+    subroutine sync_all_stat_undeclared()
+        implicit none
+        sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "eb992e024ea132b9dbb4b322e41cbac9460962b5d7c78c4bdc06bea8",
+    "infile_hash": "6e1f6944039ff2271581b1f828a11a7dc0bb8512a6fced1bad1db1f5",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "af33874114310cb2230e916080676808242b06f224e624af54160cf9",
+    "stderr_hash": "2d2ebe676c400b2b4471bd3a5ca7e5f7b388938c2c586d63a5143797",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1611,3 +1611,27 @@ semantic error: Alternate return arguments are not permitted in calls to the 'cp
     |
 753 |         call cpu_time(*1)
     |         ^^^^^^^^^^^^^^^^^ 
+
+semantic error: `stat` argument of `sync all` must be of type integer, found string
+   --> tests/errors/continue_compilation_1.f90:759:9
+    |
+759 |         sync all (stat=cstat)  ! {Error} `stat` argument of `sync all` must be of type integer
+    |         ^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `errmsg` argument of `sync all` must be of type character, found integer
+   --> tests/errors/continue_compilation_1.f90:764:9
+    |
+764 |         sync all (errmsg=imsg)  ! {Error} `errmsg` argument of `sync all` must be of type character
+    |         ^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `stat` argument of `sync all` must be scalar
+   --> tests/errors/continue_compilation_1.f90:769:9
+    |
+769 |         sync all (stat=astat)  ! {Error} `stat` argument of `sync all` must be scalar
+    |         ^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Variable 'nosuch' is not declared
+   --> tests/errors/continue_compilation_1.f90:773:9
+    |
+773 |         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
+    |         ^^^^^^^^^^^^^^^^^^^^^^ 'nosuch' is undeclared


### PR DESCRIPTION
fixes #11798

`sync all` accepted `stat` and `errmsg` arguments of any type. A character `stat` or an integer `errmsg` compiled silently, and an undeclared variable crashed later since the Var node was built with a null symbol.

`visit_SyncAll` now resolves the variables through `resolve_variable` and raises a semantic error unless `stat` is a scalar integer and `errmsg` is a scalar character. Also added the asr_verify assertions requested in the #11781 review discussion.

Added error cases to `continue_compilation_1.f90` (references updated) and a `sync_all_02` integration test for valid usage. Reference and integration suites (llvm, gfortran) pass locally.