### PR TITLE
Fix generic nopass type-bound procedure calls

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3172,6 +3172,7 @@ RUN(NAME class_148 LABELS gfortran llvm)
 RUN(NAME class_149 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
+RUN(NAME generic_nopass_01 LABELS gfortran llvm)
 
 RUN(NAME derived_type_member_procedure_call_01 LABELS gfortran llvm)
 RUN(NAME derived_type_member_procedure_call_02 LABELS gfortran llvm)

--- a/integration_tests/generic_nopass_01.f90
+++ b/integration_tests/generic_nopass_01.f90
@@ -1,0 +1,62 @@
+module generic_nopass_01_mod
+    implicit none
+    private
+    public :: command_line_t
+
+    type :: command_line_t
+        integer :: base = 1000
+    contains
+        ! Generic type-bound procedure resolving to `nopass` specifics.
+        generic :: flag_value => character_flag_value, integer_flag_value
+        procedure, nopass :: character_flag_value, integer_flag_value
+        ! Generic mixing a `pass` and a `nopass` specific.
+        generic :: combined => pass_add, nopass_len
+        procedure :: pass_add
+        procedure, nopass :: nopass_len
+    end type
+
+contains
+
+    function character_flag_value(flag) result(val)
+        character(len=*), intent(in) :: flag
+        character(len=:), allocatable :: val
+        val = "char:" // flag
+    end function
+
+    function integer_flag_value(flag) result(val)
+        integer, intent(in) :: flag
+        integer :: val
+        val = flag + 1
+    end function
+
+    integer function pass_add(self, i)
+        class(command_line_t), intent(in) :: self
+        integer, intent(in) :: i
+        pass_add = self%base + i
+    end function
+
+    integer function nopass_len(c)
+        character(len=*), intent(in) :: c
+        nopass_len = len(c)
+    end function
+
+end module generic_nopass_01_mod
+
+program generic_nopass_01
+    use generic_nopass_01_mod, only: command_line_t
+    implicit none
+    type(command_line_t) :: cl
+
+    ! Calling a generic that resolves to a `nopass` specific as a function in
+    ! an expression previously failed with "Function 'flag_value' not found".
+    if (cl%flag_value("--contains") /= "char:--contains") error stop 1
+
+    ! The generic must disambiguate `nopass` specifics by argument type.
+    if (cl%flag_value(5) /= 6) error stop 2
+
+    ! A generic mixing `pass` and `nopass` specifics must resolve both.
+    if (cl%combined(5) /= 1005) error stop 3
+    if (cl%combined("hello") /= 5) error stop 4
+
+    print *, "ok"
+end program generic_nopass_01

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11599,7 +11599,7 @@ public:
     }
 
     ASR::asr_t* create_GenericProcedureWithASTNode(const AST::FuncCallOrArray_t& x,
-                Vec<ASR::call_arg_t>& args, ASR::symbol_t *v) {
+                Vec<ASR::call_arg_t>& args, ASR::symbol_t *v, bool is_dt_present=false) {
         const Location& loc = x.base.base.loc;
         if (ASR::is_a<ASR::ExternalSymbol_t>(*v)) {
             return symbol_resolve_external_generic_procedure_with_ast_node(x, v,
@@ -11611,7 +11611,7 @@ public:
                             diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                             throw SemanticAbort();
                         },
-                    false);
+                    false, is_dt_present);
             if( idx == -1 ) {
                 ASR::symbol_t* tmp_v = current_scope->resolve_symbol(std::string(x.m_func));
                 if (tmp_v && ASR::is_a<ASR::Struct_t>(*ASRUtils::symbol_get_past_external(tmp_v))) {
@@ -11631,13 +11631,30 @@ public:
             ASR::ttype_t *type = nullptr;
             ASR::symbol_t *cp_s = nullptr;
             ASR::symbol_t *final_sym_past_ext = ASRUtils::symbol_get_past_external(final_sym);
+            bool is_nopass_method = false;
             if (ASR::is_a<ASR::StructMethodDeclaration_t>(*final_sym_past_ext)) {
+                is_nopass_method = ASR::down_cast<ASR::StructMethodDeclaration_t>(
+                    final_sym_past_ext)->m_is_nopass;
                 cp_s = ASRUtils::import_class_procedure(al, x.base.base.loc,
                     final_sym_past_ext, current_scope);
                 final_sym = ASR::down_cast<ASR::StructMethodDeclaration_t>(final_sym_past_ext)->m_proc;
             }
             LCOMPILERS_ASSERT(ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(final_sym)))
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(final_sym));
+            // For a `nopass` specific selected from a type-bound generic call,
+            // `args[0]` is the passed-object, which a nopass procedure does not
+            // accept as an argument. Drop it so the actual arguments line up
+            // with the procedure's dummy arguments.
+            ASR::expr_t* passed_object = nullptr;
+            if (is_nopass_method && is_dt_present && args.size() >= 1) {
+                passed_object = args[0].m_value;
+                Vec<ASR::call_arg_t> args_no_dt;
+                args_no_dt.reserve(al, args.size() - 1);
+                for (size_t i = 1; i < args.size(); i++) {
+                    args_no_dt.push_back(al, args[i]);
+                }
+                args = args_no_dt;
+            }
             ASR::expr_t* first_array_arg = ASRUtils::find_first_array_arg_if_elemental(func, args);
             if (first_array_arg) {
                 ASR::dimension_t* array_dims;
@@ -11658,6 +11675,16 @@ public:
                 }
                 ASRUtils::insert_module_dependency(cp_s, al, current_module_dependencies);
                 ASRUtils::insert_module_dependency(final_sym, al, current_module_dependencies);
