### PR TITLE
fix: inline character layout for SEQUENCE types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2504,6 +2504,7 @@ RUN(NAME derived_types_146 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME derived_types_147 LABELS gfortran llvm)
 RUN(NAME derived_types_148 LABELS gfortran llvm)
 RUN(NAME derived_types_149 LABELS gfortran llvm)
+RUN(NAME derived_types_150 LABELS gfortran llvm) # SEQUENCE char(len>1) inline + storage_size + memcpy
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME derived_type_with_default_init_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/derived_types_150.f90
+++ b/integration_tests/derived_types_150.f90
@@ -1,0 +1,57 @@
+! Verify that SEQUENCE derived types with character(len>1) members are
+! laid out inline, so storage_size reports the full inline byte count
+! and c_loc + memcpy correctly copies the object representation.
+program derived_types_150
+  use iso_c_binding, only: c_ptr, c_loc, c_size_t
+  implicit none
+
+  type :: object_t
+    sequence
+    integer :: i
+    logical :: fallacy
+    character(len=5) :: actor
+    complex :: issues
+  end type
+
+  interface
+    subroutine memcpy(dest, src, n) bind(c, name="memcpy")
+      import :: c_ptr, c_size_t
+      type(c_ptr), value :: dest
+      type(c_ptr), value :: src
+      integer(c_size_t), value :: n
+    end subroutine memcpy
+  end interface
+
+  type(object_t), target :: obj1, obj2
+  integer(c_size_t) :: bytes_to_copy
+  integer :: ss1, ss2
+
+  obj1%i = 42
+  obj1%fallacy = .true.
+  obj1%actor = "fooey"
+  obj1%issues = cmplx(3.0, 4.0)
+
+  ! Assignment into a SEQUENCE character component (inline [len x i8])
+  obj2%actor = "xx"
+  if (obj2%actor /= "xx   ") error stop
+  obj2%actor = "toolong"
+  if (obj2%actor /= "toolo") error stop
+
+  ss1 = storage_size(obj1)
+  ss2 = storage_size(obj2)
+  if (ss1 /= ss2) error stop
+  ! integer(4)+logical(4)+character(5)+complex(8) with alignment = 24 bytes = 192 bits
+  ! (matches gfortran/flang; the old descriptor layout under-reported this).
+  if (ss1 /= 192) error stop
+
+  bytes_to_copy = int(ss1 / 8, kind=c_size_t)
+  call memcpy(c_loc(obj2), c_loc(obj1), bytes_to_copy)
+
+  if (obj2%i /= 42) error stop
+  if (.not. obj2%fallacy) error stop
+  if (obj2%actor /= "fooey") error stop
+  if (abs(real(obj2%issues) - 3.0) > 1.0e-6) error stop
+  if (abs(aimag(obj2%issues) - 4.0) > 1.0e-6) error stop
+
+  print *, "ok", ss1
+end program derived_types_150

--- a/integration_tests/derived_types_150.f90
+++ b/integration_tests/derived_types_150.f90
@@ -46,6 +46,7 @@ program derived_types_150
 
   bytes_to_copy = int(ss1 / 8, kind=c_size_t)
   call memcpy(c_loc(obj2), c_loc(obj1), bytes_to_copy)
+  call consume(obj2)
 
   if (obj2%i /= 42) error stop
   if (.not. obj2%fallacy) error stop
@@ -54,4 +55,11 @@ program derived_types_150
   if (abs(aimag(obj2%issues) - 4.0) > 1.0e-6) error stop
 
   print *, "ok", ss1
+
+contains
+
+  subroutine consume(value)
+    class(*), intent(inout) :: value(..)
+  end subroutine consume
+
 end program derived_types_150

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4517,7 +4517,7 @@ public:
             ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(make_Struct_t(
                 al, loc, struct_scope, s2c(al,common_block_name),
                 nullptr,
-                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false,
+                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false, false,
                 nullptr, 0, nullptr, nullptr, nullptr, 0));
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
@@ -9053,6 +9053,7 @@ public:
             new_data_member_names.p, new_data_member_names.size(),
             pdt_final_proc_names.p, pdt_final_proc_names.size(),
             ASR::abiType::Source, dflt_access, false, pdt_struct->m_is_abstract,
+            pdt_struct->m_is_sequence,
             nullptr, 0, nullptr, new_parent, nullptr, 0);
 
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(tmp);
@@ -9568,7 +9569,7 @@ public:
                         current_scope = al.make_new<SymbolTable>(parent_scope);
                         ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, current_scope,
                                                         s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
-                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
+                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true, false,
                                                         nullptr, 0, nullptr, nullptr, nullptr, 0);
                         ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
@@ -9873,7 +9874,7 @@ public:
                         SymbolTable *struct_symtab = al.make_new<SymbolTable>(target_scope);
                         ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
                                                         s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
-                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
+                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true, false,
                                                         nullptr, 0, nullptr, nullptr, nullptr, 0);
                         ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
@@ -14831,17 +14832,6 @@ public:
                     ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
                         ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
                     int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
-                    // For character types: mold_bytes = kind * length
-                    if( ASR::is_a<ASR::String_t>(*mold_elem_type) ) {
-                        ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
-                        if( mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len) ) {
-                            int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
-                                ASRUtils::expr_value(mold_str_type->m_len))->m_n;
-                            mold_bytes = mold_bytes * str_len;
-                        } else {
-                            mold_bytes = -1; // Runtime-sized string
-                        }
-                    }
                     if( mold_bytes > 0 ) {
                         result_size = (src_bytes + mold_bytes - 1) / mold_bytes;
                     }
@@ -14850,17 +14840,6 @@ public:
                     ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
                         ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
                     int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
-                    // For character types: mold_bytes = kind * length
-                    if( ASR::is_a<ASR::String_t>(*mold_elem_type) ) {
-                        ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
-                        if( mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len) ) {
-                            int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
-                                ASRUtils::expr_value(mold_str_type->m_len))->m_n;
-                            mold_bytes = mold_bytes * str_len;
-                        } else {
-                            mold_bytes = -1;
-                        }
-                    }
                     if( mold_bytes > 0 ) {
                         // Calculate: ceiling(src_len_expr / mold_bytes)
                         // = (src_len_expr + mold_bytes - 1) / mold_bytes
@@ -15860,11 +15839,51 @@ public:
         return resolve_intrinsic_function(x.base.base.loc, var_name);
     }
 
+    bool struct_has_descriptor_string_member(ASR::expr_t* expr) {
+        ASR::ttype_t* type = ASRUtils::expr_type(expr);
+        type = ASRUtils::type_get_past_array(
+                   ASRUtils::type_get_past_allocatable(
+                       ASRUtils::type_get_past_pointer(type)));
+        if (!ASR::is_a<ASR::StructType_t>(*type)) return false;
+        ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(
+            ASRUtils::get_struct_sym_from_struct_expr(expr));
+        if (struct_sym && ASR::is_a<ASR::Struct_t>(*struct_sym)) {
+            ASR::Struct_t* st_sym = ASR::down_cast<ASR::Struct_t>(struct_sym);
+            // bind(C) and SEQUENCE types have a defined storage layout,
+            // so c_loc is allowed without warning.
+            if (st_sym->m_abi == ASR::abiType::BindC) return false;
+            if (st_sym->m_is_sequence) return false;
+        }
+        ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(type);
+        for (size_t i = 0; i < st->n_data_member_types; i++) {
+            ASR::ttype_t* mt = ASRUtils::type_get_past_array(
+                                   ASRUtils::type_get_past_allocatable(
+                                       ASRUtils::type_get_past_pointer(
+                                           st->m_data_member_types[i])));
+            if (ASR::is_a<ASR::String_t>(*mt)) return true;
+        }
+        return false;
+    }
+
     ASR::asr_t* create_PointerToCptr(const AST::FuncCallOrArray_t& x) {
         Vec<ASR::expr_t*> args;
         std::vector<std::string> kwarg_names = {"X"};
         handle_intrinsic_node_args(x, args, kwarg_names, 1, 1, std::string("c_loc"));
         ASR::expr_t *v_Var = args[0];
+        if (struct_has_descriptor_string_member(v_Var)) {
+            diag.semantic_warning_label(
+                "c_loc() on a non-bind(C)/non-SEQUENCE derived type containing a "
+                "character component is not portable",
+                {x.base.base.loc},
+                "LFortran represents fixed-length character components as a "
+                "descriptor (pointer + length); the in-memory layout differs "
+                "from the standard inline layout used by gfortran/flang. "
+                "Code that relies on this layout (e.g. memcpy via storage_size, "
+                "raw bytewise transfer) will not behave portably. "
+                "Use SEQUENCE (or bind(C) with interoperable components) for "
+                "a defined contiguous layout."
+            );
+        }
         if( !ASR::is_a<ASR::GetPointer_t>(*v_Var) &&
             !ASRUtils::is_pointer(ASRUtils::expr_type(v_Var)) ) {
             ASR::ttype_t* ptr_type = ASRUtils::make_Pointer_t_util(al, x.base.base.loc,

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -2773,6 +2773,22 @@ public:
                 }
             }
 
+            // Detect SEQUENCE attribute among declarations.
+            bool is_sequence = false;
+            for (size_t i = 0; i < x.n_items; i++) {
+                if (!AST::is_a<AST::Declaration_t>(*x.m_items[i])) continue;
+                AST::Declaration_t &decl = *AST::down_cast<AST::Declaration_t>(x.m_items[i]);
+                if (decl.m_vartype != nullptr) continue;
+                for (size_t j = 0; j < decl.n_attributes; j++) {
+                    if (AST::is_a<AST::SimpleAttribute_t>(*decl.m_attributes[j])) {
+                        AST::SimpleAttribute_t *sa = AST::down_cast<AST::SimpleAttribute_t>(decl.m_attributes[j]);
+                        if (sa->m_attr == AST::simple_attributeType::AttrSequence) {
+                            is_sequence = true;
+                        }
+                    }
+                }
+            }
+
             // Create a preliminary Struct_t and add it to the parent scope
             // so that recursive self-references (e.g., type(recursive_t(k))
             // inside recursive_t) can resolve during member processing.
@@ -2782,6 +2798,7 @@ public:
                 nullptr, 0,
                 nullptr, 0,
                 is_bindc ? ASR::abiType::BindC : ASR::abiType::Source, dflt_access, false, is_abstract,
+                is_sequence,
                 nullptr, 0, nullptr, parent_sym,
                 kind_params.p, kind_params.size());
             ASR::symbol_t* derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);
@@ -2876,11 +2893,27 @@ public:
                 struct_dependencies.push_back(al, aggregate_type_name);
             }
         }
