### PR TITLE
fix : ASR verify failure for array intrinsic parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1839,6 +1839,7 @@ RUN(NAME parameter_14 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTR
 RUN(NAME parameter_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME parameter_16 LABELS gfortran llvm)
 RUN(NAME parameter_17 LABELS gfortran llvm)
+RUN(NAME parameter_18 LABELS gfortran llvm)
 
 RUN(NAME fortuno_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/parameter_18.f90
+++ b/integration_tests/parameter_18.f90
@@ -1,0 +1,10 @@
+program parameter_18
+  implicit none
+
+  integer, parameter :: grid(2, 2) = reshape([1, 2, 2, 1], [2, 2])
+  integer, parameter :: where_is_two(2) = minloc(grid, dim=1, mask=grid > 1, back=.true.)
+
+  print *, "minloc:", where_is_two
+
+  if (any(where_is_two /= [2, 1])) error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -791,9 +791,13 @@ static inline ASR::expr_t* evaluate_compiletime_values(Allocator &al, std::vecto
 
     if (compiletime_values.size() == 0) {
         ASR::ttype_t* logical_type = ASRUtils::type_get_past_array(type);
-        if (ASRUtils::is_array(type) && ASRUtils::get_fixed_size_of_array(type) == 0) {
-            return ASRUtils::EXPR(ASR::make_ArrayConstant_t(
-                al, loc, 0, nullptr, type, ASR::arraystorageType::ColMajor));
+        if (ASRUtils::is_array(type)) {
+            if (ASRUtils::get_fixed_size_of_array(type) == 0) {
+                return ASRUtils::EXPR(ASR::make_ArrayConstant_t(
+                    al, loc, 0, nullptr, type, ASR::arraystorageType::ColMajor));
+            } else {
+                return nullptr;
+            }
         }
         return compare_helper(al, ASRUtils::expr_value(left), ASRUtils::expr_value(right), asr_op, logical_type, loc, diag);
     } else {
@@ -802,7 +806,12 @@ static inline ASR::expr_t* evaluate_compiletime_values(Allocator &al, std::vecto
         for (size_t i = 0; i < compiletime_values.size(); i++) {
             ASR::expr_t* left_val = compiletime_values[i].first;
             ASR::expr_t* right_val = compiletime_values[i].second;
-            args.push_back(al, compare_helper(al, left_val, right_val, asr_op, logical_type, loc, diag));
+            if (ASRUtils::is_array(ASRUtils::expr_type(left_val)) || ASRUtils::is_array(ASRUtils::expr_type(right_val))) {
+                return nullptr;
+            }
+            ASR::expr_t* res = compare_helper(al, left_val, right_val, asr_op, logical_type, loc, diag);
+            if (!res) return nullptr;
+            args.push_back(al, res);
         }
         if (ASRUtils::is_array(type) && ASRUtils::extract_n_dims_from_ttype(type) > 1) {
             Vec<ASR::expr_t*> values;
@@ -830,7 +839,13 @@ static inline void populate_compiletime_values(Allocator &al, std::vector<std::p
         for (size_t i=0; i<(size_t) ASRUtils::get_fixed_size_of_array(array->m_type); i++) {
             compiletime_values.push_back({ASRUtils::fetch_ArrayConstant_value(al, array, i), nullptr});
         }
+    } else if (ASR::is_a<ASR::ArrayConstructor_t>(*ASRUtils::expr_value(left))) {
+        ASR::ArrayConstructor_t* array = ASR::down_cast<ASR::ArrayConstructor_t>(ASRUtils::expr_value(left));
+        for (size_t i=0; i<array->n_args; i++) {
+            compiletime_values.push_back({array->m_args[i], nullptr});
+        }
     }
+
     if (ASR::is_a<ASR::ArrayConstant_t>(*ASRUtils::expr_value(right))) {
         ASR::ArrayConstant_t* array = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(right));
         for (size_t i=0; i<(size_t) ASRUtils::get_fixed_size_of_array(array->m_type); i++) {
@@ -838,6 +853,15 @@ static inline void populate_compiletime_values(Allocator &al, std::vector<std::p
                 compiletime_values[i].second = ASRUtils::fetch_ArrayConstant_value(al, array, i);
             } else {
                 compiletime_values.push_back({nullptr, ASRUtils::fetch_ArrayConstant_value(al, array, i)});
+            }
+        }
+    } else if (ASR::is_a<ASR::ArrayConstructor_t>(*ASRUtils::expr_value(right))) {
+        ASR::ArrayConstructor_t* array = ASR::down_cast<ASR::ArrayConstructor_t>(ASRUtils::expr_value(right));
+        for (size_t i=0; i<array->n_args; i++) {
+            if(compiletime_values.size() > i) {
+                compiletime_values[i].second = array->m_args[i];
+            } else {
+                compiletime_values.push_back({nullptr, array->m_args[i]});
             }
         }
     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -845,7 +845,6 @@ static inline void populate_compiletime_values(Allocator &al, std::vector<std::p
             compiletime_values.push_back({array->m_args[i], nullptr});
         }
     }
-
     if (ASR::is_a<ASR::ArrayConstant_t>(*ASRUtils::expr_value(right))) {
         ASR::ArrayConstant_t* array = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(right));
         for (size_t i=0; i<(size_t) ASRUtils::get_fixed_size_of_array(array->m_type); i++) {

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -167,6 +167,8 @@ class ReplaceIntrinsicFunctionsVisitor : public ASR::CallReplacerOnExpressionsVi
             in_ttype = in_ttype_copy;
         }
 
+
+
         void call_replacer() {
             replacer.current_expr = current_expr;
             replacer.replace_expr(*current_expr);
@@ -299,6 +301,22 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             return;
         }
 
+        ASR::expr_t* target_var = this->result_var_;
+        bool is_param = false;
+        if (ASR::is_a<ASR::Var_t>(*target_var)) {
+            ASR::Variable_t* v = ASRUtils::EXPR2VAR(target_var);
+            if (v->m_storage == ASR::storage_typeType::Parameter) {
+                is_param = true;
+            }
+        }
+
+        if (is_param) {
+            ASR::ttype_t* target_type = ASRUtils::expr_type(target_var);
+            target_var = PassUtils::create_var(++result_counter,
+                                        "_param_init_temp",
+                                        x->base.base.loc, target_type, al, current_scope);
+        }
+
         Vec<ASR::call_arg_t> new_args;
         new_args.reserve(al, x->n_args + 1);
         for( size_t i = 0; i < x->n_args; i++ ) {
@@ -308,9 +326,9 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             new_args.push_back(al, new_arg);
         }
         ASR::call_arg_t new_arg;
-        LCOMPILERS_ASSERT(this->result_var_)
-        new_arg.loc = this->result_var_->base.loc;
-        new_arg.m_value = this->result_var_;
+        LCOMPILERS_ASSERT(target_var)
+        new_arg.loc = target_var->base.loc;
+        new_arg.m_value = target_var;
         new_args.push_back(al, new_arg);
 
 
@@ -318,6 +336,12 @@ class ReplaceFunctionCallReturningArray: public ASR::BaseExprReplacer<ReplaceFun
             al, x->base.base.loc, x->m_name, x->m_original_name, new_args.p,
             new_args.size(), x->m_dt, nullptr, false));
         pass_result.push_back(al, subrout_call);
+
+        if (is_param) {
+            ASR::stmt_t* param_assign = ASRUtils::STMT(ASR::make_Assignment_t(
+                al, x->base.base.loc, this->result_var_, target_var, nullptr, false, false));
+            pass_result.push_back(al, param_assign);
+        }
     }
 };
 

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -167,8 +167,6 @@ class ReplaceIntrinsicFunctionsVisitor : public ASR::CallReplacerOnExpressionsVi
             in_ttype = in_ttype_copy;
         }
 
-
-
         void call_replacer() {
             replacer.current_expr = current_expr;
             replacer.replace_expr(*current_expr);


### PR DESCRIPTION

fixes #12008


This patch resolves an Internal Compiler Error (ICE) triggered by "Non-variable expression in variable definition context" during the ASR verify pass. 

Previously, when parameter initializations involving array intrinsics (e.g., `minloc`) were pulled out into assignments, the `ReplaceFunctionCallReturningArrayVisitor` pass would directly pass the parameter as an `INTENT(OUT)` argument into the generated `SubroutineCall`. This violates the strict verification rule that parameters are non-modifiable and cannot be bound to `INTENT(OUT)` dummies.

The fix introduces a check within `replace_FunctionCall`. If the target variable has `Parameter` storage, the pass now dynamically allocates a temporary intermediate variable, binds that temporary to the subroutine's `INTENT(OUT)` argument, and properly appends an assignment from the temporary back to the parameter.
