### PR TITLE
fix: Internal read into assumed shape array fails with LLVM type mismatch

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3600,6 +3600,7 @@ RUN(NAME read_93 LABELS gfortran llvm)
 RUN(NAME read_94 LABELS gfortran llvm EXTRAFILES read_94.c)
 RUN(NAME read_95 LABELS gfortran llvm)
 RUN(NAME read_96 LABELS gfortran llvm)
+RUN(NAME read_97 LABELS gfortran llvm)
 
 RUN(NAME write_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME write_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/read_97.f90
+++ b/integration_tests/read_97.f90
@@ -1,0 +1,29 @@
+module read_97_mod
+contains
+    subroutine read_assumed_shape(unit, values)
+        integer, intent(in) :: unit
+        real, intent(out) :: values(:)
+
+        read(unit, *) values
+    end subroutine
+end module
+
+program read_97
+    use read_97_mod, only: read_assumed_shape
+    implicit none
+
+    integer :: unit
+    real :: values(3)
+
+    unit = 21
+    open(unit, file="read_97_input.txt", status="replace", action="write")
+    write(unit, *) 1.0, 2.0, 3.0
+    close(unit)
+
+    open(unit, file="read_97_input.txt", status="old", action="read")
+    call read_assumed_shape(unit, values)
+    close(unit)
+
+    if (any(abs(values - [1.0, 2.0, 3.0]) > 1.e-6)) error stop 1
+    print *, "assumed-shape read ok"
+end program

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18114,7 +18114,8 @@ public:
                         var_to_read_into = arr_descr->get_pointer_to_data(llvm_utils->get_type_from_ttype_t_util(x.m_values[i], ASRUtils::type_get_past_allocatable_pointer(type), module.get()), var_to_read_into);
                     }
                     if (ASR::is_a<ASR::Allocatable_t>(*type)
-                        || ASR::is_a<ASR::Pointer_t>(*type)) {
+                        || ASR::is_a<ASR::Pointer_t>(*type)
+                        || arr_tp->m_physical_type == ASR::array_physical_typeType::DescriptorArray) {
                         var_to_read_into = llvm_utils->CreateLoad2(el_type->getPointerTo(), var_to_read_into);
                     }
                     llvm::Value *arr = var_to_read_into;


### PR DESCRIPTION
fixes #12017 