### PR TITLE
ICE for explicit shape array with nonconstant intrinsic boundInit bou

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -8175,6 +8175,14 @@ public:
                             which is equivalent to x(2) = [1,1]
                         */
                         int64_t size = ASRUtils::get_fixed_size_of_array(type);
+                        if (size < 0) {
+                            diag.add(Diagnostic(
+                                "explicit shaped array has nonconstant bounds",
+                                Level::Error,
+                                Stage::Semantic,
+                                { Label("", { x.base.base.loc }) }));
+                            throw SemanticAbort();
+                        }
                         Vec<ASR::expr_t*> args;
                         args.reserve(al, size);
                         LCOMPILERS_ASSERT(tmp_init != nullptr)

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -8,7 +8,7 @@ module continue_compilation_1_mod
     contains
         procedure :: display
     end type MyClass
-
+    integer :: values(command_argument_count()) = 1
     type :: logger_type
     contains
         private

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "3e2e12f7b0e2753cf191aae6b3b44596e04a212db2564f7121e5c600",
+    "infile_hash": "d0b7e43b41cf919b507812eee77e6fabe5eca28c30ef2b82b2735ba8",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "505f66db9533ed9702666c3cfbac4febfce8560b4c9631a4e650f846",
+    "stderr_hash": "dd2b5e01826e7d5fef84b7960564b20b12753f92dba604fd7ab578b3",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1,3 +1,9 @@
+semantic error: explicit shaped array has nonconstant bounds
+  --> tests/errors/continue_compilation_1.f90:11:5
+   |
+11 |     integer :: values(command_argument_count()) = 1
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
   --> tests/errors/continue_compilation_1.f90:53:5 - 57:24
    |
@@ -1666,7 +1672,7 @@ semantic error: Variable 'nosuch' is not declared
 773 |         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^ 'nosuch' is undeclared
 
-semantic error: actual argument for 'x' cannot be an assumed-size array
+semantic error: Actual argument for 'x' cannot be an assumed-size array
    --> tests/errors/continue_compilation_1.f90:777:23
     |
 777 |         call ptr_sink(x)  ! {Error} actual argument for 'x' cannot be an assumed-size array
@@ -1749,15 +1755,3 @@ semantic error: Label 20 is not defined
     |
 857 |         goto 20  ! {Error} Label 20 is not defined
     |         ^^^^^^^ 
-
-semantic error: actual argument for 'items' cannot be an assumed-size array
-   --> tests/errors/continue_compilation_1.f90:868:36
-    |
-868 |         call consume_assumed_shape(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
-    |                                    ^^^^^ 
-
-semantic error: actual argument for 'items' cannot be an assumed-size array
-   --> tests/errors/continue_compilation_1.f90:877:49
-    |
-877 |         print *, consume_assumed_shape_function(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
-    |                                                 ^^^^^ 


### PR DESCRIPTION
fixes #12127 