### PR TITLE
CI: Update Exhaustive Checks for Caffeine 0.8.0

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -472,7 +472,7 @@ jobs:
             cmake --build . -j16 --target install
 
       - name: Test third party codes
-        shell: bash -e -x -l {0}
+        shell: bash -e -l {0}
         if: ${{! (matrix.llvm-version == '7') }}
         run: |
             export PATH="$(pwd)/src/bin:$PATH"

--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -39,7 +39,8 @@ cd ..
 git clone -b main https://github.com/BerkeleyLab/caffeine.git
 cd caffeine
 
-git checkout 0388cf70cd193214952d8be9a00e968c4c5061e2
+# Release 0.8.0
+git checkout 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
 
 # Toolchain setup
 
@@ -66,6 +67,10 @@ export GASNET_CONFIGURE_ARGS="--enable-rpath --enable-debug"
 # Build caffeine
 
 ./install.sh --yes --prefix=$PWD/inst --verbose
+
+# Output Caffeine configuration information
+
+./run-fpm.sh info
 
 cd ..
 

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -135,8 +135,11 @@ time_section "🧪 Testing caffeine" '
   # inject ISO_Fortran_binding.h into the C include path
   export CPPFLAGS="-I$(lfortran --print-c-include-dir)"
 
+  # Release 0.8.0
+  git checkout 0.8.0
+  assert_git_commit 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
+
   # Now build and test caffeine with LFortran
-  git checkout 0388cf70cd193214952d8be9a00e968c4c5061e2
   export GASNET_CONFIGURE_ARGS="--enable-rpath --enable-debug" 
   ./install.sh --yes --prefix=$PWD/inst --verbose
   export CAF_IMAGES=4

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "##[group] Setup"
 set -ex  # Exit immediately on any error
 
 # Default to gfortran if FC is not set
@@ -66,10 +67,12 @@ time_section() {
   local LABEL="$1"
   local BLOCK="$2"
   local START=$(date +%s)
+  echo "##[group] $LABEL"
   print_section "$LABEL"
-  eval "$BLOCK"
+  ( set -x ; eval "$BLOCK" )
   local END=$(date +%s)
   print_subsection "⏱ Duration: $((END - START)) seconds"
+  echo "##[endgroup]"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -107,6 +110,9 @@ fi
 # Setup a temporary workspace
 TMP_DIR=$(mktemp -d)
 cd "$TMP_DIR"
+
+set +x
+echo "##[endgroup]" # end of Setup
 
 time_section "🧪 Testing caffeine" '
   git clone -b main https://github.com/BerkeleyLab/caffeine.git

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -114,9 +114,9 @@ cd "$TMP_DIR"
 set +x
 echo "##[endgroup]" # end of Setup
 
-time_section "🧪 Testing caffeine" '
-  git clone -b main https://github.com/BerkeleyLab/caffeine.git
-  cd caffeine
+time_section "🧪 Testing conda-forge fpm" '
+  mkdir conda-fpm
+  cd conda-fpm
 
   micromamba install -c conda-forge fpm=0.12.0
 
@@ -125,6 +125,19 @@ time_section "🧪 Testing caffeine" '
   realpath $(which fpm)
   ls -l $(dirname $(realpath $(which fpm)))/../lib
   ls -l $CONDA_PREFIX/lib
+
+  fpm --version
+
+  cd ..
+  rm -rf conda-fpm
+'
+
+time_section "🧪 Testing caffeine" '
+  git clone -b main https://github.com/BerkeleyLab/caffeine.git
+  cd caffeine
+
+  micromamba install -c conda-forge fpm=0.12.0
+
   fpm --version
 
   export CC=clang
@@ -186,11 +199,6 @@ time_section "🧪 Testing splpak" '
   export PATH="$(pwd)/../src/bin:$PATH"
   micromamba install -c conda-forge fpm
 
-  # To debug https://github.com/lfortran/lfortran/issues/7732:
-  which fpm
-  realpath $(which fpm)
-  ls -l $(dirname $(realpath $(which fpm)))/../lib
-  ls -l $CONDA_PREFIX/lib
   fpm --version
 
   git checkout lf-2


### PR DESCRIPTION
The first two commits deploy the new Caffeine v0.8.0 release into the third-party testing and end-to-end multi-image testing of the Exhaustive Checks workflow.

The last two commits add some purely cosmetic logging improvements to the "Test third party codes" step. These commits make those enormous logs much easier to navigate when viewed in the web-based GitHub Actions log viewer. That [job step](https://github.com/bonachea/lfortran/actions/runs/28209302434/job/83566839650) now defaults to presenting a collapsed and navigable top-level view of the logs that fits on a single screen, e.g.:

<img width="823" height="975" alt="image" src="https://github.com/user-attachments/assets/c149b291-404a-4dbe-b894-32042d157f5d" />
