### PR TITLE
fix: ICE for array parameter initialized with implied-do using achar and iachar

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3403,6 +3403,7 @@ RUN(NAME implied_do_loops41 LABELS gfortran llvm)
 RUN(NAME implied_do_loops42 LABELS gfortran llvm)
 RUN(NAME implied_do_loops43 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME implied_do_loops44 LABELS gfortran llvm)
+RUN(NAME implied_do_loops45 LABELS gfortran llvm)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops45.f90
+++ b/integration_tests/implied_do_loops45.f90
@@ -1,0 +1,10 @@
+program implied_do_loops45
+    implicit none
+
+    integer :: i
+    character(len=1), parameter :: chars(*) = [(achar(iachar("A")), i = 1, 1)]
+
+    if (size(chars) /= 1) error stop 1
+    if (chars(1) /= "A") error stop 2
+    print *, chars
+end program implied_do_loops45

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -193,6 +193,7 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
         {ASRUtils::IntrinsicElementalFunctions::SelectedRealKind, 3},
         {ASRUtils::IntrinsicElementalFunctions::Ishftc, 3},
         {ASRUtils::IntrinsicElementalFunctions::Ichar, 2},
+        {ASRUtils::IntrinsicElementalFunctions::Iachar, 2},
         {ASRUtils::IntrinsicElementalFunctions::Char, 2},
         {ASRUtils::IntrinsicElementalFunctions::Achar, 2},
         {ASRUtils::IntrinsicElementalFunctions::Logical, 2},


### PR DESCRIPTION
fixes #12136 