+        bool is_sequence = false;
+        for (size_t i = 0; i < x.n_items; i++) {
+            if (!AST::is_a<AST::Declaration_t>(*x.m_items[i])) continue;
+            AST::Declaration_t &decl = *AST::down_cast<AST::Declaration_t>(x.m_items[i]);
+            if (decl.m_vartype != nullptr) continue;
+            for (size_t j = 0; j < decl.n_attributes; j++) {
+                if (AST::is_a<AST::SimpleAttribute_t>(*decl.m_attributes[j])) {
+                    AST::SimpleAttribute_t *sa = AST::down_cast<AST::SimpleAttribute_t>(decl.m_attributes[j]);
+                    if (sa->m_attr == AST::simple_attributeType::AttrSequence) {
+                        is_sequence = true;
+                    }
+                }
+            }
+        }
         tmp = ASR::make_Struct_t(al, x.base.base.loc, current_scope,
             s2c(al, to_lower(x.m_name)), nullptr, struct_dependencies.p, struct_dependencies.size(),
             data_member_names.p, data_member_names.size(),
             final_proc_names.p, final_proc_names.size(),
-            is_bindc ? ASR::abiType::BindC : ASR::abiType::Source, dflt_access, false, is_abstract, nullptr, 0, nullptr, parent_sym,
+            is_bindc ? ASR::abiType::BindC : ASR::abiType::Source, dflt_access, false, is_abstract,
+            is_sequence,
+            nullptr, 0, nullptr, parent_sym,
             nullptr, 0);
 
         ASR::symbol_t* derived_type_sym = ASR::down_cast<ASR::symbol_t>(tmp);

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -15,7 +15,7 @@ symbol
     | GenericProcedure(symbol_table parent_symtab, identifier name, symbol* procs, access access)
     | CustomOperator(symbol_table parent_symtab, identifier name, symbol* procs, access access)
     | ExternalSymbol(symbol_table parent_symtab, identifier name, symbol external, identifier module_name, identifier* scope_names, identifier original_name, access access)
-    | Struct(symbol_table symtab, identifier name, ttype struct_signature, identifier* dependencies, identifier* members, identifier* member_functions, abi abi, access access, bool is_packed, bool is_abstract, call_arg* initializers, expr? alignment, symbol? parent, identifier* kind_params)
+    | Struct(symbol_table symtab, identifier name, ttype struct_signature, identifier* dependencies, identifier* members, identifier* member_functions, abi abi, access access, bool is_packed, bool is_abstract, bool is_sequence, call_arg* initializers, expr? alignment, symbol? parent, identifier* kind_params)
     | Enum(symbol_table symtab, identifier name, identifier* dependencies, identifier* members, abi abi, access access, enumtype enum_value_type, ttype type, symbol? parent)
     | Union(symbol_table symtab, identifier name, identifier* dependencies, identifier* members, abi abi, access access, call_arg* initializers, symbol? parent)
     | Variable(symbol_table parent_symtab, identifier name, identifier* dependencies, intent intent,

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3298,9 +3298,16 @@ static inline std::pair<int64_t, int64_t> compute_type_size_align(ASR::ttype_t* 
     } else if (ASR::is_a<ASR::CPtr_t>(*type)) {
         return {8, 8};
     } else if (ASR::is_a<ASR::String_t>(*type)) {
-        int64_t kind = ASR::down_cast<ASR::String_t>(type)->m_kind;
-        if (kind > 0) return {kind, 1};
-        return {-1, -1};
+        ASR::String_t* st = ASR::down_cast<ASR::String_t>(type);
+        int64_t kind = st->m_kind;
+        if (kind <= 0) return {-1, -1};
+        int64_t len = 1;
+        if (st->m_len == nullptr ||
+            !ASRUtils::extract_value(st->m_len, len)) {
+            return {-1, -1};
+        }
+        if (len < 0) return {-1, -1};
+        return {kind * len, 1};
     } else if (ASR::is_a<ASR::StructType_t>(*type)) {
         ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(type);
         int64_t offset = 0;
@@ -5513,7 +5520,7 @@ static inline ASR::symbol_t* import_struct_type(Allocator& al, ASR::symbol_t* st
         ASR::asr_t* dtype = ASR::make_Struct_t(al, struct_sym->base.loc,
             upt_symtab, s2c(al, struct_name), nullptr, nullptr, 0,
             nullptr, 0, nullptr, 0, ASR::abiType::Source,
-            ASR::accessType::Public, false, true, nullptr, 0,
+            ASR::accessType::Public, false, true, false, nullptr, 0,
             nullptr, nullptr, nullptr, 0);
         ASR::symbol_t* new_sym = ASR::down_cast<ASR::symbol_t>(dtype);
         ASR::ttype_t* sig = ASRUtils::make_StructType_t_util(
@@ -6387,6 +6394,7 @@ class SymbolDuplicator {
             struct_type_t->m_members, struct_type_t->n_members,
             struct_type_t->m_member_functions, struct_type_t->n_member_functions, struct_type_t->m_abi,
             struct_type_t->m_access, struct_type_t->m_is_packed, struct_type_t->m_is_abstract,
+            struct_type_t->m_is_sequence,
             struct_type_t->m_initializers, struct_type_t->n_initializers, struct_type_t->m_alignment,
             struct_type_t->m_parent,
             struct_type_t->m_kind_params, struct_type_t->n_kind_params));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -12838,7 +12838,7 @@ public:
         dt_sym = ASRUtils::symbol_get_past_external(dt_sym);
         if (!ASR::is_a<ASR::Struct_t>(*dt_sym)) return false;
         ASR::Struct_t* dt = ASR::down_cast<ASR::Struct_t>(dt_sym);
-        if (dt->m_abi == ASR::abiType::BindC) return false;
+        if (dt->m_abi == ASR::abiType::BindC || dt->m_is_sequence) return false;
 
         llvm::DataLayout data_layout(module->getDataLayout());
         llvm::StructType* st = llvm::cast<llvm::StructType>(elem_llvm_type);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -949,11 +949,12 @@ public:
             ASRUtils::extract_type(expr_type(str_expr)));
         this->visit_expr_load_wrapper(str_expr, 0);
 
-        // For bind(C) struct character members, the LLVM type is i8*
-        // even though the ASR physical type says DescriptorString.
+        // For bind(C)/SEQUENCE struct character members, the LLVM type is
+        // [len x i8]* even though the ASR physical type says DescriptorString.
         ASR::string_physical_typeType phys_type = str->m_physical_type;
+        int64_t bindc_inline_len = 0;
         if (phys_type == ASR::DescriptorString && tmp->getType()->isPointerTy()) {
-            // Check if this is a non-pointer character member of a bind(C) struct
+            // Check if this is a non-pointer character member of a bind(C)/SEQUENCE struct
             if (ASR::is_a<ASR::StructInstanceMember_t>(*str_expr)) {
                 ASR::StructInstanceMember_t* sim =
                     ASR::down_cast<ASR::StructInstanceMember_t>(str_expr);
@@ -963,17 +964,31 @@ public:
                     member_var->m_parent_symtab->asr_owner);
                 struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
                 if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
-                    ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC) {
+                    (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC ||
+                     ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence)) {
                     ASR::ttype_t* mem_type = sim->m_type;
                     if (!ASR::is_a<ASR::Pointer_t>(*mem_type) &&
                         !ASR::is_a<ASR::Allocatable_t>(*mem_type)) {
                         phys_type = ASR::CChar;
+                        bindc_inline_len = 1;
+                        if (str->m_len) {
+                            ASRUtils::extract_value(str->m_len, bindc_inline_len);
+                        }
+                        if (bindc_inline_len < 1) bindc_inline_len = 1;
                     }
                 }
             }
         }
 
         std::pair<llvm::Value*, llvm::Value*> data_and_length;
+        if (bindc_inline_len > 0) {
+            // tmp is a pointer to inline [len x i8]; bitcast to i8* (first byte).
+            data_and_length.first = builder->CreateBitCast(
+                tmp, character_type);
+            data_and_length.second = llvm::ConstantInt::get(
+                context, llvm::APInt(64, bindc_inline_len));
+            return data_and_length;
+        }
         switch (phys_type)
         {
             case ASR::DescriptorString:{
@@ -6763,8 +6778,10 @@ public:
                     allocate_array_members_of_struct(struct_sym, ptr_member, symbol_type,
                         is_intent_out, initialize_val, skip_allocatable_array_descriptor_init);
                 }  else if(ASRUtils::is_string_only(symbol_type) && !is_intent_out) {
-                    // Skip string descriptor setup for bind(C) struct non-pointer character members
-                    bool is_bindc = (struct_type_t->m_abi == ASR::abiType::BindC);
+                    // Skip string descriptor setup for bind(C)/SEQUENCE struct
+                    // non-pointer character members (inline [len x i8]).
+                    bool is_bindc = (struct_type_t->m_abi == ASR::abiType::BindC) ||
+                                    struct_type_t->m_is_sequence;
                     ASR::Variable_t* v_sym = ASR::down_cast<ASR::Variable_t>(sym);
                     bool is_direct_char = is_bindc &&
                         !ASR::is_a<ASR::Pointer_t>(*v_sym->m_type) &&
@@ -12080,7 +12097,7 @@ public:
         }
         if ( ASRUtils::is_string_only(ASRUtils::expr_type(x.m_value)) &&
              ASR::is_a<ASR::String_t>(*ASRUtils::extract_type(asr_target_type))) {
-            // Check if target is a character member of a bind(C) struct
+            // Check if target is a character member of a bind(C)/SEQUENCE struct
             bool is_bindc_char_member = false;
             if (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target)) {
                 ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(x.m_target);
@@ -12090,7 +12107,8 @@ public:
                     member_var->m_parent_symtab->asr_owner);
                 struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
                 if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
-                    ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC) {
+                    (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC ||
+                     ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence)) {
                     ASR::ttype_t* mem_type = sim->m_type;
                     is_bindc_char_member = !ASR::is_a<ASR::Pointer_t>(*mem_type) &&
                         !ASR::is_a<ASR::Allocatable_t>(*mem_type);
@@ -12102,8 +12120,67 @@ public:
                 is_cchar_array_item = ASR::is_a<ASR::String_t>(*target_item_type) &&
                     ASR::down_cast<ASR::String_t>(target_item_type)->m_physical_type == ASR::CChar;
             }
