### PR TITLE
fix: array reallocation pass order of visitation and statement recursion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -947,6 +947,7 @@ RUN(NAME arrays_122 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_123 LABELS gfortran llvm)
 RUN(NAME arrays_124 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_125 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME arrays_126 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 
 # DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_126.f90
+++ b/integration_tests/arrays_126.f90
@@ -1,0 +1,18 @@
+program arrays_126
+    implicit none
+    character(len=5), allocatable :: narrow(:)
+    narrow = ["hello"]
+    narrow = [narrow, " " // paragraph("world")]
+    if (narrow(1) /= 'hello') error stop
+    if (narrow(2) /= ' worl') error stop
+
+contains
+
+    function paragraph(s) result(res)
+        character(len=*), intent(in) :: s
+        character(len=5) :: res(1)
+        res(1) = s
+    end function
+
+end program
+

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -1623,6 +1623,7 @@ class ArgSimplifier: public ASR::CallReplacerOnExpressionsVisitor<ArgSimplifier>
                 }
 
                 if (create_temp_var_for_rhs) {
+                    visit_expr(*xx.m_value);
                     std::string name_hint = "_assignment_";
                     ASR::expr_t* array_var_temporary = call_create_and_allocate_temporary_variable(xx.m_value, al, current_body, name_hint, current_scope, exprs_with_target);
                     xx.m_value = array_var_temporary;


### PR DESCRIPTION
Fixes #11855 
Towards #10888
