### PR TITLE
fix: ASR verify error for StructType in implicit interface dummy args

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2173,6 +2173,7 @@ RUN(NAME implicit_interface_38 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_40 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_43.f90
+++ b/integration_tests/implicit_interface_43.f90
@@ -1,0 +1,28 @@
+module implicit_interface_43_mod
+    implicit none
+    type :: runner
+        procedure(), nopass, pointer :: caller => null()
+    contains
+        procedure, pass(this) :: set_caller
+    end type
+contains
+    subroutine set_caller(this, caller)
+        class(runner), intent(inout) :: this
+        procedure() :: caller
+        this%caller => caller
+    end subroutine
+end module
+
+program implicit_interface_43
+    use implicit_interface_43_mod
+    implicit none
+    type(runner) :: br
+    call br%set_caller(upper_caller)
+    
+    ! Verification: check that the procedure pointer was set
+    if (.not. associated(br%caller)) error stop
+contains
+    subroutine upper_caller(a)
+        class(*), intent(in) :: a
+    end subroutine
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8111,9 +8111,20 @@ public:
                             if (existing_ft->n_arg_types == 0 && var_has_no_args) {
                                 Vec<ASR::ttype_t*> arg_types;
                                 arg_types.reserve(al, args.size());
+                                Vec<ASR::symbol_t*> arg_type_decls;
+                                arg_type_decls.reserve(al, args.size());
                                 for (size_t i = 0; i < args.size(); i++) {
                                     if (args[i].m_value == nullptr) continue;
                                     arg_types.push_back(al, ASRUtils::expr_type(args[i].m_value));
+                                    ASR::symbol_t* td = nullptr;
+                                    if (ASR::is_a<ASR::Var_t>(*args[i].m_value)) {
+                                        ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
+                                            ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v);
+                                        if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                                            td = ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration;
+                                        }
+                                    }
+                                    arg_type_decls.push_back(al, td);
                                 }
                                 SymbolTable* parent_scope = current_scope->parent
                                     ? current_scope->parent : current_scope;
@@ -8121,7 +8132,7 @@ public:
                                     proc_var, x.base.base.loc,
                                     arg_types.p, arg_types.size(),
                                     nullptr, parent_scope, sub_name,
-                                    current_scope);
+                                    current_scope, arg_type_decls.p);
                             }
                         }
                     }
