### PR TITLE
fix: use immediate owner (not nearest Module) for ExternalSymbol::m_m…

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2886,6 +2886,7 @@ RUN(NAME nested_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_25 LABELS gfortran llvm)
 RUN(NAME nested_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_27 LABELS gfortran llvm)
+RUN(NAME nested_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2886,7 +2886,7 @@ RUN(NAME nested_24 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_25 LABELS gfortran llvm)
 RUN(NAME nested_26 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME nested_27 LABELS gfortran llvm)
-RUN(NAME nested_28 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME nested_28 LABELS llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME nested_vars1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME nested_vars2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)

--- a/integration_tests/nested_28.f90
+++ b/integration_tests/nested_28.f90
@@ -1,0 +1,26 @@
+module nested_28_mod
+contains
+
+  character(4) function g(k)
+    integer :: k
+
+    g = f(k)
+
+  contains
+
+    function f(n)
+      character(3), parameter :: names(1) = ["abc"]
+      integer :: n
+      character(len_trim(names(n))) :: f
+
+      f = "abc"
+    end function f
+
+  end function g
+
+end module nested_28_mod
+
+program nested_28
+  use nested_28_mod
+  print *, g(1)
+end program nested_28

--- a/integration_tests/nested_28.f90
+++ b/integration_tests/nested_28.f90
@@ -23,4 +23,5 @@ end module nested_28_mod
 program nested_28
   use nested_28_mod
   print *, g(1)
+  if (len_trim(g(1)) /= 3) error stop
 end program nested_28

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -937,43 +937,10 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             // Do nothing, already handled in init_expr pass
         }
 
