### PR TITLE
fix: ICE for invalid print format expression

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8426,6 +8426,15 @@ public:
                     }));
                 throw SemanticAbort();
             }
+            if (!ASRUtils::is_character(*fmt_type) && !(ASR::is_a<ASR::IntegerConstant_t>(*fmt)
+                    && AST::is_a<AST::Num_t>(*x.m_fmt))) {
+                diag.add(Diagnostic(
+                    "Format specifier in print statement must be of type default character",
+                    Level::Error, Stage::Semantic, {
+                        Label("", {x.m_fmt->base.loc})
+                    }));
+                throw SemanticAbort();
+            }
             
             if (ASR::is_a<ASR::StringConstant_t>(*fmt)) {
                 ASR::StringConstant_t *fmt_const = ASR::down_cast<ASR::StringConstant_t>(fmt);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -323,7 +323,7 @@ program continue_compilation_1
     !
     ! Only put statements below. If you need to call a function, put it into a
     ! module above.
-
+    print 1+2
     a = 1
     print *, a(10)
     a5 = 8

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "e7428559e356ed34a74db0bfa7250e8db010f61bd32f7e768cb448ef",
+    "infile_hash": "925a60dafdfd420dcc8b0a31f43bcb627df1a40c707bf4043ac05f93",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "a5c2b02c663d72a94f295a6251aa985caf679970672c4e3c1de13bf9",
+    "stderr_hash": "20fcd60e51fc3901cce0048e6353a54e635ac2524e5267eab2873e75",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -554,6 +554,12 @@ semantic error: Intrinsic 'not_real' is not recognized
 268 |     call sub(not_real)
     |              ^^^^^^^^ 'not_real' is not a known intrinsic function
 
+semantic error: Format specifier in print statement must be of type default character
+   --> tests/errors/continue_compilation_1.f90:326:11
+    |
+326 |     print 1+2
+    |           ^^^ 
+
 semantic error: Array index 10 is out of bounds (1 to 3) in dimension 1
    --> tests/errors/continue_compilation_1.f90:328:14
     |


### PR DESCRIPTION
fixes https://github.com/lfortran/lfortran/issues/11863