### PR TITLE
fix: reject assumed-size array for pointer/allocatable dummy

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7551,6 +7551,24 @@ public:
                     ASR::Variable_t* dummy_var = ASR::down_cast<ASR::Variable_t>(dummy_sym);
                     ASR::ttype_t* dummy_type = dummy_var->m_type;
                     ASR::ttype_t* actual_type = ASRUtils::expr_type(args[i].m_value);
+                    // An assumed-size array has no known extent for its last
+                    // dimension, so it cannot be used where the dummy requires
+                    // a descriptor (pointer or allocatable).
+                    if (ASRUtils::is_pointer(dummy_type) ||
+                        ASRUtils::is_allocatable(dummy_type)) {
+                        ASR::ttype_t* actual_array =
+                            ASRUtils::type_get_past_allocatable_pointer(actual_type);
+                        if (ASR::is_a<ASR::Array_t>(*actual_array) &&
+                            ASR::down_cast<ASR::Array_t>(actual_array)->m_physical_type ==
+                                ASR::array_physical_typeType::UnboundedPointerArray) {
+                            std::string dummy_name = dummy_var->m_name;
+                            diag.semantic_error_label(
+                                "Actual argument for '" + dummy_name +
+                                "' cannot be an assumed-size array",
+                                {args[i].m_value->base.loc}, "");
+                            throw SemanticAbort();
+                        }
+                    }
                     if (ASRUtils::is_allocatable(dummy_type)) {
                         ASR::ttype_t* dummy_type_unwrapped = ASRUtils::type_get_past_array(
                             ASRUtils::type_get_past_allocatable(dummy_type));

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -772,4 +772,11 @@ program continue_compilation_1
         implicit none
         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
     end subroutine
+    subroutine assumed_size_to_pointer_dummy(x)
+        integer :: x(*)
+        call ptr_sink(x)  ! {Error} Actual argument for 'x' cannot be an assumed-size array
+    end subroutine
+    subroutine ptr_sink(x)
+        integer, pointer :: x(..)
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "6e1f6944039ff2271581b1f828a11a7dc0bb8512a6fced1bad1db1f5",
+    "infile_hash": "277e19bbdf4fab7dfd161b43d23f32e6601860fe66403d36650737ef",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2d2ebe676c400b2b4471bd3a5ca7e5f7b388938c2c586d63a5143797",
+    "stderr_hash": "7dbaf220a13bc6f7b9967890ce14bfc7b4f8bed1f5a0933c273184af",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1635,3 +1635,9 @@ semantic error: Variable 'nosuch' is not declared
     |
 773 |         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^ 'nosuch' is undeclared
+
+semantic error: Actual argument for 'x' cannot be an assumed-size array
+   --> tests/errors/continue_compilation_1.f90:777:23
+    |
+777 |         call ptr_sink(x)  ! {Error} Actual argument for 'x' cannot be an assumed-size array
+    |                       ^ 


### PR DESCRIPTION
fixes #11846

## Summary
Passing an assumed-size array (`integer :: x(*)`) to a pointer or allocatable dummy caused an ICE, `AssertFailed: m_dim.m_start != nullptr`, in `PointerToData_to_Descriptor`. An assumed-size array has no known extent for its last dimension, so it cannot be built into a descriptor. gfortran rejects this with a semantic error, so this adds the same check.

## Scope
`visit_SubroutineCall` in `src/lfortran/semantics/ast_body_visitor.cpp`. In the existing dummy-argument validation loop, when the dummy has the `pointer` or `allocatable` attribute and the actual is an assumed-size array (`UnboundedPointerArray`), emit `Actual argument for '<name>' cannot be an assumed-size array` instead of ICE'ing.

The trigger is the dummy being pointer/allocatable, not assumed-rank itself. Verified against gfortran across several variants (pointer vs allocatable dummy, assumed-rank vs fixed rank, `target`/`intent` on the actual). A non-pointer assumed-rank dummy is unaffected; that combination compiles in gfortran and is a separate pre-existing codegen limitation.

## Verification
- The issue MRE now reports the same error as gfortran.
- Added an error case to `tests/errors/continue_compilation_1.f90`; reference updated.
- Full integration suite on the llvm backend: 3706/3706 pass.

## Rationale
Matches gfortran's behavior and message. Kept in semantics per the rule that codegen must not infer or fix types.