### PR TITLE
fix: preserve character kind in repeat

### DIFF
--- a/integration_tests/char4_string_intrinsics_01.f90
+++ b/integration_tests/char4_string_intrinsics_01.f90
@@ -1,12 +1,15 @@
 program char4_string_intrinsics_01
   implicit none
   character(kind=4, len=5) :: s = 4_"ab"
+  character(kind=4, len=1) :: c
 
   ! len_trim with character(kind=4) previously ICE'd
   if (len_trim(s) /= 2) error stop 1
 
   ! repeat with character(kind=4) previously ICE'd
   if (repeat(4_"x", 3) /= 4_"xxx") error stop 2
+  c = "x"
+  if (repeat(c, 3) /= 4_"xxx") error stop 3
 
   print *, "ok"
 end program

--- a/integration_tests/char4_string_intrinsics_01.f90
+++ b/integration_tests/char4_string_intrinsics_01.f90
@@ -1,7 +1,8 @@
 program char4_string_intrinsics_01
   implicit none
   character(kind=4, len=5) :: s = 4_"ab"
-  character(kind=4, len=1) :: c
+  character(kind=4, len=1) :: c, glyph
+  character(kind=4, len=2) :: glyph_pair
 
   ! len_trim with character(kind=4) previously ICE'd
   if (len_trim(s) /= 2) error stop 1
@@ -10,6 +11,10 @@ program char4_string_intrinsics_01
   if (repeat(4_"x", 3) /= 4_"xxx") error stop 2
   c = "x"
   if (repeat(c, 3) /= 4_"xxx") error stop 3
+  glyph = achar(9731, kind=4)
+  glyph_pair(1:1) = achar(9731, kind=4)
+  glyph_pair(2:2) = achar(9731, kind=4)
+  if (repeat(glyph, 2) /= glyph_pair) error stop 4
 
   print *, "ok"
 end program

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -185,8 +185,9 @@ class ASRBuilder {
     }
 
     ASR::ttype_t* String(ASR::expr_t* len,
-        ASR::string_length_kindType len_kind, 
-        ASR::string_physical_typeType physical_type = ASR::DescriptorString) {
+        ASR::string_length_kindType len_kind,
+        ASR::string_physical_typeType physical_type = ASR::DescriptorString,
+        int character_kind = 1) {
         if(!(
                 (len_kind == ASR::AssumedLength && !len) || 
                 (len_kind == ASR::DeferredLength && !len) ||
@@ -201,7 +202,7 @@ class ASRBuilder {
                 LCompilersException("Invalid String Node Status");
         }
 
-        return ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, len,
+        return ASRUtils::TYPE(ASR::make_String_t(al, loc, character_kind, len,
             len_kind, physical_type));
     }
 
@@ -360,13 +361,17 @@ class ASRBuilder {
     inline ASR::expr_t* StringSection(ASR::expr_t* s, ASR::expr_t* start, ASR::expr_t* end) {
         int64_t start_const, end_const;
         ASR::ttype_t* string_type {};
+        int character_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(s));
         LCOMPILERS_ASSERT(start && end)
         if( ASRUtils::is_value_constant(start, start_const) &&
             ASRUtils::is_value_constant(end, end_const)){
-            string_type = character(end_const - start_const + 1);
+            string_type = String(i_t(end_const - start_const + 1, int32),
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::string_physical_typeType::DescriptorString, character_kind);
         } else {
             string_type = String(Add(Sub(end, start),i_t(1, expr_type(start))),
-                ASR::string_length_kindType::ExpressionLength);
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::string_physical_typeType::DescriptorString, character_kind);
         }
         return EXPR(ASR::make_StringSection_t(al, loc, s, start, end, i32(1), string_type, nullptr));
     }

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -6467,6 +6467,20 @@ namespace Rrspacing {
 
 namespace Repeat {
 
+    static inline ASR::ttype_t* character_type_with_kind(Allocator &al,
+            const Location &loc, int kind, ASR::expr_t *len,
+            ASR::string_length_kindType len_kind) {
+        return ASRUtils::TYPE(ASR::make_String_t(al, loc, kind, len,
+            len_kind, ASR::string_physical_typeType::DescriptorString));
+    }
+
+    static inline ASR::ttype_t* allocatable_deferred_string_with_kind(
+            Allocator &al, const Location &loc, int kind) {
+        return ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
+            character_type_with_kind(al, loc, kind, nullptr,
+                ASR::string_length_kindType::DeferredLength)));
+    }
+
     static ASR::expr_t *eval_Repeat(Allocator &al, const Location &loc,
             ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
         char* str = ASR::down_cast<ASR::StringConstant_t>(expr_value(args[0]))->m_s;
@@ -6478,7 +6492,12 @@ namespace Repeat {
             result[i] = str[i%len];
         }
         result[new_len] = '\0';
-        return make_ConstantWithType(make_StringConstant_t, result, character(new_len), loc);
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
+        ASR::ttype_t *return_type = character_type_with_kind(al, loc, char_kind,
+            ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, new_len,
+                ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
+            ASR::string_length_kindType::ExpressionLength);
+        return make_ConstantWithType(make_StringConstant_t, result, return_type, loc);
     }
 
     static inline ASR::expr_t* instantiate_Repeat(Allocator &al, const Location &loc,
@@ -6496,7 +6515,8 @@ namespace Repeat {
             ASR::string_length_kindType::AssumedLength,
             ASR::string_physical_typeType::DescriptorString)));
         fill_func_arg("y", arg_types[1]);
