### PR TITLE
fix: append trailing newline before preprocessing source

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4029,6 +4029,10 @@ RUN(NAME cpp_pre_16 LABELS gfortran llvm
     EXTRA_ARGS --cpp
     GFORTRAN_ARGS -cpp)
 
+RUN(NAME cpp_pre_17 LABELS gfortran llvm
+    EXTRA_ARGS --cpp
+    GFORTRAN_ARGS -cpp)
+
 RUN(NAME dabs_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME minpack_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/cpp_pre_17.f90
+++ b/integration_tests/cpp_pre_17.f90
@@ -1,0 +1,17 @@
+program cpp_pre_17
+    ! Regression: source files ending in `#endif` without a trailing
+    ! newline must still preprocess successfully. Modelled after
+    ! `json-fortran/test/jf_test_47.F90`.
+    implicit none
+    integer :: x
+#ifndef NDEBUG
+    x = 42
+#else
+    x = 0
+#endif
+    if (x /= 42) error stop
+    print *, x
+end program
+#ifndef INTEGRATED_TESTS
+!*****************************************************************************************
+#endif

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2379,6 +2379,9 @@ int link_executable(const std::vector<std::string> &infiles,
 int emit_c_preprocessor(const std::string &infile, CompilerOptions &compiler_options)
 {
     std::string input = read_file_ok(infile);
+    if (!input.empty() && input.back() != '\n') {
+        input.push_back('\n');
+    }
 
     LCompilers::LFortran::CPreprocessor cpp(compiler_options);
     LCompilers::LocationManager lm;

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -245,7 +245,14 @@ Result<LFortran::AST::TranslationUnit_t*> FortranEvaluator::get_ast2(
     if (compiler_options.c_preprocessor) {
         // Preprocessor
         LFortran::CPreprocessor cpp(compiler_options);
-        Result<std::string> res = cpp.run(code_orig, lm, cpp.macro_definitions, diagnostics);
+        const std::string *cpp_input = &code_orig;
+        std::string cpp_input_with_newline;
+        if (!code_orig.empty() && code_orig.back() != '\n') {
+            cpp_input_with_newline = code_orig;
+            cpp_input_with_newline.push_back('\n');
+            cpp_input = &cpp_input_with_newline;
+        }
+        Result<std::string> res = cpp.run(*cpp_input, lm, cpp.macro_definitions, diagnostics);
         if (res.ok) {
             tmp = res.result;
         } else {


### PR DESCRIPTION
https://github.com/lfortran/lfortran/issues/11870