### PR TITLE
fix : tokenizer to support PUBLIC and PRIVATE statements in fixed-form parsing

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -467,6 +467,7 @@ RUN(NAME fixed_form_goto LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_A
 RUN(NAME fixed_form_stmt_func_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_do_name_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --use-loop-variable-after-loop GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_where_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_module_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_module_01.f90
+++ b/integration_tests/fixed_form_module_01.f90
@@ -1,0 +1,11 @@
+      MODULE fixed_form_module_01_mod
+      IMPLICIT NONE
+      PRIVATE
+      INTEGER :: X = 42
+      PUBLIC :: X
+      END MODULE fixed_form_module_01_mod
+
+      PROGRAM fixed_form_module_01
+      USE fixed_form_module_01_mod
+      IF (X /= 42) ERROR STOP 1
+      END PROGRAM fixed_form_module_01

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -292,7 +292,9 @@ const std::vector<std::string> declarators{
             "bytes",
             "data",
             "type",
-            "class"
+            "class",
+            "public",
+            "private"
         };
 
 std::vector<std::string> lines{};


### PR DESCRIPTION
fixes #11814
