### PR TITLE
fix: ASR constant evaluation for parameter arrays of derived types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1842,6 +1842,7 @@ RUN(NAME parameter_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME parameter_16 LABELS gfortran llvm)
 RUN(NAME parameter_17 LABELS gfortran llvm)
 RUN(NAME parameter_18 LABELS gfortran llvm)
+RUN(NAME struct_parameter_array_01 LABELS gfortran llvm)
 
 RUN(NAME fortuno_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/struct_parameter_array_01.f90
+++ b/integration_tests/struct_parameter_array_01.f90
@@ -1,0 +1,14 @@
+program struct_parameter_array_01
+  implicit none
+
+  type :: item
+    character(1) :: tag
+  end type
+
+  type(item), parameter :: items(2) = [item("a"), item("b")]
+  character(1), parameter :: tags(*) = items%tag
+
+  print *, tags
+
+  if (tags(1) /= "a" .or. tags(2) /= "b") error stop
+end program struct_parameter_array_01

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1497,6 +1497,14 @@ ASR::asr_t* getStructInstanceMember_t(Allocator& al, const Location& loc,
             }
         }
 
+        ASR::ttype_t* value_type = member_type;
+        if (ASRUtils::is_array(ASRUtils::expr_type(ASRUtils::EXPR(v_var)))) {
+            size_t n_dims_local = ASRUtils::extract_dimensions_from_ttype(
+                ASRUtils::type_get_past_allocatable_pointer(
+                    ASRUtils::expr_type(ASRUtils::EXPR(v_var))), m_dims);
+            value_type = ASRUtils::make_Array_t_util(al, loc, member_type_, m_dims, n_dims_local);
+        }
+
         ASR::symbol_t* member_ext = ASRUtils::import_struct_instance_member(al, member, current_scope);
         ASR::expr_t* value = nullptr;
         v = ASRUtils::symbol_get_past_external(v);