-            if (is_bindc_char_member || is_cchar_array_item) {
-                // bind(C) character storage: store first byte directly as i8
+            if (is_bindc_char_member) {
+                // bind(C)/SEQUENCE character member: layout is inline [dst_len x i8].
+                // memcpy min(src_len, dst_len) bytes, then space-pad the rest.
+                ASR::String_t* dst_str_type = ASR::down_cast<ASR::String_t>(
+                    ASRUtils::extract_type(asr_target_type));
+                int64_t dst_len = 1;
+                if (dst_str_type->m_len) {
+                    ASRUtils::extract_value(dst_str_type->m_len, dst_len);
+                }
+                if (dst_len < 1) dst_len = 1;
+                ASR::String_t* src_str_type = ASR::down_cast<ASR::String_t>(
+                    ASRUtils::extract_type(asr_value_type));
+                llvm::Value* src_data;
+                llvm::Value* src_len_val;
+                if (src_str_type->m_physical_type == ASR::CChar) {
+                    src_data = value;
+                    src_len_val = llvm::ConstantInt::get(
+                        context, llvm::APInt(64, 1));
+                } else {
+                    // DescriptorString
+                    src_data = llvm_utils->CreateLoad2(character_type,
+                        llvm_utils->create_gep2(llvm_utils->string_descriptor, value, 0));
+                    if (src_str_type->m_len &&
+                        ASR::is_a<ASR::IntegerConstant_t>(*src_str_type->m_len)) {
+                        int64_t l = ASR::down_cast<ASR::IntegerConstant_t>(
+                            src_str_type->m_len)->m_n;
+                        src_len_val = llvm::ConstantInt::get(
+                            context, llvm::APInt(64, l));
+                    } else {
+                        src_len_val = llvm_utils->CreateLoad2(
+                            llvm::Type::getInt64Ty(context),
+                            llvm_utils->create_gep2(llvm_utils->string_descriptor, value, 1));
+                    }
+                }
+                llvm::Value* dst_len_val = llvm::ConstantInt::get(
+                    context, llvm::APInt(64, dst_len));
+                // copy_len = min(src_len, dst_len)
+                llvm::Value* cmp = builder->CreateICmpULT(src_len_val, dst_len_val);
+                llvm::Value* copy_len = builder->CreateSelect(cmp, src_len_val, dst_len_val);
+                builder->CreateMemCpy(target, llvm::MaybeAlign(),
+                    src_data, llvm::MaybeAlign(), copy_len);
+                // pad remaining bytes (dst_len - copy_len) with ' '
+                llvm::Value* pad_len = builder->CreateSub(dst_len_val, copy_len);
+#if LLVM_VERSION_MAJOR >= 17
+                llvm::Type* i8_ptr_ty_pad
+                    = llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context));
+#else
+                llvm::Type* i8_ptr_ty_pad = llvm::Type::getInt8PtrTy(context);
+#endif
+                llvm::Value* target_i8 = builder->CreateBitCast(
+                    target, i8_ptr_ty_pad);
+                llvm::Value* pad_dst = builder->CreateGEP(
+                    llvm::Type::getInt8Ty(context), target_i8, copy_len);
+                builder->CreateMemSet(pad_dst,
+                    llvm::ConstantInt::get(context, llvm::APInt(8, ' ')),
+                    pad_len, llvm::MaybeAlign());
+                tmp = nullptr;
+                return;
+            }
+            if (is_cchar_array_item) {
+                // CChar array item: store first byte directly as i8
                 ASR::String_t* src_str_type = ASR::down_cast<ASR::String_t>(
                     ASRUtils::extract_type(asr_value_type));
                 llvm::Value* byte_val;
@@ -26922,6 +26999,46 @@ public:
                     llvm::Value* tmp_ptr = builder->CreateAlloca(tmp->getType());
                     builder->CreateStore(tmp, tmp_ptr);
                     tmp = tmp_ptr;
+                }
+                // bind(C)/SEQUENCE inline char member: tmp is [len x i8]* but
+                // format expects string_descriptor*. Materialize a temp descriptor.
+                if (ASRUtils::is_character(*expr_type(x.m_args[i])) &&
+                    ASRUtils::get_string_type(expr_type(x.m_args[i]))->m_physical_type
+                        == ASR::DescriptorString &&
+                    ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i])) {
+                    ASR::StructInstanceMember_t* sim = ASR::down_cast<
+                        ASR::StructInstanceMember_t>(x.m_args[i]);
+                    ASR::symbol_t* member_sym = ASRUtils::symbol_get_past_external(sim->m_m);
+                    ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(member_sym);
+                    ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(
+                        member_var->m_parent_symtab->asr_owner);
+                    struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
+                    if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
+                        (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi
+                            == ASR::abiType::BindC ||
+                         ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence) &&
+                        !ASR::is_a<ASR::Pointer_t>(*sim->m_type) &&
+                        !ASR::is_a<ASR::Allocatable_t>(*sim->m_type)) {
+                        ASR::String_t* str_ty = ASR::down_cast<ASR::String_t>(
+                            ASRUtils::extract_type(sim->m_type));
+                        int64_t slen = 1;
+                        if (str_ty->m_len) {
+                            ASRUtils::extract_value(str_ty->m_len, slen);
+                        }
+                        if (slen < 1) slen = 1;
+                        llvm::Value* desc = builder->CreateAlloca(
+                            llvm_utils->string_descriptor);
+                        llvm::Value* data_field = llvm_utils->create_gep2(
+                            llvm_utils->string_descriptor, desc, 0);
+                        llvm::Value* len_field = llvm_utils->create_gep2(
+                            llvm_utils->string_descriptor, desc, 1);
+                        llvm::Value* data_ptr = builder->CreateBitCast(
+                            tmp, llvm::Type::getInt8Ty(context)->getPointerTo());
+                        builder->CreateStore(data_ptr, data_field);
+                        builder->CreateStore(llvm::ConstantInt::get(
+                            context, llvm::APInt(64, slen)), len_field);
+                        tmp = desc;
+                    }
                 }
                 args.push_back(tmp);
                 ptr_loads = ptr_load_copy;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10617,6 +10617,22 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
                     llvm::Type *mem_type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::get_expr_from_sym(al, mem_sym),
                         ASRUtils::symbol_type(mem_sym), module);
                     ASR::ttype_t* member_type = ASRUtils::symbol_type(mem_sym);
+                    bool is_inline_char = (struct_sym->m_abi == ASR::abiType::BindC ||
+                            struct_sym->m_is_sequence) &&
+                        !ASR::is_a<ASR::Pointer_t>(*member_type) &&
+                        !ASR::is_a<ASR::Allocatable_t>(*member_type) &&
+                        ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_array(member_type));
+                    if (is_inline_char) {
+                        llvm::Type* inline_type = llvm_utils->name2dertype[
+                            der_type_name]->getElementType(mem_idx);
+                        if (src_member->getType()->isPointerTy()) {
+                            src_member = llvm_utils->CreateLoad2(inline_type, src_member);
+                        }
+                        llvm::Value* dest_member = llvm_utils->create_gep2(
+                            llvm_utils->name2dertype[der_type_name], dest, mem_idx);
+                        builder->CreateStore(src_member, dest_member);
+                        continue;
+                    }
                     if( !LLVM::is_llvm_struct(member_type) &&
                         !ASRUtils::is_array(member_type) &&
                         !ASRUtils::is_pointer(member_type) &&

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -496,19 +496,27 @@ namespace LCompilers {
                 member_idx += 1;
             }
             Allocator al(1024);
-            bool is_bindc = (der_type->m_abi == ASR::abiType::BindC);
+            bool is_bindc = (der_type->m_abi == ASR::abiType::BindC) || der_type->m_is_sequence;
             for( size_t i = 0; i < der_type->n_members; i++ ) {
                 std::string member_name = der_type->m_members[i];
                 ASR::Variable_t* member = ASR::down_cast<ASR::Variable_t>(der_type->m_symtab->get_symbol(member_name));
                 llvm::Type* llvm_mem_type;
-                // bind(C) struct: non-pointer, non-allocatable character maps to i8
+                // bind(C)/SEQUENCE: non-pointer, non-allocatable character maps to inline [len x i8]
                 ASR::ttype_t* mem_type = member->m_type;
                 bool is_direct_char = is_bindc &&
                     !ASR::is_a<ASR::Pointer_t>(*mem_type) &&
                     !ASR::is_a<ASR::Allocatable_t>(*mem_type) &&
                     ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_array(mem_type));
                 if (is_direct_char) {
-                    llvm_mem_type = llvm::Type::getInt8Ty(context);
+                    ASR::String_t* s = ASR::down_cast<ASR::String_t>(
+                        ASRUtils::type_get_past_array(mem_type));
+                    int64_t slen = 1;
+                    if (s->m_len) {
+                        ASRUtils::extract_value(s->m_len, slen);
+                    }
+                    if (slen < 1) slen = 1;
+                    llvm_mem_type = llvm::ArrayType::get(
+                        llvm::Type::getInt8Ty(context), (uint64_t)slen);
                 } else {
                     llvm_mem_type = get_type_from_ttype_t_util(ASRUtils::EXPR(ASR::make_Var_t(
                         al, member->base.base.loc, &member->base)), member->m_type, module, member->m_abi);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -1463,10 +1463,10 @@ class ASRToLLVMVisitor;
             }
 
             // Finalize members
-            bool is_bindc = (struct_sym->m_abi == ASR::abiType::BindC);
+            bool is_bindc = (struct_sym->m_abi == ASR::abiType::BindC) || struct_sym->m_is_sequence;
             for (int i = 0; i < (int)struct_sym->n_members; i++){
                 auto const member_variable =  ASR::down_cast<ASR::Variable_t>(struct_sym->m_symtab->get_symbol(struct_sym->m_members[i]));
-                // bind(C) struct: non-pointer character members are inline i8, nothing to free
+                // bind(C)/SEQUENCE: non-pointer character members are inline, nothing to free
                 if(is_bindc &&
                    !ASR::is_a<ASR::Allocatable_t>(*member_variable->m_type) &&
                    ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_array(member_variable->m_type))) { continue; }

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -75,7 +75,7 @@ class PRIFInterface {
                 al, loc, struct_symtab, s2c(al, symbol_name), nullptr,
                 nullptr, 0, nullptr, 0, nullptr, 0,
                 ASR::abiType::Source, ASR::accessType::Public,
-                false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                false, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
             ASR::symbol_t *struct_sym = ASR::down_cast<ASR::symbol_t>(struct_asr);
             ASR::Struct_t *struct_t = ASR::down_cast<ASR::Struct_t>(struct_sym);
             ASR::ttype_t *struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_sym, true);
@@ -107,7 +107,7 @@ class PRIFInterface {
                 al, loc, struct_symtab, s2c(al, symbol_name), nullptr,
                 nullptr, 0, members.p, members.n, nullptr, 0,
                 ASR::abiType::BindC, ASR::accessType::Public,
-                false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                false, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
             ASR::symbol_t *struct_sym = ASR::down_cast<ASR::symbol_t>(struct_asr);
             ASR::Struct_t *struct_t = ASR::down_cast<ASR::Struct_t>(struct_sym);
 
@@ -799,7 +799,7 @@ class PRIFInterface {
                 al, loc, struct_symtab, s2c(al, symbol_name), nullptr,
                 nullptr, 0, nullptr, 0, nullptr, 0,
                 ASR::abiType::Source, ASR::accessType::Public,
-                false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
+                false, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0);
             ASR::symbol_t *struct_sym = ASR::down_cast<ASR::symbol_t>(struct_asr);
             ASR::Struct_t *struct_t = ASR::down_cast<ASR::Struct_t>(struct_sym);
             global_scope->add_symbol(symbol_name, struct_sym);
@@ -1087,7 +1087,7 @@ class PRIFInterface {
                 SymbolTable *struct_symtab = al.make_new<SymbolTable>(global_scope);
                 ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
                                                 s2c(al, derived_type_name), nullptr, nullptr, 0, nullptr, 0,
-                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, true,
+                                                nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, true, false,
                                                 nullptr, 0, nullptr, nullptr, nullptr, 0);
                 ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                 ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -851,6 +851,7 @@ public:
             nullptr, 0,
             orig_struct->m_abi, orig_struct->m_access,
             orig_struct->m_is_packed, orig_struct->m_is_abstract,
+            orig_struct->m_is_sequence,
             nullptr, 0, nullptr, nullptr, nullptr, 0);
         ASR::symbol_t *kernel_struct = down_cast<ASR::symbol_t>(new_struct);
         kernel_scope->add_symbol(struct_name, kernel_struct);

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -337,6 +337,7 @@ public:
             nullptr, 0,
             data_member_names.p, data_member_names.size(), nullptr, 0,
             x->m_abi, x->m_access, x->m_is_packed, x->m_is_abstract,
+            x->m_is_sequence,
             nullptr, 0, m_alignment, nullptr, nullptr, 0);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_signature = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
