### PR TITLE
fix : ICE  Unwrap external symbols before casting to Function_t for implicit interfaces

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2141,6 +2141,7 @@ RUN(NAME implicit_interface_38 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 
 RUN(NAME implicit_interface_40 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-interface)
 RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_42.f90
+++ b/integration_tests/implicit_interface_42.f90
@@ -1,0 +1,19 @@
+module implicit_interface_42_mod
+contains
+    subroutine sub_a(caller)
+        procedure() :: caller
+    end subroutine
+end module
+
+program implicit_interface_42
+    use implicit_interface_42_mod
+    
+    type :: runner
+        procedure(), nopass, pointer :: caller => null()
+    end type
+
+    type(runner) :: r
+    
+    ! Verification: check that the procedure pointer is initially null
+    if (associated(r%caller)) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9876,6 +9876,7 @@ public:
                         // all variables sharing this iface reference the same object.
                         // In-place updates to the iface's arg_types will then
                         // propagate to struct members and dummy arguments alike.
+                        existing = ASRUtils::symbol_get_past_external(existing);
                         type = ASR::down_cast<ASR::Function_t>(existing)->m_function_signature;
                     }
                     type_declaration = existing;


### PR DESCRIPTION

fixes #11976
When checking for existing implicit interfaces in `determine_type`, 
the compiler blindly casted the returned symbol to a `Function_t`. 
If the symbol was imported via a module `use` statement, the symbol 
was actually an `ExternalSymbol`, which caused an `AssertFailed: is_a<T>(*f)` 
crash during the downcast.

This fix safely unwraps the symbol using `ASRUtils::symbol_get_past_external` 
before casting, ensuring that we extract the `m_function_signature` 
from the underlying function safely.