@@ -1505,21 +1513,97 @@ ASR::asr_t* getStructInstanceMember_t(Allocator& al, const Location& loc,
             if (member_variable->m_symbolic_value != nullptr) {
                 value = expr_value(member_variable->m_symbolic_value);
             }
-            // Check for compile time value in StructConstant
             ASR::Variable_t *v_variable_s = ASR::down_cast<ASR::Variable_t>(v);
-            if (v_variable_s->m_value != nullptr && ASR::is_a<ASR::StructConstant_t>(*v_variable_s->m_value)) {
-                ASR::Struct_t *struct_s = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(v_variable_s->m_type_declaration));
-                std::string mem_name = ASRUtils::symbol_name(member);
-                // Find the index i of the member in the Struct symbol and set value to ith argument of StructConstant
-                size_t i = 0;
-                for (i = 0; i < struct_s->n_members; i++) {
-                    if (struct_s->m_members[i] == mem_name) {
-                        break;
+            ASR::expr_t* v_var_value = ASRUtils::expr_value(ASRUtils::EXPR(v_var));
+            if (!v_var_value) {
+                v_var_value = v_variable_s->m_symbolic_value;
+            }
+
+            if (v_var_value != nullptr) {
+                if (ASR::is_a<ASR::StructConstant_t>(*v_var_value) || ASR::is_a<ASR::StructConstructor_t>(*v_var_value)) {
+                    ASR::Struct_t *struct_s = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external((ASR::symbol_t*)ASRUtils::symbol_parent_symtab(member)->asr_owner));
+                    std::string mem_name = ASRUtils::symbol_name(member);
+                    size_t i = 0;
+                    for (i = 0; i < struct_s->n_members; i++) {
+                        if (struct_s->m_members[i] == mem_name) {
+                            break;
+                        }
+                    }
+
+                    if (ASR::is_a<ASR::StructConstant_t>(*v_var_value)) {
+                        ASR::StructConstant_t *stc = ASR::down_cast<ASR::StructConstant_t>(v_var_value);
+                        value = stc->m_args[i].m_value;
+                    } else {
+                        ASR::StructConstructor_t *stc = ASR::down_cast<ASR::StructConstructor_t>(v_var_value);
+                        value = stc->m_args[i].m_value;
+                        if (!value) value = ASRUtils::expr_value(stc->m_args[i].m_value);
+                    }
+                } else if (ASR::is_a<ASR::ArrayConstant_t>(*v_var_value)) {
+                    ASR::Struct_t *struct_s = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external((ASR::symbol_t*)ASRUtils::symbol_parent_symtab(member)->asr_owner));
+                    std::string mem_name = ASRUtils::symbol_name(member);
+                    size_t mem_idx = 0;
+                    for (mem_idx = 0; mem_idx < struct_s->n_members; mem_idx++) {
+                        if (struct_s->m_members[mem_idx] == mem_name) {
+                            break;
+                        }
+                    }
+
+                    ASR::ArrayConstant_t* array_const = ASR::down_cast<ASR::ArrayConstant_t>(v_var_value);
+                    Vec<ASR::expr_t*> args;
+                    args.reserve(al, array_const->m_n_data);
+                    bool all_extracted = true;
+                    for (size_t k = 0; k < (size_t) array_const->m_n_data; k++) {
+                        ASR::expr_t* struct_const_expr = ASRUtils::fetch_ArrayConstant_value(al, array_const, k);
+                        if (struct_const_expr && ASR::is_a<ASR::StructConstant_t>(*struct_const_expr)) {
+                            ASR::StructConstant_t* stc = ASR::down_cast<ASR::StructConstant_t>(struct_const_expr);
+                            args.push_back(al, stc->m_args[mem_idx].m_value);
+                        } else {
+                            all_extracted = false;
+                            break;
+                        }
+                    }
+                    if (all_extracted) {
+                        void* new_data = ASRUtils::set_ArrayConstant_data(args.p, args.n, member_type_);
+                        value = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, loc, args.n, new_data, value_type, array_const->m_storage_format));
+                    }
+                } else if (ASR::is_a<ASR::ArrayConstructor_t>(*v_var_value)) {
+                    ASR::Struct_t *struct_s = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external((ASR::symbol_t*)ASRUtils::symbol_parent_symtab(member)->asr_owner));
+                    std::string mem_name = ASRUtils::symbol_name(member);
+                    size_t mem_idx = 0;
+                    for (mem_idx = 0; mem_idx < struct_s->n_members; mem_idx++) {
+                        if (struct_s->m_members[mem_idx] == mem_name) {
+                            break;
+                        }
+                    }
+
+                    ASR::ArrayConstructor_t* array_ctor = ASR::down_cast<ASR::ArrayConstructor_t>(v_var_value);
+                    Vec<ASR::expr_t*> args;
+                    args.reserve(al, array_ctor->n_args);
+                    bool all_extracted = true;
+                    for (size_t k = 0; k < array_ctor->n_args; k++) {
+                        ASR::expr_t* struct_const_expr = array_ctor->m_args[k];
+                        if (!ASR::is_a<ASR::StructConstant_t>(*struct_const_expr) && !ASR::is_a<ASR::StructConstructor_t>(*struct_const_expr)) {
+                            ASR::expr_t* struct_const_expr_val = ASRUtils::expr_value(struct_const_expr);
+                            if (struct_const_expr_val) struct_const_expr = struct_const_expr_val;
+                        }
+
+                        if (struct_const_expr && ASR::is_a<ASR::StructConstant_t>(*struct_const_expr)) {
+                            ASR::StructConstant_t* stc = ASR::down_cast<ASR::StructConstant_t>(struct_const_expr);
+                            args.push_back(al, stc->m_args[mem_idx].m_value);
+                        } else if (struct_const_expr && ASR::is_a<ASR::StructConstructor_t>(*struct_const_expr)) {
+                            ASR::StructConstructor_t* stc = ASR::down_cast<ASR::StructConstructor_t>(struct_const_expr);
+                            ASR::expr_t* arg_val = stc->m_args[mem_idx].m_value;
+                            if (!arg_val) arg_val = ASRUtils::expr_value(stc->m_args[mem_idx].m_value);
+                            args.push_back(al, arg_val);
+                        } else {
+                            all_extracted = false;
+                            break;
+                        }
+                    }
+                    if (all_extracted) {
+                        value = ASRUtils::EXPR(ASR::make_ArrayConstructor_t(al, loc, args.p, args.n, value_type, nullptr, array_ctor->m_storage_format, nullptr));
                     }
                 }