@@ -1232,7 +1233,7 @@ public:
         ASR::asr_t* result = ASR::make_Struct_t(al, x->base.base.loc,
             new_scope, s2c(al, new_sym_name), nullptr, nullptr, 0, data_member_names.p,
             data_member_names.size(), nullptr, 0, x->m_abi, x->m_access, x->m_is_packed,
-            x->m_is_abstract, nullptr, 0, m_alignment, nullptr, nullptr, 0);
+            x->m_is_abstract, x->m_is_sequence, nullptr, 0, m_alignment, nullptr, nullptr, 0);
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(result);
         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, x->base.base.loc, struct_sym, true);
         ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_sym);

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -868,7 +868,7 @@ class ParallelRegionVisitor :
             std::string thread_data_name = data_struct_name + suffix;
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
                 current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
-                ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0));
+                ASR::accessType::Public, false, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0));
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
             struct_->m_struct_signature = struct_type;
@@ -2053,7 +2053,7 @@ class ParallelRegionVisitor :
             
             ASR::symbol_t* thread_data_struct = ASR::down_cast<ASR::symbol_t>(ASR::make_Struct_t(al, loc,
                 current_scope, s2c(al, thread_data_name), nullptr, nullptr, 0, involved_symbols_set.p, involved_symbols_set.n, nullptr, 0, ASR::abiType::Source,
-                ASR::accessType::Public, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0));
+                ASR::accessType::Public, false, false, false, nullptr, 0, nullptr, nullptr, nullptr, 0));
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, thread_data_struct, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(thread_data_struct);
             struct_->m_struct_signature = struct_type;

--- a/tests/reference/asr-arrays_23-a731033.json
+++ b/tests/reference/asr-arrays_23-a731033.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-arrays_23-a731033.stdout",
-    "stdout_hash": "bf437c2d7dc9fd4413f31de6baeb0c52a3f42a4bcec3b05d26d630f6",
+    "stdout_hash": "81c838ca48067212811407ed4648c35f97c5debf141325ce35f3a0e4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-arrays_23-a731033.stdout
+++ b/tests/reference/asr-arrays_23-a731033.stdout
@@ -465,6 +465,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-associate_08-570ac7d.json
+++ b/tests/reference/asr-associate_08-570ac7d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-associate_08-570ac7d.stdout",
-    "stdout_hash": "7d57bb5e57e40d668cf26791d9a32ccb02cb948e9d3e9c5dbe960a99",
+    "stdout_hash": "02ebac4f03af663e7aec5f3536e064a8806e6316c319bba6c166bd3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-associate_08-570ac7d.stdout
+++ b/tests/reference/asr-associate_08-570ac7d.stdout
@@ -896,6 +896,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -967,6 +968,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-c_ptr_02-fce1b0e.json
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-c_ptr_02-fce1b0e.stdout",
-    "stdout_hash": "b740f4cba0a88d7af4270e1e4d0585d2522c7b5dfb1f56a823f852a0",
+    "stdout_hash": "331702bd6777aea6a01928b6fc7a7ae2fb64ff597654c1dcae7baab2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-c_ptr_02-fce1b0e.stdout
+++ b/tests/reference/asr-c_ptr_02-fce1b0e.stdout
@@ -652,6 +652,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-class_01-704dee8.json
+++ b/tests/reference/asr-class_01-704dee8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_01-704dee8.stdout",
-    "stdout_hash": "f6ad21190dae36321708580f2a3e5b3ded2142e9753f8ade5f29b3f4",
+    "stdout_hash": "5960850eff770ee6e4fecda9d526262ed0dc8a813cdfdd99873c5271",
     "stderr": "asr-class_01-704dee8.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/asr-class_01-704dee8.stdout
+++ b/tests/reference/asr-class_01-704dee8.stdout
@@ -190,6 +190,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-class_02-b56b852.json
+++ b/tests/reference/asr-class_02-b56b852.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_02-b56b852.stdout",
-    "stdout_hash": "ab0c8631f4f333bc5bde6e0612629078a89db9d2e8f2faf56a67c7a0",
+    "stdout_hash": "4970e3e6e9f603c024b094e59a862e1b420548cc8838f53fc7ee93a9",
     "stderr": "asr-class_02-b56b852.stderr",
     "stderr_hash": "cbe4c6f9d712b9d5ee417de42e2ce3b69d43ea5a0b463256ad71acfe",
     "returncode": 0

--- a/tests/reference/asr-class_02-b56b852.stdout
+++ b/tests/reference/asr-class_02-b56b852.stdout
@@ -99,6 +99,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-class_04-285a1df.json
+++ b/tests/reference/asr-class_04-285a1df.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-class_04-285a1df.stdout",
-    "stdout_hash": "d045e6c05b0c137df65836432d58c12fdd80d55c8e59c5aaa5fc5862",
+    "stdout_hash": "b8ccb4ce41fec9af27c55c9f155de684cedda3ed3b4d0f6b85268d18",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-class_04-285a1df.stdout
+++ b/tests/reference/asr-class_04-285a1df.stdout
@@ -111,6 +111,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -160,6 +161,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 bar_a
@@ -207,6 +209,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -302,6 +305,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -361,6 +365,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 foo_a
@@ -418,6 +423,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-common2-64c97b2.json
+++ b/tests/reference/asr-common2-64c97b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common2-64c97b2.stdout",
-    "stdout_hash": "c2e4af65b2e8334d3c26eb0b195d60a9a170b0a1031f2f347d6cc839",
+    "stdout_hash": "f8e6da2b31930be5798ce4f2989d7b2f4b623b60e67a2ef3270da4e9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common2-64c97b2.stdout
+++ b/tests/reference/asr-common2-64c97b2.stdout
@@ -132,6 +132,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -246,6 +247,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -364,6 +366,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -453,6 +456,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -569,6 +573,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-common_03-9052466.json
+++ b/tests/reference/asr-common_03-9052466.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_03-9052466.stdout",
-    "stdout_hash": "c32030525336e47e42c1d04bd1268d95c2083286f05ae29700b2b435",
+    "stdout_hash": "67283774b977377290af5f4ddc994228e201dda03f3a6a8b9ec0e1d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_03-9052466.stdout
+++ b/tests/reference/asr-common_03-9052466.stdout
@@ -231,6 +231,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -345,6 +346,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -513,6 +515,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -662,6 +665,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-common_04-b603709.json
+++ b/tests/reference/asr-common_04-b603709.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_04-b603709.stdout",
-    "stdout_hash": "bfb1d8e4a51968470b2a19e08850863af79c2a77a5dab41930ceccc0",
+    "stdout_hash": "58ec4c736cc0845c4e14c2f028c380e8a98dc2029477828d687ceba5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_04-b603709.stdout
+++ b/tests/reference/asr-common_04-b603709.stdout
@@ -106,6 +106,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_05-f767179.json
+++ b/tests/reference/asr-common_05-f767179.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_05-f767179.stdout",
-    "stdout_hash": "eb006a1c81c4d5ed25f3bb45c77a0063989cfbb431bb77045cd56f54",
+    "stdout_hash": "af57fbdd125e390f28b4368e800843071aa04e7570840ab48ac34dfa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_05-f767179.stdout
+++ b/tests/reference/asr-common_05-f767179.stdout
@@ -106,6 +106,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_06-4a72d58.json
+++ b/tests/reference/asr-common_06-4a72d58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_06-4a72d58.stdout",
-    "stdout_hash": "beb1025534a65b5e5c6227961a8f2d587b579dfc7c7dfc4b81d5fcca",
+    "stdout_hash": "7c53b371e75414ef248b6aeb9078d7f3d96869c6ac6748b630b8f815",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_06-4a72d58.stdout
+++ b/tests/reference/asr-common_06-4a72d58.stdout
@@ -73,6 +73,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_13-fa7cbf0.json
+++ b/tests/reference/asr-common_13-fa7cbf0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_13-fa7cbf0.stdout",
-    "stdout_hash": "49c348a1aab6d38ca2dd4a84733ceacdefecb12678dbf28491901ff8",
+    "stdout_hash": "66868ae4b5235632e5d965f21ae5be68cfbf89db76df599171fcfc42",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_13-fa7cbf0.stdout
+++ b/tests/reference/asr-common_13-fa7cbf0.stdout
@@ -219,6 +219,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -371,6 +372,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-dependency_test_01-280d5b3.json
+++ b/tests/reference/asr-dependency_test_01-280d5b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-dependency_test_01-280d5b3.stdout",
-    "stdout_hash": "bd64626b17bb1b22d8a4bbc056d36d9aac2692eb4cbabef26205e5c3",
+    "stdout_hash": "d785c226f6e0086d38fd7dbdd24139c61fde9344bdf2eff772e9010f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-dependency_test_01-280d5b3.stdout
+++ b/tests/reference/asr-dependency_test_01-280d5b3.stdout
@@ -299,6 +299,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -444,6 +445,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -705,6 +707,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_type1-c109ce6.json
+++ b/tests/reference/asr-derived_type1-c109ce6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_type1-c109ce6.stdout",
-    "stdout_hash": "f5bfbcc6e4af66eb6033851787a87ccfa69eb72b706a009e3342123a",
+    "stdout_hash": "e77736c8108ab4715b993fa49c6d686e694931f9a23560803057c972",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_type1-c109ce6.stdout
+++ b/tests/reference/asr-derived_type1-c109ce6.stdout
@@ -73,6 +73,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_01-960dafe.json
+++ b/tests/reference/asr-derived_types_01-960dafe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_01-960dafe.stdout",
-    "stdout_hash": "211c8e8acda4b3294f60e1e61685fd7579281f87225a1c9f4184505f",
+    "stdout_hash": "eb98beef1b2f6ca36c228c3027897b3d84c91f3baa47eb64c4bc31f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_01-960dafe.stdout
+++ b/tests/reference/asr-derived_types_01-960dafe.stdout
@@ -752,6 +752,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -837,6 +838,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -959,6 +961,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_03-b1d32aa.json
+++ b/tests/reference/asr-derived_types_03-b1d32aa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_03-b1d32aa.stdout",
-    "stdout_hash": "4a630061695d0af943dd9fc706d31be22febea1c5d86df63a8b72642",
+    "stdout_hash": "90090ff31bebc60ebf53fdddaab791cc4f3218e3a2cfb77aa5068ae3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_03-b1d32aa.stdout
+++ b/tests/reference/asr-derived_types_03-b1d32aa.stdout
@@ -80,6 +80,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -132,6 +133,7 @@
                                                     []
                                                     Source
                                                     Public
