### PR TITLE
fix: compile-time evaluation and ICEs for array-scalar operations in implied-do loops

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3363,6 +3363,7 @@ RUN(NAME implied_do_loops37 LABELS gfortran llvm)
 RUN(NAME implied_do_loops38 LABELS gfortran llvm EXTRA_ARGS --use-loop-variable-after-loop)
 RUN(NAME implied_do_loops39 LABELS gfortran llvm)
 RUN(NAME implied_do_loops40 LABELS gfortran llvm)
+RUN(NAME implied_do_loops41 LABELS gfortran llvm)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops41.f90
+++ b/integration_tests/implied_do_loops41.f90
@@ -1,0 +1,22 @@
+program implied_do_loops41
+    implicit none
+
+    integer :: i
+    integer, parameter :: dims(2) = [2, 2]
+    integer, parameter :: values_mul(2) = [(dims*i, i=1,1)]
+    integer, parameter :: values_add(2) = [(dims+i, i=2,2)]
+    integer, parameter :: values_sub(2) = [(dims-i, i=1,1)]
+    integer, parameter :: values_div(2) = [(dims/i, i=2,2)]
+    
+    integer, parameter :: exp_mul(2) = [2, 2]
+    integer, parameter :: exp_add(2) = [4, 4]
+    integer, parameter :: exp_sub(2) = [1, 1]
+    integer, parameter :: exp_div(2) = [1, 1]
+
+    if (any(values_mul /= exp_mul)) error stop "Mul failed"
+    if (any(values_add /= exp_add)) error stop "Add failed"
+    if (any(values_sub /= exp_sub)) error stop "Sub failed"
+    if (any(values_div /= exp_div)) error stop "Div failed"
+
+    print *, values_mul
+end program implied_do_loops41

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -448,34 +448,67 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
     }
 
     void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
-        int left_val, right_val;
+        value = nullptr;
         this->visit_expr(*x.m_left);
-        left_val = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
+        ASR::expr_t* left_val = value;
+        value = nullptr;
         this->visit_expr(*x.m_right);
