### PR TITLE
fix : ICE for elemental int on zero-sized parameter array  

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3200,6 +3200,7 @@ RUN(NAME empty_array_01 LABELS gfortran llvm)
 RUN(NAME empty_array_02 LABELS gfortran llvm)
 
 RUN(NAME empty_array_03 LABELS gfortran llvm)
+RUN(NAME empty_array_04 LABELS gfortran llvm)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/empty_array_04.f90
+++ b/integration_tests/empty_array_04.f90
@@ -1,0 +1,20 @@
+! Test: elemental intrinsics on zero-sized parameter arrays.
+! Regression test for ICE in compiletime_broadcast_elemental_intrinsic
+! when max_array_size == 0 (AssertFailed: f != nullptr).
+program empty_array_04
+    implicit none
+
+    integer, parameter :: xi(0) = 1
+    real, parameter :: xr(0) = 1.0
+
+    ! Elemental type-conversion intrinsics on zero-sized arrays
+    if (size(int(xi)) /= 0) error stop
+    if (size(real(xi)) /= 0) error stop
+    if (size(dble(xr)) /= 0) error stop
+
+    ! Elemental math intrinsics on zero-sized arrays
+    if (size(abs(xi)) /= 0) error stop
+    if (size(abs(xr)) /= 0) error stop
+
+    print *, "PASS"
+end program empty_array_04

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -15413,6 +15413,11 @@ public:
     {
         ASR::expr_t* first_arg_ = ASRUtils::expr_value(args[array_indices_in_args[0]]);
         size_t max_array_size = ASRUtils::get_fixed_size_of_array(ASRUtils::expr_type(first_arg_));
+        if (max_array_size == 0) {
+            // Zero-sized array: nothing to broadcast; keep the original
+            // (empty) result_array unchanged.
+            return;
+        }
         ASR::ttype_t* array_type = ASRUtils::expr_type(first_arg_);
         Vec<ASR::expr_t*> new_expr; new_expr.reserve(al, max_array_size);
 


### PR DESCRIPTION

fixes #12051
Elemental intrinsics (e.g. `int()`, `abs()`) applied to zero-sized
parameter arrays caused an AssertFailed (f != nullptr) because the
broadcast loop never executed, producing an empty ArrayConstructor
whose expr_value() was nullptr.

Add an early return when max_array_size == 0 to keep the original
(empty) result_array unchanged.