+                                                    .false.
                                                     .false.
                                                     .false.
                                                     []
@@ -240,6 +242,7 @@
                                                     []
                                                     Source
                                                     Public
+                                                    .false.
                                                     .false.
                                                     .false.
                                                     []

--- a/tests/reference/asr-derived_types_04-b960162.json
+++ b/tests/reference/asr-derived_types_04-b960162.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-b960162.stdout",
-    "stdout_hash": "e54470dd6679007d489b849ecb582a465bbb401d033cad024c6f4951",
+    "stdout_hash": "9a000b30e9bb99ee11eeb47eb3a2726045e23279ddee379f324b6921",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-b960162.stdout
+++ b/tests/reference/asr-derived_types_04-b960162.stdout
@@ -161,6 +161,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_04-da02dd9.json
+++ b/tests/reference/asr-derived_types_04-da02dd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_04-da02dd9.stdout",
-    "stdout_hash": "41e19a71b6f20f4a0c17993cc6217559f31b64b09168c8759f23bc66",
+    "stdout_hash": "3ba0c5ef9a6c2234ba0fb9a01b4d0e4d678d132c9a2cee5a1fafe8d2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_04-da02dd9.stdout
+++ b/tests/reference/asr-derived_types_04-da02dd9.stdout
@@ -1546,6 +1546,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1685,6 +1686,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1864,6 +1866,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_05-35150cd.json
+++ b/tests/reference/asr-derived_types_05-35150cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_05-35150cd.stdout",
-    "stdout_hash": "8c984b76399940c06fbdbc5387c47fe5455c5218fac85016a5889f46",
+    "stdout_hash": "382b7d8a158a7231280205e18beae687c43a3ac7675c0af91e61b470",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_05-35150cd.stdout
+++ b/tests/reference/asr-derived_types_05-35150cd.stdout
@@ -434,6 +434,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_06-5ae916e.json
+++ b/tests/reference/asr-derived_types_06-5ae916e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-5ae916e.stdout",
-    "stdout_hash": "2abef3572ee5830f23fbb6b724afdccd82e0fa84f5c091c6df09a5f6",
+    "stdout_hash": "11b3a64f726d9251fa77640aa5e8f2d39eb24fef62edabeb01dd1cec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-5ae916e.stdout
+++ b/tests/reference/asr-derived_types_06-5ae916e.stdout
@@ -92,6 +92,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_06-847ca73.json
+++ b/tests/reference/asr-derived_types_06-847ca73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_06-847ca73.stdout",
-    "stdout_hash": "f4869179ca8490de67fb8ad898502cfe984d77e1b5d5364cd549c55b",
+    "stdout_hash": "5429dcb0e7826fbf332b80cbaebc81bdbc40914065c9504045317a93",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_06-847ca73.stdout
+++ b/tests/reference/asr-derived_types_06-847ca73.stdout
@@ -1546,6 +1546,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1685,6 +1686,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1864,6 +1866,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_07-c5a29e3.json
+++ b/tests/reference/asr-derived_types_07-c5a29e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-c5a29e3.stdout",
-    "stdout_hash": "e8f63d4f115df062cf7c38e567731dbddec0d06f32afc4f946df4b15",
+    "stdout_hash": "c5a1c9b4a4f22a535cf939b9d35a09372ed66fef4efc7cf9774a7d22",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-c5a29e3.stdout
+++ b/tests/reference/asr-derived_types_07-c5a29e3.stdout
@@ -825,6 +825,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -950,6 +951,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1170,6 +1172,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1512,6 +1515,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_07-ccfd81f.json
+++ b/tests/reference/asr-derived_types_07-ccfd81f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_07-ccfd81f.stdout",
-    "stdout_hash": "e5714e3d69e5b489af2dab288a3eb5bb35739340fe7f0b8a9025ca81",
+    "stdout_hash": "b9c5d61096de2e0c9a7e635cb93b0b11a35d2a2d7cb28f29f5a70b4b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_07-ccfd81f.stdout
+++ b/tests/reference/asr-derived_types_07-ccfd81f.stdout
@@ -288,6 +288,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_08-3680946.json
+++ b/tests/reference/asr-derived_types_08-3680946.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_08-3680946.stdout",
-    "stdout_hash": "7ecc011fd7ea2795be02afd29ce61403c117693912a2633e5c2d2589",
+    "stdout_hash": "5b433acb7b62e7a949f30ca68768f3fd9c8399fdbda1bc611b2024ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_08-3680946.stdout
+++ b/tests/reference/asr-derived_types_08-3680946.stdout
@@ -651,6 +651,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 shape
@@ -787,6 +788,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_10-526e3f4.json
+++ b/tests/reference/asr-derived_types_10-526e3f4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_10-526e3f4.stdout",
-    "stdout_hash": "1506ab70cf493988f2cf62532a36482617734aa81d3727ed497cabb4",
+    "stdout_hash": "f51dcc92ebfa2fefee591f35d0c446e2ed0746bccbb01c200b699b12",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_10-526e3f4.stdout
+++ b/tests/reference/asr-derived_types_10-526e3f4.stdout
@@ -127,6 +127,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -259,6 +260,7 @@
                                     [finalize]
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_11-c169ea7.json
+++ b/tests/reference/asr-derived_types_11-c169ea7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_11-c169ea7.stdout",
-    "stdout_hash": "cdee785e1bb23d3e1117ad9d042aa10e26ebfed3d538ee802ddb2832",
+    "stdout_hash": "79f37b3b196b6a9de75b2932a2d1ee0307088af6eb864c1da2da8523",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_11-c169ea7.stdout
+++ b/tests/reference/asr-derived_types_11-c169ea7.stdout
@@ -168,6 +168,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_14-75884fe.json
+++ b/tests/reference/asr-derived_types_14-75884fe.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_14-75884fe.stdout",
-    "stdout_hash": "121470a5fdd50722dc4e9de5406a13876edf98a62e7b659004c18b25",
+    "stdout_hash": "eb893dff5a62a3c7ac930e16e84fe54a239ef717f706a6f070831a60",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_14-75884fe.stdout
+++ b/tests/reference/asr-derived_types_14-75884fe.stdout
@@ -181,6 +181,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_15-7fde02a.json
+++ b/tests/reference/asr-derived_types_15-7fde02a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_15-7fde02a.stdout",
-    "stdout_hash": "d9d9d288b45981adc32870dc4a76310f0383c1a946ebb7c5cbf7a38e",
+    "stdout_hash": "4de54a5b199ac83f7eda37c075bf40a800859a8c050d0c998c9bf8b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_15-7fde02a.stdout
+++ b/tests/reference/asr-derived_types_15-7fde02a.stdout
@@ -378,6 +378,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_16_module-4aac273.json
+++ b/tests/reference/asr-derived_types_16_module-4aac273.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_16_module-4aac273.stdout",
-    "stdout_hash": "4336b04d5aed3267291c50714dadda93dcdca24d87df79eb8e536947",
+    "stdout_hash": "5464795b6e2d35f8243b2034673c4e5714b4f8b92c5217e7d2984d43",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_16_module-4aac273.stdout
+++ b/tests/reference/asr-derived_types_16_module-4aac273.stdout
@@ -290,6 +290,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_17-17c3d46.json
+++ b/tests/reference/asr-derived_types_17-17c3d46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_17-17c3d46.stdout",
-    "stdout_hash": "4ca689e5c9385bc42c93c2ed8f22d99682815d86c12498c4eeb2e4a5",
+    "stdout_hash": "f9f90320b033dcfd842a996fe522ed5353f6435ea3ddcb2af433f54e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_17-17c3d46.stdout
+++ b/tests/reference/asr-derived_types_17-17c3d46.stdout
@@ -279,6 +279,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_18-e69cac3.json
+++ b/tests/reference/asr-derived_types_18-e69cac3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_18-e69cac3.stdout",
-    "stdout_hash": "ee6f95cde338339a4a3dc1242100a014706890048400b1145066f7bb",
+    "stdout_hash": "9174dded3639753574af46692b4e6b90b75f21c8fc333f9a1c57e8c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_18-e69cac3.stdout
+++ b/tests/reference/asr-derived_types_18-e69cac3.stdout
@@ -253,6 +253,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -300,6 +301,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-derived_types_19-26385d4.json
+++ b/tests/reference/asr-derived_types_19-26385d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_19-26385d4.stdout",
-    "stdout_hash": "1c9ca44536a33f28df42bcbecb90fc51c614049dcfa0c8148d14338d",
+    "stdout_hash": "94222d0653c35b2fb4202c54aca7e7273647b0f90c7306ae56608a9e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_19-26385d4.stdout
+++ b/tests/reference/asr-derived_types_19-26385d4.stdout
@@ -252,6 +252,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 toml_value
@@ -384,6 +385,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-derived_types_41-d6b8ce9.json
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-derived_types_41-d6b8ce9.stdout",
-    "stdout_hash": "489e80b4588ed0a8ac20fc4be74a2c4fd14ef3bbb003e5b471eb33d1",
+    "stdout_hash": "18a16c523322e17f9ac06b680209c8d1fb7c0568c4be7f08904288f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-derived_types_41-d6b8ce9.stdout
+++ b/tests/reference/asr-derived_types_41-d6b8ce9.stdout
@@ -313,6 +313,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-function_call1-0b992da.json
+++ b/tests/reference/asr-function_call1-0b992da.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-function_call1-0b992da.stdout",
-    "stdout_hash": "a444399d1bed589bb22e5cc23170394fac4578e71525aeb12010381c",
+    "stdout_hash": "56b93110deab3091bb7604200274dc45592dba3189fbabfb1b1ae1ef",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-function_call1-0b992da.stdout
+++ b/tests/reference/asr-function_call1-0b992da.stdout
@@ -389,6 +389,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-functions_16-3e10090.json
+++ b/tests/reference/asr-functions_16-3e10090.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_16-3e10090.stdout",
-    "stdout_hash": "da470d43e0320e70db11ff325d69727d5b7344a91e346e6401781e73",
+    "stdout_hash": "df4611f92f76571258b8cfa538e731f172e4e129f2b9278cff1f5e12",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_16-3e10090.stdout
+++ b/tests/reference/asr-functions_16-3e10090.stdout
@@ -1630,6 +1630,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-generic_name_01-9f2fd25.json
+++ b/tests/reference/asr-generic_name_01-9f2fd25.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generic_name_01-9f2fd25.stdout",
-    "stdout_hash": "ba78c741b6055c3b95d654d5a0bf41c9219202227bb5d55bbbde862d",
+    "stdout_hash": "76234898350c4d56b2a16970aca6ee7f6c3dae182814df708f425300",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generic_name_01-9f2fd25.stdout
+++ b/tests/reference/asr-generic_name_01-9f2fd25.stdout
@@ -107,6 +107,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-intrinsics_334-6d740cf.json
+++ b/tests/reference/asr-intrinsics_334-6d740cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intrinsics_334-6d740cf.stdout",
-    "stdout_hash": "c65edb3b5c49c988e9f1b6dd53bc42fa117441e57d3d093e5fc6583a",
+    "stdout_hash": "5fdfa541d09c2aecdeeab1abe174bb0c3204f355ebe1037d9071ccba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intrinsics_334-6d740cf.stdout
+++ b/tests/reference/asr-intrinsics_334-6d740cf.stdout
@@ -61,6 +61,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -390,6 +391,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-kwargs_02-1588831.json
+++ b/tests/reference/asr-kwargs_02-1588831.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-kwargs_02-1588831.stdout",
-    "stdout_hash": "8a25e8068504ac231e6c864a3cd101486ddcbdb382ec9bd0e9e2e88d",
+    "stdout_hash": "90d550190917a7b4aae7e95338866d7942839cb878c3bf9d2c958c02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-kwargs_02-1588831.stdout
+++ b/tests/reference/asr-kwargs_02-1588831.stdout
@@ -337,6 +337,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules1-d3dc674.json
+++ b/tests/reference/asr-modules1-d3dc674.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules1-d3dc674.stdout",
-    "stdout_hash": "e4850018f9c438c0dd2ad1810da1f66cb0d01753963bba79544bf6d7",
+    "stdout_hash": "ec26a71a9eb9927fc9ca25bcf6a860aa703b9e7499a9401b0eb3bf82",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules1-d3dc674.stdout
+++ b/tests/reference/asr-modules1-d3dc674.stdout
@@ -126,6 +126,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -374,6 +375,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules2-98d8120.json
+++ b/tests/reference/asr-modules2-98d8120.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules2-98d8120.stdout",
-    "stdout_hash": "1cadc116d8e8863f8cb5ac16fa4ccc532909fda4d48493cdc59a0b68",
+    "stdout_hash": "5fa6003c029290c45f0075b0e5acf2b9f6f324814500bce99c7d5a7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules2-98d8120.stdout
+++ b/tests/reference/asr-modules2-98d8120.stdout
@@ -125,6 +125,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     10 toml_structure
@@ -161,6 +162,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -547,6 +549,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 toml_value
@@ -714,6 +717,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules3-8936416.json
+++ b/tests/reference/asr-modules3-8936416.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules3-8936416.stdout",
-    "stdout_hash": "539988cf73b981dc6a3033b943fe9eb75f1a043021d5c0941696c5b1",
+    "stdout_hash": "87037b4156461ceeec9077563d08f961a1277fd669b8215d294c7fb6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules3-8936416.stdout
+++ b/tests/reference/asr-modules3-8936416.stdout
@@ -125,6 +125,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     15 toml_structure
@@ -161,6 +162,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -622,6 +624,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 toml_value
@@ -789,6 +792,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules4-22712cd.json
+++ b/tests/reference/asr-modules4-22712cd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules4-22712cd.stdout",
-    "stdout_hash": "38bc315ee1d83c2c5800f74ec38194beba2b53696e3ecd716a19fe02",
+    "stdout_hash": "05126a4e7ff64759faa78c7f29670feebbaf5786d3befe0487e33ed3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules4-22712cd.stdout
+++ b/tests/reference/asr-modules4-22712cd.stdout
@@ -125,6 +125,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     15 toml_structure
@@ -161,6 +162,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -610,6 +612,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 toml_value
@@ -927,6 +930,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     20 toml_value
@@ -991,6 +995,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1136,6 +1141,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules_24-996af24.json
+++ b/tests/reference/asr-modules_24-996af24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_24-996af24.stdout",
-    "stdout_hash": "143493675c269fd1bab84b9ed9d83e8d18a97429ff032bd5eeb54758",
+    "stdout_hash": "dc75fc7ae3d8392bc968655f87e31688ed5832375f661bd908a4b7cf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_24-996af24.stdout
+++ b/tests/reference/asr-modules_24-996af24.stdout
@@ -321,6 +321,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -404,6 +405,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -428,6 +430,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_25-b0e87c0.json
+++ b/tests/reference/asr-modules_25-b0e87c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_25-b0e87c0.stdout",
-    "stdout_hash": "788c1658d7e3c30b3d780d10605b306e85c77682cf92152b7fde554a",
+    "stdout_hash": "8dc0ca8ba73e072aca2b7b8c28bc4178b88f34c8eb92e9c7e1c38d7d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_25-b0e87c0.stdout
+++ b/tests/reference/asr-modules_25-b0e87c0.stdout
@@ -185,6 +185,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 toml_tokenizer
@@ -524,6 +525,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -618,6 +620,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -644,6 +647,7 @@
                                     Private
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     8 toml_tokenizer