-        right_val = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
-        int res;
-        switch (x.m_op) {
-            case ASR::binopType::Mul:
-                res = left_val * right_val;
-                break;
-            case ASR::binopType::Add:
-                res = left_val + right_val;
-                break;
-            case ASR::binopType::Sub:
-                res = left_val - right_val;
-                break;
-            case ASR::binopType::Div:
-                res = left_val / right_val;
-                break;
-            case ASR::binopType::Pow:
-                res = std::pow(left_val, right_val);
-                break;
-            default:
-                diag.add(Diagnostic("Unsupported binary operation in implied do loop",
-                                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
+        ASR::expr_t* right_val = value;
+
+        if (left_val && right_val) {
+            bool left_is_array = ASR::is_a<ASR::ArrayConstant_t>(*left_val);
+            bool right_is_array = ASR::is_a<ASR::ArrayConstant_t>(*right_val);
+
+            if (left_is_array || right_is_array) {
+                ASR::ArrayConstant_t* arr = ASR::down_cast<ASR::ArrayConstant_t>(left_is_array ? left_val : right_val);
+                int32_t scalar = ASR::down_cast<ASR::IntegerConstant_t>(left_is_array ? right_val : left_val)->m_n;
+                int64_t n_data = arr->m_n_data;
+                int64_t n_elements = n_data / sizeof(int32_t);
+                int32_t* new_data = al.allocate<int32_t>(n_elements);
+                int32_t* old_data = (int32_t*)arr->m_data;
+                for(int64_t i=0; i<n_elements; ++i) {
+                    int32_t a = left_is_array ? old_data[i] : scalar;
+                    int32_t b = left_is_array ? scalar : old_data[i];
+                    switch (x.m_op) {
+                        case ASR::binopType::Add: new_data[i] = a + b; break;
+                        case ASR::binopType::Sub: new_data[i] = a - b; break;
+                        case ASR::binopType::Mul: new_data[i] = a * b; break;
+                        case ASR::binopType::Div: new_data[i] = b != 0 ? a / b : 0; break;
+                        case ASR::binopType::Pow: new_data[i] = std::pow(a, b); break;
+                        default: new_data[i] = 0; break;
+                    }
+                }
+                value = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, x.base.base.loc, n_data, new_data, x.m_type, ASR::arraystorageType::ColMajor));
+                return;
+            }
+
+            // Both are scalars
+            int32_t a = ASR::down_cast<ASR::IntegerConstant_t>(left_val)->m_n;
+            int32_t b = ASR::down_cast<ASR::IntegerConstant_t>(right_val)->m_n;
+            int32_t res;
+            switch (x.m_op) {
+                case ASR::binopType::Mul: res = a * b; break;
+                case ASR::binopType::Add: res = a + b; break;
+                case ASR::binopType::Sub: res = a - b; break;
+                case ASR::binopType::Div: res = a / b; break;
+                case ASR::binopType::Pow: res = std::pow(a, b); break;
+                default:
+                    diag.add(Diagnostic("Unsupported binary operation in implied do loop",
+                                        Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                    throw SemanticAbort();
+            }
+            value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, res, x.m_type));
+        } else {
+            value = nullptr;
         }
-        value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, res, x.m_type));
+    }
+
+    void visit_ArrayConstant(const ASR::ArrayConstant_t &x) {
+        value = const_cast<ASR::expr_t*>(&(x.base));
+    }
+
+    void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {
+        this->visit_expr(*x.m_array);
     }
 
     void visit_RealBinOp(const ASR::RealBinOp_t &x) {
@@ -10832,7 +10865,7 @@ public:
                 }
             }
             if (type == nullptr) {
-                type = expr_type;
+                type = ASRUtils::extract_type(expr_type);
                 extracted_type = ASRUtils::extract_type(type);
                 if (ASR::is_a<ASR::Tuple_t>(*extracted_type)) {
                      ASR::Tuple_t *t = ASR::down_cast<ASR::Tuple_t>(extracted_type);
@@ -16148,6 +16181,30 @@ public:
                 if (ASR::is_a<ASR::ImpliedDoLoop_t>(*idl->m_values[i])) {
                     curr_nesting_level++;
                     populate_compiletime_array_for_idl(ASR::down_cast<ASR::ImpliedDoLoop_t>(idl->m_values[i]), array, loop_vars, loop_indices, curr_nesting_level, itr);
+                } else if (ASRUtils::is_array(ASRUtils::expr_type(idl->m_values[i]))) {
+                    ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
+                    visitor.value = nullptr;
+                    visitor.visit_expr(*idl->m_values[i]);
+                    if (visitor.value && ASR::is_a<ASR::ArrayConstant_t>(*visitor.value)) {
+                        ASR::ArrayConstant_t* arr = ASR::down_cast<ASR::ArrayConstant_t>(visitor.value);
+                        if constexpr (std::is_same_v<T,int32_t>) {
+                            int32_t* arr_data = (int32_t*)arr->m_data;
+                            for(int64_t k=0; k < arr->m_n_data / (int64_t)sizeof(int32_t); ++k) {
+                                array.push_back(al, arr_data[k]);
+                                itr++;
+                            }
+                        } else if constexpr (std::is_same_v<T,int64_t>) {
+                            int64_t* arr_data = (int64_t*)arr->m_data;
+                            for(int64_t k=0; k < arr->m_n_data / (int64_t)sizeof(int64_t); ++k) {
+                                array.push_back(al, arr_data[k]);
+                                itr++;
+                            }
+                        }
+                    } else {
+                        // fallback
+                        array.push_back(al, get_constant_value<T>(idl->m_values[i], visitor));
+                        itr++;
+                    }
                 } else {
                     ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
                     array.push_back(al, get_constant_value<T>(idl->m_values[i], visitor));
@@ -16338,11 +16395,12 @@ public:
                 if (ASRUtils::is_character(*type)) {
                     physical_type = ASR::array_physical_typeType::PointerArray;
                 }
-                ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, x.base.base.loc, type, dims.p, dims.n, physical_type));
-                int64_t n_data = itr * ASRUtils::extract_kind_from_ttype_t(type);
-                if (ASRUtils::is_character(*type)) {
+                ASR::ttype_t* base_type = ASRUtils::extract_type(type);
+                ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, x.base.base.loc, base_type, dims.p, dims.n, physical_type));
+                int64_t n_data = itr * ASRUtils::extract_kind_from_ttype_t(base_type);
+                if (ASRUtils::is_character(*base_type)) {
                     int len;
-                    if(!ASRUtils::extract_value(ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(type))->m_len, len)){
+                    if(!ASRUtils::extract_value(ASR::down_cast<ASR::String_t>(base_type)->m_len, len)){
                         LCOMPILERS_ASSERT(false);
                     }
                     n_data = itr * len;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -174,6 +174,7 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
     ASR::expr_t* value;
     ASR::ttype_t* type;
     diag::Diagnostics& diag;
+    int64_t element_idx;
     const std::map<ASRUtils::IntrinsicElementalFunctions, size_t> name2signature_varargs = {
         // max0 can accept any arbitrary number of arguments 2<=x<=100
         {ASRUtils::IntrinsicElementalFunctions::Max, 100},
@@ -205,7 +206,7 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
 
     ImpliedDoLoopValuesVisitor(Allocator& al, std::vector<ASR::symbol_t*>& loop_vars, std::vector<int>& loop_indices, ASR::expr_t* value_,
         ASR::ttype_t* type, diag::Diagnostics& diag) :
-        al(al), loop_vars(loop_vars), loop_indices(loop_indices), value(value_), type(type), diag(diag) {}
+        al(al), loop_vars(loop_vars), loop_indices(loop_indices), value(value_), type(type), diag(diag), element_idx(-1) {}
 
     void visit_Var(const ASR::Var_t &x) {
         int loop_var_index = std::find(loop_vars.begin(), loop_vars.end(), x.m_v) - loop_vars.begin();
@@ -447,6 +448,8 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
             s2c(al, result), x.m_type));
     }
 
