### PR TITLE
fix : procedure pointer array argument physical type mismatch in Call_t_body

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -432,6 +432,8 @@ RUN(NAME ilp64_logical_read_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer
 RUN(NAME ilp64_complex_literal_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 RUN(NAME ilp64_logical_compare_01 LABELS gfortran llvm EXTRA_ARGS -fdefault-integer-8 GFORTRAN_ARGS -fdefault-integer-8)
 
+RUN(NAME procedure_pointer_array_01 LABELS gfortran llvm)
+
 RUN(NAME label_01 LABELS gfortran llvm)
 RUN(NAME format_hollerith_01 LABELS gfortran llvm)
 

--- a/integration_tests/procedure_pointer_array_01.f90
+++ b/integration_tests/procedure_pointer_array_01.f90
@@ -1,0 +1,33 @@
+module mre_array_ptr_mod
+    implicit none
+
+    abstract interface
+        subroutine my_interface(args)
+            real(8), intent(in) :: args(100)
+        end subroutine my_interface
+    end interface
+
+    procedure(my_interface), pointer :: my_ptr => my_placeholder
+
+contains
+
+    subroutine my_placeholder(args)
+        real(8), intent(in) :: args(100)
+        if (abs(args(1) - 1.0_8) > 1e-10) then
+            error stop "Value mismatch in procedure pointer call"
+        end if
+    end subroutine my_placeholder
+
+    subroutine call_ptr()
+        real(8) :: args(100)
+        args(1) = 1.0_8
+        call my_ptr(args)
+    end subroutine call_ptr
+
+end module mre_array_ptr_mod
+
+program main
+    use mre_array_ptr_mod
+    implicit none
+    call call_ptr()
+end program main

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -8028,6 +8028,33 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
         ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
+        // When calling through a procedure pointer, `func_type` is the pointer
+        // variable's own FunctionType, whose array argument types are not
+        // normalized to the dummy-argument physical type (a fixed-size dummy is
+        // lowered to PointerArray, see make_Array_t_util). The interface
+        // function reached via `func` does carry the normalized type. Without
+        // this, both sides compare as FixedSizeArray, the ArrayPhysicalCast
+        // below is skipped, and codegen passes [N x T]* where the callee
+        // expects T*.
+        // Only the physical type is taken from the interface: the dummy's full
+        // type may contain dimension expressions referring to symbols in the
+        // interface's own symbol table (e.g. res(minval(shape(A)))), which must
+        // not leak into the caller's scope.
+        if (ASR::is_a<ASR::Variable_t>(*a_name_) &&
+                ASRUtils::is_array(orig_arg_type) &&
+                i < func->n_args && func->m_args[i] != nullptr) {
+            ASR::ttype_t* iface_arg_type = ASRUtils::type_get_past_allocatable(
+                ASRUtils::type_get_past_pointer(ASRUtils::expr_type(func->m_args[i])));
+            if (ASRUtils::is_array(iface_arg_type)) {
+                ASR::array_physical_typeType iface_ptype =
+                    ASRUtils::extract_physical_type(iface_arg_type);
+                ASR::Array_t* orig_arg_array_t = ASR::down_cast<ASR::Array_t>(orig_arg_type);
+                if (orig_arg_array_t->m_physical_type != iface_ptype) {
+                    orig_arg_type = ASRUtils::duplicate_type(al, orig_arg_type,
+                        nullptr, iface_ptype, true);
+                }
+            }
+        }
 
 
         if (ASR::is_a<ASR::FunctionType_t>(*arg_type) && ASR::is_a<ASR::FunctionType_t>(*orig_arg_type)) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4022,9 +4022,12 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
             Vec<ASR::ttype_t*> arg_types;
             arg_types.reserve(al, ft->n_arg_types);
             for( size_t i = 0; i < ft->n_arg_types; i++ ) {
-                ASR::ttype_t *t = ASRUtils::duplicate_type(al, ft->m_arg_types[i],
-                    nullptr, physical_type, override_physical_type);
-                arg_types.push_back(al, t);
+                auto const t = ft->m_arg_types[i];
+                ASR::ttype_t *duplicate_t = 
+                    ASRUtils::duplicate_type(al, t, nullptr, 
+                        is_array_t(t) ? extract_physical_type(t) : physical_type
+                        , true);
+                arg_types.push_back(al, duplicate_t);
             }
             return ASRUtils::TYPE(ASR::make_FunctionType_t(al, ft->base.base.loc,
                 arg_types.p, arg_types.size(), ft->m_return_var_type, ft->m_abi,
@@ -8028,33 +8031,6 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
             ASRUtils::type_get_past_pointer(ASRUtils::expr_type(arg)));
         ASR::ttype_t* orig_arg_type = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(func_type->m_arg_types[i]));
-        // When calling through a procedure pointer, `func_type` is the pointer
-        // variable's own FunctionType, whose array argument types are not
-        // normalized to the dummy-argument physical type (a fixed-size dummy is
-        // lowered to PointerArray, see make_Array_t_util). The interface
-        // function reached via `func` does carry the normalized type. Without
-        // this, both sides compare as FixedSizeArray, the ArrayPhysicalCast
-        // below is skipped, and codegen passes [N x T]* where the callee
-        // expects T*.
-        // Only the physical type is taken from the interface: the dummy's full
-        // type may contain dimension expressions referring to symbols in the
-        // interface's own symbol table (e.g. res(minval(shape(A)))), which must
-        // not leak into the caller's scope.
-        if (ASR::is_a<ASR::Variable_t>(*a_name_) &&
-                ASRUtils::is_array(orig_arg_type) &&
-                i < func->n_args && func->m_args[i] != nullptr) {
-            ASR::ttype_t* iface_arg_type = ASRUtils::type_get_past_allocatable(
-                ASRUtils::type_get_past_pointer(ASRUtils::expr_type(func->m_args[i])));
-            if (ASRUtils::is_array(iface_arg_type)) {
-                ASR::array_physical_typeType iface_ptype =
-                    ASRUtils::extract_physical_type(iface_arg_type);
-                ASR::Array_t* orig_arg_array_t = ASR::down_cast<ASR::Array_t>(orig_arg_type);
-                if (orig_arg_array_t->m_physical_type != iface_ptype) {
-                    orig_arg_type = ASRUtils::duplicate_type(al, orig_arg_type,
-                        nullptr, iface_ptype, true);
-                }
-            }
-        }
 
 
         if (ASR::is_a<ASR::FunctionType_t>(*arg_type) && ASR::is_a<ASR::FunctionType_t>(*orig_arg_type)) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -25903,6 +25903,19 @@ public:
             }
             args = convert_call_args(x, is_method /* skip_self */);
 
+#if LLVM_VERSION_MAJOR < 15
+            // Bitcast arguments when their types don't match the function
+            // signature (e.g., [100 x double]* passed where double* expected
+            // for fixed-size array parameters called through procedure pointers).
+            for (size_t i = 0; i < args.size(); i++) {
+                if (i < fntype->getNumParams()) {
+                    llvm::Type* expected_type = fntype->getParamType(i);
+                    if (args[i]->getType() != expected_type) {
+                        args[i] = builder->CreateBitCast(args[i], expected_type);
+                    }
+                }
+            }
+#endif
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym) &&
                 llvm_symtab.find(h) != llvm_symtab.end()) {
@@ -25917,6 +25930,19 @@ public:
             std::string m_name = ASRUtils::symbol_name(x.m_name);
             args = convert_call_args(x, is_method /* skip_self */);
 
+#if LLVM_VERSION_MAJOR < 15
+            // Bitcast arguments when their types don't match the function
+            // signature (e.g., [100 x double]* passed where double* expected
+            // for fixed-size array parameters called through procedure pointers).
+            for (size_t i = 0; i < args.size(); i++) {
+                if (i < fntype->getNumParams()) {
+                    llvm::Type* expected_type = fntype->getParamType(i);
+                    if (args[i]->getType() != expected_type) {
+                        args[i] = builder->CreateBitCast(args[i], expected_type);
+                    }
+                }
+            }
+#endif
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
             throw CodeGenError("Subroutine code not generated for '"

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -25903,19 +25903,6 @@ public:
             }
             args = convert_call_args(x, is_method /* skip_self */);
 
-#if LLVM_VERSION_MAJOR < 15
-            // Bitcast arguments when their types don't match the function
-            // signature (e.g., [100 x double]* passed where double* expected
-            // for fixed-size array parameters called through procedure pointers).
-            for (size_t i = 0; i < args.size(); i++) {
-                if (i < fntype->getNumParams()) {
-                    llvm::Type* expected_type = fntype->getParamType(i);
-                    if (args[i]->getType() != expected_type) {
-                        args[i] = builder->CreateBitCast(args[i], expected_type);
-                    }
-                }
-            }
-#endif
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (ASR::is_a<ASR::Variable_t>(*proc_sym) &&
                 llvm_symtab.find(h) != llvm_symtab.end()) {
@@ -25930,19 +25917,6 @@ public:
             std::string m_name = ASRUtils::symbol_name(x.m_name);
             args = convert_call_args(x, is_method /* skip_self */);
 
-#if LLVM_VERSION_MAJOR < 15
-            // Bitcast arguments when their types don't match the function
-            // signature (e.g., [100 x double]* passed where double* expected
-            // for fixed-size array parameters called through procedure pointers).
-            for (size_t i = 0; i < args.size(); i++) {
-                if (i < fntype->getNumParams()) {
-                    llvm::Type* expected_type = fntype->getParamType(i);
-                    if (args[i]->getType() != expected_type) {
-                        args[i] = builder->CreateBitCast(args[i], expected_type);
-                    }
-                }
-            }
-#endif
             tmp = builder->CreateCall(fntype, fn, args);
         } else if (llvm_symtab_fn.find(h) == llvm_symtab_fn.end()) {
             throw CodeGenError("Subroutine code not generated for '"

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -360,8 +360,10 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
         ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(func_sym);
         LCOMPILERS_ASSERT(ASR::is_a<ASR::FunctionType_t>(*ASRUtils::extract_type(v->m_type)));
         func_sym = ASRUtils::symbol_get_past_external(v->m_type_declaration);
-        ASR::ttype_t* new_type = ASRUtils::duplicate_type(al, ASR::down_cast<ASR::Function_t>(
-            ASRUtils::symbol_get_past_external(v->m_type_declaration))->m_function_signature);
+        ASR::ttype_t* new_type = ASRUtils::TYPE(
+            ASRUtils::ExprStmtWithScopeDuplicator(al, scope).
+                duplicate_FunctionType(ASRUtils::get_FunctionType(
+                    ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(v->m_type_declaration)))));
         if (ASR::is_a<ASR::Pointer_t>(*v->m_type)) {
             new_type = ASRUtils::TYPE(ASR::make_Pointer_t(al, v->base.base.loc, new_type));
         }


### PR DESCRIPTION
fixes #12109

Fix procedure pointer array argument physical type mismatch in Call_t_body

Calling a procedure pointer with a fixed-size array argument failed LLVM
verification: `"Call parameter type does not match function signature!
double* call void %18([100 x double]* %args)".`

The frontend emits the correct `ArrayPhysicalCast` (FixedSizeArray ->
PointerArray), but dumping the ASR after every pass showed it gone at
`nested_vars`. `nested_vars` is not what removes it: its visit_SubroutineCall
ends with `Call_t_body()`, which recomputes argument casts from scratch and
only builds a cast when actual and formal physical types differ. Since
a_args[i] is written only inside that branch, a "no cast needed" verdict
silently drops the frontend's cast. `nested_vars` is just the first pass to
call `Call_t_body` here.

The comparison used two inconsistent views of the formal type:

  - `get_FunctionType()` on a `Variable_t` returns the pointer variable's own
    FunctionType, whose array argument types are never normalized.
  -` get_function() `follows `m_type_declaration` to the interface function,
    whose dummy went through `make_Array_t_util` with `is_argument=true `and so
    became PointerArray.

Both read `FixedSizeArray`, so no cast was produced and codegen passed
`[100 x double]* into a double* parameter.`

Take the physical type of an array formal from the interface function's
dummy when calling through a procedure pointer. Only the physical type is
borrowed: a dummy's full type can contain dimension expressions referring to
symbols in the interface's symbol table (e.g. res(minval(shape(A))) in
functions_19.f90), and splicing those into the caller's scope trips the ASR
verifier with `"Var::m_v cannot point outside of its symbol table".`
duplicate_type() rebuilds from the caller-safe type, changing only the
physical-type field. Guarded on ASR::Variable_t, so ordinary Function_t
calls are unaffected.

