### PR TITLE
Fix: Skip Warning about symbols that shadow the same symbol in the current scope

### DIFF
--- a/integration_tests/shadow_same_symbol.f90
+++ b/integration_tests/shadow_same_symbol.f90
@@ -1,0 +1,15 @@
+module a_shadow_same_symbol
+    use, intrinsic :: ISO_FORTRAN_ENV, only: int64
+    implicit none
+end module
+
+module b_shadow_same_symbol
+    use a_shadow_same_symbol
+    use, intrinsic :: ISO_FORTRAN_ENV, only: int64
+    implicit none
+end module
+
+program shadow_same_symbol
+    use b_shadow_same_symbol
+    implicit none
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -20469,7 +20469,13 @@ public:
                 );
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
         } else if (ASR::is_a<ASR::Variable_t>(*t)) {
-            if (current_scope->get_symbol(local_sym) != nullptr) {
+            ASR::symbol_t* existing = current_scope->get_symbol(local_sym);
+            if (existing != nullptr) {
+                existing = ASRUtils::symbol_get_past_external(existing);
+                ASR::symbol_t* incoming = ASRUtils::symbol_get_past_external(t);
+                if (existing == incoming) {
+                    return;
+                }
                 diag.add(Diagnostic(
                     "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
                     Level::Warning, Stage::Semantic, {

--- a/tests/reference/run-shadow_same_symbol-61059c4.json
+++ b/tests/reference/run-shadow_same_symbol-61059c4.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-shadow_same_symbol-61059c4",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/../integration_tests/shadow_same_symbol.f90",
+    "infile_hash": "d8eebcf56defefc61c05ba66b58fa1dc4637acff91791a0e46936462",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5221,3 +5221,7 @@ run = true
 [[test]]
 filename = "errors/read_eof_01.f90"
 run = true
+
+[[test]]
+filename = "../integration_tests/shadow_same_symbol.f90"
+run = true


### PR DESCRIPTION
Fixes #11286