+
+
     void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
         value = nullptr;
         this->visit_expr(*x.m_left);
@@ -456,41 +459,15 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
         ASR::expr_t* right_val = value;
 
         if (left_val && right_val) {
-            bool left_is_array = ASR::is_a<ASR::ArrayConstant_t>(*left_val);
-            bool right_is_array = ASR::is_a<ASR::ArrayConstant_t>(*right_val);
+            int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(left_val)->m_n;
+            int64_t b = ASR::down_cast<ASR::IntegerConstant_t>(right_val)->m_n;
+            int64_t res;
 
-            if (left_is_array || right_is_array) {
-                ASR::ArrayConstant_t* arr = ASR::down_cast<ASR::ArrayConstant_t>(left_is_array ? left_val : right_val);
-                int32_t scalar = ASR::down_cast<ASR::IntegerConstant_t>(left_is_array ? right_val : left_val)->m_n;
-                int64_t n_data = arr->m_n_data;
-                int64_t n_elements = n_data / sizeof(int32_t);
-                int32_t* new_data = al.allocate<int32_t>(n_elements);
-                int32_t* old_data = (int32_t*)arr->m_data;
-                for(int64_t i=0; i<n_elements; ++i) {
-                    int32_t a = left_is_array ? old_data[i] : scalar;
-                    int32_t b = left_is_array ? scalar : old_data[i];
-                    switch (x.m_op) {
-                        case ASR::binopType::Add: new_data[i] = a + b; break;
-                        case ASR::binopType::Sub: new_data[i] = a - b; break;
-                        case ASR::binopType::Mul: new_data[i] = a * b; break;
-                        case ASR::binopType::Div: new_data[i] = b != 0 ? a / b : 0; break;
-                        case ASR::binopType::Pow: new_data[i] = std::pow(a, b); break;
-                        default: new_data[i] = 0; break;
-                    }
-                }
-                value = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, x.base.base.loc, n_data, new_data, x.m_type, ASR::arraystorageType::ColMajor));
-                return;
-            }
-
-            // Both are scalars
-            int32_t a = ASR::down_cast<ASR::IntegerConstant_t>(left_val)->m_n;
-            int32_t b = ASR::down_cast<ASR::IntegerConstant_t>(right_val)->m_n;
-            int32_t res;
             switch (x.m_op) {
                 case ASR::binopType::Mul: res = a * b; break;
                 case ASR::binopType::Add: res = a + b; break;
                 case ASR::binopType::Sub: res = a - b; break;
-                case ASR::binopType::Div: res = a / b; break;
+                case ASR::binopType::Div: res = b != 0 ? a / b : 0; break;
                 case ASR::binopType::Pow: res = std::pow(a, b); break;
                 default:
                     diag.add(Diagnostic("Unsupported binary operation in implied do loop",
@@ -504,7 +481,35 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
     }
 
     void visit_ArrayConstant(const ASR::ArrayConstant_t &x) {
-        value = const_cast<ASR::expr_t*>(&(x.base));
+        if (element_idx != -1) {
+            ASR::ttype_t* base_type = ASRUtils::extract_type(x.m_type);
+            int kind = ASRUtils::extract_kind_from_ttype_t(base_type);
+            if (ASRUtils::is_integer(*base_type)) {
+                if (kind == 4) {
+                    int32_t val = ((int32_t*)x.m_data)[element_idx];
+                    value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, val, base_type));
+                } else if (kind == 8) {
+                    int64_t val = ((int64_t*)x.m_data)[element_idx];
+                    value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, val, base_type));
+                } else {
+                    LCOMPILERS_ASSERT(false);
+                }
+            } else if (ASRUtils::is_real(*base_type)) {
+                if (kind == 4) {
+                    float val = ((float*)x.m_data)[element_idx];
+                    value = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, val, base_type));
+                } else if (kind == 8) {
+                    double val = ((double*)x.m_data)[element_idx];
+                    value = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, val, base_type));
+                } else {
+                    LCOMPILERS_ASSERT(false);
+                }
+            } else {
+                value = nullptr;
+            }
+        } else {
+            value = const_cast<ASR::expr_t*>(&(x.base));
+        }
     }
 
     void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {
@@ -16182,26 +16187,14 @@ public:
                     curr_nesting_level++;
                     populate_compiletime_array_for_idl(ASR::down_cast<ASR::ImpliedDoLoop_t>(idl->m_values[i]), array, loop_vars, loop_indices, curr_nesting_level, itr);
                 } else if (ASRUtils::is_array(ASRUtils::expr_type(idl->m_values[i]))) {
-                    ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
-                    visitor.value = nullptr;
-                    visitor.visit_expr(*idl->m_values[i]);
-                    if (visitor.value && ASR::is_a<ASR::ArrayConstant_t>(*visitor.value)) {
-                        ASR::ArrayConstant_t* arr = ASR::down_cast<ASR::ArrayConstant_t>(visitor.value);
-                        if constexpr (std::is_same_v<T,int32_t>) {
-                            int32_t* arr_data = (int32_t*)arr->m_data;
-                            for(int64_t k=0; k < arr->m_n_data / (int64_t)sizeof(int32_t); ++k) {
-                                array.push_back(al, arr_data[k]);
-                                itr++;
-                            }
-                        } else if constexpr (std::is_same_v<T,int64_t>) {
-                            int64_t* arr_data = (int64_t*)arr->m_data;
-                            for(int64_t k=0; k < arr->m_n_data / (int64_t)sizeof(int64_t); ++k) {
-                                array.push_back(al, arr_data[k]);
-                                itr++;
-                            }
-                        }
-                    } else {
-                        // fallback
+                    int64_t n_elements = ASRUtils::get_fixed_size_of_array(ASRUtils::expr_type(idl->m_values[i]));
+                    if (n_elements <= 0) {
+                        n_elements = 1;
+                    }
+                    
+                    for (int64_t element_idx = 0; element_idx < n_elements; ++element_idx) {
+                        ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
+                        visitor.element_idx = element_idx;
                         array.push_back(al, get_constant_value<T>(idl->m_values[i], visitor));
                         itr++;
                     }

--- a/tests/reference/asr-modules_37-7eba027.json
+++ b/tests/reference/asr-modules_37-7eba027.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_37-7eba027.stdout",
-    "stdout_hash": "a15f9cb06ec014e39b158598b82f754f55692676f2bc00932ed6d29a",
+    "stdout_hash": "2eb45987762ff955ce0d07cf2fc75a938ef203bbacb6e0a808d96660",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_37-7eba027.stdout
+++ b/tests/reference/asr-modules_37-7eba027.stdout
@@ -162,20 +162,18 @@
                                                         (ArrayConstructor
                                                             [(Var 9 build_dirs)
                                                             (Var 9 temp)]
-                                                            (Allocatable
-                                                                (Array
-                                                                    (StructType
-                                                                        [(Allocatable
-                                                                            (String 1 () DeferredLength DescriptorString)
-                                                                        )]
-                                                                        []
-                                                                        .true.
-                                                                        .false.
-                                                                    )
-                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
-                                                                    ())]
-                                                                    DescriptorArray
+                                                            (Array
+                                                                (StructType
+                                                                    [(Allocatable
+                                                                        (String 1 () DeferredLength DescriptorString)
+                                                                    )]
+                                                                    []
+                                                                    .true.
+                                                                    .false.
                                                                 )
+                                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                ())]
+                                                                DescriptorArray
                                                             )
                                                             ()
                                                             ColMajor

--- a/tests/reference/asr-modules_43-d01691f.json
+++ b/tests/reference/asr-modules_43-d01691f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_43-d01691f.stdout",
-    "stdout_hash": "4a491a59d53c22d64849d3622968e697187e455c5751c48bc56bcdad",
+    "stdout_hash": "579b20a69dad26d854197662afbf1187cf3248c4b709c61ba41a5bc9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_43-d01691f.stdout
+++ b/tests/reference/asr-modules_43-d01691f.stdout
@@ -376,24 +376,22 @@
                                                     )
                                                     ()
                                                 )]
