### PR TITLE
LLVM: Fix ICE when assigning transfer result to allocatable character array

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3938,6 +3938,7 @@ RUN(NAME character_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llv
 RUN(NAME character_array_parameter_padding_trimming LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME character_array_block_padding LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME character_max_parameter_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME transfer_allocatable_character_array LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME c_ptr_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME c_ptr_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/transfer_allocatable_character_array.f90
+++ b/integration_tests/transfer_allocatable_character_array.f90
@@ -1,0 +1,9 @@
+program transfer_allocatable_character_array
+  implicit none
+
+  character(len=1), allocatable :: chars(:)
+
+  chars = transfer(" ABCDEFG abcdefg ", "A", size=17)
+
+  print *, chars
+end program transfer_allocatable_character_array

--- a/integration_tests/transfer_allocatable_character_array.f90
+++ b/integration_tests/transfer_allocatable_character_array.f90
@@ -3,6 +3,8 @@ program transfer_allocatable_character_array
 
   character(len=1), allocatable :: chars(:)
 
+  allocate(chars(17))
+
   chars = transfer(" ABCDEFG abcdefg ", "A", size=17)
 
   print *, chars

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1068,12 +1068,16 @@ public:
     */
     llvm::Value* get_string_length(ASR::expr_t* str_expr){
         ASR::ttype_t* exp_type = ASRUtils::expr_type(str_expr);
+        
+
+        ASR::ttype_t* el_type = ASRUtils::type_get_past_array(
+            ASRUtils::type_get_past_allocatable_pointer(exp_type));
+
         LCOMPILERS_ASSERT(ASR::is_a<ASR::String_t>(*
-            ASRUtils::extract_type(exp_type)))
+            ASRUtils::extract_type(el_type)))
 
         ASR::String_t* str = ASR::down_cast<ASR::String_t>(
-            ASRUtils::extract_type(exp_type));
-
+            ASRUtils::extract_type(el_type));
 
         switch (str->m_physical_type)
         {
@@ -1143,27 +1147,33 @@ public:
     }
 
     llvm::Value* get_string_data(ASR::expr_t* str_expr){
-        LCOMPILERS_ASSERT(ASR::is_a<ASR::String_t>(*
-            ASRUtils::extract_type(ASRUtils::expr_type(str_expr))))
+        ASR::ttype_t* raw_type = ASRUtils::expr_type(str_expr);
+        ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable_pointer(raw_type);
+        
+        ASR::ttype_t* el_type = ASRUtils::type_get_past_array(base_type);
 
-        // Evaluate Expression
+        LCOMPILERS_ASSERT(ASR::is_a<ASR::String_t>(*
+            ASRUtils::extract_type(el_type)))
+
         ASR::String_t* str = ASR::down_cast<ASR::String_t>(
-            ASRUtils::extract_type(expr_type(str_expr)));
+            ASRUtils::extract_type(el_type));
+            
         int ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
         visit_expr(*str_expr);
         ptr_loads = ptr_loads_copy;