-        auto result = declare(fn_name, b.allocatable(b.String(nullptr, ASR::DeferredLength)), ReturnVar);
+        auto result = declare(fn_name,
+            allocatable_deferred_string_with_kind(al, loc, char_kind), ReturnVar);
         auto i = declare("i", int32, Local);
         auto j = declare("j", int32, Local);
         auto m = declare("m", int32, Local);
@@ -6521,8 +6541,8 @@ namespace Repeat {
         */
         body.push_back(al, b.Allocate(result, nullptr, 0, 
             ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, loc,
-                ASRUtils::EXPR(ASR::make_StringLen_t(al, loc, args[0], ASRUtils::expr_type(args[1]), nullptr)),
-                ASR::binopType::Mul, args[1], ASRUtils::expr_type(args[1]), nullptr))));
+                ASRUtils::EXPR(ASR::make_StringLen_t(al, loc, args[0], int64, nullptr)),
+                ASR::binopType::Mul, b.i2i_t(args[1], int64), int64, nullptr))));
         body.push_back(al, b.Assignment(m, b.StringLen(args[0])));
         body.push_back(al, b.Assignment(i, b.i32(1)));
         body.push_back(al, b.Assignment(j, m));
@@ -6573,7 +6593,8 @@ namespace Repeat {
             if (diag.has_error()) return nullptr;
             return_type = expr_type(m_value);
         } else {
-            return_type = allocatable_deferred_string();
+            return_type = allocatable_deferred_string_with_kind(al, loc,
+                ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0])));
         }
         
         for( size_t i = 0; i < 2; i++ ) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -6467,22 +6467,9 @@ namespace Rrspacing {
 
 namespace Repeat {
 
-    static inline ASR::ttype_t* character_type_with_kind(Allocator &al,
-            const Location &loc, int kind, ASR::expr_t *len,
-            ASR::string_length_kindType len_kind) {
-        return ASRUtils::TYPE(ASR::make_String_t(al, loc, kind, len,
-            len_kind, ASR::string_physical_typeType::DescriptorString));
-    }
-
-    static inline ASR::ttype_t* allocatable_deferred_string_with_kind(
-            Allocator &al, const Location &loc, int kind) {
-        return ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
-            character_type_with_kind(al, loc, kind, nullptr,
-                ASR::string_length_kindType::DeferredLength)));
-    }
-
     static ASR::expr_t *eval_Repeat(Allocator &al, const Location &loc,
             ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
+        ASRUtils::ASRBuilder b(al, loc);
         char* str = ASR::down_cast<ASR::StringConstant_t>(expr_value(args[0]))->m_s;
         int64_t n = ASR::down_cast<ASR::IntegerConstant_t>(expr_value(args[1]))->m_n;
         size_t len = std::strlen(str);
@@ -6493,10 +6480,11 @@ namespace Repeat {
         }
         result[new_len] = '\0';
         int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
-        ASR::ttype_t *return_type = character_type_with_kind(al, loc, char_kind,
+        ASR::ttype_t *return_type = b.String(
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, new_len,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
-            ASR::string_length_kindType::ExpressionLength);
+            ASR::string_length_kindType::ExpressionLength,
+            ASR::string_physical_typeType::DescriptorString, char_kind);
         return make_ConstantWithType(make_StringConstant_t, result, return_type, loc);
     }
 
@@ -6511,12 +6499,12 @@ namespace Repeat {
             return b.Call(s, new_args, return_type, nullptr);
         }
         int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
-        fill_func_arg("x", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, 
-            ASR::string_length_kindType::AssumedLength,
-            ASR::string_physical_typeType::DescriptorString)));
+        fill_func_arg("x", b.String(nullptr, ASR::string_length_kindType::AssumedLength,
+            ASR::string_physical_typeType::DescriptorString, char_kind));
         fill_func_arg("y", arg_types[1]);
         auto result = declare(fn_name,
-            allocatable_deferred_string_with_kind(al, loc, char_kind), ReturnVar);
+            b.allocatable(b.String(nullptr, ASR::string_length_kindType::DeferredLength,
+                ASR::string_physical_typeType::DescriptorString, char_kind)), ReturnVar);
         auto i = declare("i", int32, Local);
         auto j = declare("j", int32, Local);
         auto m = declare("m", int32, Local);
@@ -6593,8 +6581,11 @@ namespace Repeat {
             if (diag.has_error()) return nullptr;
             return_type = expr_type(m_value);
         } else {
-            return_type = allocatable_deferred_string_with_kind(al, loc,
-                ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0])));
+            ASRUtils::ASRBuilder b(al, loc);
+            int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
+            return_type = b.allocatable(b.String(nullptr,
+                ASR::string_length_kindType::DeferredLength,
+                ASR::string_physical_typeType::DescriptorString, char_kind));
         }
         
         for( size_t i = 0; i < 2; i++ ) {


### PR DESCRIPTION
fix #12139
Fixed repeat() for character(kind=4) by preserving the input string kind, and extended the existing kind-4 string intrinsics integration test.