### PR TITLE
Fix select type with PDT kind parameters

### DIFF
--- a/ci/parser.yy.patch
+++ b/ci/parser.yy.patch
@@ -1,8 +1,8 @@
 diff --git a/src/lfortran/parser/parser.yy b/src/lfortran/parser/parser.yy
-index 300dbffdb..79dbf0b14 100644
+index 9c0d9f80e2..38d36955f6 100644
 --- a/src/lfortran/parser/parser.yy
 +++ b/src/lfortran/parser/parser.yy
-@@ -2550,177 +2550,4 @@ id_opt
+@@ -2642,177 +2642,4 @@ id_opt
  
  id
      : TK_NAME { $$ = SYMBOL($1, @$); }

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2065,6 +2065,8 @@ RUN(NAME select_type_49 LABELS gfortran llvm)
 RUN(NAME select_type_50 LABELS gfortran llvm)
 RUN(NAME select_type_51 LABELS gfortran llvm)
 RUN(NAME select_type_52 LABELS gfortran llvm)
+# type is (pdt(kind)) — not supported by gfortran
+RUN(NAME select_type_53 LABELS llvm)
 
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME where_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2065,7 +2065,6 @@ RUN(NAME select_type_49 LABELS gfortran llvm)
 RUN(NAME select_type_50 LABELS gfortran llvm)
 RUN(NAME select_type_51 LABELS gfortran llvm)
 RUN(NAME select_type_52 LABELS gfortran llvm)
