### PR TITLE
fix : ensure bind(c, name=...) subroutines are exported with external linkage

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1964,6 +1964,7 @@ RUN(NAME bindc_08 LABELS gfortran llvm EXTRAFILES bindc_08.c EXTRA_ARGS --reallo
 RUN(NAME bindc_09 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME bindc_10 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME bindc_11 LABELS gfortran llvm fortran)
+RUN(NAME bindc_c_main LABELS gfortran llvm EXTRAFILES bindc_c_main.c)
 RUN(NAME bindc_12 LABELS gfortran llvm)
 RUN(NAME bindc_13 LABELS gfortran llvm)
 RUN(NAME bindc_14 LABELS gfortran llvm)

--- a/integration_tests/bindc_c_main.c
+++ b/integration_tests/bindc_c_main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+void
+bump_value(int* val);
+
+int
+main()
+{
+    int v = 41;
+    bump_value(&v);
+    if (v != 42) {
+        printf("Failed! v = %d\n", v);
+        return 1;
+    }
+    printf("Success!\n");
+    return 0;
+}

--- a/integration_tests/bindc_c_main.f90
+++ b/integration_tests/bindc_c_main.f90
@@ -1,0 +1,10 @@
+module bindc_c_main_mod
+  use iso_c_binding, only: c_int
+  implicit none
+contains
+  subroutine bump_value(val) bind(c, name="bump_value")
+    integer(c_int), intent(inout) :: val
+    if (val /= 41) error stop
+    val = val + 1
+  end subroutine bump_value
+end module

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1247,7 +1247,8 @@ int compile_src_to_object_file(const std::string &infile,
 
     if (!(compiler_options.separate_compilation || compiler_options.generate_code_for_global_procedures)
         && !LCompilers::ASRUtils::main_program_present(*asr)
-        && !LCompilers::ASRUtils::global_function_present(*asr)) {
+        && !LCompilers::ASRUtils::global_function_present(*asr)
+        && !LCompilers::ASRUtils::bind_c_present(*asr)) {
         if (!arg_c) {
             diagnostics.add(LCompilers::diag::Diagnostic(
                 "no main program found; cannot build an executable. "

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2852,6 +2852,47 @@ static inline bool global_function_present(const ASR::TranslationUnit_t &unit)
     return contains_global_function;
 }
 
+static inline bool bind_c_present(const ASR::TranslationUnit_t &unit)
+{
+    for (auto &a : unit.m_symtab->get_scope()) {
+        if (ASR::is_a<ASR::Function_t>(*a.second)) {
+            ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(a.second);
+            if (ASRUtils::get_FunctionType(*fn)->m_abi == ASR::abiType::BindC) return true;
+        } else if (ASR::is_a<ASR::Variable_t>(*a.second)) {
+            ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(a.second);
+            if (v->m_abi == ASR::abiType::BindC) return true;
+        } else if (ASR::is_a<ASR::Module_t>(*a.second)) {
+            ASR::Module_t* m = ASR::down_cast<ASR::Module_t>(a.second);
+            if (!m->m_loaded_from_mod) {
+                for (auto &b : m->m_symtab->get_scope()) {
+                    if (ASR::is_a<ASR::Function_t>(*b.second)) {
+                        ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(b.second);
+                        if (ASRUtils::get_FunctionType(*fn)->m_abi == ASR::abiType::BindC) return true;
+                    } else if (ASR::is_a<ASR::Variable_t>(*b.second)) {
+                        ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(b.second);
+                        if (v->m_abi == ASR::abiType::BindC) return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+static inline bool bind_c_present(const ASR::Module_t &m)
+{
+    for (auto &b : m.m_symtab->get_scope()) {
+        if (ASR::is_a<ASR::Function_t>(*b.second)) {
+            ASR::Function_t* fn = ASR::down_cast<ASR::Function_t>(b.second);
+            if (ASRUtils::get_FunctionType(*fn)->m_abi == ASR::abiType::BindC) return true;
+        } else if (ASR::is_a<ASR::Variable_t>(*b.second)) {
+            ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(b.second);
+            if (v->m_abi == ASR::abiType::BindC) return true;
+        }
+    }
+    return false;
+}
+
 // Accepts dependencies in the form A -> [B, D, ...], B -> [C, D]
 // Returns a list of dependencies in the order that they should be built:
 // [D, C, B, A]

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1894,6 +1894,12 @@ public:
             if (!item.compare("_lcompilers_mlir_gpu_offloading")) continue;
             ASR::symbol_t *mod = x.m_symtab->get_symbol(item);
             if (mod == nullptr) continue;
+            if (ASR::is_a<ASR::Module_t>(*mod)) {
+                ASR::Module_t* m = ASR::down_cast<ASR::Module_t>(mod);
+                if (m->m_loaded_from_mod && LCompilers::ASRUtils::bind_c_present(*m)) {
+                    m->m_symtab->mark_all_variables_external(al);
+                }
+            }
             visit_symbol(*mod);
         }
 
@@ -8090,8 +8096,11 @@ public:
             );
             if (llvm_symtab_fn_names.find(fn_name) == llvm_symtab_fn_names.end()) {
                 llvm_symtab_fn_names[fn_name] = h;
-                F = llvm::Function::Create(function_type,
-                    llvm::Function::ExternalLinkage, fn_name, module.get());
+                llvm::GlobalValue::LinkageTypes linkage = llvm::Function::ExternalLinkage;
+                if (startswith(fn_name, "_lcompilers_")) {
+                    linkage = llvm::Function::LinkOnceODRLinkage;
+                }
+                F = llvm::Function::Create(function_type, linkage, fn_name, module.get());
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];
@@ -8163,8 +8172,11 @@ public:
                     }
                     if (llvm_symtab_fn_names.find(fn_name) == llvm_symtab_fn_names.end()) {
                         llvm_symtab_fn_names[fn_name] = h;
-                        llvm::Function* F = llvm::Function::Create(function_type,
-                            llvm::Function::ExternalLinkage, fn_name, module.get());
+                        llvm::GlobalValue::LinkageTypes linkage = llvm::Function::ExternalLinkage;
+                        if (startswith(fn_name, "_lcompilers_")) {
+                            linkage = llvm::Function::LinkOnceODRLinkage;
+                        }
+                        llvm::Function* F = llvm::Function::Create(function_type, linkage, fn_name, module.get());
                         llvm_symtab_fn[h] = F;
                     } else {
                         uint32_t old_h = llvm_symtab_fn_names[fn_name];

--- a/tests/reference/llvm-abort_01-7212a3d.json
+++ b/tests/reference/llvm-abort_01-7212a3d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-abort_01-7212a3d.stdout",
-    "stdout_hash": "af197c3f92b3558b7df838df81d7def4c701eb5db5cace0c1c2b1daa",
+    "stdout_hash": "c1fa824c35b86ca178984804c3ac1fbaa7f63dfd95d51fdd2665e1ed",
     "stderr": "llvm-abort_01-7212a3d.stderr",
     "stderr_hash": "132e12d6d59905849ec72f4c5e5303920f043e68e199519ab136643f",
     "returncode": 0

--- a/tests/reference/llvm-abort_01-7212a3d.stdout
+++ b/tests/reference/llvm-abort_01-7212a3d.stdout
@@ -2,7 +2,7 @@
 source_filename = "LFortran"
 target datalayout = "..."
 
-define void @_lcompilers_abort_() {
+define linkonce_odr void @_lcompilers_abort_() {
 .entry:
   call void @_lfortran_abort()
   br label %return

--- a/tests/reference/llvm-arrays_101-8ed52ae.json
+++ b/tests/reference/llvm-arrays_101-8ed52ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_101-8ed52ae.stdout",
-    "stdout_hash": "3d53bfb5fed0d2173e9785f585739f0dfa7fe8386a1dbfb4a227178f",
+    "stdout_hash": "0c3cdb0915ce8590a0e3b07ed6cd2745bbded4a713bcb27088838323",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_101-8ed52ae.stdout
+++ b/tests/reference/llvm-arrays_101-8ed52ae.stdout
@@ -40,7 +40,7 @@ target datalayout = "..."
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data, i32 0, i32 0), i64 2 }>
 @31 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_real_i32(i32* %x) {
+define linkonce_odr float @_lcompilers_real_i32(i32* %x) {
 .entry:
   %_lcompilers_real_i32 = alloca float, align 4
   %0 = load i32, i32* %x, align 4

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "29e561c66bb1202d565380fe6249881fc42703c0dc90d7c6e147c74c",
+    "stdout_hash": "22c2ea92d63f0f4d228a478387a05c2f368e9857994be7e54ed4fb84",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -14,7 +14,7 @@ target datalayout = "..."
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_cos_f32(float* %x) {
+define linkonce_odr float @_lcompilers_cos_f32(float* %x) {
 .entry:
   %_lcompilers_cos_f32 = alloca float, align 4
   %0 = load float, float* %x, align 4

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "a85bb846d5580291fbd2a7412b3d1cec7ca8c82fdb982ac977c50b5c",
+    "stdout_hash": "705a4931ee9636a91af248ba11f6fb58bd0a6f195b15045afcb0a6dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -22,7 +22,7 @@ target datalayout = "..."
 @5 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @6 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
+define linkonce_odr i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
 .entry:
   %StringItem = alloca %string_descriptor, align 8
   %result = alloca i32, align 4
@@ -93,7 +93,7 @@ FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
   ret i32 %23
 }
 
-define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
+define linkonce_odr void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
 .entry:
   %0 = call i8* @_lfortran_get_default_allocator()
   %StrSlice_StrView = alloca %string_descriptor, align 8

--- a/tests/reference/llvm-execute_command_line-0e9cd63.json
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-execute_command_line-0e9cd63.stdout",
-    "stdout_hash": "f2ea6c742324a963e43e392fca6847b1dee12d61f139e39d0265ff19",
+    "stdout_hash": "389112ece66e65d16a7aeae712a055f524d4f840328bf1d9ea7a12f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-execute_command_line-0e9cd63.stdout
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.stdout
@@ -9,7 +9,7 @@ target datalayout = "..."
 @string_const_data.1 = private constant [2 x i8] c"ls"
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data.1, i32 0, i32 0), i64 2 }>
 
-define void @_lcompilers_execute_command_line_(%string_descriptor* %command, i32* %wait) {
+define linkonce_odr void @_lcompilers_execute_command_line_(%string_descriptor* %command, i32* %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
@@ -32,7 +32,7 @@ FINALIZE_SYMTABLE__lcompilers_execute_command_line_: ; preds = %return
 
 declare i32 @_lfortran_exec_command(i8*, i32)
 
-define void @_lcompilers_execute_command_line_1(%string_descriptor* %command, i32* %wait) {
+define linkonce_odr void @_lcompilers_execute_command_line_1(%string_descriptor* %command, i32* %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
   %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "36d631646b2e0282357e06b935ae7114348892d5b7dc329ba2b3adbe",
+    "stdout_hash": "5974b575160c9ddbf6fece36fc0a56eccb41165b29ea934ca2f2bdfe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -20,7 +20,7 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_sin_f32(float* %x) {
+define linkonce_odr float @_lcompilers_sin_f32(float* %x) {
 .entry:
   %_lcompilers_sin_f32 = alloca float, align 4
   %0 = load float, float* %x, align 4
@@ -38,7 +38,7 @@ FINALIZE_SYMTABLE__lcompilers_sin_f32:            ; preds = %return
 
 declare float @_lfortran_ssin(float)
 
-define double @_lcompilers_sin_f64(double* %x) {
+define linkonce_odr double @_lcompilers_sin_f64(double* %x) {
 .entry:
   %_lcompilers_sin_f64 = alloca double, align 8
   %0 = load double, double* %x, align 8

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "c0a691677b320e98077e06350f60195b3f721682b801200f1ce1a86c",
+    "stdout_hash": "c052f7f90fcca2032af623184363c78ba4b37976cfd561d909d6aa32",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -20,7 +20,7 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define double @_lcompilers_cos_f64(double* %x) {
+define linkonce_odr double @_lcompilers_cos_f64(double* %x) {
 .entry:
   %_lcompilers_cos_f64 = alloca double, align 8
   %0 = load double, double* %x, align 8

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "e0dc21f81a7b6b11c114cda899443d50385b8b1d8850ff80c0897941",
+    "stdout_hash": "eb4d7897fe43aa20a31ff29d2e89bed32484a868bde4d656a2d6ee97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -39,7 +39,7 @@ target datalayout = "..."
 @_Type_Info_fpm_run_settings = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([17 x i8], [17 x i8]* @_Name_fpm_run_settings, i32 0, i32 0), i8* inttoptr (i64 56 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*) }, align 8
 @_VTable_fpm_run_settings = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_run_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8*)* @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly to i8*)] }, align 8
 
-define i32 @_lcompilers_Any_4_1_0_logical____0(i32* %mask, i32* %__1mask) {
+define linkonce_odr i32 @_lcompilers_Any_4_1_0_logical____0(i32* %mask, i32* %__1mask) {
 .entry:
   %0 = call i8* @_lfortran_get_default_allocator()
   %__1_i = alloca i32, align 4

--- a/tests/reference/llvm-read_83-d6544e3.json
+++ b/tests/reference/llvm-read_83-d6544e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-read_83-d6544e3.stdout",
-    "stdout_hash": "47f9f2d340cb680fc3a9822dbaedf41c20dee9bc6854d05764f0d4a8",
+    "stdout_hash": "e70d6fab997ba2fce1204ff1338d85ed94ae09b5f925071f5964dfd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-read_83-d6544e3.stdout
+++ b/tests/reference/llvm-read_83-d6544e3.stdout
@@ -39,7 +39,7 @@ target datalayout = "..."
 @string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([77 x i8], [77 x i8]* @string_const_data.13, i32 0, i32 0), i64 77 }>
 @16 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @_lcompilers_get_command_argument_(i32* %number, %string_descriptor* %value) {
+define linkonce_odr void @_lcompilers_get_command_argument_(i32* %number, %string_descriptor* %value) {
 .entry:
   %0 = call i8* @_lfortran_get_default_allocator()
   %command_argument_holder = alloca %string_descriptor, align 8
@@ -104,7 +104,7 @@ declare i32 @_lfortran_get_command_argument_length(i32)
 
 declare void @_lfortran_get_command_argument_value(i32, i8*)
 
-define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
+define linkonce_odr i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
 .entry:
   %StringItem = alloca %string_descriptor, align 8
   %result = alloca i32, align 4
@@ -175,7 +175,7 @@ FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
   ret i32 %23
 }
 
-define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
+define linkonce_odr void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
 .entry:
   %0 = call i8* @_lfortran_get_default_allocator()
   %StrSlice_StrView = alloca %string_descriptor, align 8

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "a35884a9d02713f3221183ee155eedacf29970c0b241d35773b05995",
+    "stdout_hash": "81e61ea3a8103e2bc3ec5436ba387d35606a01fb891bddbe106442bc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -36,7 +36,7 @@ target datalayout = "..."
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @_lcompilers_stringconcat(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
+define linkonce_odr void @_lcompilers_stringconcat(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
 .entry:
   %StrSlice_StrView2 = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "2ef42d973a53bdb53be49e9d010bd271b8a78d3703992d11b5573ba4",
+    "stdout_hash": "aa87dff57cd927a83bd7a68699c8024768c2efd28e64ff066bc90903",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -18,7 +18,7 @@ target datalayout = "..."
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([24 x i8], [24 x i8]* @string_const_data.5, i32 0, i32 0), i64 24 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @_lcompilers_index_str(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
+define linkonce_odr i32 @_lcompilers_index_str(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
 .entry:
   %StrSlice_StrView4 = alloca %string_descriptor, align 8
   %StrSlice_StrView = alloca %string_descriptor, align 8
@@ -182,7 +182,7 @@ FINALIZE_SYMTABLE__lcompilers_index_str:          ; preds = %return
   ret i32 %79
 }
 
-define i32 @_lcompilers_index_str1(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
+define linkonce_odr i32 @_lcompilers_index_str1(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
 .entry:
   %StrSlice_StrView4 = alloca %string_descriptor, align 8
   %StrSlice_StrView = alloca %string_descriptor, align 8


### PR DESCRIPTION
fixes #12039 