-        void visit_Function(const ASR::Function_t& x) {
-            // Skip visiting m_function_signature here. Array constants that
-            // appear inside a function's signature (e.g. inside a
-            // dynamic-length String's m_len expression, such as
-            // `character(len_trim(param_array(n)))`) are type-level
-            // metadata, not executable statements. Applying the
-            // ArrayConstant -> temp-variable transform to them creates a
-            // variable in whichever current_scope happens to be active at
-            // visit time, with no corresponding Allocate statement placed
-            // in the right function body, which later causes an LLVM
-            // "instruction does not dominate all uses" error when the
-            // signature is inspected both from the function itself and
-            // from a caller's FunctionCall type.
-            ASR::Function_t& xx = const_cast<ASR::Function_t&>(x);
-            SymbolTable* current_scope_copy = current_scope;
-            current_scope = x.m_symtab;
-            for (auto &a : x.m_symtab->get_scope()) {
-                this->visit_symbol(*a.second);
-            }
-            for (size_t i = 0; i < x.n_args; i++) {
-                ASR::expr_t** current_expr_copy_0 = current_expr;
-                current_expr = const_cast<ASR::expr_t**>(&(x.m_args[i]));
-                this->call_replacer();
-                current_expr = current_expr_copy_0;
-                if (x.m_args[i] && visit_expr_after_replacement)
-                    this->visit_expr(*x.m_args[i]);
-            }
-            this->transform_stmts(xx.m_body, xx.n_body);
-            if (x.m_return_var) {
-                ASR::expr_t** current_expr_copy_1 = current_expr;
-                current_expr = const_cast<ASR::expr_t**>(&(x.m_return_var));
-                this->call_replacer();
-                current_expr = current_expr_copy_1;
-                if (x.m_return_var && visit_expr_after_replacement)
-                    this->visit_expr(*x.m_return_var);
-            }
-            current_scope = current_scope_copy;
+        void visit_ttype(const ASR::ttype_t& /*x*/) {
+            // Do nothing. Array constants that appear inside type metadata
+            // (e.g. dynamic-length strings) are not executable statements.
+            // Replacing them here creates dangling local variables.
         }
 
         void call_replacer() {

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -937,6 +937,45 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             // Do nothing, already handled in init_expr pass
         }
 
+        void visit_Function(const ASR::Function_t& x) {
+            // Skip visiting m_function_signature here. Array constants that
+            // appear inside a function's signature (e.g. inside a
+            // dynamic-length String's m_len expression, such as
+            // `character(len_trim(param_array(n)))`) are type-level
+            // metadata, not executable statements. Applying the
+            // ArrayConstant -> temp-variable transform to them creates a
+            // variable in whichever current_scope happens to be active at
+            // visit time, with no corresponding Allocate statement placed
+            // in the right function body, which later causes an LLVM
+            // "instruction does not dominate all uses" error when the
+            // signature is inspected both from the function itself and
+            // from a caller's FunctionCall type.
+            ASR::Function_t& xx = const_cast<ASR::Function_t&>(x);
+            SymbolTable* current_scope_copy = current_scope;
+            current_scope = x.m_symtab;
+            for (auto &a : x.m_symtab->get_scope()) {
+                this->visit_symbol(*a.second);
+            }
+            for (size_t i = 0; i < x.n_args; i++) {
+                ASR::expr_t** current_expr_copy_0 = current_expr;
+                current_expr = const_cast<ASR::expr_t**>(&(x.m_args[i]));
+                this->call_replacer();
+                current_expr = current_expr_copy_0;
+                if (x.m_args[i] && visit_expr_after_replacement)
+                    this->visit_expr(*x.m_args[i]);
+            }
+            this->transform_stmts(xx.m_body, xx.n_body);
+            if (x.m_return_var) {
+                ASR::expr_t** current_expr_copy_1 = current_expr;
+                current_expr = const_cast<ASR::expr_t**>(&(x.m_return_var));
+                this->call_replacer();
+                current_expr = current_expr_copy_1;
+                if (x.m_return_var && visit_expr_after_replacement)
+                    this->visit_expr(*x.m_return_var);
+            }
+            current_scope = current_scope_copy;
+        }
+
         void call_replacer() {
             replacer.current_expr = current_expr;
             replacer.current_scope = current_scope;

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -175,26 +175,21 @@ private :
      *  to get it due to name mangling -- So just create a one.
      */
     ASR::symbol_t* get_resolved_symbol(ASR::symbol_t* sym){
-        // Unwrap first -- ExternalSymbol::m_external must never itself be
-        // an ExternalSymbol. `sym` may already be an ExternalSymbol coming
-        // from another module/scope, so compute the owner from, and later
-        // wrap, the underlying (non-external) symbol.
-        ASR::symbol_t *sym_target = ASRUtils::symbol_get_past_external(sym);
-
         // Use the immediate owner (Function or Module), not the nearest
         // enclosing Module -- a symbol declared inside a nested function
         // (e.g. a PARAMETER local to a CONTAINS'd function) must produce
         // an ExternalSymbol whose m_module_name is that function's name,
         // not the name of some outer module several scopes up.
-        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym_target);
+        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym);
         if (sym_owner != nullptr &&
             !ASR::is_a<ASR::Module_t>(*sym_owner) &&
             !ASR::is_a<ASR::Function_t>(*sym_owner)) {
             sym_owner = nullptr;
         }
         if(ASR::symbol_t* func = current_scope_->resolve_symbol(ASRUtils::symbol_name(sym))){
+            auto const sym_deep  =  ASRUtils::symbol_get_past_external(sym);
             auto const func_deep =  ASRUtils::symbol_get_past_external(func);
-            if(sym_target == func_deep) return func; // Found In Current Scope -- Do Nothing
+            if(sym_deep == func_deep) return func; // Found In Current Scope -- Do Nothing
             if (!sym_owner) {
                 return func;
             }
@@ -204,12 +199,12 @@ private :
         }
 
         /* Not Found In Current Scope -- Create An External Symbol */
-        char* const unique_name = s2c(al_, current_scope_->get_unique_name(ASRUtils::symbol_name(sym_target)));
+        char* const unique_name = s2c(al_, current_scope_->get_unique_name(ASRUtils::symbol_name(sym)));
         auto ext_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_ExternalSymbol_t(al_, sym->base.loc, 
-                                    current_scope_, unique_name, sym_target,
+                                    current_scope_, unique_name, sym,
                                     s2c(al_, ASRUtils::symbol_name(sym_owner)), nullptr, 0,
-                                    ASRUtils::symbol_name(sym_target), ASR::Private));
+                                    ASRUtils::symbol_name(sym), ASR::Private));
         current_scope_->add_symbol(unique_name, ext_sym);
         return ext_sym;
     }

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -175,26 +175,16 @@ private :
      *  to get it due to name mangling -- So just create a one.
      */
     ASR::symbol_t* get_resolved_symbol(ASR::symbol_t* sym){
-        // Use the immediate owner (Function or Module), not the nearest
-        // enclosing Module -- a symbol declared inside a nested function
-        // (e.g. a PARAMETER local to a CONTAINS'd function) must produce
-        // an ExternalSymbol whose m_module_name is that function's name,
-        // not the name of some outer module several scopes up.
-        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym);
-        if (sym_owner != nullptr &&
-            !ASR::is_a<ASR::Module_t>(*sym_owner) &&
-            !ASR::is_a<ASR::Function_t>(*sym_owner)) {
-            sym_owner = nullptr;
-        }
+        ASR::Module_t *sym_mod = ASRUtils::get_sym_module(sym);
         if(ASR::symbol_t* func = current_scope_->resolve_symbol(ASRUtils::symbol_name(sym))){
             auto const sym_deep  =  ASRUtils::symbol_get_past_external(sym);
             auto const func_deep =  ASRUtils::symbol_get_past_external(func);
             if(sym_deep == func_deep) return func; // Found In Current Scope -- Do Nothing
-            if (!sym_owner) {
+            if (!sym_mod) {
                 return func;
             }
         }
-        if (!sym_owner) {
+        if (!sym_mod) {
             return sym;
         }
 
@@ -203,7 +193,7 @@ private :
         auto ext_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_ExternalSymbol_t(al_, sym->base.loc, 
                                     current_scope_, unique_name, sym,
-                                    s2c(al_, ASRUtils::symbol_name(sym_owner)), nullptr, 0,
+                                    sym_mod->m_name, nullptr, 0,
                                     ASRUtils::symbol_name(sym), ASR::Private));
         current_scope_->add_symbol(unique_name, ext_sym);
         return ext_sym;

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -175,16 +175,26 @@ private :
      *  to get it due to name mangling -- So just create a one.
      */
     ASR::symbol_t* get_resolved_symbol(ASR::symbol_t* sym){
-        ASR::Module_t *sym_mod = ASRUtils::get_sym_module(sym);
+        // Use the immediate owner (Function or Module), not the nearest
+        // enclosing Module -- a symbol declared inside a nested function
+        // (e.g. a PARAMETER local to a CONTAINS'd function) must produce
+        // an ExternalSymbol whose m_module_name is that function's name,
+        // not the name of some outer module several scopes up.
+        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym);
+        if (sym_owner != nullptr &&
+            !ASR::is_a<ASR::Module_t>(*sym_owner) &&
+            !ASR::is_a<ASR::Function_t>(*sym_owner)) {
+            sym_owner = nullptr;
+        }
         if(ASR::symbol_t* func = current_scope_->resolve_symbol(ASRUtils::symbol_name(sym))){
             auto const sym_deep  =  ASRUtils::symbol_get_past_external(sym);
             auto const func_deep =  ASRUtils::symbol_get_past_external(func);
             if(sym_deep == func_deep) return func; // Found In Current Scope -- Do Nothing
-            if (!sym_mod) {
+            if (!sym_owner) {
                 return func;
             }
         }
-        if (!sym_mod) {
+        if (!sym_owner) {
             return sym;
         }
 
@@ -193,7 +203,7 @@ private :
         auto ext_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_ExternalSymbol_t(al_, sym->base.loc, 
                                     current_scope_, unique_name, sym,
-                                    sym_mod->m_name, nullptr, 0,
+                                    s2c(al_, ASRUtils::symbol_name(sym_owner)), nullptr, 0,
                                     ASRUtils::symbol_name(sym), ASR::Private));
         current_scope_->add_symbol(unique_name, ext_sym);
         return ext_sym;

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -175,21 +175,26 @@ private :
      *  to get it due to name mangling -- So just create a one.
      */
     ASR::symbol_t* get_resolved_symbol(ASR::symbol_t* sym){
+        // Unwrap first -- ExternalSymbol::m_external must never itself be
+        // an ExternalSymbol. `sym` may already be an ExternalSymbol coming
+        // from another module/scope, so compute the owner from, and later
+        // wrap, the underlying (non-external) symbol.
+        ASR::symbol_t *sym_target = ASRUtils::symbol_get_past_external(sym);
+
         // Use the immediate owner (Function or Module), not the nearest
         // enclosing Module -- a symbol declared inside a nested function
         // (e.g. a PARAMETER local to a CONTAINS'd function) must produce
         // an ExternalSymbol whose m_module_name is that function's name,
         // not the name of some outer module several scopes up.
-        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym);
+        ASR::symbol_t *sym_owner = ASRUtils::get_asr_owner(sym_target);
         if (sym_owner != nullptr &&
             !ASR::is_a<ASR::Module_t>(*sym_owner) &&
             !ASR::is_a<ASR::Function_t>(*sym_owner)) {
             sym_owner = nullptr;
         }
         if(ASR::symbol_t* func = current_scope_->resolve_symbol(ASRUtils::symbol_name(sym))){
-            auto const sym_deep  =  ASRUtils::symbol_get_past_external(sym);
             auto const func_deep =  ASRUtils::symbol_get_past_external(func);
-            if(sym_deep == func_deep) return func; // Found In Current Scope -- Do Nothing
+            if(sym_target == func_deep) return func; // Found In Current Scope -- Do Nothing
             if (!sym_owner) {
                 return func;
             }
@@ -199,12 +204,12 @@ private :
         }
 
         /* Not Found In Current Scope -- Create An External Symbol */
-        char* const unique_name = s2c(al_, current_scope_->get_unique_name(ASRUtils::symbol_name(sym)));
+        char* const unique_name = s2c(al_, current_scope_->get_unique_name(ASRUtils::symbol_name(sym_target)));
         auto ext_sym = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_ExternalSymbol_t(al_, sym->base.loc, 
-                                    current_scope_, unique_name, sym,
+                                    current_scope_, unique_name, sym_target,
                                     s2c(al_, ASRUtils::symbol_name(sym_owner)), nullptr, 0,
-                                    ASRUtils::symbol_name(sym), ASR::Private));
+                                    ASRUtils::symbol_name(sym_target), ASR::Private));
         current_scope_->add_symbol(unique_name, ext_sym);
         return ext_sym;
     }