-# type is (pdt(kind)) — not supported by gfortran
 RUN(NAME select_type_53 LABELS llvm)
 
 RUN(NAME where_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/select_type_53.f90
+++ b/integration_tests/select_type_53.f90
@@ -1,0 +1,71 @@
+! Issue: https://github.com/lfortran/lfortran/issues/8825
+! select type with parametrized derived types (kind parameters)
+program select_type_53
+    implicit none
+
+    type :: parent
+    end type parent
+
+    type, extends(parent) :: child_int(k)
+        integer, kind :: k = 4
+        integer(k) :: a
+    end type child_int
+
+    type, extends(parent) :: child_real(k)
+        integer, kind :: k = 8
+        real(k) :: a
+    end type child_real
+
+    type(child_int(4)) :: i
+    type(child_real(8)) :: r
+    class(parent), allocatable :: p
+
+    i%a = 42
+    r%a = 3.141592653589793_8
+
+    allocate(p, source=i)
+    call check_int(p)
+    deallocate(p)
+
+    allocate(p, source=r)
+    call check_real(p)
+    deallocate(p)
+
+    ! Associate-name form
+    call try_select(i)
+    call try_select(r)
+
+    print *, "ok"
+contains
+    subroutine check_int(par)
+        class(parent), intent(in) :: par
+        select type (par)
+        type is (child_int(4))
+            if (par%a /= 42) error stop 1
+        class default
+            error stop 2
+        end select
+    end subroutine check_int
+
+    subroutine check_real(par)
+        class(parent), intent(in) :: par
+        select type (par)
+        type is (child_real(8))
+            if (abs(par%a - 3.141592653589793_8) > 1.0e-12_8) error stop 3
+        class default
+            error stop 4
+        end select
+    end subroutine check_real
+
+    subroutine try_select(par)
+        class(parent), intent(in) :: par
+        select type (q => par)
+        type is (child_int(4))
+            if (q%a /= 42) error stop 5
+        type is (child_real(8))
+            if (abs(q%a - 3.141592653589793_8) > 1.0e-12_8) error stop 6
+        class default
+            error stop 7
+        end select
+    end subroutine try_select
+end program select_type_53

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -14,7 +14,7 @@ see the documentation in that script for details and motivation.
 %param {LCompilers::LFortran::Parser &p}
 %locations
 %glr-parser
-%expect    238 // shift/reduce conflicts
+%expect    241 // shift/reduce conflicts
 %expect-rr 180 // reduce/reduce conflicts
 
 // Uncomment this to get verbose error messages
@@ -2146,6 +2146,10 @@ select_type_body_statements
 
 select_type_body_statement
     : KW_TYPE KW_IS "(" TK_NAME ")" sep statements { $$ = TYPE_STMTNAME($4, TRIVIA_AFTER($6, @$), $7, @$); }
+    // type is (pdt(kind)) — TK_NAME keeps integer(4)/real(8) on the var_type path
+    | KW_TYPE KW_IS "(" TK_NAME "(" kind_arg_list ")" ")" sep statements {
+            $$ = TYPE_STMTVAR(ATTR_TYPE_NAME_KIND(Type, SYMBOL($4, @4), $6, @$),
+                TRIVIA_AFTER($9, @$), $10, @$); }
     | KW_TYPE KW_IS "(" var_type ")" sep statements { $$ = TYPE_STMTVAR($4, TRIVIA_AFTER($6, @$), $7, @$); }
     | KW_CLASS KW_IS "(" id ")" sep statements { $$ = CLASS_STMT($4, TRIVIA_AFTER($6, @$), $7, @$); }
     | KW_CLASS KW_DEFAULT sep statements { $$ = CLASS_DEFAULT(TRIVIA_AFTER($3, @$), $4, @$); }

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -4499,11 +4499,11 @@ public:
                     ASR::ttype_t* view_type = nullptr;
                     // Whether the selector is an array — determines which path we use
                     bool is_selector_array = false;
+                    ASR::symbol_t *type_declaration = nullptr;
                     if( assoc_variable ) {
                         Vec<ASR::dimension_t> m_dims;
                         m_dims.reserve(al, 1);
                         std::string assoc_variable_name = std::string(assoc_variable->m_name);
-                        ASR::symbol_t *type_declaration;
                         selector_type = determine_type(type_stmt_type->base.base.loc,
                                                        assoc_variable_name,
                                                        type_stmt_type->m_vartype, false, false, m_dims,
@@ -4517,6 +4517,87 @@ public:
                                 str_type->m_len_kind = ASR::string_length_kindType::DeferredLength;
                             }
                         }
+                    }
+
+                    // type is (derived) / type is (pdt(kind)): treat like TypeStmtName
+                    // (ClassToStruct) so members are accessible on the associate name.
+                    ASR::symbol_t* struct_sym = type_declaration
+                        ? ASRUtils::symbol_get_past_external(type_declaration) : nullptr;
+                    if (struct_sym && ASR::is_a<ASR::Struct_t>(*struct_sym)) {
+                        ASR::symbol_t* sym = type_declaration;
+                        if (assoc_variable) {
+                            ASR::ttype_t* stype = ASRUtils::make_StructType_t_util(
+                                al, sym->base.loc, sym, true);
+                            if (selector_variable_type && ASRUtils::is_array(selector_variable_type)) {
+                                stype = make_typed_selector_view_type(
+                                    type_stmt_type->base.base.loc,
+                                    ASRUtils::type_get_past_allocatable(selector_variable_type),
+                                    stype);
+                            } else if (!selector_variable_type
+                                    || ASRUtils::is_pointer(selector_variable_type)
+                                    || assoc_sym) {
+                                stype = ASRUtils::make_Pointer_t_util(
+                                    al, sym->base.loc, ASRUtils::extract_type(stype));
+                            }
+                            SetChar assoc_deps;
+                            assoc_deps.reserve(al, 1);
+                            ASRUtils::collect_variable_dependencies(al, assoc_deps, stype,
+                                nullptr, nullptr, ASRUtils::symbol_name(struct_sym));
+                            assoc_variable->m_dependencies = assoc_deps.p;
+                            assoc_variable->n_dependencies = assoc_deps.size();
+                            assoc_variable->m_type = stype;
+                            assoc_variable->m_type_declaration = sym;
+                        }
+                        Vec<ASR::stmt_t*> type_stmt_name_body;
+                        type_stmt_name_body.reserve(al, type_stmt_type->n_body);
+                        ASR::expr_t* dest_expr_tsn = assoc_sym
+                            ? ASRUtils::EXPR(ASR::make_Var_t(al, type_stmt_type->base.base.loc, assoc_sym))
+                            : m_selector;
+                        ASR::expr_t* casted_selector_tsn = m_selector;
+                        if (!ASRUtils::is_unlimited_polymorphic_type(m_selector)) {
+                            casted_selector_tsn = ASRUtils::EXPR(ASR::make_Cast_t(al,
+                                type_stmt_type->base.base.loc, m_selector,
+                                ASR::cast_kindType::ClassToStruct,
+                                assoc_variable->m_type, nullptr, dest_expr_tsn));
+                        }
+                        if (assoc_sym) {
+                            type_stmt_name_body.push_back(al, ASRUtils::STMT(
+                                ASRUtils::make_Associate_t_util(al, type_stmt_type->base.base.loc,
+                                    dest_expr_tsn, casted_selector_tsn)));
+                        }
+                        std::string block_name = parent_scope->get_unique_name("~select_type_block_");
+                        ASR::symbol_t* block_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Block_t(
+                            al, type_stmt_type->base.base.loc,
+                            current_scope, s2c(al, block_name), nullptr, 0));
+                        ASR::symbol_t* selector_sym_for_map_tsn = nullptr;
+                        if (!assoc_sym && ASR::is_a<ASR::Var_t>(*m_selector) &&
+                                !ASRUtils::is_unlimited_polymorphic_type(m_selector)) {
+                            selector_sym_for_map_tsn = ASR::down_cast<ASR::Var_t>(m_selector)->m_v;
+                            select_type_casts_map[selector_sym_for_map_tsn] = {
+                                ASR::cast_kindType::ClassToStruct, assoc_variable->m_type, sym};
+                        }
+                        transform_stmts(type_stmt_name_body, type_stmt_type->n_body,
+                            type_stmt_type->m_body);
+                        if (selector_sym_for_map_tsn) {
+                            select_type_casts_map.erase(selector_sym_for_map_tsn);
+                        }
+                        ASR::Block_t* block_t_ = ASR::down_cast<ASR::Block_t>(block_sym);
+                        block_t_->m_body = type_stmt_name_body.p;
+                        block_t_->n_body = type_stmt_name_body.size();
+                        parent_scope->add_symbol(block_name, block_sym);
+                        Vec<ASR::stmt_t*> block_call_stmt;
+                        block_call_stmt.reserve(al, 1);
+                        block_call_stmt.push_back(al, ASRUtils::STMT(ASR::make_BlockCall_t(
+                            al, type_stmt_type->base.base.loc, -1, block_sym)));
+                        // Prefer TypeStmtName so the branch carries the concrete Struct symbol
+                        // (used by runtime type matching for monomorphized PDTs).
+                        select_type_body.push_back(al, ASR::down_cast<ASR::type_stmt_t>(
+                            ASR::make_TypeStmtName_t(al, type_stmt_type->base.base.loc, sym,
+                                block_call_stmt.p, block_call_stmt.size())));
+                        break;
+                    }
+
+                    if( assoc_variable ) {
                         selector_ttype = selector_variable ? selector_variable->m_type : nullptr;
                         if (selector_ttype) {
                             view_type = make_typed_selector_view_type(
@@ -4567,6 +4648,7 @@ public:
                         // Dependencies are still computed from the guard type.
                         SetChar assoc_deps;
                         assoc_deps.reserve(al, 1);
+                        std::string assoc_variable_name = std::string(assoc_variable->m_name);
                         ASRUtils::collect_variable_dependencies(al, assoc_deps, view_type, nullptr, nullptr, assoc_variable_name);
                         assoc_variable->m_dependencies = assoc_deps.p;
                         assoc_variable->n_dependencies = assoc_deps.size();


### PR DESCRIPTION
LFortran rejected `type is (child(4))` as a syntax error. Accept parametrized derived types with kind arguments in type-is guards by extending the parser, and route those guards through the existing TypeStmtName/ClassToStruct path so associate names can access members.

Adds integration_tests/select_type_53.f90 (llvm only; gfortran lacks support for this construct). Regenerates ci/parser.yy.patch.

Fixes #8825.