@@ -8228,8 +8239,29 @@ public:
                                         }
                                     }
                                     if (!has_type_decl || (!has_arg_info && expected_ft->n_arg_types > 0)) {
+                                        // Extract type_declarations from the parameter function's args
+                                        ASR::symbol_t** param_arg_type_decls = nullptr;
+                                        if (v->m_type_declaration) {
+                                            ASR::symbol_t* param_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
+                                            if (ASR::is_a<ASR::Function_t>(*param_decl)) {
+                                                ASR::Function_t* param_func = ASR::down_cast<ASR::Function_t>(param_decl);
+                                                if (param_func->n_args == expected_ft->n_arg_types) {
+                                                    param_arg_type_decls = al.allocate<ASR::symbol_t*>(expected_ft->n_arg_types);
+                                                    for (size_t pi = 0; pi < expected_ft->n_arg_types; pi++) {
+                                                        param_arg_type_decls[pi] = nullptr;
+                                                        if (ASR::is_a<ASR::Var_t>(*param_func->m_args[pi])) {
+                                                            ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(param_func->m_args[pi])->m_v;
+                                                            if (ASR::is_a<ASR::Variable_t>(*ps)) {
+                                                                param_arg_type_decls[pi] = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                         create_interface_for_procedure_variable(
-                                            proc_var, passed_arg->base.loc, expected_ft);
+                                            proc_var, passed_arg->base.loc, expected_ft,
+                                            param_arg_type_decls);
                                     } else if (has_arg_info && expected_ft->n_arg_types == 0) {
                                         // Reverse: passed has arg_types but param doesn't.
                                         // Update the parameter's type to match what we're passing.
@@ -8263,17 +8295,29 @@ public:
                                         {
                                             // Use create_or_update_implicit_interface to properly
                                             // create/update the interface with matching args and arg_types.
-                                            // This handles both "interface exists" and "no interface" cases.
-                                            // For existing interfaces, it shares the source arg_types array
-                                            // directly for cross-scope type propagation (see #11924).
+                                            // Extract type_declarations from the passed function's args.
                                             SymbolTable* callee_scope = f->m_symtab;
                                             SymbolTable* iface_parent = callee_scope->parent ? callee_scope->parent : callee_scope;
                                             std::string var_name = v->m_name;
                                             ASR::ttype_t* return_type = passed_ft->m_return_var_type;
+                                            ASR::symbol_t** fn_arg_type_decls = nullptr;
+                                            if (passed_func->n_args == passed_ft->n_arg_types) {
+                                                fn_arg_type_decls = al.allocate<ASR::symbol_t*>(passed_ft->n_arg_types);
+                                                for (size_t pi = 0; pi < passed_ft->n_arg_types; pi++) {
+                                                    fn_arg_type_decls[pi] = nullptr;
+                                                    if (ASR::is_a<ASR::Var_t>(*passed_func->m_args[pi])) {
+                                                        ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(passed_func->m_args[pi])->m_v;
+                                                        if (ASR::is_a<ASR::Variable_t>(*ps)) {
+                                                            fn_arg_type_decls[pi] = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
+                                                        }
+                                                    }
+                                                }
+                                            }
                                             ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                                                 v, passed_arg->base.loc,
                                                 passed_ft->m_arg_types, passed_ft->n_arg_types,
-                                                return_type, iface_parent, var_name);
+                                                return_type, iface_parent, var_name, nullptr,
+                                                fn_arg_type_decls);
                                             // Update the callee function's signature
                                             ASR::FunctionType_t* callee_ft = ASR::down_cast<ASR::FunctionType_t>(
                                                 f->m_function_signature);
@@ -10252,33 +10296,22 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
                                     ASR::ttype_t* arg_type = param_ft->m_arg_types[j];
                                     std::string arg_name = std::string(passed_func->m_name) + "_arg_" + std::to_string(j);
                                     if (passed_func->m_symtab->get_symbol(arg_name) == nullptr) {
-                                        // For StructType args, resolve type_declaration
+                                        // Get type_declaration from the callee's parameter function args
                                         ASR::symbol_t* arg_type_decl = nullptr;
-                                        ASR::ttype_t* base_arg_type = ASRUtils::extract_type(arg_type);
-                                        if (ASR::is_a<ASR::StructType_t>(*base_arg_type)) {
-                                            ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_arg_type);
-                                            SymbolTable* search_scope = passed_func->m_symtab->parent;
-                                            if (st->m_is_unlimited_polymorphic && search_scope) {
-                                                arg_type_decl = search_scope->resolve_symbol("~unlimited_polymorphic_type");
-                                                if (!arg_type_decl) {
-                                                    std::string poly_name = "~unlimited_polymorphic_type";
-                                                    SymbolTable *st_tab = al.make_new<SymbolTable>(search_scope);
-                                                    ASR::asr_t* dtype = ASR::make_Struct_t(al, call->base.base.loc, st_tab,
-                                                        s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
-                                                        nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
-                                                        false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
-                                                    ASR::symbol_t* ss = ASR::down_cast<ASR::symbol_t>(dtype);
-                                                    ASR::ttype_t* sst = ASRUtils::make_StructType_t_util(al, call->base.base.loc, ss, false);
-                                                    ASR::down_cast<ASR::Struct_t>(ss)->m_struct_signature = sst;
-                                                    search_scope->add_symbol(poly_name, ss);
-                                                    arg_type_decl = ss;
-                                                }
-                                            } else if (search_scope) {
-                                                for (auto& sp : search_scope->get_scope()) {
-                                                    ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sp.second);
-                                                    if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
-                                                        arg_type_decl = sp.second;
-                                                        break;
+                                        if (i < callee->n_args && ASR::is_a<ASR::Var_t>(*callee->m_args[i])) {
+                                            ASR::symbol_t* callee_param = ASR::down_cast<ASR::Var_t>(callee->m_args[i])->m_v;
+                                            if (ASR::is_a<ASR::Variable_t>(*callee_param)) {
+                                                ASR::Variable_t* callee_param_var = ASR::down_cast<ASR::Variable_t>(callee_param);
+                                                if (callee_param_var->m_type_declaration) {
+                                                    ASR::symbol_t* param_decl = ASRUtils::symbol_get_past_external(callee_param_var->m_type_declaration);
+                                                    if (ASR::is_a<ASR::Function_t>(*param_decl)) {
+                                                        ASR::Function_t* param_iface = ASR::down_cast<ASR::Function_t>(param_decl);
+                                                        if (j < param_iface->n_args && ASR::is_a<ASR::Var_t>(*param_iface->m_args[j])) {
+                                                            ASR::symbol_t* iface_arg_sym = ASR::down_cast<ASR::Var_t>(param_iface->m_args[j])->m_v;
+                                                            if (ASR::is_a<ASR::Variable_t>(*iface_arg_sym)) {
+                                                                arg_type_decl = ASR::down_cast<ASR::Variable_t>(iface_arg_sym)->m_type_declaration;
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -10320,37 +10353,13 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
                             ASR::symbol_t* arg_sym = ASR::down_cast<ASR::Var_t>(func->m_args[i])->m_v;
                             if (ASR::is_a<ASR::Variable_t>(*arg_sym)) {
                                 ASR::Variable_t* arg_var = ASR::down_cast<ASR::Variable_t>(arg_sym);
-                                arg_var->m_type = ft->m_arg_types[i];
-                                // If the new type is StructType and no type_declaration, resolve it
-                                ASR::ttype_t* base_t = ASRUtils::extract_type(arg_var->m_type);
-                                if (ASR::is_a<ASR::StructType_t>(*base_t) && !arg_var->m_type_declaration) {
-                                    ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_t);
-                                    SymbolTable* search_scope = func->m_symtab->parent;
-                                    if (st->m_is_unlimited_polymorphic && search_scope) {
-                                        arg_var->m_type_declaration = search_scope->resolve_symbol("~unlimited_polymorphic_type");
-                                        if (!arg_var->m_type_declaration) {
-                                            std::string poly_name = "~unlimited_polymorphic_type";
-                                            SymbolTable *st_tab = al.make_new<SymbolTable>(search_scope);
-                                            ASR::asr_t* dtype = ASR::make_Struct_t(al, func->base.base.loc, st_tab,
-                                                s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
-                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
-                                                false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
-                                            ASR::symbol_t* ss = ASR::down_cast<ASR::symbol_t>(dtype);
-                                            ASR::ttype_t* sst = ASRUtils::make_StructType_t_util(al, func->base.base.loc, ss, false);
-                                            ASR::down_cast<ASR::Struct_t>(ss)->m_struct_signature = sst;
-                                            search_scope->add_symbol(poly_name, ss);
-                                            arg_var->m_type_declaration = ss;
-                                        }
-                                    } else if (search_scope) {
-                                        for (auto& sp : search_scope->get_scope()) {
-                                            ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sp.second);
-                                            if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
-                                                arg_var->m_type_declaration = sp.second;
-                                                break;
-                                            }
-                                        }
-                                    }
+                                // Skip syncing if the new type is StructType to avoid
+                                // incorrectly deducing type_declaration from scope
+                                ASR::ttype_t* base_t = ASRUtils::extract_type(ft->m_arg_types[i]);
+                                if (ASR::is_a<ASR::StructType_t>(*base_t)) {
+                                    continue;
                                 }
+                                arg_var->m_type = ft->m_arg_types[i];
                             }
                         }
                     }

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8132,7 +8132,7 @@ public:
                                     proc_var, x.base.base.loc,
                                     arg_types.p, arg_types.size(),
                                     nullptr, parent_scope, sub_name,
-                                    current_scope, arg_type_decls.p);
+                                    arg_type_decls, current_scope);
                             }
                         }
                     }
@@ -8240,28 +8240,34 @@ public:
                                     }
                                     if (!has_type_decl || (!has_arg_info && expected_ft->n_arg_types > 0)) {
                                         // Extract type_declarations from the parameter function's args
-                                        ASR::symbol_t** param_arg_type_decls = nullptr;
+                                        Vec<ASR::symbol_t*> param_arg_type_decls;
+                                        param_arg_type_decls.reserve(al, expected_ft->n_arg_types);
                                         if (v->m_type_declaration) {
                                             ASR::symbol_t* param_decl = ASRUtils::symbol_get_past_external(v->m_type_declaration);
                                             if (ASR::is_a<ASR::Function_t>(*param_decl)) {
                                                 ASR::Function_t* param_func = ASR::down_cast<ASR::Function_t>(param_decl);
-                                                if (param_func->n_args == expected_ft->n_arg_types) {
-                                                    param_arg_type_decls = al.allocate<ASR::symbol_t*>(expected_ft->n_arg_types);
-                                                    for (size_t pi = 0; pi < expected_ft->n_arg_types; pi++) {
-                                                        param_arg_type_decls[pi] = nullptr;
-                                                        if (ASR::is_a<ASR::Var_t>(*param_func->m_args[pi])) {
-                                                            ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(param_func->m_args[pi])->m_v;
-                                                            if (ASR::is_a<ASR::Variable_t>(*ps)) {
-                                                                param_arg_type_decls[pi] = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
-                                                            }
+                                                LCOMPILERS_ASSERT(param_func->n_args == expected_ft->n_arg_types)
+                                                for (size_t pi = 0; pi < expected_ft->n_arg_types; pi++) {
+                                                    ASR::symbol_t* td = nullptr;
+                                                    if (ASR::is_a<ASR::Var_t>(*param_func->m_args[pi])) {
+                                                        ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(param_func->m_args[pi])->m_v;
+                                                        if (ASR::is_a<ASR::Variable_t>(*ps)) {
+                                                            td = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
                                                         }
                                                     }
+                                                    param_arg_type_decls.push_back(al, td);
                                                 }
                                             }
                                         }
+                                        if (param_arg_type_decls.size() == 0) {
+                                            // No type_declaration info found; fill with nullptrs
+                                            for (size_t pi = 0; pi < expected_ft->n_arg_types; pi++) {
+                                                param_arg_type_decls.push_back(al, nullptr);
+                                            }
+                                        }
                                         create_interface_for_procedure_variable(
-                                            proc_var, passed_arg->base.loc, expected_ft,
-                                            param_arg_type_decls);
+                                            proc_var, passed_arg->base.loc,
+                                            param_arg_type_decls, expected_ft);
                                     } else if (has_arg_info && expected_ft->n_arg_types == 0) {
                                         // Reverse: passed has arg_types but param doesn't.
                                         // Update the parameter's type to match what we're passing.
@@ -8300,23 +8306,23 @@ public:
                                             SymbolTable* iface_parent = callee_scope->parent ? callee_scope->parent : callee_scope;
                                             std::string var_name = v->m_name;
                                             ASR::ttype_t* return_type = passed_ft->m_return_var_type;
-                                            ASR::symbol_t** fn_arg_type_decls = nullptr;
-                                            if (passed_func->n_args == passed_ft->n_arg_types) {
-                                                fn_arg_type_decls = al.allocate<ASR::symbol_t*>(passed_ft->n_arg_types);
-                                                for (size_t pi = 0; pi < passed_ft->n_arg_types; pi++) {
-                                                    fn_arg_type_decls[pi] = nullptr;
-                                                    if (ASR::is_a<ASR::Var_t>(*passed_func->m_args[pi])) {
-                                                        ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(passed_func->m_args[pi])->m_v;
-                                                        if (ASR::is_a<ASR::Variable_t>(*ps)) {
-                                                            fn_arg_type_decls[pi] = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
-                                                        }
+                                            Vec<ASR::symbol_t*> fn_arg_type_decls;
+                                            fn_arg_type_decls.reserve(al, passed_ft->n_arg_types);
+                                            LCOMPILERS_ASSERT(passed_func->n_args == passed_ft->n_arg_types)
+                                            for (size_t pi = 0; pi < passed_ft->n_arg_types; pi++) {
+                                                ASR::symbol_t* td = nullptr;
+                                                if (ASR::is_a<ASR::Var_t>(*passed_func->m_args[pi])) {
+                                                    ASR::symbol_t* ps = ASR::down_cast<ASR::Var_t>(passed_func->m_args[pi])->m_v;
+                                                    if (ASR::is_a<ASR::Variable_t>(*ps)) {
+                                                        td = ASR::down_cast<ASR::Variable_t>(ps)->m_type_declaration;
                                                     }
                                                 }
+                                                fn_arg_type_decls.push_back(al, td);
                                             }
                                             ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                                                 v, passed_arg->base.loc,
                                                 passed_ft->m_arg_types, passed_ft->n_arg_types,
-                                                return_type, iface_parent, var_name, nullptr,
+                                                return_type, iface_parent, var_name,
                                                 fn_arg_type_decls);
                                             // Update the callee function's signature
                                             ASR::FunctionType_t* callee_ft = ASR::down_cast<ASR::FunctionType_t>(

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -10252,11 +10252,42 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
                                     ASR::ttype_t* arg_type = param_ft->m_arg_types[j];
                                     std::string arg_name = std::string(passed_func->m_name) + "_arg_" + std::to_string(j);
                                     if (passed_func->m_symtab->get_symbol(arg_name) == nullptr) {
+                                        // For StructType args, resolve type_declaration
+                                        ASR::symbol_t* arg_type_decl = nullptr;
+                                        ASR::ttype_t* base_arg_type = ASRUtils::extract_type(arg_type);
+                                        if (ASR::is_a<ASR::StructType_t>(*base_arg_type)) {
+                                            ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_arg_type);
+                                            SymbolTable* search_scope = passed_func->m_symtab->parent;
+                                            if (st->m_is_unlimited_polymorphic && search_scope) {
+                                                arg_type_decl = search_scope->resolve_symbol("~unlimited_polymorphic_type");
+                                                if (!arg_type_decl) {
+                                                    std::string poly_name = "~unlimited_polymorphic_type";
+                                                    SymbolTable *st_tab = al.make_new<SymbolTable>(search_scope);
+                                                    ASR::asr_t* dtype = ASR::make_Struct_t(al, call->base.base.loc, st_tab,
+                                                        s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
+                                                        nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
+                                                        false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                                                    ASR::symbol_t* ss = ASR::down_cast<ASR::symbol_t>(dtype);
+                                                    ASR::ttype_t* sst = ASRUtils::make_StructType_t_util(al, call->base.base.loc, ss, false);
+                                                    ASR::down_cast<ASR::Struct_t>(ss)->m_struct_signature = sst;
+                                                    search_scope->add_symbol(poly_name, ss);
+                                                    arg_type_decl = ss;
+                                                }
+                                            } else if (search_scope) {
+                                                for (auto& sp : search_scope->get_scope()) {
+                                                    ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sp.second);
+                                                    if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
+                                                        arg_type_decl = sp.second;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
                                         ASR::symbol_t* arg_sym = ASR::down_cast<ASR::symbol_t>(
                                             ASR::make_Variable_t(al, call->base.base.loc, passed_func->m_symtab,
                                                 s2c(al, arg_name), nullptr, 0, ASR::intentType::Unspecified,
                                                 nullptr, nullptr, ASR::storage_typeType::Default, arg_type,
-                                                nullptr, ASR::abiType::BindC, ASR::accessType::Public,
+                                                arg_type_decl, ASR::abiType::BindC, ASR::accessType::Public,
                                                 ASR::presenceType::Required, false, false, false, nullptr, false, false,
                                                 ASR::pass_attrType::NotMethod, nullptr, nullptr, 0));
                                         passed_func->m_symtab->add_symbol(arg_name, arg_sym);
@@ -10290,6 +10321,36 @@ Result<ASR::TranslationUnit_t*> body_visitor(Allocator &al,
                             if (ASR::is_a<ASR::Variable_t>(*arg_sym)) {
                                 ASR::Variable_t* arg_var = ASR::down_cast<ASR::Variable_t>(arg_sym);
                                 arg_var->m_type = ft->m_arg_types[i];
+                                // If the new type is StructType and no type_declaration, resolve it
+                                ASR::ttype_t* base_t = ASRUtils::extract_type(arg_var->m_type);
+                                if (ASR::is_a<ASR::StructType_t>(*base_t) && !arg_var->m_type_declaration) {
+                                    ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_t);
+                                    SymbolTable* search_scope = func->m_symtab->parent;
+                                    if (st->m_is_unlimited_polymorphic && search_scope) {
+                                        arg_var->m_type_declaration = search_scope->resolve_symbol("~unlimited_polymorphic_type");
+                                        if (!arg_var->m_type_declaration) {
+                                            std::string poly_name = "~unlimited_polymorphic_type";
+                                            SymbolTable *st_tab = al.make_new<SymbolTable>(search_scope);
+                                            ASR::asr_t* dtype = ASR::make_Struct_t(al, func->base.base.loc, st_tab,
+                                                s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
+                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
+                                                false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                                            ASR::symbol_t* ss = ASR::down_cast<ASR::symbol_t>(dtype);
+                                            ASR::ttype_t* sst = ASRUtils::make_StructType_t_util(al, func->base.base.loc, ss, false);
+                                            ASR::down_cast<ASR::Struct_t>(ss)->m_struct_signature = sst;
+                                            search_scope->add_symbol(poly_name, ss);
+                                            arg_var->m_type_declaration = ss;
+                                        }
+                                    } else if (search_scope) {
+                                        for (auto& sp : search_scope->get_scope()) {
+                                            ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sp.second);
+                                            if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
+                                                arg_var->m_type_declaration = sp.second;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -19613,10 +19613,43 @@ public:
         arg_types_vec.reserve(al, n_arg_types);
         for (size_t i = 0; i < n_arg_types; i++) {
             std::string arg_name = iface_name + "_arg_" + std::to_string(i);
+            // For StructType args, resolve the type_declaration from the scope chain
+            ASR::symbol_t* arg_type_decl = nullptr;
+            ASR::ttype_t* base_type = ASRUtils::extract_type(arg_type_arr[i]);
+            if (ASR::is_a<ASR::StructType_t>(*base_type)) {
+                ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_type);
+                if (st->m_is_unlimited_polymorphic) {
+                    arg_type_decl = parent_scope->resolve_symbol("~unlimited_polymorphic_type");
+                    if (!arg_type_decl) {
+                        // Create it here, mirroring determine_type's logic
+                        std::string poly_name = "~unlimited_polymorphic_type";
+                        SymbolTable *struct_symtab = al.make_new<SymbolTable>(parent_scope);
+                        ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
+                            s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
+                            nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
+                            false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                        ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
+                        ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(
+                            al, loc, struct_symbol, false);
+                        ASR::down_cast<ASR::Struct_t>(struct_symbol)->m_struct_signature = struct_type;
+                        parent_scope->add_symbol(poly_name, struct_symbol);
+                        arg_type_decl = struct_symbol;
+                    }
+                } else {
+                    // For named struct types, search scope for a matching Struct
+                    for (auto& sym_pair : parent_scope->get_scope()) {
+                        ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sym_pair.second);
+                        if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
+                            arg_type_decl = sym_pair.second;
+                            break;
+                        }
+                    }
+                }
+            }
             ASR::symbol_t* arg_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_Variable_t(al, loc, fn_scope, s2c(al, arg_name),
                     nullptr, 0, ASR::intentType::Unspecified, nullptr, nullptr,
-                    ASR::storage_typeType::Default, arg_type_arr[i], nullptr,
+                    ASR::storage_typeType::Default, arg_type_arr[i], arg_type_decl,
                     ASR::abiType::BindC, ASR::accessType::Public,
                     ASR::presenceType::Required, false, false, false, nullptr,
                     false, false, ASR::pass_attrType::NotMethod, nullptr,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -16977,16 +16977,29 @@ public:
                         }
                     }
                     SymbolTable* parent_scope = current_scope->parent ? current_scope->parent : current_scope;
-                    // Resolve arg types from the call arguments
+                    // Resolve arg types and type_declarations from the call arguments
                     Vec<ASR::ttype_t*> arg_types;
                     arg_types.reserve(al, x.n_args);
+                    Vec<ASR::symbol_t*> arg_type_decls;
+                    arg_type_decls.reserve(al, x.n_args);
                     for (size_t i = 0; i < x.n_args; i++) {
                         this->visit_expr(*x.m_args[i].m_end);
-                        arg_types.push_back(al, ASRUtils::expr_type(ASRUtils::EXPR(tmp)));
+                        ASR::expr_t* arg_expr = ASRUtils::EXPR(tmp);
+                        arg_types.push_back(al, ASRUtils::expr_type(arg_expr));
+                        ASR::symbol_t* td = nullptr;
+                        if (ASR::is_a<ASR::Var_t>(*arg_expr)) {
+                            ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
+                                ASR::down_cast<ASR::Var_t>(arg_expr)->m_v);
+                            if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                                td = ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration;
+                            }
+                        }
+                        arg_type_decls.push_back(al, td);
                     }
                     ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                         proc_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                        return_type, parent_scope, var_name);
+                        return_type, parent_scope, var_name, nullptr,
+                        arg_type_decls.p);
                     // Update the arg type in the containing function's signature
                     if (current_scope->asr_owner &&
                             ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner) &&
@@ -17091,12 +17104,24 @@ public:
                     SymbolTable* parent_scope = current_scope->parent ? current_scope->parent : current_scope;
                     Vec<ASR::ttype_t*> arg_types;
                     arg_types.reserve(al, c_args.size());
+                    Vec<ASR::symbol_t*> arg_type_decls;
+                    arg_type_decls.reserve(al, c_args.size());
                     for (size_t i = 0; i < c_args.size(); i++) {
                         arg_types.push_back(al, ASRUtils::expr_type(c_args[i].m_value));
+                        ASR::symbol_t* td = nullptr;
+                        if (ASR::is_a<ASR::Var_t>(*c_args[i].m_value)) {
+                            ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
+                                ASR::down_cast<ASR::Var_t>(c_args[i].m_value)->m_v);
+                            if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                                td = ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration;
+                            }
+                        }
+                        arg_type_decls.push_back(al, td);
                     }
                     create_or_update_implicit_interface(
                         proc_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                        return_type, parent_scope, var_name);
+                        return_type, parent_scope, var_name, nullptr,
+                        arg_type_decls.p);
                     // Update the arg type in the containing function's signature
                     ASR::ttype_t* updated_type = proc_var->m_type;
                     if (current_scope->asr_owner &&
@@ -17138,12 +17163,24 @@ public:
 
                 Vec<ASR::ttype_t*> arg_types;
                 arg_types.reserve(al, c_args.size());
+                Vec<ASR::symbol_t*> arg_type_decls;
+                arg_type_decls.reserve(al, c_args.size());
                 for (size_t i = 0; i < c_args.size(); i++) {
                     arg_types.push_back(al, ASRUtils::expr_type(c_args[i].m_value));
+                    ASR::symbol_t* td = nullptr;
+                    if (ASR::is_a<ASR::Var_t>(*c_args[i].m_value)) {
+                        ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
+                            ASR::down_cast<ASR::Var_t>(c_args[i].m_value)->m_v);
+                        if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                            td = ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration;
+                        }
+                    }
+                    arg_type_decls.push_back(al, td);
                 }
                 ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                     dummy_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                    return_type, owner_scope, var_name);
+                    return_type, owner_scope, var_name, nullptr,
+                    arg_type_decls.p);
 
                 if (owner_scope->asr_owner &&
                     ASR::is_a<ASR::symbol_t>(*owner_scope->asr_owner) &&
@@ -19590,7 +19627,8 @@ public:
             ASR::ttype_t** arg_type_arr, size_t n_arg_types,
             ASR::ttype_t* return_type, SymbolTable* parent_scope,
             const std::string& var_name,
-            SymbolTable* owner_scope = nullptr) {
+            SymbolTable* owner_scope = nullptr,
+            ASR::symbol_t** arg_type_decls = nullptr) {
         bool update_existing = proc_var->m_type_declaration != nullptr &&
             ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(
                 proc_var->m_type_declaration));
@@ -19613,39 +19651,8 @@ public:
         arg_types_vec.reserve(al, n_arg_types);
         for (size_t i = 0; i < n_arg_types; i++) {
             std::string arg_name = iface_name + "_arg_" + std::to_string(i);
-            // For StructType args, resolve the type_declaration from the scope chain
-            ASR::symbol_t* arg_type_decl = nullptr;
-            ASR::ttype_t* base_type = ASRUtils::extract_type(arg_type_arr[i]);
-            if (ASR::is_a<ASR::StructType_t>(*base_type)) {
-                ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(base_type);
-                if (st->m_is_unlimited_polymorphic) {
-                    arg_type_decl = parent_scope->resolve_symbol("~unlimited_polymorphic_type");
-                    if (!arg_type_decl) {
-                        // Create it here, mirroring determine_type's logic
-                        std::string poly_name = "~unlimited_polymorphic_type";
-                        SymbolTable *struct_symtab = al.make_new<SymbolTable>(parent_scope);
-                        ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
-                            s2c(al, poly_name), nullptr, nullptr, 0, nullptr, 0,
-                            nullptr, 0, ASR::abiType::Source, ASR::accessType::Public,
-                            false, true, nullptr, 0, nullptr, nullptr, nullptr, 0);
-                        ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
-                        ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(
-                            al, loc, struct_symbol, false);
-                        ASR::down_cast<ASR::Struct_t>(struct_symbol)->m_struct_signature = struct_type;
-                        parent_scope->add_symbol(poly_name, struct_symbol);
-                        arg_type_decl = struct_symbol;
-                    }
-                } else {
-                    // For named struct types, search scope for a matching Struct
-                    for (auto& sym_pair : parent_scope->get_scope()) {
-                        ASR::symbol_t* past_ext = ASRUtils::symbol_get_past_external(sym_pair.second);
-                        if (ASR::is_a<ASR::Struct_t>(*past_ext)) {
-                            arg_type_decl = sym_pair.second;
-                            break;
-                        }
-                    }
-                }
-            }
+            // Use the type_declaration passed by the caller (nullptr when not available)
+            ASR::symbol_t* arg_type_decl = (arg_type_decls ? arg_type_decls[i] : nullptr);
             ASR::symbol_t* arg_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_Variable_t(al, loc, fn_scope, s2c(al, arg_name),
                     nullptr, 0, ASR::intentType::Unspecified, nullptr, nullptr,
@@ -19742,7 +19749,8 @@ public:
 
     // Convenience wrapper: creates interface from an existing FunctionType.
     void create_interface_for_procedure_variable(ASR::Variable_t* proc_var,
-            const Location& loc, ASR::FunctionType_t* expected_type = nullptr) {
+            const Location& loc, ASR::FunctionType_t* expected_type = nullptr,
+            ASR::symbol_t** arg_type_decls = nullptr) {
         ASR::FunctionType_t* func_type = expected_type ? expected_type :
             ASR::down_cast<ASR::FunctionType_t>(proc_var->m_type);
         ASR::ttype_t* return_type = func_type->m_return_var_type;
@@ -19753,7 +19761,8 @@ public:
         std::string var_name = proc_var->m_name;
         ASR::ttype_t* iface_type = create_or_update_implicit_interface(
             proc_var, loc, func_type->m_arg_types, func_type->n_arg_types,
-            return_type, parent_scope, var_name, current_scope);
+            return_type, parent_scope, var_name, current_scope,
+            arg_type_decls);
         (void)iface_type;
     }
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -16998,8 +16998,8 @@ public:
                     }
                     ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                         proc_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                        return_type, parent_scope, var_name, nullptr,
-                        arg_type_decls.p);
+                        return_type, parent_scope, var_name,
+                        arg_type_decls);
                     // Update the arg type in the containing function's signature
                     if (current_scope->asr_owner &&
                             ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner) &&
@@ -17120,8 +17120,8 @@ public:
                     }
                     create_or_update_implicit_interface(
                         proc_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                        return_type, parent_scope, var_name, nullptr,
-                        arg_type_decls.p);
+                        return_type, parent_scope, var_name,
+                        arg_type_decls);
                     // Update the arg type in the containing function's signature
                     ASR::ttype_t* updated_type = proc_var->m_type;
                     if (current_scope->asr_owner &&
@@ -17179,8 +17179,8 @@ public:
                 }
                 ASR::ttype_t* iface_type = create_or_update_implicit_interface(
                     dummy_var, x.base.base.loc, arg_types.p, arg_types.size(),
-                    return_type, owner_scope, var_name, nullptr,
-                    arg_type_decls.p);
+                    return_type, owner_scope, var_name,
+                    arg_type_decls);
 
                 if (owner_scope->asr_owner &&
                     ASR::is_a<ASR::symbol_t>(*owner_scope->asr_owner) &&
@@ -19627,8 +19627,9 @@ public:
             ASR::ttype_t** arg_type_arr, size_t n_arg_types,
             ASR::ttype_t* return_type, SymbolTable* parent_scope,
             const std::string& var_name,
-            SymbolTable* owner_scope = nullptr,
-            ASR::symbol_t** arg_type_decls = nullptr) {
+            Vec<ASR::symbol_t*>& arg_type_decls,
+            SymbolTable* owner_scope = nullptr) {
+        LCOMPILERS_ASSERT(arg_type_decls.size() == n_arg_types)
         bool update_existing = proc_var->m_type_declaration != nullptr &&
             ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(
                 proc_var->m_type_declaration));
