### PR TITLE
fix: ICE for function result length using len_trim of parameter array element

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -701,6 +701,7 @@ RUN(NAME functions_58 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_59 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_60 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME functions_61 LABELS gfortran llvm fortran)
+RUN(NAME functions_62 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME common_01 LABELS gfortran)
 

--- a/integration_tests/functions_62.f90
+++ b/integration_tests/functions_62.f90
@@ -1,0 +1,16 @@
+program function_62
+    implicit none
+
+    if (make_value(1) /= "x") error stop
+    print *, "test passed"
+contains
+
+    function make_value(i)
+        integer, intent(in) :: i
+        character(1), parameter :: names(1) = ["x"]
+        character(len_trim(names(i))) :: make_value
+
+        make_value = "x"
+    end function make_value
+
+end program function_62

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -115,7 +115,7 @@ public:
  * @see @ref doc/passes/subroutine_from_function.md
  */
 class AllocateVarBasedOnFuncCall : public ASR::BaseExprReplacer<AllocateVarBasedOnFuncCall> {
-        
+
 private :
 
     Allocator            &al_;
@@ -254,6 +254,27 @@ public :
         ASR::ttype_t* return_t {};
         {
             ASR::ttype_t* return_t_ = ASRUtils::get_FunctionType(ASRUtils::get_function(f_call->m_name))->m_return_var_type;
+            bool use_func_call_type = f_call->m_type != nullptr;
+            if (use_func_call_type) {
+                SetChar dependencies;
+                dependencies.reserve(al, 1);
+                ASRUtils::collect_variable_dependencies(al, dependencies, f_call->m_type);
+                for (size_t i = 0; i < dependencies.size(); i++) {
+                    ASR::symbol_t* sym = current_scope->resolve_symbol(dependencies.p[i]);
+                    if (!sym) {
+                        continue;
+                    }
+                    sym = ASRUtils::symbol_get_past_external(sym);
+                    if (ASR::is_a<ASR::Function_t>(*sym) &&
+                            ASRUtils::get_FunctionType(ASR::down_cast<ASR::Function_t>(sym))->m_return_var_type == nullptr) {
+                        use_func_call_type = false;
+                        break;
+                    }
+                }
+            }
+            if(use_func_call_type){
+                return_t_ = f_call->m_type;
+            }
             if(!return_t_){
                 LCOMPILERS_ASSERT_MSG(func_ret_type,
                                         "Must pass Function Return Type manually -- "


### PR DESCRIPTION
fixes #11852