### PR TITLE
Fix associate on transitively-imported types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2704,6 +2704,7 @@ RUN(NAME associate_51 LABELS gfortran llvm)
 RUN(NAME associate_52 LABELS gfortran llvm)
 RUN(NAME associate_53 LABELS gfortran llvm)
 RUN(NAME associate_54 LABELS gfortran llvm)
+RUN(NAME associate_55 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_55.f90
+++ b/integration_tests/associate_55.f90
@@ -1,0 +1,53 @@
+! Issue: https://github.com/lfortran/lfortran/issues/11906
+! ASSOCIATE on a component whose type is only transitively imported
+! (use outer, only: outer_t — component type not imported) must resolve
+! member access on the associate name.
+module associate_55_inner
+    implicit none
+    type :: inner_t
+        integer :: n = 0
+    end type
+end module
+
+module associate_55_outer
+    use associate_55_inner, only: inner_t
+    implicit none
+    type :: outer_t
+        type(inner_t) :: c
+    end type
+end module
+
+module associate_55_driver
+    use associate_55_outer, only: outer_t
+    implicit none
+contains
+    integer function get_n(s) result(x)
+        type(outer_t), intent(in) :: s
+        associate (a => s%c)
+            x = a%n
+        end associate
+    end function
+end module
+
+program associate_55
+    use associate_55_outer, only: outer_t
+    use associate_55_driver, only: get_n
+    implicit none
+    type(outer_t) :: s
+    integer :: x
+
+    s%c%n = 42
+
+    ! Associate in the main program (component type not imported)
+    associate (a => s%c)
+        if (a%n /= 42) error stop 1
+        a%n = 7
+    end associate
+    if (s%c%n /= 7) error stop 2
+
+    ! Associate inside a module procedure (three-module chain)
+    x = get_n(s)
+    if (x /= 7) error stop 3
+
+    print *, "ok"
+end program associate_55

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7236,11 +7236,17 @@ static inline ASR::symbol_t* import_struct_sym_as_external(Allocator& al,
     const Location& loc, ASR::expr_t* v_expr, SymbolTable* current_scope) {
     ASR::symbol_t* struct_sym = get_struct_sym_from_struct_expr(v_expr);
     if (struct_sym == nullptr) return nullptr;
-    std::string struct_name = symbol_name(struct_sym);
+    // ExternalSymbol.m_external must point at the original definition (e.g.
+    // Struct), never another ExternalSymbol. Expressions like s%component can
+    // yield a use-associated ExternalSymbol when the component type is only
+    // reached transitively (not imported into the current scope).
+    ASR::symbol_t* original_struct = symbol_get_past_external(struct_sym);
+    if (original_struct == nullptr) return nullptr;
+    std::string struct_name = symbol_name(original_struct);
     if (current_scope->resolve_symbol(struct_name) == nullptr) {
         struct_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(
-            al, loc, current_scope, s2c(al, struct_name), struct_sym,
-            ASRUtils::symbol_name(ASRUtils::get_asr_owner(struct_sym)), nullptr, 0,
+            al, loc, current_scope, s2c(al, struct_name), original_struct,
+            ASRUtils::symbol_name(ASRUtils::get_asr_owner(original_struct)), nullptr, 0,
             s2c(al, struct_name), ASR::accessType::Public));
         current_scope->add_symbol(struct_name, struct_sym);
     } else {
@@ -7251,8 +7257,8 @@ static inline ASR::symbol_t* import_struct_sym_as_external(Allocator& al,
         } else {
             std::string unique_name = current_scope->get_unique_name(struct_name);
             struct_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_ExternalSymbol_t(
-                al, loc, current_scope, s2c(al, unique_name), struct_sym,
-                ASRUtils::symbol_name(ASRUtils::get_asr_owner(struct_sym)), nullptr, 0,
+                al, loc, current_scope, s2c(al, unique_name), original_struct,
+                ASRUtils::symbol_name(ASRUtils::get_asr_owner(original_struct)), nullptr, 0,
                 s2c(al, struct_name), ASR::accessType::Public));
             current_scope->add_symbol(unique_name, struct_sym);
         }


### PR DESCRIPTION
When ASSOCIATE bound a name to a derived-type component whose type was only reached transitively (use outer, only: outer_t), import_struct_sym_as_external built an ExternalSymbol whose m_external pointed at another ExternalSymbol. That violates the ASR invariant and caused an ICE in resolve_variable2 (AssertFailed: is_a<Struct_t>). Always peel past ExternalSymbol so m_external points at the original Struct definition.

Adds integration_tests/associate_55.f90. Fixes #11906.