### PR TITLE
fix : Resolve ICE and LLVM verification failures for null() assignments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -706,6 +706,7 @@ RUN(NAME functions_61 LABELS gfortran llvm fortran)
 RUN(NAME common_01 LABELS gfortran)
 
 
+RUN(NAME pointer_null_01 LABELS gfortran llvm)
 RUN(NAME types_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm fortran)
 RUN(NAME types_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm fortran)
 RUN(NAME types_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm fortran)

--- a/integration_tests/pointer_null_01.f90
+++ b/integration_tests/pointer_null_01.f90
@@ -1,0 +1,11 @@
+program pointer_null_01
+  call sink(null())
+
+contains
+
+  subroutine sink(x)
+    integer, pointer :: x(..)
+    if (associated(x)) error stop
+  end subroutine sink
+
+end program 

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7170,8 +7170,31 @@ public:
         Allocator& al,
         bool& nopass
     ) {
-        visit_expr_list(x.m_args, x.n_args, args);
-        ASR::symbol_t* f2 = ASRUtils::symbol_get_past_external(original_sym);
+        ASR::symbol_t* f2 = original_sym ? ASRUtils::symbol_get_past_external(original_sym) : nullptr;
+        ASR::FunctionType_t* fn_type = nullptr;
+        if (f2 && ASR::is_a<ASR::Function_t>(*f2)) {
+            fn_type = ASRUtils::get_FunctionType(f2);
+        } else if (f2 && ASR::is_a<ASR::StructMethodDeclaration_t>(*f2)) {
+            fn_type = ASRUtils::get_FunctionType(f2);
+        } else if (f2 && ASR::is_a<ASR::Variable_t>(*f2)) {
+            ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASR::down_cast<ASR::Variable_t>(f2)->m_type);
+            if (ASR::is_a<ASR::FunctionType_t>(*var_type)) {
+                fn_type = ASR::down_cast<ASR::FunctionType_t>(var_type);
+            }
+        }
+        if (fn_type && fn_type->n_arg_types > 0) {
+            std::vector<ASR::ttype_t*> expected_types;
+            bool is_nopass_ = ASRUtils::get_class_proc_nopass_val(f2);
+            size_t start_idx = (v_expr != nullptr && !is_nopass_) ? 1 : 0;
+            for (size_t i = start_idx; i < fn_type->n_arg_types; i++) {
+                expected_types.push_back(fn_type->m_arg_types[i]);
+            }
+            visit_expr_list(x.m_args, x.n_args, args, expected_types);
+        } else {
+            visit_expr_list(x.m_args, x.n_args, args);
+        }
+        
+        f2 = original_sym ? ASRUtils::symbol_get_past_external(original_sym) : nullptr;
 
         // we handle kwargs here
         if (x.n_keywords > 0) {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -14911,7 +14911,12 @@ public:
         if( mold_ ) {
             null_ptr_type_ = ASRUtils::expr_type(mold_);
         } else {
-            LCOMPILERS_ASSERT(current_variable_type_ != nullptr);
+            if (current_variable_type_ == nullptr) {
+                diag.add(Diagnostic(
+                    "NULL() without MOLD argument cannot be resolved in this context (e.g. as an actual argument to a generic procedure)",
+                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
             null_ptr_type_ = current_variable_type_;
         }
         return ASR::make_PointerNullConstant_t(al, x.base.base.loc, null_ptr_type_, current_struct_type_var_expr);
@@ -16869,7 +16874,29 @@ public:
             }
             Vec<ASR::call_arg_t> args;
             Vec<ASR::call_arg_t> args_with_mdt;
-            visit_expr_list(x.m_args, x.n_args, args);
+            
+            ASR::FunctionType_t* fn_type = nullptr;
+            if (f2 && ASR::is_a<ASR::Function_t>(*f2)) {
+                fn_type = ASRUtils::get_FunctionType(f2);
+            } else if (f2 && ASR::is_a<ASR::StructMethodDeclaration_t>(*f2)) {
+                fn_type = ASRUtils::get_FunctionType(f2);
+            } else if (f2 && ASR::is_a<ASR::Variable_t>(*f2)) {
+                ASR::ttype_t* var_type = ASRUtils::type_get_past_pointer(ASR::down_cast<ASR::Variable_t>(f2)->m_type);
+                if (ASR::is_a<ASR::FunctionType_t>(*var_type)) {
+                    fn_type = ASR::down_cast<ASR::FunctionType_t>(var_type);
+                }
+            }
+            if (fn_type && fn_type->n_arg_types > 0) {
+                std::vector<ASR::ttype_t*> expected_types;
+                bool is_nopass_ = ASRUtils::get_class_proc_nopass_val(f2);
+                size_t start_idx = (v_expr != nullptr && !is_nopass_) ? 1 : 0;
+                for (size_t i = start_idx; i < fn_type->n_arg_types; i++) {
+                    expected_types.push_back(fn_type->m_arg_types[i]);
+                }
+                visit_expr_list(x.m_args, x.n_args, args, expected_types);
+            } else {
+                visit_expr_list(x.m_args, x.n_args, args);
+            }
             if (x.n_member >= 1) {
                 args_with_mdt.reserve(al, x.n_args + 1);
                 ASR::call_arg_t v_expr_call_arg;
@@ -19269,11 +19296,16 @@ public:
         }
     }
 
-    void visit_expr_list(AST::fnarg_t *ast_list, size_t n, Vec<ASR::call_arg_t>& call_args) {
+    void visit_expr_list(const AST::fnarg_t *ast_list, size_t n, Vec<ASR::call_arg_t>& call_args, const std::vector<ASR::ttype_t*>& expected_types = {}) {
         call_args.reserve(al, n);
         for (size_t i = 0; i < n; i++) {
             LCOMPILERS_ASSERT(ast_list[i].m_end != nullptr);
+            ASR::ttype_t* temp = current_variable_type_;
+            if (i < expected_types.size() && expected_types[i] != nullptr) {
+                current_variable_type_ = expected_types[i];
+            }
             this->visit_expr(*ast_list[i].m_end);
+            current_variable_type_ = temp;
             ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             if (ASR::is_a<ASR::Var_t>(*expr) &&
                     ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(expr))) {
@@ -19371,8 +19403,6 @@ public:
         }
 
         for (int i = 0; i < (int)n; i++) {
-            this->visit_expr(*kwargs[i].m_value);
-            ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             std::string name = to_lower(kwargs[i].m_arg);
             auto search = std::find(fn_args2.begin(), fn_args2.end(), name);
             if (search == fn_args2.end()) {
@@ -19398,6 +19428,18 @@ public:
                     name + " keyword argument is already specified.");
                 return ;
             }
+
+            ASR::ttype_t* temp = current_variable_type_;
+            int original_idx = std::distance(fn_args2.begin(), search);
+            if (original_idx >= 0 && original_idx < (int)fn_n_args) {
+                current_variable_type_ = ASRUtils::expr_type(fn_args[original_idx]);
+            }
+            
+            this->visit_expr(*kwargs[i].m_value);
+            current_variable_type_ = temp;
+            
+            ASR::expr_t *expr = ASRUtils::EXPR(tmp);
+
             args.p[idx].loc = expr->base.loc;
             args.p[idx].m_value = expr;
         }
@@ -19456,8 +19498,6 @@ public:
         LCOMPILERS_ASSERT(args.size() == constructor_args.size());
 
         for (size_t i = 0; i < n; i++) {
-            this->visit_expr(*kwargs[i].m_value);
-            ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             std::string name = to_lower(kwargs[i].m_arg);
             auto search = std::find(constructor_args.begin(),
                                     constructor_args.end(), name);
@@ -19474,9 +19514,18 @@ public:
                 diag.semantic_error_label(
                     "Keyword argument is already specified",
                     {loc},
-                    "'" + name + "'" + + " keyword argument is already specified");
+                    "'" + name + "'" + " keyword argument is already specified");
                 throw SemanticAbort();
             }
+
+            ASR::ttype_t* temp = current_variable_type_;
+            current_variable_type_ = ASRUtils::symbol_type(constructor_arg_syms[idx]);
+            
+            this->visit_expr(*kwargs[i].m_value);
+            
+            current_variable_type_ = temp;
+            
+            ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             args.p[idx].loc = expr->base.loc;
             args.p[idx].m_value = expr;
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5807,7 +5807,7 @@ public:
                 // bare element-pointer constant whose LLVM type doesn't match
                 // the pointer-to-descriptor global type; drop it and let the
                 // companion-descriptor path below run instead.
-                if (init_value && init_value->getType() != x_ptr) {
+                if (init_value && llvm::isa<llvm::ConstantPointerNull>(init_value)) {
                     init_value = nullptr;
                 }
                 allocatable_array_details.push_back(
@@ -5953,12 +5953,10 @@ public:
     void visit_PointerNullConstant(const ASR::PointerNullConstant_t& x){
         llvm::Type* value_type;
 
-        value_type = ASRUtils::is_array(x.m_type)?
-            llvm_utils->get_el_type(x.m_var_expr,
-                ASRUtils::extract_type(x.m_type), module.get())->getPointerTo():
-            llvm_utils->get_type_from_ttype_t_util(x.m_var_expr, x.m_type, module.get());
         if (ASRUtils::is_string_only(x.m_type)) {
             value_type = llvm_utils->i8_ptr;
+        } else {
+            value_type = llvm_utils->get_type_from_ttype_t_util(x.m_var_expr, x.m_type, module.get());
         }
         tmp = llvm::ConstantPointerNull::get(static_cast<llvm::PointerType*>(value_type));
     }
@@ -6747,8 +6745,13 @@ public:
                                         ASRUtils::extract_type(v->m_type),
                                         module.get()),
                                     false);
+                                llvm::Type* el_ptr_type = llvm_utils->get_el_type(
+                                    ASRUtils::EXPR(ASR::make_Var_t(al, v->base.base.loc, &v->base)),
+                                    ASRUtils::extract_type(v->m_type),
+                                    module.get())->getPointerTo();
                                 builder->CreateStore(
-                                    tmp, llvm_utils->create_gep2(array_desc_type, pointer_array, 0));
+                                    llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(el_ptr_type)),
+                                    llvm_utils->create_gep2(array_desc_type, pointer_array, 0));
                             } else {
                                 // Non-pointer array (e.g. c_funptr array): the inline
                                 // fixed-size storage is null when zero-initialized.
@@ -7057,10 +7060,12 @@ public:
             }
             case ASR::exprType::PointerNullConstant: {
                 ASR::PointerNullConstant_t* pnc = ASR::down_cast<ASR::PointerNullConstant_t>(expr);
-                llvm::Type* value_type = ASRUtils::is_array(pnc->m_type)
-                    ? llvm_utils->get_el_type(pnc->m_var_expr,
-                        ASRUtils::extract_type(pnc->m_type), module.get())->getPointerTo()
-                    : llvm_utils->get_type_from_ttype_t_util(pnc->m_var_expr, pnc->m_type, module.get());
+                llvm::Type* value_type;
+                if (ASRUtils::is_string_only(pnc->m_type)) {
+                    value_type = llvm_utils->i8_ptr;
+                } else {
+                    value_type = llvm_utils->get_type_from_ttype_t_util(pnc->m_var_expr, pnc->m_type, module.get());
+                }
                 return llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(value_type));
             }
             default:


### PR DESCRIPTION
fixes #11911

Bug:
Assigning `null()` to array pointers and struct array members caused two crashes:
1. Semantic ICEs: The compiler incorrectly attempted to cast array and generic symbols into function types while processing arguments.
2. LLVM Verification Failures: The backend stored an incorrectly typed null pointer (`%array* null` instead of `element** null`) into the array descriptor's internal data pointer.

Fix:
1. Semantics: Added explicit type checks in `ast_common_visitor.h` and `ast_body_visitor.cpp` to only extract signatures from actual functions/procedures.
2. Codegen: Updated `asr_to_llvm.cpp` to correctly generate and assign an element-typed `ConstantPointerNull` to the array descriptor's data pointer.