+        
         switch (str->m_physical_type)
         {
             case ASR::DescriptorString:{
-                // CHANGED: Branch based on whether we are loading an array descriptor or scalar string descriptor
-                ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable_pointer(expr_type(str_expr));
                 if (ASRUtils::is_array(base_type)) {
-                    // Extract data pointer from Array Descriptor
                     llvm::Type* arr_type_llvm = llvm_utils->get_type_from_ttype_t_util(str_expr, base_type, module.get());
-                    return builder->CreateLoad(
-                        arr_type_llvm->getStructElementType(0), 
-                        llvm_utils->create_gep2(arr_type_llvm, tmp, 0));
+                    
+                    llvm::Value* arr_desc = tmp;
+                    if (ASRUtils::is_allocatable_or_pointer(raw_type)) {
+                        arr_desc = llvm_utils->CreateLoad2(arr_type_llvm->getPointerTo(), arr_desc);
+                    }
+                    return arr_descr->get_array_data(arr_type_llvm, arr_desc);
                 } else {
                     // Extract data pointer from String Descriptor (scalar)
                     return builder->CreateLoad(

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1170,7 +1170,7 @@ public:
                         character_type,
                         llvm_utils->create_gep2(string_descriptor, tmp, 0));
                 }
-            }s
+            }
             case ASR::CChar:{
                 llvm::Value* char_ptr = builder->CreateAlloca(llvm::Type::getInt8Ty(context));
                 return builder->CreateStore(tmp, char_ptr);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1150,11 +1150,13 @@ public:
         ASR::ttype_t* raw_type = ASRUtils::expr_type(str_expr);
         ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable_pointer(raw_type);
         
+        // Strip array to get the actual String type for physical_type checking
         ASR::ttype_t* el_type = ASRUtils::type_get_past_array(base_type);
 
         LCOMPILERS_ASSERT(ASR::is_a<ASR::String_t>(*
             ASRUtils::extract_type(el_type)))
 
+        // Evaluate Expression
         ASR::String_t* str = ASR::down_cast<ASR::String_t>(
             ASRUtils::extract_type(el_type));
             
@@ -1167,18 +1169,26 @@ public:
         {
             case ASR::DescriptorString:{
                 if (ASRUtils::is_array(base_type)) {
+                    // 1. Get the correct LLVM structure type for the array descriptor
                     llvm::Type* arr_type_llvm = llvm_utils->get_type_from_ttype_t_util(str_expr, base_type, module.get());
                     
+                    // 2. Dereference the descriptor pointer if the expression is allocatable/pointer
                     llvm::Value* arr_desc = tmp;
                     if (ASRUtils::is_allocatable_or_pointer(raw_type)) {
                         arr_desc = llvm_utils->CreateLoad2(arr_type_llvm->getPointerTo(), arr_desc);
                     }
-                    return arr_descr->get_array_data(arr_type_llvm, arr_desc);
+                    
+                    // 3. Manually extract the array data pointer (index 0 of the descriptor struct)
+                    return builder->CreateLoad(
+                        arr_type_llvm->getStructElementType(0),
+                        llvm_utils->create_gep2(arr_type_llvm, arr_desc, 0)
+                    );
                 } else {
                     // Extract data pointer from String Descriptor (scalar)
                     return builder->CreateLoad(
                         character_type,
-                        llvm_utils->create_gep2(string_descriptor, tmp, 0));
+                        llvm_utils->create_gep2(string_descriptor, tmp, 0)
+                    );
                 }
             }
             case ASR::CChar:{

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1084,7 +1084,7 @@ public:
                     llvm::Value* len_value = llvm::ConstantInt::get(context, llvm::APInt(64, len->m_n));
                     return len_value;
                 } else { // Implicit Length
-                    if(ASRUtils::is_array(exp_type)){
+                    if(ASRUtils::is_array(ASRUtils::type_get_past_allocatable_pointer(exp_type))){
                         visit_expr_load_wrapper(str_expr, ASRUtils::is_allocatable_or_pointer(exp_type) ? 1 : 0);
                         return get_string_length_in_array(str_expr, tmp);
                     } else {
@@ -1156,10 +1156,21 @@ public:
         switch (str->m_physical_type)
         {
             case ASR::DescriptorString:{
-                return builder->CreateLoad(
-                    character_type,
-                    llvm_utils->create_gep2(string_descriptor, tmp, 0));
-            }
+                // CHANGED: Branch based on whether we are loading an array descriptor or scalar string descriptor
+                ASR::ttype_t* base_type = ASRUtils::type_get_past_allocatable_pointer(expr_type(str_expr));
+                if (ASRUtils::is_array(base_type)) {
+                    // Extract data pointer from Array Descriptor
+                    llvm::Type* arr_type_llvm = llvm_utils->get_type_from_ttype_t_util(str_expr, base_type, module.get());
+                    return builder->CreateLoad(
+                        arr_type_llvm->getStructElementType(0), 
+                        llvm_utils->create_gep2(arr_type_llvm, tmp, 0));
+                } else {
+                    // Extract data pointer from String Descriptor (scalar)
+                    return builder->CreateLoad(
+                        character_type,
+                        llvm_utils->create_gep2(string_descriptor, tmp, 0));
+                }
+            }s
             case ASR::CChar:{
                 llvm::Value* char_ptr = builder->CreateAlloca(llvm::Type::getInt8Ty(context));
                 return builder->CreateStore(tmp, char_ptr);


### PR DESCRIPTION
Fixes #12118 