### PR TITLE
fix :  add support for TARGET attribute

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3934,6 +3934,7 @@ RUN(NAME c_ptr_14 LABELS gfortran llvm)
 RUN(NAME c_ptr_15 LABELS gfortran llvm)
 RUN(NAME c_ptr_16 LABELS gfortran llvm EXTRAFILES c_ptr_16_module.f90)
 RUN(NAME c_ptr_17 LABELS gfortran llvm EXTRAFILES c_ptr_17_module.f90)
+RUN(NAME target_01 LABELS gfortran llvm)
 
 RUN(NAME c_f_proc_ptr_01 LABELS gfortran llvm EXTRAFILES c_f_proc_ptr_01.c) # c_f_procpointer
 

--- a/integration_tests/target_01.f90
+++ b/integration_tests/target_01.f90
@@ -1,0 +1,10 @@
+program target_01
+  implicit none
+  real, target :: x = 5.0
+  real, pointer :: p
+
+  p => x
+  if (p /= 5.0) error stop
+  
+  print *, "target variable successfully implemented"
+end program target_01

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -2082,6 +2082,7 @@ public:
     std::map<std::string, ASR::presenceType> assgnd_presence;
     std::set<std::string> assgnd_pointer;
     std::set<std::string> assgnd_allocatable;
+    std::set<std::string> assgnd_target;
     // Current procedure arguments. Only non-empty for SymbolTableVisitor,
     // empty for BodyVisitor.
     std::vector<std::string> current_procedure_args;
@@ -5825,6 +5826,17 @@ public:
                                     } else {
                                         assgnd_allocatable.insert(to_lower(sym));
                                     }
+                                } else if (sa->m_attr == AST::simple_attributeType::AttrTarget) {
+                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
+                                    if (sym_) {
+                                        ASR::symbol_t* sym_past_external = ASRUtils::symbol_get_past_external(sym_);
+                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
+                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past_external);
+                                            v->m_target_attr = true;
+                                        }
+                                    } else {
+                                        assgnd_target.insert(to_lower(sym));
+                                    }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
                                 } else {
@@ -7041,6 +7053,12 @@ public:
                 bool is_pointer = false;
                 if (assgnd_pointer.count(sym)) {
                     is_pointer = true;
+                }
+                if (assgnd_allocatable.count(sym)) {
+                    is_allocatable = true;
+                }
+                if (assgnd_target.count(sym)) {
+                    target_attr = true;
                 }
                 if (current_scope->get_symbol(sym) !=
                         nullptr) {


### PR DESCRIPTION
fixes #12010


This commit implements semantic analysis support for the `target` attribute in LFortran. Previously, variables declared with `target` on a separate line (e.g., `target :: value`) would throw a semantic error: "Attribute declaration not supported".

Changes:
- Added `assgnd_target` state tracking in `ast_common_visitor.h` to identify target attributes on untyped variable declarations.
- Updated the AST attribute visitor to properly detect `AST::simple_attributeType::AttrTarget` and populate the corresponding `m_target_attr` field during the `ASR::Variable_t` node construction.
- Fixed an identical underlying issue where separate `allocatable` attribute declarations were silently failing to apply their ASR flags.

