### PR TITLE
fix: missing duplicate statement label error causes wrong goto behavior 

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1380,7 +1380,15 @@ public:
             if (!stmt) return;
             int64_t label = stmt_label(stmt);
             if (label != 0) {
-                labels.insert(std::to_string(label));
+                std::string label_name = std::to_string(label);
+                if (!labels.insert(label_name).second) {
+                    diag.add(Diagnostic(
+                        "duplicate statement label " + label_name,
+                        Level::Error, Stage::Semantic, {
+                            Label("", {stmt->base.loc})
+                        }));
+                    throw SemanticAbort();
+                }
             }
 
             switch (stmt->type) {

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -1387,7 +1387,9 @@ public:
                         Level::Error, Stage::Semantic, {
                             Label("", {stmt->base.loc})
                         }));
-                    throw SemanticAbort();
+                    if (!compiler_options.continue_compilation) {
+                        throw SemanticAbort();
+                    }
                 }
             }
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -305,8 +305,8 @@ program continue_compilation_1
         integer, len :: n
         real :: data(n)
     end type
-1000    continue
-1000    continue
+
+
 
 
 
@@ -809,5 +809,10 @@ program continue_compilation_1
         type :: holder
             type(c_ptr) :: ptr = c_loc(target_value)
         end type
+    end subroutine
+
+    subroutine duplicate_statement_label()
+1000    continue
+1000    continue
     end subroutine
 end program

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -305,8 +305,8 @@ program continue_compilation_1
         integer, len :: n
         real :: data(n)
     end type
-
-
+1000    continue
+1000    continue
 
 
 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "7afc6d2d40cf2e257d30797416af66073a770dca4c8109cd0a40043d",
+    "infile_hash": "0fc5b753a7e1ed7760379b4ae23b94a10ab06eb65c97a1adf0242cf9",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "de419439c7961f6fd19500eabd6d9820c567b5e9b9811e82e913fdf7",
+    "stderr_hash": "bebdf5066201ecf9d3c2d6f689a95c0b645cef4eee5ae49c7a90f350",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "f33241dddff000ef78bf59043924172ab1396778cb50ded6edac5f85",
+    "infile_hash": "7afc6d2d40cf2e257d30797416af66073a770dca4c8109cd0a40043d",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "c196205a8ab732a31466548b3a68cec89d0d20705c918d93ce83e2b5",
+    "stderr_hash": "de419439c7961f6fd19500eabd6d9820c567b5e9b9811e82e913fdf7",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -554,12 +554,6 @@ semantic error: Interface mismatch in procedure pointer assignment at (1): 'dumm
 183 |         pf2 => dummy_func
     |         ^^^^^^^^^^^^^^^^^ (1)
 
-semantic error: duplicate statement label 1000
-   --> tests/errors/continue_compilation_1.f90:309:9
-    |
-309 | 1000    continue
-    |         ^^^^^^^^ 
-
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:268:14
     |
@@ -1695,3 +1689,9 @@ semantic error: first argument of `llt` must have kind equal to 1
     |
 803 |         print *, llt(glyph, "z")  
     |                  ^^^^^^^^^^^^^^^ 
+
+semantic error: duplicate statement label 1000
+   --> tests/errors/continue_compilation_1.f90:816:9
+    |
+816 | 1000    continue
+    |         ^^^^^^^^ 

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -554,6 +554,12 @@ semantic error: Interface mismatch in procedure pointer assignment at (1): 'dumm
 183 |         pf2 => dummy_func
     |         ^^^^^^^^^^^^^^^^^ (1)
 
+semantic error: duplicate statement label 1000
+   --> tests/errors/continue_compilation_1.f90:309:9
+    |
+309 | 1000    continue
+    |         ^^^^^^^^ 
+
 semantic error: Intrinsic 'not_real' is not recognized
    --> tests/errors/continue_compilation_1.f90:268:14
     |


### PR DESCRIPTION
fixes  #11945 