### PR TITLE
fix: reject length specifier (*n) on non-character types

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7381,7 +7381,15 @@ public:
                     } else {
                         lhs_type->m_len = char_length;
                     }
-                }                
+                } 
+                else if (!is_char_type && s.m_length) {
+                    diag.add(Diagnostic(
+                        "length specifier (*n) is only valid for character type",
+                        Level::Error, Stage::Semantic, {
+                            Label("", {s.m_length->base.loc})
+                        }));
+                    throw SemanticAbort();
+                }               
                 ASR::Variable_t* variable_added_to_symtab = nullptr;
                 if( std::find(excluded_from_symtab.begin(), excluded_from_symtab.end(), sym) == excluded_from_symtab.end() ) {
                     if ( !is_implicitly_declared && !is_external) {

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -779,4 +779,22 @@ program continue_compilation_1
     subroutine ptr_sink(x)
         integer, pointer :: x(..)
     end subroutine
+    subroutine select_case_complex()
+        implicit none
+        complex :: nn = (1.0, 0.0)
+        select case (nn)
+        case default
+        end select
+    end subroutine
+    subroutine select_case_real()
+        implicit none
+        real :: x = 1.0
+        select case (x)
+        case default
+        end select
+    end subroutine
+    subroutine integer_length_specifier()
+        implicit none
+        integer :: i*2
+    end subroutine
 end program

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -779,20 +779,6 @@ program continue_compilation_1
     subroutine ptr_sink(x)
         integer, pointer :: x(..)
     end subroutine
-    subroutine select_case_complex()
-        implicit none
-        complex :: nn = (1.0, 0.0)
-        select case (nn)
-        case default
-        end select
-    end subroutine
-    subroutine select_case_real()
-        implicit none
-        real :: x = 1.0
-        select case (x)
-        case default
-        end select
-    end subroutine
     subroutine integer_length_specifier()
         implicit none
         integer :: i*2

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "277e19bbdf4fab7dfd161b43d23f32e6601860fe66403d36650737ef",
+    "infile_hash": "d12d2591a49877bbc45048a08f827a76f29b5e9250635977b985728c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "7dbaf220a13bc6f7b9967890ce14bfc7b4f8bed1f5a0933c273184af",
+    "stderr_hash": "5d9e47fbce878281c68523bf2221e49ba68339ca3bc55a66b3dfbd3f",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "d12d2591a49877bbc45048a08f827a76f29b5e9250635977b985728c",
+    "infile_hash": "c19d4bfbe24bdb84c1ad24301917fe84f09b08d3754ca80a4a1ee948",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "5d9e47fbce878281c68523bf2221e49ba68339ca3bc55a66b3dfbd3f",
+    "stderr_hash": "a6817062c45b9ac31234c1a74b8bc94068b4d29b0214944d23a5122f",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -488,6 +488,24 @@ semantic error: Variable `a` cannot have both the OPTIONAL and VALUE attribute b
 751 |        end subroutine
     | ...^^^^^^^^^^^^^^^^^^ 
 
+warning: Assuming implicit save attribute for variable declaration
+   --> tests/errors/continue_compilation_1.f90:784:20
+    |
+784 |         complex :: nn = (1.0, 0.0)
+    |                    ^^^^^^^^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
+
+warning: Assuming implicit save attribute for variable declaration
+   --> tests/errors/continue_compilation_1.f90:791:17
+    |
+791 |         real :: x = 1.0
+    |                 ^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
+
+semantic error: length specifier (*n) is only valid for character type
+   --> tests/errors/continue_compilation_1.f90:798:22
+    |
+798 |         integer :: i*2
+    |                      ^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |
@@ -1641,3 +1659,15 @@ semantic error: Actual argument for 'x' cannot be an assumed-size array
     |
 777 |         call ptr_sink(x)  ! {Error} Actual argument for 'x' cannot be an assumed-size array
     |                       ^ 
+
+semantic error: select case expression must be of type integer, character, or logical
+   --> tests/errors/continue_compilation_1.f90:785:22
+    |
+785 |         select case (nn)
+    |                      ^^ 
+
+semantic error: select case expression must be of type integer, character, or logical
+   --> tests/errors/continue_compilation_1.f90:792:22
+    |
+792 |         select case (x)
+    |                      ^ 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -488,22 +488,10 @@ semantic error: Variable `a` cannot have both the OPTIONAL and VALUE attribute b
 751 |        end subroutine
     | ...^^^^^^^^^^^^^^^^^^ 
 
-warning: Assuming implicit save attribute for variable declaration
-   --> tests/errors/continue_compilation_1.f90:784:20
-    |
-784 |         complex :: nn = (1.0, 0.0)
-    |                    ^^^^^^^^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
-
-warning: Assuming implicit save attribute for variable declaration
-   --> tests/errors/continue_compilation_1.f90:791:17
-    |
-791 |         real :: x = 1.0
-    |                 ^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
-
 semantic error: length specifier (*n) is only valid for character type
-   --> tests/errors/continue_compilation_1.f90:798:22
+   --> tests/errors/continue_compilation_1.f90:784:22
     |
-798 |         integer :: i*2
+784 |         integer :: i*2
     |                      ^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -1659,15 +1647,3 @@ semantic error: Actual argument for 'x' cannot be an assumed-size array
     |
 777 |         call ptr_sink(x)  ! {Error} Actual argument for 'x' cannot be an assumed-size array
     |                       ^ 
-
-semantic error: select case expression must be of type integer, character, or logical
-   --> tests/errors/continue_compilation_1.f90:785:22
-    |
-785 |         select case (nn)
-    |                      ^^ 
-
-semantic error: select case expression must be of type integer, character, or logical
-   --> tests/errors/continue_compilation_1.f90:792:22
-    |
-792 |         select case (x)
-    |                      ^ 


### PR DESCRIPTION
## Summary

The `*n` length specifier is only valid for character type per the Fortran standard. LFortran was silently accepting it on integer, real, logical, and other types. It now emits a semantic error.

## Changes

- `src/lfortran/semantics/ast_common_visitor.h` — added `else if` branch after the existing `is_char_type && s.m_length` check to reject `*n` on non-character types
- `tests/errors/continue_compilation_1.f90` — new subroutine verifying integer with `*n` is rejected

## Verification

Before fix — silently compiles:

```fortran
integer :: i*2    ! no error
real :: x*4       ! no error
logical :: flag*1 ! no error
```

After fix:

```
semantic error: length specifier (*n) is only valid for character type
```

Valid character usage still works:

```fortran
character :: s*10   ! accepted correctly
```

## Test Results

- Reference tests: all pass
- Integration tests: 3712/3713 passed (`file_open_10` is a pre-existing platform-specific failure unrelated to this fix)

fixes #3855
