### PR TITLE
fix: ICE for pointer bounds remapping to null target 

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2818,6 +2818,14 @@ public:
         ASR::expr_t* value = ASRUtils::EXPR(tmp);
         ASR::ttype_t* value_type = ASRUtils::expr_type(value);
         tmp = nullptr;
+        if (ASR::is_a<ASR::ArraySection_t>(*target) && ASR::is_a<ASR::PointerNullConstant_t>(*value)) {
+            diag.add(Diagnostic(
+                "A pointer with bounds remapping cannot be associated with NULL()",
+                Level::Error, Stage::Semantic, {
+                    Label("", {x.base.base.loc})
+                }));
+            throw SemanticAbort();
+        }
         bool is_target_pointer = ASRUtils::is_pointer(target_type);
         if (ASR::is_a<ASR::ArraySection_t>(*target)) {
             ASR::ArraySection_t* array_section = ASR::down_cast<ASR::ArraySection_t>(target);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -815,4 +815,9 @@ program continue_compilation_1
 1000    continue
 1000    continue
     end subroutine
+
+    subroutine pointer_bounds_remapping_to_null()
+        real, pointer :: values(:)
+        values(1:2) => null()
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "0fc5b753a7e1ed7760379b4ae23b94a10ab06eb65c97a1adf0242cf9",
+    "infile_hash": "24caaa60e86d92ca169292ba549cefb876bba4df7882e4c8b222f20c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "bebdf5066201ecf9d3c2d6f689a95c0b645cef4eee5ae49c7a90f350",
+    "stderr_hash": "a5901a091ba70a7c9865f5fd8b273aadedbb3b90ab532475f3b42a43",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1695,3 +1695,9 @@ semantic error: duplicate statement label 1000
     |
 816 | 1000    continue
     |         ^^^^^^^^ 
+
+semantic error: A pointer with bounds remapping cannot be associated with NULL()
+   --> tests/errors/continue_compilation_1.f90:821:9
+    |
+821 |         values(1:2) => null()
+    |         ^^^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
fixes  #11991