### PR TITLE
fix: ICE for eoshift on derived type array without boundary argument

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -3036,6 +3036,10 @@ namespace Eoshift {
             append_error(diag, "'boundary' argument of 'eoshift' intrinsic must be a scalar of same type as array type", boundary->base.loc);
             return nullptr;
         }
+        if (!is_boundary_present && ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(type_array))) {
+            append_error(diag, "Missing 'boundary' argument to 'eoshift' intrinsic", array->base.loc);
+            return nullptr;
+        }
         ASR::dimension_t* array_dims = nullptr;
         int array_rank = extract_dimensions_from_ttype(type_array, array_dims);
         int array_dim = -1;

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -305,7 +305,7 @@ program continue_compilation_1
         integer, len :: n
         real :: data(n)
     end type
-
+    type(MyClass) :: eoshift_derived_array(1), eoshift_derived_result(1)
 
 
 
@@ -639,7 +639,7 @@ program continue_compilation_1
     interface undeclared_iface
         module procedure undeclared_proc  ! {Error} Symbol 'undeclared_proc' not declared
     end interface
-
+    eoshift_derived_result = eoshift(eoshift_derived_array, 1)
     integer, parameter :: n2 = "abc"
     type(MyClass) :: ptr_src_no_target
     type(MyClass), pointer :: ptr_requires_target => ptr_src_no_target

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "b3d105b7044767b41bf90142cec1afbcace083d0f0c2d5b075b61d70",
+    "infile_hash": "a398a2cd9751f98a8fc507c3c778866d3a6ec03e6074f8b7d8c3c549",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "13eb94bcc4a2c7e5e840bc4d2dfbe5b90466ea5943267edc36452b60",
+    "stderr_hash": "2de1b75e8df63aa0355f1659959e0944f2d15a3f92591ef696084c70",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1540,6 +1540,12 @@ semantic error: Duplicate value of `decimal` found
 636 |     open(unit=7, decimal="POINT", decimal="comma")
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
+semantic error: Missing 'boundary' argument to 'eoshift' intrinsic
+   --> tests/errors/continue_compilation_1.f90:642:38
+    |
+642 |     eoshift_derived_result = eoshift(eoshift_derived_array, 1)
+    |                                      ^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Implicit casting from LOGICAL to INTEGER is not allowed by default. Use `--logical-casting` flag to enable it.
    --> tests/errors/continue_compilation_1.f90:648:5
     |


### PR DESCRIPTION
fixes #12100 