@@ -19652,7 +19653,7 @@ public:
         for (size_t i = 0; i < n_arg_types; i++) {
             std::string arg_name = iface_name + "_arg_" + std::to_string(i);
             // Use the type_declaration passed by the caller (nullptr when not available)
-            ASR::symbol_t* arg_type_decl = (arg_type_decls ? arg_type_decls[i] : nullptr);
+            ASR::symbol_t* arg_type_decl = arg_type_decls[i];
             ASR::symbol_t* arg_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_Variable_t(al, loc, fn_scope, s2c(al, arg_name),
                     nullptr, 0, ASR::intentType::Unspecified, nullptr, nullptr,
@@ -19749,10 +19750,11 @@ public:
 
     // Convenience wrapper: creates interface from an existing FunctionType.
     void create_interface_for_procedure_variable(ASR::Variable_t* proc_var,
-            const Location& loc, ASR::FunctionType_t* expected_type = nullptr,
-            ASR::symbol_t** arg_type_decls = nullptr) {
+            const Location& loc, Vec<ASR::symbol_t*>& arg_type_decls,
+            ASR::FunctionType_t* expected_type = nullptr) {
         ASR::FunctionType_t* func_type = expected_type ? expected_type :
             ASR::down_cast<ASR::FunctionType_t>(proc_var->m_type);
+        LCOMPILERS_ASSERT(arg_type_decls.size() == func_type->n_arg_types)
         ASR::ttype_t* return_type = func_type->m_return_var_type;
         if (!return_type) {
             return_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 8));
@@ -19761,8 +19763,8 @@ public:
         std::string var_name = proc_var->m_name;
         ASR::ttype_t* iface_type = create_or_update_implicit_interface(
             proc_var, loc, func_type->m_arg_types, func_type->n_arg_types,
-            return_type, parent_scope, var_name, current_scope,
-            arg_type_decls);
+            return_type, parent_scope, var_name,
+            arg_type_decls, current_scope);
         (void)iface_type;
     }
 


### PR DESCRIPTION
fixes #11974

When `create_or_update_implicit_interface` generates dummy arguments
for implicit procedure interfaces, Variables with StructType (e.g.
class(*)) were created with nullptr for m_type_declaration, causing
ASR verification failures.

The fix resolves/creates the ~unlimited_polymorphic_type struct symbol
in three code paths:
- create_or_update_implicit_interface (ast_common_visitor.h)
- reverse propagation arg creation (ast_body_visitor.cpp)
- sync lambda type update (ast_body_visitor.cpp)

For class(*), if the symbol isn't found via resolve_symbol (which
can't cross sibling scopes like module vs program), a new Struct is
created in the target scope mirroring determine_type's logic.