--- a/tests/reference/asr-modules_28-9506bba.json
+++ b/tests/reference/asr-modules_28-9506bba.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_28-9506bba.stdout",
-    "stdout_hash": "88a7ab28e8a258008d60e03e003c3c43f919150428506a8e20213506",
+    "stdout_hash": "c676785e4673bf18c2c7105b3565b1df2122c2f10b390973b7cdb1a1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_28-9506bba.stdout
+++ b/tests/reference/asr-modules_28-9506bba.stdout
@@ -256,6 +256,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -402,6 +403,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -453,6 +455,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1010,6 +1013,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_29-dc71c55.json
+++ b/tests/reference/asr-modules_29-dc71c55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_29-dc71c55.stdout",
-    "stdout_hash": "bce7fa69aa81abdf6ed880fc1032f12de790522f18b9a1e49d0ed58b",
+    "stdout_hash": "a586030acd0a3042756f6b9e5e5db3293b4acff5b320ee2f2be9d6b0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_29-dc71c55.stdout
+++ b/tests/reference/asr-modules_29-dc71c55.stdout
@@ -256,6 +256,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -402,6 +403,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -453,6 +455,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1012,6 +1015,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1242,6 +1246,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_30-9f519b4.json
+++ b/tests/reference/asr-modules_30-9f519b4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_30-9f519b4.stdout",
-    "stdout_hash": "e07569abda040fb3e00ae7fc605ff76cef4d2482fc1addbed0aaabb7",
+    "stdout_hash": "5517866456c8efc366b029e891e1efb4969ece41c59a1796323b4ede",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_30-9f519b4.stdout
+++ b/tests/reference/asr-modules_30-9f519b4.stdout
@@ -298,6 +298,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -724,6 +725,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_31-cd9bfef.json
+++ b/tests/reference/asr-modules_31-cd9bfef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_31-cd9bfef.stdout",
-    "stdout_hash": "bb644de6893ec75ab1b7e76ef0085641af8c920d1677320c225ac5b3",
+    "stdout_hash": "a6f03793892d6892dd8817a73711b0d332cea800983b4178fd7ce0c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_31-cd9bfef.stdout
+++ b/tests/reference/asr-modules_31-cd9bfef.stdout
@@ -412,6 +412,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -527,6 +528,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 fpm_cmd_settings
@@ -621,6 +623,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -768,6 +771,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1013,6 +1017,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1064,6 +1069,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_32-ca5fb91.json
+++ b/tests/reference/asr-modules_32-ca5fb91.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_32-ca5fb91.stdout",
-    "stdout_hash": "17a7460ca6690c08eb31668f2018455a430b7d1f8b4b910cec2bb3e4",
+    "stdout_hash": "b202a7cfa841f7327520ba3cd174a12ba798d276122e4119703d0137",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_32-ca5fb91.stdout
+++ b/tests/reference/asr-modules_32-ca5fb91.stdout
@@ -100,6 +100,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -181,6 +182,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_33-b589c22.json
+++ b/tests/reference/asr-modules_33-b589c22.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_33-b589c22.stdout",
-    "stdout_hash": "5294aa9d5d673f80bd0a27c41659e59492088c62da6c7ebb97dcbc51",
+    "stdout_hash": "0d60eddac767c33e32d3c5ff7d0a10c1b68993c9b97ffe9fe7f3a3df",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_33-b589c22.stdout
+++ b/tests/reference/asr-modules_33-b589c22.stdout
@@ -528,6 +528,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -673,6 +674,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -948,6 +950,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1001,6 +1004,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1052,6 +1056,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1592,6 +1597,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_34-f98f7e3.json
+++ b/tests/reference/asr-modules_34-f98f7e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_34-f98f7e3.stdout",
-    "stdout_hash": "3361baad8fd44f2b12e356fb9da8df7ede705b12780d35296ea3378d",
+    "stdout_hash": "6cceca955c8d9afd949b80420e221545590b46937a9253e3172284a5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_34-f98f7e3.stdout
+++ b/tests/reference/asr-modules_34-f98f7e3.stdout
@@ -151,6 +151,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -776,6 +777,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_37-7eba027.json
+++ b/tests/reference/asr-modules_37-7eba027.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_37-7eba027.stdout",
-    "stdout_hash": "2eb45987762ff955ce0d07cf2fc75a938ef203bbacb6e0a808d96660",
+    "stdout_hash": "6636984e82df89e4aaa8969bc6d69f1cb70fd507087903c2caaa630f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_37-7eba027.stdout
+++ b/tests/reference/asr-modules_37-7eba027.stdout
@@ -556,6 +556,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -607,6 +608,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -794,6 +796,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 fpm_cmd_settings
@@ -849,6 +852,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -873,6 +877,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -926,6 +931,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_40-d3a41b5.json
+++ b/tests/reference/asr-modules_40-d3a41b5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_40-d3a41b5.stdout",
-    "stdout_hash": "5b5b180ff13a6e304777cb7a3ed7412a32d1b9b60b96fdd5eceaf4df",
+    "stdout_hash": "c1aa3356e22b24fc7a9da3755e83bf28bb11dc7b018b503fa9406df5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_40-d3a41b5.stdout
+++ b/tests/reference/asr-modules_40-d3a41b5.stdout
@@ -442,6 +442,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -478,6 +479,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules_43-d01691f.json
+++ b/tests/reference/asr-modules_43-d01691f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_43-d01691f.stdout",
-    "stdout_hash": "579b20a69dad26d854197662afbf1187cf3248c4b709c61ba41a5bc9",
+    "stdout_hash": "8e25753b3446b2d866b74fa9efdb1507cb5be967e10ac83209f73129",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_43-d01691f.stdout
+++ b/tests/reference/asr-modules_43-d01691f.stdout
@@ -512,6 +512,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules_44-ec0baa3.json
+++ b/tests/reference/asr-modules_44-ec0baa3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_44-ec0baa3.stdout",
-    "stdout_hash": "695890c644848dd251b086ad6553a78b62f155a982a0261121454905",
+    "stdout_hash": "64d7fe7804e2949f1675291214003a523aa05e37b3c37d9b945e7d16",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_44-ec0baa3.stdout
+++ b/tests/reference/asr-modules_44-ec0baa3.stdout
@@ -283,6 +283,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -334,6 +335,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_45-c69c75f.json
+++ b/tests/reference/asr-modules_45-c69c75f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_45-c69c75f.stdout",
-    "stdout_hash": "9f122c749f03d504804f1008995ad61ea2e25128056f9d26ecddeee5",
+    "stdout_hash": "b1da2e27aa30c3862798a712e821d6289490ab9aa22d586af553a7d9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_45-c69c75f.stdout
+++ b/tests/reference/asr-modules_45-c69c75f.stdout
@@ -312,6 +312,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -1731,6 +1732,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-modules_48-6cf0505.json
+++ b/tests/reference/asr-modules_48-6cf0505.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_48-6cf0505.stdout",
-    "stdout_hash": "27b60dca3f8e76cb75020a5d08a8cc5839de3771e071f3c25670a7b2",
+    "stdout_hash": "d68892843a820accd52e8a5095706124b5d86cea87393ad6a961339c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_48-6cf0505.stdout
+++ b/tests/reference/asr-modules_48-6cf0505.stdout
@@ -1980,6 +1980,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-modules_52-5261d38.json
+++ b/tests/reference/asr-modules_52-5261d38.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_52-5261d38.stdout",
-    "stdout_hash": "1e8da667c30441c3fe6938b2f30aaea19c493a379f05849d328b3717",
+    "stdout_hash": "5ffc9202dc16e67c1e1b52f3be95face4193431729ec886b5c848430",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-modules_52-5261d38.stdout
+++ b/tests/reference/asr-modules_52-5261d38.stdout
@@ -603,6 +603,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -701,6 +702,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.json
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nested_struct_proc_01-3b9017b.stdout",
-    "stdout_hash": "bfc2a2cdbff77634fa1b0b067eddb85007d12f66883d6c53eb9a0596",
+    "stdout_hash": "b24376b478027aaf40cc4b48ccd7c8b46ecf05f7e285fcf4b433f0b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
+++ b/tests/reference/asr-nested_struct_proc_01-3b9017b.stdout
@@ -265,6 +265,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -570,6 +571,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -1075,6 +1077,7 @@
                                     []
                                     Source
                                     Private
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-nullify_03-e2c1d62.json
+++ b/tests/reference/asr-nullify_03-e2c1d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nullify_03-e2c1d62.stdout",
-    "stdout_hash": "3f95293b76ef33bf9aa9e5c06f65789b432288c714d107ec6839c47c",
+    "stdout_hash": "492a687a1d49739ed4ff2a5fdcb59617f401b895f09be949f75db9ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nullify_03-e2c1d62.stdout
+++ b/tests/reference/asr-nullify_03-e2c1d62.stdout
@@ -89,6 +89,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -306,6 +307,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-nullify_04-a75db8a.json
+++ b/tests/reference/asr-nullify_04-a75db8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-nullify_04-a75db8a.stdout",
-    "stdout_hash": "476f187dfda6eb94f637cd8d3f5496e71c4504eacf5e94ef68b15b85",
+    "stdout_hash": "3f3f8bd205e899fc522ebd510464a655e39b7f617f23724d91ac3995",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-nullify_04-a75db8a.stdout
+++ b/tests/reference/asr-nullify_04-a75db8a.stdout
@@ -65,6 +65,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-operator_overloading_04-e28fb55.json
+++ b/tests/reference/asr-operator_overloading_04-e28fb55.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-operator_overloading_04-e28fb55.stdout",
-    "stdout_hash": "ec574a989b60f00bea64d7a272cc1bff8cbe0493c40a2669cc5fe59b",
+    "stdout_hash": "3304eca7c49a84e4e1a3e68167ac67f0ad790d6ec39ca4ad600a1954",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-operator_overloading_04-e28fb55.stdout
+++ b/tests/reference/asr-operator_overloading_04-e28fb55.stdout
@@ -172,6 +172,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-operator_overloading_08-52825a6.json
+++ b/tests/reference/asr-operator_overloading_08-52825a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-operator_overloading_08-52825a6.stdout",
-    "stdout_hash": "f573c3102053ce7cedae0adb9db1cfece482bc0977e242e741dfc427",
+    "stdout_hash": "511c22dc92fe6c278c27850a119ccc5b1ccfd550c844706ab9343282",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-operator_overloading_08-52825a6.stdout
+++ b/tests/reference/asr-operator_overloading_08-52825a6.stdout
@@ -334,6 +334,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.json
+++ b/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-optional_argument_subroutine_in_type-0d81d24.stdout",
-    "stdout_hash": "3344657f0c4363c1914bd00bcbb604b168d9c219fdaf2f782bba2d0b",
+    "stdout_hash": "95e0f8c1a1be9f5531c0404015e86b574299511e091411c8bf2d8f8c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.stdout
+++ b/tests/reference/asr-optional_argument_subroutine_in_type-0d81d24.stdout
@@ -196,6 +196,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_arguments_02-bb6f3e2.stdout",
-    "stdout_hash": "8dab099712e8de5199eb6bfc27315cbf9fc5abdbc82859b3f62abff7",
+    "stdout_hash": "118544e56b29120f3cf6f05b05ed7acdda349e35f22d0acd550bf49c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
+++ b/tests/reference/asr-polymorphic_arguments_02-bb6f3e2.stdout
@@ -249,6 +249,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-polymorphic_class_compare-e58def6.json
+++ b/tests/reference/asr-polymorphic_class_compare-e58def6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_compare-e58def6.stdout",
-    "stdout_hash": "763c577acef35961314508099a341fa104839e3d386f099b7f9061a4",
+    "stdout_hash": "d93c806fde984dd8befe67f234e4d10e2b4a66d236b9a7d8894f638e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_compare-e58def6.stdout
+++ b/tests/reference/asr-polymorphic_class_compare-e58def6.stdout
@@ -363,6 +363,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-polymorphic_class_in_derived_type-15eb7b6.stdout",
-    "stdout_hash": "587fcded93c225ef6dca81c1044713f8a6e44db1910c318b233831ed",
+    "stdout_hash": "96c7df98337ba8ed7968447e93c5df326378f7ee702178e1bb83339d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
+++ b/tests/reference/asr-polymorphic_class_in_derived_type-15eb7b6.stdout
@@ -105,6 +105,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -131,6 +132,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-select_type_01-204dfa1.json
+++ b/tests/reference/asr-select_type_01-204dfa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_01-204dfa1.stdout",
-    "stdout_hash": "568b8bf69b485ae9cd17499bf4e06512fd84a148aea22fc80c79cf9a",
+    "stdout_hash": "928659b1182a1a5a453600de689bdb6c885ef4eb63b1ad88ab3b03b4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_01-204dfa1.stdout
+++ b/tests/reference/asr-select_type_01-204dfa1.stdout
@@ -71,6 +71,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -188,6 +189,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-select_type_02-6e04a0b.json
+++ b/tests/reference/asr-select_type_02-6e04a0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_02-6e04a0b.stdout",
-    "stdout_hash": "354c213bf81ddebaee88cbf05afcd397aedaa22854a34822efd13376",
+    "stdout_hash": "1a88459bf534df35fc3210d73d205711412ef302c61fe89a9f83da6e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_02-6e04a0b.stdout
+++ b/tests/reference/asr-select_type_02-6e04a0b.stdout
@@ -77,6 +77,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -177,6 +178,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -356,6 +358,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-select_type_03-f21585a.json
+++ b/tests/reference/asr-select_type_03-f21585a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_03-f21585a.stdout",
-    "stdout_hash": "b72b1aa546ecb79ba65069f5b936455a9639055e8736faa83efe2da6",
+    "stdout_hash": "1a87e65f09d07d8b49bdf7cfc03093725bf18c43bc67266588cc1c3c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_03-f21585a.stdout
+++ b/tests/reference/asr-select_type_03-f21585a.stdout
@@ -81,6 +81,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -623,6 +624,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 toml_value
@@ -696,6 +698,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-select_type_04-e8b402f.json
+++ b/tests/reference/asr-select_type_04-e8b402f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-select_type_04-e8b402f.stdout",
-    "stdout_hash": "aa7881afcdc65832656825e0ccb974e296217c2872decbd0d215821e",
+    "stdout_hash": "e1632ed5b5bb2f38b2e5a4111153bd1b4224af64c573966c8f775dd5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-select_type_04-e8b402f.stdout
+++ b/tests/reference/asr-select_type_04-e8b402f.stdout
@@ -81,6 +81,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -623,6 +624,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     4 toml_value
@@ -696,6 +698,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-string1-f6332d9.json
+++ b/tests/reference/asr-string1-f6332d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-f6332d9.stdout",
-    "stdout_hash": "5b5adea5892bff61fa224fa1e8882898bbea1aa31b71d3c8e2d4e434",
+    "stdout_hash": "3b7bc247dca95e8a393df16f66f963ec69e839df932d63132afb71da",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-f6332d9.stdout
+++ b/tests/reference/asr-string1-f6332d9.stdout
@@ -506,6 +506,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "15e36aee3c514cd0b20845c5bc6fde40131a5855f7b6f6ecc6e0829f",
+    "stdout_hash": "2ca7d2cc6ad441bdbc5bd9e5287a91952ead20b62b330f6cf86bf877",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -857,6 +857,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-string_14-861794e.json
+++ b/tests/reference/asr-string_14-861794e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_14-861794e.stdout",
-    "stdout_hash": "498f24573fbf44cbe498816b199fd2ba8162ca94f06d7f3d1ca87af9",
+    "stdout_hash": "cf4e205b9c836dad8b233512fefdfcd49e9503517a32afd3f55438fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_14-861794e.stdout
+++ b/tests/reference/asr-string_14-861794e.stdout
@@ -300,6 +300,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-string_17-29e01e3.json
+++ b/tests/reference/asr-string_17-29e01e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_17-29e01e3.stdout",
-    "stdout_hash": "4bb773340fec657d2604ede2dfee68381b952cc7e2a6014e127c7bcc",
+    "stdout_hash": "a46ce87799b29e6f943f789a9cf22305f572d577e7cdfcb8bef30bbc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_17-29e01e3.stdout
+++ b/tests/reference/asr-string_17-29e01e3.stdout
@@ -373,6 +373,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-string_19-d880475.json
+++ b/tests/reference/asr-string_19-d880475.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string_19-d880475.stdout",
-    "stdout_hash": "1c1ee4cc2d6bc5a9ae099dd73c55b1c7711ec6efc6e47eec63648396",
+    "stdout_hash": "1b473fd75b82e3af952ee5a89dc81303a4aacbf8e9976ceada124d6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string_19-d880475.stdout
+++ b/tests/reference/asr-string_19-d880475.stdout
@@ -420,6 +420,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-struct_allocate-606e066.json
+++ b/tests/reference/asr-struct_allocate-606e066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-struct_allocate-606e066.stdout",
-    "stdout_hash": "d9f8d11645ed814e7ef84ba150edc0df254ea2fbc86c5c4a6af5406d",
+    "stdout_hash": "81a148bafd1b5e9c49841e3a6a57589290ed13f18da233d48cef121d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-struct_allocate-606e066.stdout
+++ b/tests/reference/asr-struct_allocate-606e066.stdout
@@ -89,6 +89,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -170,6 +171,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/asr-submodule_02-9152b7b.json
+++ b/tests/reference/asr-submodule_02-9152b7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_02-9152b7b.stdout",
-    "stdout_hash": "5f8e59ce8ed4f759c5e35fb768d24655453bd39bc1e9dff3d7781221",
+    "stdout_hash": "944c5df5f25765d18e28769446b7771b3102ae05233432cd81af4e5f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_02-9152b7b.stdout
+++ b/tests/reference/asr-submodule_02-9152b7b.stdout
@@ -79,6 +79,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-submodule_04-987b68b.json
+++ b/tests/reference/asr-submodule_04-987b68b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-submodule_04-987b68b.stdout",
-    "stdout_hash": "6fa1da157c6413ac0dbea6b1755c0995ffd53455247f49aca81e89f7",
+    "stdout_hash": "b7ac9c52a93ace152fa8372f96586d57b193e284f3bf3a0cc27e0398",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-submodule_04-987b68b.stdout
+++ b/tests/reference/asr-submodule_04-987b68b.stdout
@@ -128,6 +128,7 @@
                                     Private
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-template_sort_01-b412f73.json
+++ b/tests/reference/asr-template_sort_01-b412f73.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_sort_01-b412f73.stdout",
-    "stdout_hash": "cc1b39877d699bf22cc61a58ff8f78cf3f7b7dab29dc9963450754e0",
+    "stdout_hash": "39fea91803230a2267fbd64836f0a5470a563b8ab34f6c757c82b740",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_sort_01-b412f73.stdout
+++ b/tests/reference/asr-template_sort_01-b412f73.stdout
@@ -3349,6 +3349,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-template_sort_02-0aa4518.json
+++ b/tests/reference/asr-template_sort_02-0aa4518.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_sort_02-0aa4518.stdout",
-    "stdout_hash": "143cff6b5057c8b78088b4a9afae26b0c4b5d4061d62255ae9ad54bd",
+    "stdout_hash": "44a4b69510bcfb8ae6981569024ec9afd9613d26c8e60a26dab8b02c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_sort_02-0aa4518.stdout
+++ b/tests/reference/asr-template_sort_02-0aa4518.stdout
@@ -4326,6 +4326,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-template_struct_01-c320d7d.json
+++ b/tests/reference/asr-template_struct_01-c320d7d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_struct_01-c320d7d.stdout",
-    "stdout_hash": "a4bcf0b1053afd20a63713a9b2cefc6748e001747458d2a1b104f4c4",
+    "stdout_hash": "3063ba1d520717a75df9ff778495b5c61c3746bd5ee8374de7dcc513",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_struct_01-c320d7d.stdout
+++ b/tests/reference/asr-template_struct_01-c320d7d.stdout
@@ -448,6 +448,7 @@
                                                     Private
                                                     .false.
                                                     .false.
