### PR TITLE
 Add co_max and co_min coarray collectives

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1761,6 +1761,7 @@ RUN(NAME intrinsics_422 LABELS llvm llvm_wasm llvm_wasm_emcc) # this_image
 RUN(NAME intrinsics_423 LABELS llvm llvm_wasm llvm_wasm_emcc) # num_images
 RUN(NAME intrinsics_424 LABELS llvm llvm_wasm llvm_wasm_emcc) # co_sum
 RUN(NAME intrinsics_425 LABELS llvm llvm_wasm llvm_wasm_emcc) # co_sum with optional args
+RUN(NAME intrinsics_470 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_max
 RUN(NAME intrinsics_426 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # count(mask, dim) with variable dim
 RUN(NAME intrinsics_427 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maxval with derived-type component in declaration
 RUN(NAME intrinsics_428 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays) # merge array mask in loop

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1762,6 +1762,7 @@ RUN(NAME intrinsics_423 LABELS llvm llvm_wasm llvm_wasm_emcc) # num_images
 RUN(NAME intrinsics_424 LABELS llvm llvm_wasm llvm_wasm_emcc) # co_sum
 RUN(NAME intrinsics_425 LABELS llvm llvm_wasm llvm_wasm_emcc) # co_sum with optional args
 RUN(NAME intrinsics_470 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_max
+RUN(NAME intrinsics_471 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_min
 RUN(NAME intrinsics_426 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # count(mask, dim) with variable dim
 RUN(NAME intrinsics_427 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # maxval with derived-type component in declaration
 RUN(NAME intrinsics_428 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays) # merge array mask in loop

--- a/integration_tests/intrinsics_470.f90
+++ b/integration_tests/intrinsics_470.f90
@@ -1,0 +1,33 @@
+program intrinsics_470
+    ! Test co_max intrinsic subroutine (no-op in single-image mode)
+    implicit none
+    integer :: a(3), b
+    real :: c(2)
+    character(3) :: d, e(2)
+
+    a = [1, 2, 3]
+    call co_max(a)
+    if (a(1) /= 1) error stop
+    if (a(2) /= 2) error stop
+    if (a(3) /= 3) error stop
+
+    b = 42
+    call co_max(b)
+    if (b /= 42) error stop
+
+    c = [1.5, 2.5]
+    call co_max(c)
+    if (abs(c(1) - 1.5) > 1e-6) error stop
+    if (abs(c(2) - 2.5) > 1e-6) error stop
+
+    d = "abc"
+    call co_max(d)
+    if (d /= "abc") error stop
+
+    e = ["abc", "xyz"]
+    call co_max(e)
+    if (e(1) /= "abc") error stop
+    if (e(2) /= "xyz") error stop
+
+    print *, "co_max: all tests passed"
+end program intrinsics_470

--- a/integration_tests/intrinsics_471.f90
+++ b/integration_tests/intrinsics_471.f90
@@ -1,0 +1,33 @@
+program intrinsics_471
+    ! Test co_min intrinsic subroutine (no-op in single-image mode)
+    implicit none
+    integer :: a(3), b
+    real :: c(2)
+    character(3) :: d, e(2)
+
+    a = [1, 2, 3]
+    call co_min(a)
+    if (a(1) /= 1) error stop
+    if (a(2) /= 2) error stop
+    if (a(3) /= 3) error stop
+
+    b = 42
+    call co_min(b)
+    if (b /= 42) error stop
+
+    c = [1.5, 2.5]
+    call co_min(c)
+    if (abs(c(1) - 1.5) > 1e-6) error stop
+    if (abs(c(2) - 2.5) > 1e-6) error stop
+
+    d = "abc"
+    call co_min(d)
+    if (d /= "abc") error stop
+
+    e = ["abc", "xyz"]
+    call co_min(e)
+    if (e(1) /= "abc") error stop
+    if (e(2) /= "xyz") error stop
+
+    print *, "co_min: all tests passed"
+end program intrinsics_471

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -6858,6 +6858,10 @@ public:
                     ASRUtils::create_intrinsic_subroutine create_func =
                         ASRUtils::IntrinsicImpureSubroutineRegistry::get_create_subroutine(var_name);
                     tmp = create_func(al, x.base.base.loc, args, diag);
+                    if (tmp == nullptr) {
+                        // create_func has already reported a diagnostic; abort this
+                        throw SemanticAbort();
+                    }
                     return tmp;
                 }
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1898,6 +1898,7 @@ public:
         {"sleep", IntrinsicSignature({"seconds"}, 1, 1)},
         {"co_sum", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
         {"co_max", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
+        {"co_min", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
         {"move_alloc", IntrinsicSignature({"from", "to"}, 2, 2)},
         {"mvbits", IntrinsicSignature({"from", "frompos", "len", "to", "topos"}, 5, 5)},
         {"modulo", IntrinsicSignature({"a", "p"}, 2, 2)},
@@ -15285,7 +15286,7 @@ public:
 
     void is_coarray_or_atomic(std::string intrinsic_name, const Location& loc){
         std::vector<std::string> coarray_intrinsics, atomic_intrinsics;
-        coarray_intrinsics = {"co_broadcast", "co_min", "co_reduce", "lcobound", "ucobound", "failed_images",
+        coarray_intrinsics = {"co_broadcast", "co_reduce", "lcobound", "ucobound", "failed_images",
             "image_status", "get_team", "image_index", "stopped_images", "team_number", "coshape", "corank",
             "event_query"};
         atomic_intrinsics = {"atomic_add", "atomic_and", "atomic_cas", "atomic_define", "atomic_fetch_add", "atomic_fetch_and",

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1897,6 +1897,7 @@ public:
         {"system", IntrinsicSignature({"command"}, 1, 1)},
         {"sleep", IntrinsicSignature({"seconds"}, 1, 1)},
         {"co_sum", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
+        {"co_max", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
         {"move_alloc", IntrinsicSignature({"from", "to"}, 2, 2)},
         {"mvbits", IntrinsicSignature({"from", "frompos", "len", "to", "topos"}, 5, 5)},
         {"modulo", IntrinsicSignature({"a", "p"}, 2, 2)},
@@ -15284,7 +15285,7 @@ public:
 
     void is_coarray_or_atomic(std::string intrinsic_name, const Location& loc){
         std::vector<std::string> coarray_intrinsics, atomic_intrinsics;
-        coarray_intrinsics = {"co_broadcast", "co_max", "co_min", "co_reduce", "lcobound", "ucobound", "failed_images",
+        coarray_intrinsics = {"co_broadcast", "co_min", "co_reduce", "lcobound", "ucobound", "failed_images",
             "image_status", "get_team", "image_index", "stopped_images", "team_number", "coshape", "corank",
             "event_query"};
         atomic_intrinsics = {"atomic_add", "atomic_and", "atomic_cas", "atomic_define", "atomic_fetch_add", "atomic_fetch_and",

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -8318,8 +8318,16 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             }
         }
         if(is_stringToArray_cast_needed(arg_type, orig_arg_type)){
-            LCOMPILERS_ASSERT_MSG(extract_n_dims_from_ttype(orig_arg_type)==1, "Casting string to array of rank == 1 is only possible")
-            a_args[i].m_value = &cast_string_to_array(al, arg, orig_arg_type)->base;
+            ASR::ttype_t* string_array_target = orig_arg_type;
+            //handle assumed rank case also
+            if (ASRUtils::is_assumed_rank_array(orig_arg_type)) {
+                Vec<ASR::dimension_t> one_dim; one_dim.reserve(al, 1);
+                one_dim.push_back(al, {arg->base.loc, nullptr, nullptr});
+                string_array_target = ASRUtils::duplicate_type(al, orig_arg_type,&one_dim, ASR::array_physical_typeType::DescriptorArray, true);
+            } else {
+                LCOMPILERS_ASSERT_MSG(extract_n_dims_from_ttype(orig_arg_type)==1, "Casting string to array of rank == 1 is only possible")
+            }
+            a_args[i].m_value = &cast_string_to_array(al, arg, string_array_target)->base;
         }
     }
 }

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -2234,6 +2234,7 @@ public:
             SET_INTRINSIC_SUBROUTINE_NAME(System, "system")
             SET_INTRINSIC_SUBROUTINE_NAME(Sleep, "sleep")
             SET_INTRINSIC_SUBROUTINE_NAME(CoSum, "co_sum")
+            SET_INTRINSIC_SUBROUTINE_NAME(CoMax, "co_max")
             default : {
                 throw LCompilersException("IntrinsicImpureSubroutine: `"
                     + ASRUtils::get_intrinsic_subroutine_name(x.m_sub_intrinsic_id)

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -2235,6 +2235,7 @@ public:
             SET_INTRINSIC_SUBROUTINE_NAME(Sleep, "sleep")
             SET_INTRINSIC_SUBROUTINE_NAME(CoSum, "co_sum")
             SET_INTRINSIC_SUBROUTINE_NAME(CoMax, "co_max")
+            SET_INTRINSIC_SUBROUTINE_NAME(CoMin, "co_min")
             default : {
                 throw LCompilersException("IntrinsicImpureSubroutine: `"
                     + ASRUtils::get_intrinsic_subroutine_name(x.m_sub_intrinsic_id)

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -844,6 +844,190 @@ class PRIFInterface {
                 al, loc, sub, nullptr, call_args.p, call_args.n, nullptr, false));
         }
 
+        ASR::symbol_t* get_or_create_prif_co_max_sub(const Location &loc, ASR::ttype_t * /*a_type*/) {
+            SymbolTable *global_scope = unit.m_symtab;
+            std::string sym_name = get_mangled_name("prif", "prif_co_max");
+            if (ASR::symbol_t *existing = global_scope->get_symbol(sym_name)) {
+                return existing;
+            }
+            SymbolTable *fn_symtab = al.make_new<SymbolTable>(global_scope);
+            ASRUtils::ASRBuilder b(al, loc);
+            ASR::ttype_t *int32_type = int32;
+            ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *alloc_str_type = allocatable_deferred_string();
+
+            std::string derived_type_name = "~assumed_type";
+            ASR::symbol_t *type_declaration = global_scope->resolve_symbol(derived_type_name);
+            if (!type_declaration) {
+                SymbolTable *struct_symtab = al.make_new<SymbolTable>(global_scope);
+                ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
+                                                s2c(al, derived_type_name), nullptr, nullptr, 0, nullptr, 0,
+                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, true,
+                                                nullptr, 0, nullptr, nullptr, nullptr, 0);
+                ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
+                ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
+                ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
+                struct_->m_struct_signature = struct_type;
+                type_declaration = struct_symbol;
+                global_scope->add_symbol(derived_type_name, type_declaration);
+            }
+            ASR::ttype_t * assumed_type = ASRUtils::make_StructType_t_util(al, loc, type_declaration, false);
+            ASR::ttype_t * a_type_assumed = ASRUtils::TYPE(ASR::make_Array_t(al, loc, assumed_type, nullptr, 0, ASR::array_physical_typeType::AssumedRankArray));
+
+            ASR::symbol_t *a_sym = declare_variable(
+                fn_symtab, loc, "a", a_type_assumed, ASR::intentType::InOut, type_declaration,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false);
+            ASR::down_cast<ASR::Variable_t>(a_sym)->m_target_attr = true;
+            ASR::expr_t *a = ASRUtils::EXPR(ASR::make_Var_t(al, loc, a_sym));
+
+            ASR::symbol_t *res_img_sym = declare_variable(
+                fn_symtab, loc, "result_image", int32_type, ASR::intentType::In, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *res_img = ASRUtils::EXPR(ASR::make_Var_t(al, loc, res_img_sym));
+
+            ASR::symbol_t *stat_sym = declare_variable(
+                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
+
+            ASR::symbol_t *errmsg_sym = declare_variable(
+                fn_symtab, loc, "errmsg", str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
+
+            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
+                fn_symtab, loc, "errmsg_alloc", alloc_str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
+
+            Vec<ASR::expr_t*> args; args.reserve(al, 5);
+            args.push_back(al, a);
+            args.push_back(al, res_img);
+            args.push_back(al, stat);
+            args.push_back(al, errmsg);
+            args.push_back(al, errmsg_alloc);
+
+            ASR::asr_t *fn = ASRUtils::make_Function_t_util(
+                al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,
+                args.p, args.n, nullptr, 0, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::deftypeType::Interface,
+                s2c(al, sym_name),
+                false, false, false, false, false, nullptr, 0,
+                false, false, false, nullptr);
+            global_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(fn));
+            return ASR::down_cast<ASR::symbol_t>(fn);
+        }
+
+        ASR::symbol_t* get_or_create_prif_co_max_character_sub(const Location &loc) {
+            SymbolTable *global_scope = unit.m_symtab;
+            std::string sym_name = get_mangled_name("prif", "prif_co_max_character");
+            if (ASR::symbol_t *existing = global_scope->get_symbol(sym_name)) {
+                return existing;
+            }
+            SymbolTable *fn_symtab = al.make_new<SymbolTable>(global_scope);
+            ASRUtils::ASRBuilder b(al, loc);
+            ASR::ttype_t *int32_type = int32;
+            ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *alloc_str_type = allocatable_deferred_string();
+
+            ASR::ttype_t *a_char_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *a_type_assumed = ASRUtils::TYPE(ASR::make_Array_t(
+                al, loc, a_char_type, nullptr, 0,
+                ASR::array_physical_typeType::AssumedRankArray));
+
+            ASR::symbol_t *a_sym = declare_variable(
+                fn_symtab, loc, "a", a_type_assumed, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false);
+            ASR::down_cast<ASR::Variable_t>(a_sym)->m_target_attr = true;
+            ASR::expr_t *a = ASRUtils::EXPR(ASR::make_Var_t(al, loc, a_sym));
+
+            ASR::symbol_t *res_img_sym = declare_variable(
+                fn_symtab, loc, "result_image", int32_type, ASR::intentType::In, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *res_img = ASRUtils::EXPR(ASR::make_Var_t(al, loc, res_img_sym));
+
+            ASR::symbol_t *stat_sym = declare_variable(
+                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
+
+            ASR::symbol_t *errmsg_sym = declare_variable(
+                fn_symtab, loc, "errmsg", str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
+
+            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
+                fn_symtab, loc, "errmsg_alloc", alloc_str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
+
+            Vec<ASR::expr_t*> args; args.reserve(al, 5);
+            args.push_back(al, a);
+            args.push_back(al, res_img);
+            args.push_back(al, stat);
+            args.push_back(al, errmsg);
+            args.push_back(al, errmsg_alloc);
+
+            ASR::asr_t *fn = ASRUtils::make_Function_t_util(
+                al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,
+                args.p, args.n, nullptr, 0, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::deftypeType::Interface,
+                s2c(al, sym_name),
+                false, false, false, false, false, nullptr, 0,
+                false, false, false, nullptr);
+            global_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(fn));
+            return ASR::down_cast<ASR::symbol_t>(fn);
+        }
+
+        ASR::stmt_t* make_prif_co_max_call(const Location &loc,
+                                           ASR::expr_t *a,
+                                           ASR::expr_t *result_image = nullptr,
+                                           ASR::expr_t *stat = nullptr,
+                                           ASR::expr_t *errmsg = nullptr,
+                                           ASR::expr_t *errmsg_alloc = nullptr) {
+            ASR::ttype_t *a_type = ASRUtils::expr_type(a);
+            ASR::symbol_t *sub = ASRUtils::is_character(*a_type) 
+                                        ? get_or_create_prif_co_max_character_sub(loc)
+                                        : get_or_create_prif_co_max_sub(loc, a_type);
+            Vec<ASR::call_arg_t> call_args; call_args.reserve(al, 5);
+
+            ASR::call_arg_t arg1; arg1.loc = loc; arg1.m_value = a;
+            ASR::call_arg_t arg2; arg2.loc = loc; arg2.m_value = result_image;
+            ASR::call_arg_t arg3; arg3.loc = loc; arg3.m_value = stat;
+            ASR::call_arg_t arg4; arg4.loc = loc; arg4.m_value = errmsg;
+            ASR::call_arg_t arg5; arg5.loc = loc; arg5.m_value = errmsg_alloc;
+
+            call_args.push_back(al, arg1);
+            call_args.push_back(al, arg2);
+            call_args.push_back(al, arg3);
+            call_args.push_back(al, arg4);
+            call_args.push_back(al, arg5);
+
+            return ASRUtils::STMT(ASR::make_SubroutineCall_t(
+                al, loc, sub, nullptr, call_args.p, call_args.n, nullptr, false));
+        }
+
         ASR::stmt_t* make_prif_sync_all_call(const Location &loc,
                                              ASR::expr_t *stat = nullptr,
                                              ASR::expr_t *errmsg = nullptr,
@@ -1247,7 +1431,21 @@ class CoarrayPrifVisitor : public ASR::CallReplacerOnExpressionsVisitor<CoarrayP
                         
                         body.push_back(replacer.al, replacer.prif.make_prif_co_sum_call(
                             x->base.base.loc, a, result_image, stat, errmsg));
-                    } else {
+                    } 
+                    else if (intrinsic_name == "CoMax") {
+                        ASR::expr_t *a = nullptr;
+                        ASR::expr_t *result_image = nullptr;
+                        ASR::expr_t *stat = nullptr;
+                        ASR::expr_t *errmsg = nullptr;
+                        if (x->n_args >= 1) a = x->m_args[0];
+                        if (x->n_args >= 2) result_image = x->m_args[1];
+                        if (x->n_args >= 3) stat = x->m_args[2];
+                        if (x->n_args >= 4) errmsg = x->m_args[3];
+                        
+                        body.push_back(replacer.al, replacer.prif.make_prif_co_max_call(
+                            x->base.base.loc, a, result_image, stat, errmsg));
+                    }
+                    else {
                         body.push_back(replacer.al, m_body[i]);
                     }
                 } else {

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -1028,6 +1028,192 @@ class PRIFInterface {
                 al, loc, sub, nullptr, call_args.p, call_args.n, nullptr, false));
         }
 
+        ASR::symbol_t* get_or_create_prif_co_min_sub(const Location &loc, ASR::ttype_t * /*a_type*/) {
+            SymbolTable *global_scope = unit.m_symtab;
+            std::string sym_name = get_mangled_name("prif", "prif_co_min");
+            if (ASR::symbol_t *existing = global_scope->get_symbol(sym_name)) {
+                return existing;
+            }
+            SymbolTable *fn_symtab = al.make_new<SymbolTable>(global_scope);
+            ASRUtils::ASRBuilder b(al, loc);
+            ASR::ttype_t *int32_type = int32;
+            ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *alloc_str_type = allocatable_deferred_string();
+
+            std::string derived_type_name = "~assumed_type";
+            ASR::symbol_t *type_declaration = global_scope->resolve_symbol(derived_type_name);
+            if (!type_declaration) {
+                SymbolTable *struct_symtab = al.make_new<SymbolTable>(global_scope);
+                ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
+                                                s2c(al, derived_type_name), nullptr, nullptr, 0, nullptr, 0,
+                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, true,
+                                                nullptr, 0, nullptr, nullptr, nullptr, 0);
+                ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
+                ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
+                ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
+                struct_->m_struct_signature = struct_type;
+                type_declaration = struct_symbol;
+                global_scope->add_symbol(derived_type_name, type_declaration);
+            }
+            ASR::ttype_t * assumed_type = ASRUtils::make_StructType_t_util(al, loc, type_declaration, false);
+            ASR::ttype_t * a_type_assumed = ASRUtils::TYPE(ASR::make_Array_t(al, loc, assumed_type, nullptr, 0, ASR::array_physical_typeType::AssumedRankArray));
+
+            ASR::symbol_t *a_sym = declare_variable(
+                fn_symtab, loc, "a", a_type_assumed, ASR::intentType::InOut, type_declaration,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false);
+            ASR::down_cast<ASR::Variable_t>(a_sym)->m_target_attr = true;
+            ASR::expr_t *a = ASRUtils::EXPR(ASR::make_Var_t(al, loc, a_sym));
+
+            ASR::symbol_t *res_img_sym = declare_variable(
+                fn_symtab, loc, "result_image", int32_type, ASR::intentType::In, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *res_img = ASRUtils::EXPR(ASR::make_Var_t(al, loc, res_img_sym));
+
+            ASR::symbol_t *stat_sym = declare_variable(
+                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
+
+            ASR::symbol_t *errmsg_sym = declare_variable(
+                fn_symtab, loc, "errmsg", str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
+
+            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
+                fn_symtab, loc, "errmsg_alloc", alloc_str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
+
+            Vec<ASR::expr_t*> args; args.reserve(al, 5);
+            args.push_back(al, a);
+            args.push_back(al, res_img);
+            args.push_back(al, stat);
+            args.push_back(al, errmsg);
+            args.push_back(al, errmsg_alloc);
+
+            ASR::asr_t *fn = ASRUtils::make_Function_t_util(
+                al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,
+                args.p, args.n, nullptr, 0, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::deftypeType::Interface,
+                s2c(al, sym_name),
+                false, false, false, false, false, nullptr, 0,
+                false, false, false, nullptr);
+            global_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(fn));
+            return ASR::down_cast<ASR::symbol_t>(fn);
+        }
+
+        ASR::symbol_t* get_or_create_prif_co_min_character_sub(const Location &loc) {
+            SymbolTable *global_scope = unit.m_symtab;
+            std::string sym_name = get_mangled_name("prif", "prif_co_min_character");
+            if (ASR::symbol_t *existing = global_scope->get_symbol(sym_name)) {
+                return existing;
+            }
+            SymbolTable *fn_symtab = al.make_new<SymbolTable>(global_scope);
+            ASRUtils::ASRBuilder b(al, loc);
+            ASR::ttype_t *int32_type = int32;
+            ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *alloc_str_type = allocatable_deferred_string();
+
+            ASR::ttype_t *a_char_type = ASRUtils::TYPE(ASR::make_String_t(
+                al, loc, 1, nullptr,
+                ASR::string_length_kindType::AssumedLength,
+                ASR::string_physical_typeType::DescriptorString));
+            ASR::ttype_t *a_type_assumed = ASRUtils::TYPE(ASR::make_Array_t(
+                al, loc, a_char_type, nullptr, 0,
+                ASR::array_physical_typeType::AssumedRankArray));
+
+            ASR::symbol_t *a_sym = declare_variable(
+                fn_symtab, loc, "a", a_type_assumed, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false);
+            ASR::down_cast<ASR::Variable_t>(a_sym)->m_target_attr = true;
+            ASR::expr_t *a = ASRUtils::EXPR(ASR::make_Var_t(al, loc, a_sym));
+
+            ASR::symbol_t *res_img_sym = declare_variable(
+                fn_symtab, loc, "result_image", int32_type, ASR::intentType::In, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *res_img = ASRUtils::EXPR(ASR::make_Var_t(al, loc, res_img_sym));
+
+            ASR::symbol_t *stat_sym = declare_variable(
+                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
+
+            ASR::symbol_t *errmsg_sym = declare_variable(
+                fn_symtab, loc, "errmsg", str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
+
+            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
+                fn_symtab, loc, "errmsg_alloc", alloc_str_type, ASR::intentType::InOut, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Optional, false);
+            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
+
+            Vec<ASR::expr_t*> args; args.reserve(al, 5);
+            args.push_back(al, a);
+            args.push_back(al, res_img);
+            args.push_back(al, stat);
+            args.push_back(al, errmsg);
+            args.push_back(al, errmsg_alloc);
+
+            ASR::asr_t *fn = ASRUtils::make_Function_t_util(
+                al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,
+                args.p, args.n, nullptr, 0, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::deftypeType::Interface,
+                s2c(al, sym_name),
+                false, false, false, false, false, nullptr, 0,
+                false, false, false, nullptr);
+            global_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(fn));
+            return ASR::down_cast<ASR::symbol_t>(fn);
+        }
+
+        ASR::stmt_t* make_prif_co_min_call(const Location &loc,
+                                           ASR::expr_t *a,
+                                           ASR::expr_t *result_image = nullptr,
+                                           ASR::expr_t *stat = nullptr,
+                                           ASR::expr_t *errmsg = nullptr,
+                                           ASR::expr_t *errmsg_alloc = nullptr) {
+            ASR::ttype_t *a_type = ASRUtils::expr_type(a);
+            ASR::symbol_t *sub = ASRUtils::is_character(*a_type) 
+                                        ? get_or_create_prif_co_min_character_sub(loc)
+                                        : get_or_create_prif_co_min_sub(loc, a_type);
+            Vec<ASR::call_arg_t> call_args; call_args.reserve(al, 5);
+
+            ASR::call_arg_t arg1; arg1.loc = loc; arg1.m_value = a;
+            ASR::call_arg_t arg2; arg2.loc = loc; arg2.m_value = result_image;
+            ASR::call_arg_t arg3; arg3.loc = loc; arg3.m_value = stat;
+            ASR::call_arg_t arg4; arg4.loc = loc; arg4.m_value = errmsg;
+            ASR::call_arg_t arg5; arg5.loc = loc; arg5.m_value = errmsg_alloc;
+
+            call_args.push_back(al, arg1);
+            call_args.push_back(al, arg2);
+            call_args.push_back(al, arg3);
+            call_args.push_back(al, arg4);
+            call_args.push_back(al, arg5);
+
+            return ASRUtils::STMT(ASR::make_SubroutineCall_t(
+                al, loc, sub, nullptr, call_args.p, call_args.n, nullptr, false));
+        }
+
+
+
         ASR::stmt_t* make_prif_sync_all_call(const Location &loc,
                                              ASR::expr_t *stat = nullptr,
                                              ASR::expr_t *errmsg = nullptr,
@@ -1443,6 +1629,19 @@ class CoarrayPrifVisitor : public ASR::CallReplacerOnExpressionsVisitor<CoarrayP
                         if (x->n_args >= 4) errmsg = x->m_args[3];
                         
                         body.push_back(replacer.al, replacer.prif.make_prif_co_max_call(
+                            x->base.base.loc, a, result_image, stat, errmsg));
+                    }
+                    else if (intrinsic_name == "CoMin") {
+                        ASR::expr_t *a = nullptr;
+                        ASR::expr_t *result_image = nullptr;
+                        ASR::expr_t *stat = nullptr;
+                        ASR::expr_t *errmsg = nullptr;
+                        if (x->n_args >= 1) a = x->m_args[0];
+                        if (x->n_args >= 2) result_image = x->m_args[1];
+                        if (x->n_args >= 3) stat = x->m_args[2];
+                        if (x->n_args >= 4) errmsg = x->m_args[3];
+                             
+                        body.push_back(replacer.al, replacer.prif.make_prif_co_min_call(
                             x->base.base.loc, a, result_image, stat, errmsg));
                     }
                     else {

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -36,6 +36,7 @@ inline std::string get_intrinsic_subroutine_name(int x) {
         INTRINSIC_SUBROUTINE_NAME_CASE(System)
         INTRINSIC_SUBROUTINE_NAME_CASE(Sleep)
         INTRINSIC_SUBROUTINE_NAME_CASE(CoSum)
+        INTRINSIC_SUBROUTINE_NAME_CASE(CoMax)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -86,6 +87,8 @@ namespace IntrinsicImpureSubroutineRegistry {
             {&Sleep::instantiate_Sleep, &Sleep::verify_args}},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::CoSum),
             {&CoSum::instantiate_CoSum, &CoSum::verify_args}},
+        {static_cast<int64_t>(IntrinsicImpureSubroutines::CoMax),
+            {&CoMax::instantiate_CoMax, &CoMax::verify_args}},
         };
         return intrinsic_subroutine_by_id_db;
     }
@@ -111,6 +114,7 @@ namespace IntrinsicImpureSubroutineRegistry {
                 {"system", &System::create_System},
                 {"sleep", &Sleep::create_Sleep},
                 {"co_sum", &CoSum::create_CoSum},
+                {"co_max", &CoMax::create_CoMax},
         };
         return intrinsic_subroutine_by_name_db;
     }

--- a/src/libasr/pass/intrinsic_subroutine_registry.h
+++ b/src/libasr/pass/intrinsic_subroutine_registry.h
@@ -37,6 +37,7 @@ inline std::string get_intrinsic_subroutine_name(int x) {
         INTRINSIC_SUBROUTINE_NAME_CASE(Sleep)
         INTRINSIC_SUBROUTINE_NAME_CASE(CoSum)
         INTRINSIC_SUBROUTINE_NAME_CASE(CoMax)
+        INTRINSIC_SUBROUTINE_NAME_CASE(CoMin)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -89,6 +90,8 @@ namespace IntrinsicImpureSubroutineRegistry {
             {&CoSum::instantiate_CoSum, &CoSum::verify_args}},
         {static_cast<int64_t>(IntrinsicImpureSubroutines::CoMax),
             {&CoMax::instantiate_CoMax, &CoMax::verify_args}},
+        {static_cast<int64_t>(IntrinsicImpureSubroutines::CoMin),
+            {&CoMin::instantiate_CoMin, &CoMin::verify_args}},
         };
         return intrinsic_subroutine_by_id_db;
     }
@@ -115,6 +118,7 @@ namespace IntrinsicImpureSubroutineRegistry {
                 {"sleep", &Sleep::create_Sleep},
                 {"co_sum", &CoSum::create_CoSum},
                 {"co_max", &CoMax::create_CoMax},
+                {"co_min", &CoMin::create_CoMin},
         };
         return intrinsic_subroutine_by_name_db;
     }

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -38,6 +38,7 @@ enum class IntrinsicImpureSubroutines : int64_t {
     Sleep,
     CoSum,
     CoMax,
+    CoMin,
     // ...
 };
 
@@ -1842,6 +1843,81 @@ namespace CoMax {
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
         // co_max is a no-op in single-image (non-coarray) mode
         const std::string new_name = "_lcompilers_co_max_"
+            + std::to_string(arg_types.n);
+        declare_basic_variables(new_name);
+        fill_func_arg_sub("a", arg_types[0], InOut);
+        if (arg_types.n >= 2) {
+            fill_func_arg_sub("result_image", arg_types[1], In);
+        }
+        if (arg_types.n >= 3) {
+            fill_func_arg_sub("stat", arg_types[2], In);
+        }
+        if (arg_types.n >= 4) {
+            fill_func_arg_sub("errmsg", arg_types[3], In);
+        }
+
+        ASR::symbol_t *fn_sym = make_ASR_Function_t(
+            s2c(al, fn_name),
+            fn_symtab,
+            dep,
+            args,
+            body,
+            nullptr,
+            ASR::abiType::Source,
+            ASR::deftypeType::Implementation,
+            nullptr
+        );
+        scope->add_symbol(fn_name, fn_sym);
+        return b.SubroutineCall(fn_sym, new_args);
+    }
+
+}
+
+namespace CoMin {
+    static inline void verify_args(const ASR::IntrinsicImpureSubroutine_t& x,
+             diag::Diagnostics& diagnostics) {
+
+        ASRUtils::require_impl(x.n_args >= 1 && x.n_args <= 4,
+            "Unexpected number of args, co_min takes 1 to 4 arguments, found "
+             + std::to_string(x.n_args),
+            x.base.base.loc, diagnostics);
+            
+        ASRUtils::require_impl(
+            ASRUtils::is_integer(*ASRUtils::expr_type(x.m_args[0])) ||
+            ASRUtils::is_real(*ASRUtils::expr_type(x.m_args[0])) ||
+            ASRUtils::is_character(*ASRUtils::expr_type(x.m_args[0])) ,
+            "First argument must be of integer, real or character type",
+            x.base.base.loc, diagnostics);
+    }
+
+    static inline ASR::asr_t* create_CoMin(Allocator& al, const Location& loc,
+            Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
+        ASR::ttype_t* arg_type = ASRUtils::expr_type(args[0]);
+        if (!ASRUtils::is_integer(*arg_type) && !ASRUtils::is_real(*arg_type) && !ASRUtils::is_character(*arg_type)) {
+            diag.add(diag::Diagnostic(
+                "`a` argument of `co_min` must be of integer, real or character type, but got " +
+                    ASRUtils::type_to_str_fortran_expr(arg_type, args[0]),
+                diag::Level::Error, diag::Stage::Semantic,
+                {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));
+            return nullptr;
+        }
+        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 1);
+        m_args.push_back(al, args[0]);
+        for (size_t i = 1; i < args.size(); i++) {
+            if (args[i]) {
+                m_args.push_back(al, args[i]);
+            }
+        }
+        return ASR::make_IntrinsicImpureSubroutine_t(al, loc,
+            static_cast<int64_t>(IntrinsicImpureSubroutines::CoMin),
+            m_args.p, m_args.n, 0);
+    }
+
+     static inline ASR::stmt_t* instantiate_CoMin(Allocator &al, const Location &loc,
+            SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types,
+            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
+        // co_min is a no-op in single-image (non-coarray) mode
+        const std::string new_name = "_lcompilers_co_min_"
             + std::to_string(arg_types.n);
         declare_basic_variables(new_name);
         fill_func_arg_sub("a", arg_types[0], InOut);

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -37,6 +37,7 @@ enum class IntrinsicImpureSubroutines : int64_t {
     System,
     Sleep,
     CoSum,
+    CoMax,
     // ...
 };
 
@@ -1796,6 +1797,80 @@ namespace CoSum {
     }
 
 } // namespace CoSum
+namespace CoMax {
+    static inline void verify_args(const ASR::IntrinsicImpureSubroutine_t& x,
+             diag::Diagnostics& diagnostics) {
+
+        ASRUtils::require_impl(x.n_args >= 1 && x.n_args <= 4,
+            "Unexpected number of args, co_max takes 1 to 4 arguments, found "
+             + std::to_string(x.n_args),
+            x.base.base.loc, diagnostics);
+            
+        ASRUtils::require_impl(
+            ASRUtils::is_integer(*ASRUtils::expr_type(x.m_args[0])) ||
+            ASRUtils::is_real(*ASRUtils::expr_type(x.m_args[0])) ||
+            ASRUtils::is_character(*ASRUtils::expr_type(x.m_args[0])) ,
+            "First argument must be of integer, real or character type",
+            x.base.base.loc, diagnostics);
+    }
+
+    static inline ASR::asr_t* create_CoMax(Allocator& al, const Location& loc,
+            Vec<ASR::expr_t*>& args, diag::Diagnostics& diag) {
+        ASR::ttype_t* arg_type = ASRUtils::expr_type(args[0]);
+        if (!ASRUtils::is_integer(*arg_type) && !ASRUtils::is_real(*arg_type) && !ASRUtils::is_character(*arg_type)) {
+            diag.add(diag::Diagnostic(
+                "`a` argument of `co_max` must be of integer, real or character type, but got " +
+                    ASRUtils::type_to_str_fortran_expr(arg_type, args[0]),
+                diag::Level::Error, diag::Stage::Semantic,
+                {diag::Label("must be integer, real or character type", { args[0]->base.loc })}));
+            return nullptr;
+        }
+        Vec<ASR::expr_t*> m_args; m_args.reserve(al, 1);
+        m_args.push_back(al, args[0]);
+        for (size_t i = 1; i < args.size(); i++) {
+            if (args[i]) {
+                m_args.push_back(al, args[i]);
+            }
+        }
+        return ASR::make_IntrinsicImpureSubroutine_t(al, loc,
+            static_cast<int64_t>(IntrinsicImpureSubroutines::CoMax),
+            m_args.p, m_args.n, 0);
+    }
+
+     static inline ASR::stmt_t* instantiate_CoMax(Allocator &al, const Location &loc,
+            SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types,
+            Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/) {
+        // co_max is a no-op in single-image (non-coarray) mode
+        const std::string new_name = "_lcompilers_co_max_"
+            + std::to_string(arg_types.n);
+        declare_basic_variables(new_name);
+        fill_func_arg_sub("a", arg_types[0], InOut);
+        if (arg_types.n >= 2) {
+            fill_func_arg_sub("result_image", arg_types[1], In);
+        }
+        if (arg_types.n >= 3) {
+            fill_func_arg_sub("stat", arg_types[2], In);
+        }
+        if (arg_types.n >= 4) {
+            fill_func_arg_sub("errmsg", arg_types[3], In);
+        }
+
+        ASR::symbol_t *fn_sym = make_ASR_Function_t(
+            s2c(al, fn_name),
+            fn_symtab,
+            dep,
+            args,
+            body,
+            nullptr,
+            ASR::abiType::Source,
+            ASR::deftypeType::Implementation,
+            nullptr
+        );
+        scope->add_symbol(fn_name, fn_sym);
+        return b.SubroutineCall(fn_sym, new_args);
+    }
+
+}
 
 } // namespace LCompilers::ASRUtils
 

--- a/tests/coarrays_09.f90
+++ b/tests/coarrays_09.f90
@@ -1,0 +1,9 @@
+program coarrays_09
+    integer :: x
+
+    x = this_image()
+
+    call co_max(x)
+
+    if (x /= num_images()) error stop ! run with 2 images
+end program coarrays_09

--- a/tests/coarrays_11.f90
+++ b/tests/coarrays_11.f90
@@ -1,0 +1,10 @@
+program coarrays_11
+    character(3) :: s
+
+    if (this_image() == 1) s = "abc"
+    if (this_image() == 2) s = "xyz"
+
+    call co_max(s)
+
+    if (s /= "xyz") error stop ! run with 2 images
+end program coarrays_11

--- a/tests/coarrays_12.f90
+++ b/tests/coarrays_12.f90
@@ -1,0 +1,9 @@
+program coarrays_12
+    integer :: x
+
+    x = this_image()
+
+    call co_min(x)
+
+    if (x /= 1) error stop ! run with 2 images
+end program coarrays_12

--- a/tests/coarrays_13.f90
+++ b/tests/coarrays_13.f90
@@ -1,0 +1,10 @@
+program coarrays_13
+    character(3) :: s
+
+    if (this_image() == 1) s = "xyz"
+    if (this_image() == 2) s = "abc"
+
+    call co_min(s)
+
+    if (s /= "abc") error stop ! run with 2 images
+end program coarrays_13

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -810,4 +810,10 @@ program continue_compilation_1
             type(c_ptr) :: ptr = c_loc(target_value)
         end type
     end subroutine
+
+    subroutine co_max_complex_arg()
+        implicit none
+        complex :: z
+        call co_max(z)
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "f33241dddff000ef78bf59043924172ab1396778cb50ded6edac5f85",
+    "infile_hash": "83248255c2b07cab12b4015f46b18193e5b9b8ebe933c6a502d3b173",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "c196205a8ab732a31466548b3a68cec89d0d20705c918d93ce83e2b5",
+    "stderr_hash": "fdb3f7276674375fe674f82dcb60ee6abf3645452595b7fb4b127311",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1689,3 +1689,9 @@ semantic error: first argument of `llt` must have kind equal to 1
     |
 803 |         print *, llt(glyph, "z")  
     |                  ^^^^^^^^^^^^^^^ 
+
+semantic error: `a` argument of `co_max` must be of integer, real or character type, but got complex
+   --> tests/errors/continue_compilation_1.f90:817:21
+    |
+817 |         call co_max(z)
+    |                     ^ must be integer, real or character type

--- a/tests/reference/fortran-coarrays_09-f696ed3.json
+++ b/tests/reference/fortran-coarrays_09-f696ed3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-coarrays_09-f696ed3",
+    "cmd": "lfortran --pass=coarray --show-fortran --no-color {infile} -o {outfile} --no-error-banner  --line=-1 --column=-1 --coarray=true",
+    "infile": "tests/coarrays_09.f90",
+    "infile_hash": "5cb2343264c42cecd8cb074f4f2261b407c66a5629e1f38b40c749b0",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-coarrays_09-f696ed3.stdout",
+    "stdout_hash": "ad65f2206edceae76ccc724bdf8e88e1dca030950e701020eec90862",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-coarrays_09-f696ed3.stdout
+++ b/tests/reference/fortran-coarrays_09-f696ed3.stdout
@@ -1,0 +1,72 @@
+type :: __module_prif_prif_dummy_team_descriptor
+end type __module_prif_prif_dummy_team_descriptor
+
+type :: __module_prif_prif_team_type
+    type(__module_prif_prif_dummy_team_descriptor), pointer :: info
+end type __module_prif_prif_team_type
+
+type :: prif_coarray_handle
+    type(c_ptr) :: info
+end type prif_coarray_handle
+
+
+program coarrays_09
+implicit none
+integer(4) :: exit_code
+integer(4) :: x
+call __module_prif_prif_init(exit_code)
+x = lcompilers_prif_this_image()
+call __module_prif_prif_co_max(x)
+if (x /= lcompilers_prif_num_images()) then
+    error stop
+end if
+call __module_prif_prif_stop(.false.)
+
+contains
+
+interface
+    subroutine __module_prif_prif_co_max(a, result_image, stat, errmsg, errmsg_alloc)
+        type(*), dimension(..), intent(inout), target :: a
+        character(len=*, kind=1), intent(inout), optional :: errmsg
+        character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
+        integer(4), intent(in), optional :: result_image
+        integer(4), intent(out), optional :: stat
+    end subroutine __module_prif_prif_co_max
+end interface
+
+interface
+    subroutine __module_prif_prif_init(exit_code)
+        integer(4), intent(out) :: exit_code
+    end subroutine __module_prif_prif_init
+end interface
+
+interface
+    subroutine __module_prif_prif_num_images(num_images)
+        integer(4), intent(out) :: num_images
+    end subroutine __module_prif_prif_num_images
+end interface
+
+interface
+    subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
+        logical(1), intent(in), value :: quiet
+        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
+        integer(4), intent(in), optional, value :: stop_code_int
+    end subroutine __module_prif_prif_stop
+end interface
+
+interface
+    subroutine __module_prif_prif_this_image_no_coarray(team, this_image)
+        type(__module_prif_prif_team_type), intent(in), optional :: team
+        integer(4), intent(out) :: this_image
+    end subroutine __module_prif_prif_this_image_no_coarray
+end interface
+
+integer(4) function lcompilers_prif_num_images()
+    call __module_prif_prif_num_images(lcompilers_prif_num_images)
+end function lcompilers_prif_num_images
+
+integer(4) function lcompilers_prif_this_image()
+    call __module_prif_prif_this_image_no_coarray(lcompilers_prif_this_image)
+end function lcompilers_prif_this_image
+
+end program coarrays_09

--- a/tests/reference/fortran-coarrays_11-fc909a7.json
+++ b/tests/reference/fortran-coarrays_11-fc909a7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-coarrays_11-fc909a7",
+    "cmd": "lfortran --pass=coarray --show-fortran --no-color {infile} -o {outfile} --no-error-banner  --line=-1 --column=-1 --coarray=true",
+    "infile": "tests/coarrays_11.f90",
+    "infile_hash": "32973828453ff49def7031657af6ac2c663d7b53fd18fe8d2da37d38",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-coarrays_11-fc909a7.stdout",
+    "stdout_hash": "2284ddeba8ac85f1bfe83f914ed8216775266b538787157e8f8d6dd1",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-coarrays_11-fc909a7.stdout
+++ b/tests/reference/fortran-coarrays_11-fc909a7.stdout
@@ -1,0 +1,66 @@
+type :: __module_prif_prif_dummy_team_descriptor
+end type __module_prif_prif_dummy_team_descriptor
+
+type :: __module_prif_prif_team_type
+    type(__module_prif_prif_dummy_team_descriptor), pointer :: info
+end type __module_prif_prif_team_type
+
+type :: prif_coarray_handle
+    type(c_ptr) :: info
+end type prif_coarray_handle
+
+program coarrays_11
+implicit none
+integer(4) :: exit_code
+character(len=3, kind=1) :: s
+call __module_prif_prif_init(exit_code)
+if (lcompilers_prif_this_image() == 1) then
+    s = "abc"
+end if
+if (lcompilers_prif_this_image() == 2) then
+    s = "xyz"
+end if
+call __module_prif_prif_co_max_character(s)
+if (s /= "xyz") then
+    error stop
+end if
+call __module_prif_prif_stop(.false.)
+
+contains
+
+interface
+    subroutine __module_prif_prif_co_max_character(a, result_image, stat, errmsg, errmsg_alloc)
+        character(len=*, kind=1), dimension(..), intent(inout), target :: a
+        character(len=*, kind=1), intent(inout), optional :: errmsg
+        character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
+        integer(4), intent(in), optional :: result_image
+        integer(4), intent(out), optional :: stat
+    end subroutine __module_prif_prif_co_max_character
+end interface
+
+interface
+    subroutine __module_prif_prif_init(exit_code)
+        integer(4), intent(out) :: exit_code
+    end subroutine __module_prif_prif_init
+end interface
+
+interface
+    subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
+        logical(1), intent(in), value :: quiet
+        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
+        integer(4), intent(in), optional, value :: stop_code_int
+    end subroutine __module_prif_prif_stop
+end interface
+
+interface
+    subroutine __module_prif_prif_this_image_no_coarray(team, this_image)
+        type(__module_prif_prif_team_type), intent(in), optional :: team
+        integer(4), intent(out) :: this_image
+    end subroutine __module_prif_prif_this_image_no_coarray
+end interface
+
+integer(4) function lcompilers_prif_this_image()
+    call __module_prif_prif_this_image_no_coarray(lcompilers_prif_this_image)
+end function lcompilers_prif_this_image
+
+end program coarrays_11

--- a/tests/reference/fortran-coarrays_12-d8feaa9.json
+++ b/tests/reference/fortran-coarrays_12-d8feaa9.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-coarrays_12-d8feaa9",
+    "cmd": "lfortran --pass=coarray --show-fortran --no-color {infile} -o {outfile} --no-error-banner  --line=-1 --column=-1 --coarray=true",
+    "infile": "tests/coarrays_12.f90",
+    "infile_hash": "42c0fc2e4eb85c8bdb8ded2a20de5c44069d22c1418bce9708aad6b4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-coarrays_12-d8feaa9.stdout",
+    "stdout_hash": "7e3c5f6453930e8c72540410fea62d6adefa071899ee2971cc05fc4f",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-coarrays_12-d8feaa9.stdout
+++ b/tests/reference/fortran-coarrays_12-d8feaa9.stdout
@@ -1,0 +1,62 @@
+type :: __module_prif_prif_dummy_team_descriptor
+end type __module_prif_prif_dummy_team_descriptor
+
+type :: __module_prif_prif_team_type
+    type(__module_prif_prif_dummy_team_descriptor), pointer :: info
+end type __module_prif_prif_team_type
+
+type :: prif_coarray_handle
+    type(c_ptr) :: info
+end type prif_coarray_handle
+
+
+program coarrays_12
+implicit none
+integer(4) :: exit_code
+integer(4) :: x
+call __module_prif_prif_init(exit_code)
+x = lcompilers_prif_this_image()
+call __module_prif_prif_co_min(x)
+if (x /= 1) then
+    error stop
+end if
+call __module_prif_prif_stop(.false.)
+
+contains
+
+interface
+    subroutine __module_prif_prif_co_min(a, result_image, stat, errmsg, errmsg_alloc)
+        type(*), dimension(..), intent(inout), target :: a
+        character(len=*, kind=1), intent(inout), optional :: errmsg
+        character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
+        integer(4), intent(in), optional :: result_image
+        integer(4), intent(out), optional :: stat
+    end subroutine __module_prif_prif_co_min
+end interface
+
+interface
+    subroutine __module_prif_prif_init(exit_code)
+        integer(4), intent(out) :: exit_code
+    end subroutine __module_prif_prif_init
+end interface
+
+interface
+    subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
+        logical(1), intent(in), value :: quiet
+        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
+        integer(4), intent(in), optional, value :: stop_code_int
+    end subroutine __module_prif_prif_stop
+end interface
+
+interface
+    subroutine __module_prif_prif_this_image_no_coarray(team, this_image)
+        type(__module_prif_prif_team_type), intent(in), optional :: team
+        integer(4), intent(out) :: this_image
+    end subroutine __module_prif_prif_this_image_no_coarray
+end interface
+
+integer(4) function lcompilers_prif_this_image()
+    call __module_prif_prif_this_image_no_coarray(lcompilers_prif_this_image)
+end function lcompilers_prif_this_image
+
+end program coarrays_12

--- a/tests/reference/fortran-coarrays_13-c7d1f5a.json
+++ b/tests/reference/fortran-coarrays_13-c7d1f5a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-coarrays_13-c7d1f5a",
+    "cmd": "lfortran --pass=coarray --show-fortran --no-color {infile} -o {outfile} --no-error-banner  --line=-1 --column=-1 --coarray=true",
+    "infile": "tests/coarrays_13.f90",
+    "infile_hash": "f9d67491e9e223714218350eed7f9f67b67265e3adf10f5dc0900235",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-coarrays_13-c7d1f5a.stdout",
+    "stdout_hash": "d679f52e45f77ad647fa956301edf11b75fc49a4923ff080bebad043",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-coarrays_13-c7d1f5a.stdout
+++ b/tests/reference/fortran-coarrays_13-c7d1f5a.stdout
@@ -1,0 +1,66 @@
+type :: __module_prif_prif_dummy_team_descriptor
+end type __module_prif_prif_dummy_team_descriptor
+
+type :: __module_prif_prif_team_type
+    type(__module_prif_prif_dummy_team_descriptor), pointer :: info
+end type __module_prif_prif_team_type
+
+type :: prif_coarray_handle
+    type(c_ptr) :: info
+end type prif_coarray_handle
+
+program coarrays_13
+implicit none
+integer(4) :: exit_code
+character(len=3, kind=1) :: s
+call __module_prif_prif_init(exit_code)
+if (lcompilers_prif_this_image() == 1) then
+    s = "xyz"
+end if
+if (lcompilers_prif_this_image() == 2) then
+    s = "abc"
+end if
+call __module_prif_prif_co_min_character(s)
+if (s /= "abc") then
+    error stop
+end if
+call __module_prif_prif_stop(.false.)
+
+contains
+
+interface
+    subroutine __module_prif_prif_co_min_character(a, result_image, stat, errmsg, errmsg_alloc)
+        character(len=*, kind=1), dimension(..), intent(inout), target :: a
+        character(len=*, kind=1), intent(inout), optional :: errmsg
+        character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
+        integer(4), intent(in), optional :: result_image
+        integer(4), intent(out), optional :: stat
+    end subroutine __module_prif_prif_co_min_character
+end interface
+
+interface
+    subroutine __module_prif_prif_init(exit_code)
+        integer(4), intent(out) :: exit_code
+    end subroutine __module_prif_prif_init
+end interface
+
+interface
+    subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
+        logical(1), intent(in), value :: quiet
+        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
+        integer(4), intent(in), optional, value :: stop_code_int
+    end subroutine __module_prif_prif_stop
+end interface
+
+interface
+    subroutine __module_prif_prif_this_image_no_coarray(team, this_image)
+        type(__module_prif_prif_team_type), intent(in), optional :: team
+        integer(4), intent(out) :: this_image
+    end subroutine __module_prif_prif_this_image_no_coarray
+end interface
+
+integer(4) function lcompilers_prif_this_image()
+    call __module_prif_prif_this_image_no_coarray(lcompilers_prif_this_image)
+end function lcompilers_prif_this_image
+
+end program coarrays_13

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2869,7 +2869,19 @@ ast = true
 ast_f90 = true
 
 [[test]]
+filename = "coarrays_09.f90"
+fortran = true
+pass = "coarray"
+options = "--coarray=true"
+
+[[test]]
 filename = "coarrays_10.f90"
+fortran = true
+pass = "coarray"
+options = "--coarray=true"
+
+[[test]]
+filename = "coarrays_11.f90"
 fortran = true
 pass = "coarray"
 options = "--coarray=true"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -2887,6 +2887,18 @@ pass = "coarray"
 options = "--coarray=true"
 
 [[test]]
+filename = "coarrays_12.f90"
+fortran = true
+pass = "coarray"
+options = "--coarray=true"
+
+[[test]]
+filename = "coarrays_13.f90"
+fortran = true
+pass = "coarray"
+options = "--coarray=true"
+
+[[test]]
 filename = "../integration_tests/program_03.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
Adds the CO_MAX and CO_MIN collectives subroutine for integer, real and character arguments

1. Added the frontend ASR Representation
2. Did the semantic checks and it fails for types other than what mentioned above
3. Added PRIF lowering support for integer, real and character types.
4. Added integration test
5. Verified execution end to end using Caffeine