+                if (is_nopass_method) {
+                    // The passed-object has already been dropped from `args`, so
+                    // the call arguments map directly onto the procedure's args.
+                    validate_missing_required_arguments(loc, args, func);
+                    ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
+                    return ASRUtils::make_FunctionCall_t_util(al, loc,
+                        cp_s, nullptr, args.p, args.size(), type,
+                        nullptr, passed_object, current_scope, current_function_dependencies,
+                        compiler_options.implicit_argument_casting);
+                }
                 Vec<ASR::call_arg_t> args_without_dt; args_without_dt.reserve(al, args.size() - 1);
                 for (size_t i = 1; i < args.size(); i++) {
                     args_without_dt.push_back(al, args[i]);
@@ -12596,7 +12623,7 @@ public:
             return create_FunctionFromFunctionTypeVariable(x.base.base.loc, new_args, v, is_dt_present);
         } else {
             LCOMPILERS_ASSERT(ASR::is_a<ASR::GenericProcedure_t>(*f2));
-            return create_GenericProcedureWithASTNode(x, new_args, v);
+            return create_GenericProcedureWithASTNode(x, new_args, v, is_dt_present);
         }
     }
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -5231,39 +5231,40 @@ template <typename T>
 int select_generic_procedure(const Vec<ASR::call_arg_t> &args,
     const T &p, Location loc,
     const std::function<void (const std::string &, const Location &)> err,
-    bool raise_error=true) {
+    bool raise_error=true, bool is_dt_present=false) {
+    // When `is_dt_present` is true, `args[0]` is the passed-object (the `dt`
+    // of a type-bound procedure call). A `nopass` specific procedure does not
+    // receive the passed-object, so it must be matched against the arguments
+    // excluding `args[0]`.
+    auto matches = [&](ASR::symbol_t* proc_sym) -> bool {
+        if( ASR::is_a<ASR::StructMethodDeclaration_t>(*proc_sym) ) {
+            ASR::StructMethodDeclaration_t *clss_fn
+                = ASR::down_cast<ASR::StructMethodDeclaration_t>(proc_sym);
+            const ASR::symbol_t *proc = ASRUtils::symbol_get_past_external(clss_fn->m_proc);
+            if( is_dt_present && clss_fn->m_is_nopass && args.n >= 1 ) {
+                Vec<ASR::call_arg_t> args_no_dt;
+                args_no_dt.from_pointer_n(args.p + 1, args.n - 1);
+                return select_func_subrout(proc, args_no_dt, loc, err);
+            }
+            return select_func_subrout(proc, args, loc, err);
+        } else {
+            return select_func_subrout(proc_sym, args, loc, err);
+        }
+    };
     for (size_t i=0; i < p.n_procs; i++) {
         if (is_elemental(p.m_procs[i])) {     // Prioritize direct arg matching, then look for elemental
             continue;
         }
-        if( ASR::is_a<ASR::StructMethodDeclaration_t>(*p.m_procs[i]) ) {
-            ASR::StructMethodDeclaration_t *clss_fn
-                = ASR::down_cast<ASR::StructMethodDeclaration_t>(p.m_procs[i]);
-            const ASR::symbol_t *proc = ASRUtils::symbol_get_past_external(clss_fn->m_proc);
-            if( select_func_subrout(proc, args, loc, err) ) {
-                return i;
-            }
-        } else {
-            if( select_func_subrout(p.m_procs[i], args, loc, err) ) {
-                return i;
-            }
+        if( matches(p.m_procs[i]) ) {
+            return i;
         }
     }
     for (size_t i=0; i < p.n_procs; i++) {
         if (!is_elemental(p.m_procs[i])) {
             continue;
         }
-        if( ASR::is_a<ASR::StructMethodDeclaration_t>(*p.m_procs[i]) ) {
-            ASR::StructMethodDeclaration_t *clss_fn
-                = ASR::down_cast<ASR::StructMethodDeclaration_t>(p.m_procs[i]);
-            const ASR::symbol_t *proc = ASRUtils::symbol_get_past_external(clss_fn->m_proc);
-            if( select_func_subrout(proc, args, loc, err) ) {
-                return i;
-            }
-        } else {
-            if( select_func_subrout(p.m_procs[i], args, loc, err) ) {
-                return i;
-            }
+        if( matches(p.m_procs[i]) ) {
+            return i;
         }
     }
     if( raise_error ) {


### PR DESCRIPTION
Calling a generic type-bound procedure that resolves to a `nopass` specific as a function in an expression (e.g. `x = obj%gen(arg)`) failed with "Function '<gen>' not found (not user defined nor intrinsic)".

For a type-bound call the passed-object is prepended to the argument list, but a `nopass` specific does not take the passed-object, so generic resolution never found a matching specific and fell back to an intrinsic lookup that failed.

`select_generic_procedure` now matches `nopass` specifics against the arguments excluding the passed-object, and `create_GenericProcedureWithASTNode` drops the passed-object before validating and building the call.

Add integration test generic_nopass_01 (covers a nopass generic called in an expression, overload disambiguation between nopass specifics, and a generic mixing pass and nopass specifics).

Fixes #12059