+                                                    .false.
                                                     []
                                                     ()
                                                     ()
@@ -1011,6 +1012,7 @@
                                                     Private
                                                     .false.
                                                     .false.
+                                                    .false.
                                                     []
                                                     ()
                                                     ()
@@ -1083,6 +1085,7 @@
                                                     []
                                                     Source
                                                     Private
+                                                    .false.
                                                     .false.
                                                     .false.
                                                     []

--- a/tests/reference/asr-template_vector-140858c.json
+++ b/tests/reference/asr-template_vector-140858c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-template_vector-140858c.stdout",
-    "stdout_hash": "861ba7f723fc9a0382d895da61a557f07d5256dfbd0c2f9aa4df5cdc",
+    "stdout_hash": "e5ae47a24ba0db720f54e00124904659531f8f7076f5979df2f1ec29",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-template_vector-140858c.stdout
+++ b/tests/reference/asr-template_vector-140858c.stdout
@@ -729,6 +729,7 @@
                                                     Private
                                                     .false.
                                                     .false.
+                                                    .false.
                                                     []
                                                     ()
                                                     ()
@@ -1597,6 +1598,7 @@
                                                     []
                                                     Source
                                                     Private
+                                                    .false.
                                                     .false.
                                                     .false.
                                                     []

--- a/tests/reference/asr-write7-6ba53a1.json
+++ b/tests/reference/asr-write7-6ba53a1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-write7-6ba53a1.stdout",
-    "stdout_hash": "3c1f6cd2104318826e0afedc3e7fb24a956474d1bb4e9e7d88af7d47",
+    "stdout_hash": "4ccab1c6f56bfbe9a9358919619cf3920b766e01916c92aacdffbb7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-write7-6ba53a1.stdout
+++ b/tests/reference/asr-write7-6ba53a1.stdout
@@ -63,6 +63,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/pass_array_op-modules_43-6930881.json
+++ b/tests/reference/pass_array_op-modules_43-6930881.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_array_op-modules_43-6930881.stdout",
-    "stdout_hash": "4b1eadc6673ad3fbeb2c39fc6029f92df19aa36e45ffea1c3969a828",
+    "stdout_hash": "628a8ea7c07b7bdce30e290f7243404fa0c2a98239cdfa991f1d1706",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_array_op-modules_43-6930881.stdout
+++ b/tests/reference/pass_array_op-modules_43-6930881.stdout
@@ -781,6 +781,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-multiple_objects_args-2d1007e.stdout",
-    "stdout_hash": "c199ebde91f0b39fbf92c16077b8b92a0ed678c38de472a7bd4d103b",
+    "stdout_hash": "4cb647a6f9ba7e9fe6ded712509cc4b9c0bd229822f2cc773b08c17b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
+++ b/tests/reference/pass_class_constructor-multiple_objects_args-2d1007e.stdout
@@ -67,6 +67,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data-modules_44-cd82150.stdout",
-    "stdout_hash": "16be4a99b1e804f96e014fc41ddeb52984ad7489a1f6aa8b99a0b963",
+    "stdout_hash": "5f2fbdb94d05125240d6e39f884620b64a895e6dd9e5e5ab8f5c1367",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
+++ b/tests/reference/pass_pass_array_by_data-modules_44-cd82150.stdout
@@ -292,6 +292,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -343,6 +344,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout",
-    "stdout_hash": "3cd69297639b51398c9bcbbce4d86a2958ade543781c0106dfa6f61e",
+    "stdout_hash": "1b5b43f46a3d15c616f823ea8c8c354299c82b580135b388ed9e3a19",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_37-1456cdb.stdout
@@ -586,6 +586,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -637,6 +638,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -855,6 +857,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     2 fpm_cmd_settings
@@ -910,6 +913,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -934,6 +938,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []
@@ -987,6 +992,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout",
-    "stdout_hash": "e18b92e12f9d67ae3d3ef20fe32a6a01aa4f2eb02f204ae423c228cf",
+    "stdout_hash": "740552ddd35973439b416afcebeea08e5003be8c7dd339c6cda633dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_40-2830409.stdout
@@ -496,6 +496,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -532,6 +533,7 @@
                                     Public
                                     .false.
                                     .true.
