### PR TITLE
CI: Tweak test_caffeine.sh

### DIFF
--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+echo "##[group] Setup"
 set -ex
 
 echo "CONDA_PREFIX=$CONDA_PREFIX"
@@ -18,6 +18,11 @@ fpm --version
 
 micromamba install -y -c conda-forge openmpi
 
+(set +x 
+ echo "##[endgroup]"
+ echo "##[group] Install OpenCoarrays"
+)
+
 git clone https://github.com/sourceryinstitute/OpenCoarrays.git
 cd OpenCoarrays
 
@@ -33,6 +38,11 @@ which caf
 caf --version
 
 cd ..
+
+(set +x 
+ echo "##[endgroup]"
+ echo "##[group] Install Caffeine"
+)
 
 # Clone caffeine
 
@@ -77,6 +87,11 @@ cd ..
 # Make caffeine launcher available
 
 export PATH="$PWD/caffeine/inst/bin:$PATH"
+
+(set +x 
+ echo "##[endgroup]"
+ echo "##[group] Test setup"
+)
 
 # Number of coarray images
 
@@ -124,10 +139,13 @@ fi
 opencoarrays_unsupported="coarrays_11 coarrays_13 coarrays_21"
 
 for testfile in $tests; do
-echo "========================================="
-echo "Running coarray test: $testfile"
-echo "========================================="
-
+(set +x
+ echo "##[endgroup]"
+ echo "##[group] testing: $testfile"
+ echo "========================================="
+ echo "Running coarray test: $testfile"
+ echo "========================================="
+)
 
 base=$(basename "$testfile" .f90)
 
@@ -173,6 +191,10 @@ rm -f "${base}_lf.out"
 
 
 done
+
+(set +x 
+ echo "##[endgroup]"
+)
 
 echo
 echo "All coarray runtime tests passed"

--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -120,7 +120,8 @@ fi
 # OpenCoarrays (caf/cafrun) does not support character arguments to co_max/co_min,
 # so the gfortran cross-check is skipped for those tests. LFortran + Caffeine still
 # runs them, so LFortran's own behaviour stays verified.
-opencoarrays_unsupported="coarrays_11 coarrays_13"
+# coarrays_21: intermittent failures on OpenCoarrays
+opencoarrays_unsupported="coarrays_11 coarrays_13 coarrays_21"
 
 for testfile in $tests; do
 echo "========================================="

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -158,6 +158,12 @@ time_section "🧪 Testing caffeine" '
   git checkout 0.8.0
   assert_git_commit 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
 
+  # An LFortran-specific fix to the Caffeine test suite
+  # until issue #11191 is resolved
+  git config --global user.email "nobody@nowhere.com"
+  git config --global user.name  "Nobody"
+  git cherry-pick fa9456c34af1914cc02b9d9bffeaca7d880313ac
+
   # Now build and test caffeine with LFortran
   export GASNET_CONFIGURE_ARGS="--enable-rpath --enable-debug" 
   ./install.sh --yes --prefix=$PWD/inst --verbose


### PR DESCRIPTION
#12097 added a new coarray test `test/coarrays_21` that it turns out experiences intermittent runtime failures on OpenCoarrays, presumably due to an incorrect implementation of coarray initialization ([example](https://github.com/bonachea/lfortran/actions/runs/28987411709/job/86019516743)). Disable that test for OpenCoarrays.

Also, cherry-pick a recent fix to the Caffeine test suite to prevent potential future failures there.

Also add some group boundaries in ci/test_caffeine.sh to simplify log navigation in GitHub Actions UI.
Example:
<img width="771" height="995" alt="image" src="https://github.com/user-attachments/assets/bbbd6bd7-f7d8-4dfa-9e5a-4c322522973b" />