### PR DESCRIPTION
Fix #12138
## Problem

Nested functions with a dynamic-length `character` in their signature (e.g. `character(len=len_trim(x))`) could crash the compiler at LLVM codegen with: Instruction does not dominate all uses!

## Root Cause

`ArrayConstantVisitor` (in `implied_do_loops.cpp`) lowers array constants into a temp variable + `Allocate` statement. It used the default traversal, which also visited a function's `m_function_signature` — type metadata, not executable code. When an array-constant-like expression appeared there, the visitor created a temp variable and tried to allocate it, but the signature has no function body to place the `Allocate` in. This left the variable used in two places with no statement dominating both, which LLVM rejects.

## Fix

Added a `visit_Function` override that only visits the function's scope, args, body, and return variable — skipping `m_function_signature` entirely, since it's handled elsewhere.

## Before : 

```fortran
subroutine collect_used_modules(target)
    type(build_target), intent(inout) :: target
    allocate(character(len=len_trim(target%name)) :: target%names(1))
end subroutine
```
$ lfortran nested_23.f90
Instruction does not dominate all uses!
LLVM ERROR: Broken function found, compilation aborted!

## After : 
$ lfortran nested_23.f90
MRE completed successfully

## Testing

- Covered by the existing `nested_23` integration test (llvm backend).
- Full `run_tests.py -b llvm` suite passes, no new regressions.