+                                    .false.
                                     []
                                     ()
                                     ()

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout",
-    "stdout_hash": "40e54dd01fb23024a4d190a2e23609360dddcfa427c6a406632d971b",
+    "stdout_hash": "0ff4a27007bab183c56a8a6decb6a16cf9072eb72cff0ead1adf98ba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
+++ b/tests/reference/pass_pass_array_by_data_transform_optional_argument_functions-modules_45-db3a04a.stdout
@@ -312,6 +312,7 @@
                                     Public
                                     .false.
                                     .false.
+                                    .false.
                                     []
                                     ()
                                     ()
@@ -2355,6 +2356,7 @@
                                     []
                                     Source
                                     Public
+                                    .false.
                                     .false.
                                     .false.
                                     []


### PR DESCRIPTION
LFortran stored fixed-length character components of derived types as string descriptors ({i8*, i64}). For SEQUENCE types this violated the requirement that components form a contiguous storage sequence, so storage_size under-reported the size and c_loc + memcpy corrupted memory (double free). That broke Caffeine's prif_co_broadcast test (issue #11191).

- Add is_sequence to ASR Struct and set it from the SEQUENCE attribute
- Lay out non-pointer, non-allocatable character members of SEQUENCE (and bind(C)) types as inline [len x i8]
- Fix assignment (memcpy + blank pad), read, print, and finalization for that layout
- Fix storage_size / compute_type_size_align to include character length
- Warn on c_loc of non-SEQUENCE types with descriptor-backed characters
- Add integration_tests/derived_types_150.f90 covering SEQUENCE + storage_size + memcpy round-trip