### PR TITLE
fix :string array concatenation codegen and intrinsic elemental evaluation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2832,6 +2832,7 @@ RUN(NAME string_115 LABELS gfortran llvm)
 RUN(NAME string_116 LABELS gfortran llvm)
 RUN(NAME string_117 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_118 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME string_array_concat_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME substring_read LABELS gfortran llvm)
 

--- a/integration_tests/string_array_concat_01.f90
+++ b/integration_tests/string_array_concat_01.f90
@@ -1,0 +1,17 @@
+program string_array_concat_01
+  implicit none
+  character(len=2) :: c(2)
+
+  c(1) = "x"
+  c(2) = "y"
+
+  ! c(1) = "x " => trim(c(1)) = "x"
+  ! [trim(c(1)), 'a'] => ["x", "a"]
+  ! 'A' // ["x", "a"] => ["Ax", "Aa"]
+  ! ["Ax", "Aa"] // 'c' => ["Axc", "Aac"]
+  ! Truncated to len=2 => "Ax", "Aa"
+  c = ['A' // [trim(c(1)), 'a']] // 'c'
+
+  if (c(1) /= "Ax") error stop
+  if (c(2) /= "Aa") error stop
+end program string_array_concat_01

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -15109,7 +15109,7 @@ public:
             int a_kind = ASR::down_cast<ASR::Logical_t>(x_m_type)->m_kind;
             el_type = llvm_utils->getIntType(a_kind);
         } else if (ASR::is_a<ASR::String_t>(*x_m_type)) {
-            el_type = character_type;
+            el_type = llvm_utils->get_StringType(x_m_type);
         } else if (ASR::is_a<ASR::Complex_t>(*x_m_type)) {
             int complex_kind = ASR::down_cast<ASR::Complex_t>(x_m_type)->m_kind;
             if( complex_kind == 4 ) {

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -372,6 +372,16 @@ class ReplaceArrayOp: public ASR::BaseExprReplacer<ReplaceArrayOp> {
         }
     }
 
+    void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
+        for (size_t i=0; i<x->n_args; i++) {
+            current_expr = &(x->m_args[i]);
+            replace_expr(*current_expr);
+        }
+        if (result_expr == nullptr) {
+            return;
+        }
+    }
+
     bool are_all_elements_scalars(ASR::expr_t** args, size_t n) {
         for( size_t i = 0; i < n; i++ ) {
             if (ASR::is_a<ASR::ImpliedDoLoop_t>(*args[i])) {

--- a/src/libasr/pass/array_struct_temporary.cpp
+++ b/src/libasr/pass/array_struct_temporary.cpp
@@ -420,7 +420,7 @@ bool set_allocation_size(
                 len_allocte_expr = str_type->m_len;
             } else {
                 ASRUtils::ASRBuilder b(al, loc);
-                len_allocte_expr = b.StringLen(value);
+                len_allocte_expr = ASRUtils::StringConcat::get_safe_string_len(al, loc, value, ASRUtils::expr_type(value), b);
             }
         }
         return true;
@@ -2509,6 +2509,13 @@ class ReplaceExprWithTemporary: public ASR::BaseExprReplacer<ReplaceExprWithTemp
             return ;
         }
         ASR::BaseExprReplacer<ReplaceExprWithTemporary>::replace_ArrayItem(x);
+    }
+
+    void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
+        for (size_t i=0; i<x->n_args; i++) {
+            current_expr = &(x->m_args[i]);
+            replace_expr(*current_expr);
+        }
     }
 
     void replace_IntegerBinOp(ASR::IntegerBinOp_t* x) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5929,6 +5929,12 @@ namespace StringConcat {
                 return b.Add(len1, len2);
             }
         }
+        if (ASR::is_a<ASR::ArrayConstructor_t>(*expr)) {
+            ASR::ArrayConstructor_t* arr = ASR::down_cast<ASR::ArrayConstructor_t>(expr);
+            if (arr->n_args > 0) {
+                return get_safe_string_len(al, loc, arr->m_args[0], ASRUtils::expr_type(arr->m_args[0]), b);
+            }
+        }
         return b.StringLen(expr);
     }
 


### PR DESCRIPTION
fixes #11908

This commit fixes an Internal Compiler Error (ICE) and LLVM verification failure 
triggered by incorrect handling of string array concatenation.

Background:
When compiling expressions like `c = ['A' // [trim(c(1)), 'a']] // 'c'`, the 
backend was attempting to pass raw array structure pointers (`%array.1*`) 
into locations expecting scalar string descriptors (`%string_descriptor*`), 
causing `asr_to_llvm` to abort.

Changes:
1. `asr_to_llvm.cpp`: Modified the `ArrayConstructor` type selection to 
   properly map string elements to string descriptors via `get_StringType` 
   instead of raw pointers.
2. `array_op.cpp` & `array_struct_temporary.cpp`: Implemented 
   `replace_IntrinsicElementalFunction` to recursively unroll and replace array 
   arguments with scalar temporaries inside elemental intrinsic function calls 
   during the `do-loop` conversion phase.
3. `intrinsic_functions.h`: Updated `get_safe_string_len` to safely extract 
   the string length type parameter directly from the first element of an 
   `ArrayConstructor`, preventing infinite recursions or unhandled nodes.