-                                                (Allocatable
-                                                    (Array
-                                                        (StructType
-                                                            [(Allocatable
-                                                                (String 1 () DeferredLength DescriptorString)
-                                                            )
-                                                            (Allocatable
-                                                                (String 1 () DeferredLength DescriptorString)
-                                                            )
-                                                            (Integer 8)]
-                                                            []
-                                                            .true.
-                                                            .false.
+                                                (Array
+                                                    (StructType
+                                                        [(Allocatable
+                                                            (String 1 () DeferredLength DescriptorString)
                                                         )
-                                                        [((IntegerConstant 1 (Integer 4) Decimal)
-                                                        ())]
-                                                        DescriptorArray
+                                                        (Allocatable
+                                                            (String 1 () DeferredLength DescriptorString)
+                                                        )
+                                                        (Integer 8)]
+                                                        []
+                                                        .true.
+                                                        .false.
                                                     )
+                                                    [((IntegerConstant 1 (Integer 4) Decimal)
+                                                    ())]
+                                                    DescriptorArray
                                                 )
                                                 ()
                                                 ColMajor

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout",
-    "stdout_hash": "6db208ff02284488429410f0a20dfbc47fc11a5780209926b896392d",
+    "stdout_hash": "3cd69297639b51398c9bcbbce4d86a2958ade543781c0106dfa6f61e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
@@ -186,20 +186,18 @@
                                                         (ArrayConstructor
                                                             [(Var 13 build_dirs)
                                                             (Var 13 temp)]
-                                                            (Allocatable
-                                                                (Array
-                                                                    (StructType
-                                                                        [(Allocatable
-                                                                            (String 1 () DeferredLength DescriptorString)
-                                                                        )]
-                                                                        []
-                                                                        .true.
-                                                                        .false.
-                                                                    )
-                                                                    [((IntegerConstant 1 (Integer 4) Decimal)
-                                                                    ())]
-                                                                    DescriptorArray
+                                                            (Array
+                                                                (StructType
+                                                                    [(Allocatable
+                                                                        (String 1 () DeferredLength DescriptorString)
+                                                                    )]
+                                                                    []
+                                                                    .true.
+                                                                    .false.
                                                                 )
+                                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                                ())]
+                                                                DescriptorArray
                                                             )
                                                             ()
                                                             ColMajor


### PR DESCRIPTION
fixes #11833

This commit fixes a bug where array constructors involving array-scalar operations within implied-do loops (e.g., `[(dims * i, i = 1, 1)]`) would either cause an Internal Compiler Error (ICE) or produce garbage output at runtime.

**Root Causes:**
1. The semantic analyzer failed to extract the base type during initialization, resulting in the creation of illegal nested `Array(Array(...))` ASR nodes in `visit_ArrayInitializer` and `visit_ImpliedDoLoop`.
2. The `ImpliedDoLoopValuesVisitor` lacked implementations for evaluating array constants and broadcasts. Because of this, it was incorrectly falling back to `BaseWalkVisitor` on array nodes, corrupting the visitor state and failing to evaluate compile-time array arithmetic correctly.

**Fixes:**
- **Flattened Type Assignments:** Applied `ASRUtils::extract_type()` in `visit_ArrayInitializer` and `visit_ImpliedDoLoop` to ensure that 1D Array types are correctly constructed without illegal nesting.
- **Element-wise Array Evaluation Strategy:** Rather than making massive changes to every binary operation (`visit_IntegerBinOp`, `visit_RealBinOp`, etc.) to support array arithmetic, we updated the visitor to evaluate expressions element-by-element:
  - Added an `element_idx` parameter to `ImpliedDoLoopValuesVisitor`.
  - Implemented `visit_ArrayConstant` and `visit_ArrayBroadcast` to extract and evaluate only the specific scalar element requested by `element_idx`. This cleanly leverages the existing scalar binary operation handlers.
  - Refactored `populate_compiletime_array_for_idl` to calculate the array dimensions using `ASRUtils::get_fixed_size_of_array()` and then loop over the expression using `element_idx`.