-
-                ASR::StructConstant_t *stc = ASR::down_cast<ASR::StructConstant_t>(v_variable_s->m_value);
-                value = stc->m_args[i].m_value;
             }
         }
         return ASR::make_StructInstanceMember_t(al, loc, ASRUtils::EXPR(v_var),

--- a/tests/reference/asr-struct_parameter_array_01-4731b46.json
+++ b/tests/reference/asr-struct_parameter_array_01-4731b46.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-struct_parameter_array_01-4731b46",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/struct_parameter_array_01.f90",
+    "infile_hash": "ac01cce47959db3d543a47ff0fe6be52f4243dcb3af3d72a7fc89f97",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "asr-struct_parameter_array_01-4731b46.stdout",
+    "stdout_hash": "ab7ac81351d13a33c13c5d9fcf167eff818437c3d3f5a28602735b68",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/asr-struct_parameter_array_01-4731b46.stdout
+++ b/tests/reference/asr-struct_parameter_array_01-4731b46.stdout
@@ -1,0 +1,293 @@
+(TranslationUnit
+    (SymbolTable
+        1
+        {
+            struct_parameter_array_01:
+                (Program
+                    (SymbolTable
+                        2
+                        {
+                            1_item_tag:
+                                (ExternalSymbol
+                                    2
+                                    1_item_tag
+                                    3 tag
+                                    item
+                                    []
+                                    tag
+                                    Public
+                                ),
+                            item:
+                                (Struct
+                                    (SymbolTable
+                                        3
+                                        {
+                                            tag:
+                                                (Variable
+                                                    3
+                                                    tag
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                    .false.
+                                                    .false.
+                                                    ()
+                                                    .false.
+                                                    .false.
+                                                    NotMethod
+                                                    ()
+                                                    []
+                                                )
+                                        })
+                                    item
+                                    (StructType
+                                        [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                        []
+                                        .true.
+                                        .false.
+                                    )
+                                    []
+                                    [tag]
+                                    []
+                                    Source
+                                    Public
+                                    .false.
+                                    .false.
+                                    []
+                                    ()
+                                    ()
+                                    []
+                                ),
+                            items:
+                                (Variable
+                                    2
+                                    items
+                                    []
+                                    Local
+                                    (ArrayConstructor
+                                        [(StructConstructor
+                                            2 item
+                                            [((StringConstant
+                                                "a"
+                                                (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            ))]
+                                            (StructType
+                                                [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                            ()
+                                        )
+                                        (StructConstructor
+                                            2 item
+                                            [((StringConstant
+                                                "b"
+                                                (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            ))]
+                                            (StructType
+                                                [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                            ()
+                                        )]
+                                        (Array
+                                            (StructType
+                                                [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                                []
+                                                .true.
+                                                .false.
+                                            )
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            FixedSizeArray
+                                        )
+                                        ()
+                                        ColMajor
+                                        ()
+                                    )
+                                    ()
+                                    Parameter
+                                    (Array
+                                        (StructType
+                                            [(String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)]
+                                            []
+                                            .true.
+                                            .false.
+                                        )
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                        FixedSizeArray
+                                    )
+                                    2 item
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                    NotMethod
+                                    ()
+                                    []
+                                ),
+                            tags:
+                                (Variable
+                                    2
+                                    tags
+                                    [items]
+                                    Local
+                                    (StructInstanceMember
+                                        (Var 2 items)
+                                        2 1_item_tag
+                                        (Array
+                                            (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            PointerArray
+                                        )
+                                        (ArrayConstructor
+                                            [(StringConstant
+                                                "a"
+                                                (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            )
+                                            (StringConstant
+                                                "b"
+                                                (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            )]
+                                            (Array
+                                                (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                                [((IntegerConstant 1 (Integer 4) Decimal)
+                                                (IntegerConstant 2 (Integer 4) Decimal))]
+                                                PointerArray
+                                            )
+                                            ()
+                                            ColMajor
+                                            ()
+                                        )
+                                    )
+                                    (ArrayConstant
+                                        2
+                                        ["a", "b"]
+                                        (Array
+                                            (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                            [((IntegerConstant 1 (Integer 4) Decimal)
+                                            (IntegerConstant 2 (Integer 4) Decimal))]
+                                            PointerArray
+                                        )
+                                        ColMajor
+                                    )
+                                    Parameter
+                                    (Array
+                                        (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                        [((IntegerConstant 1 (Integer 4) Decimal)
+                                        (IntegerConstant 2 (Integer 4) Decimal))]
+                                        PointerArray
+                                    )
+                                    ()
+                                    Source
+                                    Public
+                                    Required
+                                    .false.
+                                    .false.
+                                    .false.
+                                    ()
+                                    .false.
+                                    .false.
+                                    NotMethod
+                                    ()
+                                    []
+                                )
+                        })
+                    struct_parameter_array_01
+                    []
+                    [(Print
+                        (StringFormat
+                            ()
+                            [(Var 2 tags)]
+                            FormatFortran
+                            (Allocatable
+                                (String 1 () DeferredLength DescriptorString)
+                            )
+                            ()
+                        )
+                    )
+                    (If
+                        ()
+                        (LogicalBinOp
+                            (StringCompare
+                                (ArrayItem
+                                    (Var 2 tags)
+                                    [(()
+                                    (IntegerConstant 1 (Integer 4) Decimal)
+                                    ())]
+                                    (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                    ColMajor
+                                    (StringConstant
+                                        "a"
+                                        (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                    )
+                                )
+                                NotEq
+                                (StringConstant
+                                    "a"
+                                    (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                )
+                                (Logical 4)
+                                (LogicalConstant
+                                    .false.
+                                    (Logical 4)
+                                )
+                            )
+                            Or
+                            (StringCompare
+                                (ArrayItem
+                                    (Var 2 tags)
+                                    [(()
+                                    (IntegerConstant 2 (Integer 4) Decimal)
+                                    ())]
+                                    (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                    ColMajor
+                                    (StringConstant
+                                        "b"
+                                        (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                    )
+                                )
+                                NotEq
+                                (StringConstant
+                                    "b"
+                                    (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)
+                                )
+                                (Logical 4)
+                                (LogicalConstant
+                                    .false.
+                                    (Logical 4)
+                                )
+                            )
+                            (Logical 4)
+                            (LogicalConstant
+                                .false.
+                                (Logical 4)
+                            )
+                        )
+                        [(ErrorStop
+                            ()
+                        )]
+                        []
+                    )]
+                )
+        })
+    []
+)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5258,3 +5258,7 @@ run = true
 [[test]]
 filename = "../integration_tests/shadow_same_symbol.f90"
 run = true
+
+[[test]]
+filename = "../integration_tests/struct_parameter_array_01.f90"
+asr = true


### PR DESCRIPTION
fixes #11951 


This commit resolves an issue where parameter arrays initialized from derived-type
component references (e.g., `items%tag` where `items` is an array of structs) 
failed to evaluate at compile-time, triggering an ASR verification error.

Changes:
- Updated `getStructInstanceMember_t` in `asr_utils.cpp` to fall back to 
  `m_symbolic_value` when retrieving constant array parameters during semantic analysis.
- Implemented iteration logic to correctly extract structural members from nested 
  `ArrayConstant_t` and `ArrayConstructor_t` AST nodes.
- Introduced an isolated `value_type` for generating constant arrays so that we 
  generate validly-typed `ArrayConstant_t` elements without globally polluting 
  `member_type`, preserving downstream semantic visitor checks.
