### PR TITLE
fix : parsing and formatting of Hollerith constants in format strings

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -433,6 +433,7 @@ RUN(NAME ilp64_complex_literal_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-inte
 RUN(NAME ilp64_logical_compare_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 
 RUN(NAME label_01 LABELS gfortran llvm)
+RUN(NAME format_hollerith_01 LABELS gfortran llvm)
 
 RUN(NAME print_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm2 wasm fortran mlir)
 RUN(NAME print_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm fortran)

--- a/integration_tests/format_hollerith_01.f90
+++ b/integration_tests/format_hollerith_01.f90
@@ -1,0 +1,21 @@
+program format_hollerith_01
+  implicit none
+
+  integer :: first, second
+  character(len=100) :: str
+
+  first = 2
+  second = 3
+
+  ! Test Hollerith string format specifier
+  write (str, 100) first, second
+
+  ! The output should exactly match this, including the correct spaces
+  if (trim(str) /= "0sample hollerith format message!  2  3") then
+     print *, "Expected: '0sample hollerith format message!  2  3'"
+     print *, "Got     : '" // trim(str) // "'"
+     error stop
+  end if
+
+100 format(33h0sample hollerith format message!, 2i3)
+end program format_hollerith_01

--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -844,9 +844,7 @@ void lex_format(unsigned char *&cur, Location &loc,
                 | ':'
                 ;
 
-            hollerith_string
-                = int 'H' [^\s,)'\"\x00]+
-                ;
+
 
             * {
                 token_loc(loc, cur, tok, string_start);
@@ -912,7 +910,19 @@ void lex_format(unsigned char *&cur, Location &loc,
             '-' | '+' { continue; }
             (int)? whitespace? data_edit_desc { continue; }
             control_edit_desc { continue; }
-            (int)? whitespace? hollerith_string { continue; }
+            int [hH] {
+                uint64_t len = 0;
+                for (unsigned char *s = tok; s < cur - 1; ++s) {
+                    if (*s >= '0' && *s <= '9') {
+                        len = len * 10 + (*s - '0');
+                    }
+                }
+                for (uint64_t i = 0; i < len; ++i) {
+                    if (*cur == '\0') break;
+                    cur++;
+                }
+                continue;
+            }
         */
     }
 }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1543,6 +1543,31 @@ char* remove_spaces_except_quotes(const fchar* format, const int64_t len, int* c
             }
         }
 
+        // Handle Hollerith constants: digits followed by 'h'/'H'
+        // Copy the next n characters verbatim (preserving spaces)
+        if (!in_quotes && isdigit(c)) {
+            int digit_start = i;
+            int hollerith_len = 0;
+            int k = i;
+            while (k < len && isdigit(format[k])) {
+                hollerith_len = hollerith_len * 10 + (format[k] - '0');
+                k++;
+            }
+            if (k < len && (format[k] == 'h' || format[k] == 'H')) {
+                // Copy digits and 'h'/'H'
+                for (int m = digit_start; m <= k; m++) {
+                    cleaned_format[j++] = format[m];
+                }
+                // Copy next hollerith_len characters verbatim
+                k++;
+                for (int m = 0; m < hollerith_len && k < len; m++, k++) {
+                    cleaned_format[j++] = format[k];
+                }
+                i = k - 1; // -1 because the for loop will i++
+                continue;
+            }
+        }
+
         if (!isspace(c) || in_quotes) {
             cleaned_format[j++] = c; // copy non-space characters or any character within quotes
         }
@@ -3214,6 +3239,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
                         hollerith + 1, hollerith_len);
                     result_len += hollerith_len;
                     if (result_len > content_end) content_end = result_len;
+                    continue;
                 }
             } else if (tolower(value[strlen(value) - 1]) == 'x') {
                 // Advance position by 1 without overwriting any existing


### PR DESCRIPTION
fixes #12026
This commit resolves a runtime error and tokenizer bugs related to Hollerith
string format specifiers (e.g., `33h...`).

- Tokenizer (`tokenizer.re`): Removed the incorrect `hollerith_string` regex 
  that failed on spaces/commas and implemented manual cursor advancement 
  based on the explicit numerical length.
- Runtime (`lfortran_intrinsics.c`): 
  - Fixed `remove_spaces_except_quotes` to preserve spaces inside Hollerith 
    constants. Previously, it stripped internal spaces, breaking downstream 
    length-based parsing.
  - Added a missing `continue` in the Hollerith formatting handler to prevent 
    fall-through into argument-type error checks.
