### PR TITLE
fix: prepend parent scope hierarchy to nested context module names to prevent duplicate symbol link errors in separate compilation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3532,6 +3532,7 @@ RUN(NAME nested_vars_08 LABELS gfortran llvm)
 RUN(NAME nested_vars_09 LABELS gfortran llvm)
 RUN(NAME nested_vars_10 LABELS gfortran llvm)
 RUN(NAME nested_vars_11 LABELS gfortran llvm)
+RUN(NAME nested_vars_12 LABELS gfortran llvm EXTRAFILES nested_vars_12a.f90 nested_vars_12b.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME pass_array_by_data_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm)
 RUN(NAME pass_array_by_data_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)

--- a/integration_tests/nested_vars_12.f90
+++ b/integration_tests/nested_vars_12.f90
@@ -1,0 +1,15 @@
+program nested_vars_12
+    use nested_vars_12_mod_a, only: process_a => process
+    use nested_vars_12_mod_b, only: process_b => process
+    implicit none
+    integer :: val1, val2
+    val1 = 5
+    val2 = 5
+    call process_a(val1)
+    call process_b(val2)
+    if (val1 /= 15 .or. val2 /= 10) then
+        print *, "Failed: ", val1, val2
+        error stop
+    end if
+    print *, "Ok"
+end program nested_vars_12

--- a/integration_tests/nested_vars_12a.f90
+++ b/integration_tests/nested_vars_12a.f90
@@ -1,0 +1,12 @@
+module nested_vars_12_mod_a
+    implicit none
+contains
+    subroutine process(x)
+        integer, intent(inout) :: x
+        call inner()
+    contains
+        subroutine inner()
+            x = x + 10
+        end subroutine inner
+    end subroutine process
+end module nested_vars_12_mod_a

--- a/integration_tests/nested_vars_12b.f90
+++ b/integration_tests/nested_vars_12b.f90
@@ -1,0 +1,12 @@
+module nested_vars_12_mod_b
+    implicit none
+contains
+    subroutine process(x)
+        integer, intent(inout) :: x
+        call inner()
+    contains
+        subroutine inner()
+            x = x * 2
+        end subroutine inner
+    end subroutine process
+end module nested_vars_12_mod_b

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -522,7 +522,16 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
             // Iterate on each function with nested vars and create a context in
             // a new module.
             current_scope = al.make_new<SymbolTable>(current_scope_copy);
-            std::string module_name = "__lcompilers_created__nested_context__" + 
+            std::string parent_names = "";
+            SymbolTable *parent_scope = ASRUtils::symbol_parent_symtab(it.first);
+            while (parent_scope != nullptr) {
+                if (parent_scope->asr_owner != nullptr && ASR::is_a<ASR::symbol_t>(*parent_scope->asr_owner)) {
+                    ASR::symbol_t *parent_sym = ASR::down_cast<ASR::symbol_t>(parent_scope->asr_owner);
+                    parent_names = std::string(ASRUtils::symbol_name(parent_sym)) + "__" + parent_names;
+                }
+                parent_scope = parent_scope->parent;
+            }
+            std::string module_name = "__lcompilers_created__nested_context__" + parent_names + 
                 std::string(ASRUtils::symbol_name(it.first)) + "_"; 
             bool is_any_variable_externally_defined = false;
             std::map<ASR::symbol_t*, std::string> sym_to_name;

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "e8650db0dd50f9530a86249aeb840c737cec2bff9f68f89f3bab7bea",
+    "stdout_hash": "6f8caa387b9640d465862c6d6a05d8ee04a8b8239c1e36df5f17f333",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -6,7 +6,7 @@ target datalayout = "..."
 %module_call_subroutine_without_type_01.mytype.3 = type { float }
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__get_i__self = global %module_call_subroutine_without_type_01.mytype.3_class* null
+@__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self = global %module_call_subroutine_without_type_01.mytype.3_class* null
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,R4\00", align 1
 @string_const_data = private constant [4 x i8] c"r = "
@@ -33,11 +33,11 @@ define void @__module_module_call_subroutine_without_type_01_get_i(%module_call_
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %1 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %1 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   %2 = icmp eq %module_call_subroutine_without_type_01.mytype.3_class* %1, null
   br i1 %2, label %then1, label %else2
 
@@ -46,14 +46,14 @@ then1:                                            ; preds = %else
   %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 16)
   call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 16, i1 false)
   %5 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype.3_class*
-  store %module_call_subroutine_without_type_01.mytype.3_class* %5, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  store %module_call_subroutine_without_type_01.mytype.3_class* %5, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   br label %ifcont
 
 else2:                                            ; preds = %else
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
-  %6 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %6 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   %7 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %6 to i8*
   %8 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %self to i8*
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* %7, i8* %8, i32 16, i1 false)
@@ -75,7 +75,7 @@ define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %2 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %2, i32 0, i32 1
   %4 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
   %5 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %4, i32 0, i32 0
@@ -102,7 +102,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %18 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %18 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self, align 8
   %19 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %18, i32 0, i32 1
   %20 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %19, align 8
   %21 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %20, i32 0, i32 0

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "eca11ccd1c7f628d09fcda6fbc8ae87c1e36098840cc7b78f277d448",
+    "stdout_hash": "82dfbc2f35578a181f0a86c6582c34322de7e7ba11b6b85880aa7352",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -4,7 +4,7 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__b__x = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__nested_03_a__b__x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -23,9 +23,9 @@ define void @__module_nested_03_a_b() {
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %1 = load float, float* %x, align 4
-  store float %1, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  store float %1, float* @__module___lcompilers_created__nested_context__nested_03_a__b__x, align 4
   call void @b.__module_nested_03_a_c()
-  %2 = load float, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  %2 = load float, float* @__module___lcompilers_created__nested_context__nested_03_a__b__x, align 4
   store float %2, float* %x, align 4
   br label %return
 
@@ -65,7 +65,7 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
+  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__nested_03_a__b__x)
   %15 = load i64, i64* %13, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "0d472c8777be37de9b86abc5deef93dffbd3fd26864ba241474eafca",
+    "stdout_hash": "dc9495c5cfe2f1f202dfb3a1c9a4c5873c26523842a17e4df18dbbd2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -4,8 +4,8 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__b__y = global i32 0
-@__module___lcompilers_created__nested_context__b__yy = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__nested_04_a__b__y = global i32 0
+@__module___lcompilers_created__nested_context__nested_04_a__b__yy = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -32,15 +32,15 @@ define i32 @__module_nested_04_a_b(i32* %x) {
   %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %2 = load i32, i32* %y, align 4
-  store i32 %2, i32* @__module___lcompilers_created__nested_context__b__y, align 4
+  store i32 %2, i32* @__module___lcompilers_created__nested_context__nested_04_a__b__y, align 4
   %3 = load float, float* %yy, align 4
-  store float %3, float* @__module___lcompilers_created__nested_context__b__yy, align 4
+  store float %3, float* @__module___lcompilers_created__nested_context__nested_04_a__b__yy, align 4
   store i32 6, i32* %call_arg_value, align 4
   %4 = call i32 @b.__module_nested_04_a_c(i32* %call_arg_value)
   store i32 %4, i32* %b, align 4
-  %5 = load i32, i32* @__module___lcompilers_created__nested_context__b__y, align 4
+  %5 = load i32, i32* @__module___lcompilers_created__nested_context__nested_04_a__b__y, align 4
   store i32 %5, i32* %y, align 4
-  %6 = load float, float* @__module___lcompilers_created__nested_context__b__yy, align 4
+  %6 = load float, float* @__module___lcompilers_created__nested_context__nested_04_a__b__yy, align 4
   store float %6, float* %yy, align 4
   br label %return
 
@@ -81,7 +81,7 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__y)
+  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__nested_04_a__b__y)
   %14 = load i64, i64* %12, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
@@ -102,7 +102,7 @@ free_nonnull2:                                    ; preds = %free_done
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %23 = alloca i64, align 8
-  %24 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %23, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__yy)
+  %24 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %23, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__nested_04_a__b__yy)
   %25 = load i64, i64* %23, align 8
   %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %24, i8** %26, align 8

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "214fddad051e18f16d0549cf236b7bb194c302a4e64796824bc806d1",
+    "stdout_hash": "b3003ac48253657aa01d87609406df2df5e993d3c51e64ce382c37ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -4,8 +4,8 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__b__x = global i32 0
-@__module___lcompilers_created__nested_context__b__y = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__nested_05_a__b__x = global i32 0
+@__module___lcompilers_created__nested_context__nested_05_a__b__y = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -79,13 +79,13 @@ free_nonnull2:                                    ; preds = %free_done
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %23 = load i32, i32* %x, align 4
-  store i32 %23, i32* @__module___lcompilers_created__nested_context__b__x, align 4
+  store i32 %23, i32* @__module___lcompilers_created__nested_context__nested_05_a__b__x, align 4
   %24 = load float, float* %y, align 4
-  store float %24, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  store float %24, float* @__module___lcompilers_created__nested_context__nested_05_a__b__y, align 4
   call void @b.__module_nested_05_a_c()
-  %25 = load i32, i32* @__module___lcompilers_created__nested_context__b__x, align 4
+  %25 = load i32, i32* @__module___lcompilers_created__nested_context__nested_05_a__b__x, align 4
   store i32 %25, i32* %x, align 4
-  %26 = load float, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  %26 = load float, float* @__module___lcompilers_created__nested_context__nested_05_a__b__y, align 4
   store float %26, float* %y, align 4
   %27 = alloca i64, align 8
   %28 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %27, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %x)
@@ -144,7 +144,7 @@ define void @b.__module_nested_05_a_c() {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__x)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__nested_05_a__b__x)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -165,7 +165,7 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__y)
+  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__nested_05_a__b__y)
   %14 = load i64, i64* %12, align 8
   %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %13, i8** %15, align 8
@@ -185,8 +185,8 @@ free_nonnull2:                                    ; preds = %free_done
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  store i32 4, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  store float 3.500000e+00, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  store i32 4, i32* @__module___lcompilers_created__nested_context__nested_05_a__b__x, align 4
+  store float 3.500000e+00, float* @__module___lcompilers_created__nested_context__nested_05_a__b__y, align 4
   br label %return
 
 return:                                           ; preds = %free_done3

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "c4afe3527c18e0af0c9f276cc0fe8a9d477864773ec222c8217fd6f6",
+    "stdout_hash": "5b5f50fe38c97a432331a4a7407445a6680c550fb1f94b72493536e9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -4,7 +4,7 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__b__x = global float 0.000000e+00
+@__module___lcompilers_created__nested_context__nested_06_a__b__x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -21,9 +21,9 @@ define void @__module_nested_06_a_b(float* %x) {
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
   call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %1 = load float, float* %x, align 4
-  store float %1, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  store float %1, float* @__module___lcompilers_created__nested_context__nested_06_a__b__x, align 4
   call void @b.__module_nested_06_a_c()
-  %2 = load float, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  %2 = load float, float* @__module___lcompilers_created__nested_context__nested_06_a__b__x, align 4
   store float %2, float* %x, align 4
   br label %return
 
@@ -63,7 +63,7 @@ free_nonnull:                                     ; preds = %.entry
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
+  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__nested_06_a__b__x)
   %15 = load i64, i64* %13, align 8
   %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %14, i8** %16, align 8

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "fd992af00b868fe3898498f26fab3fda05aa9776db227cf15cc46ca4",
+    "stdout_hash": "84008494da63e339af24e9e7d9c4ad15217e7303e7fa7cd8864bc201",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -4,7 +4,7 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__sub1__x = global i32 0
+@__module___lcompilers_created__nested_context__recursion_01__sub1__x = global i32 0
 @__module_recursion_01_n = global i32 0
 @__module_recursion_01_x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -51,9 +51,9 @@ free_nonnull:                                     ; preds = %then
 
 free_done:                                        ; preds = %free_nonnull, %then
   %17 = load i32, i32* %x, align 4
-  store i32 %17, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %17, i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x, align 4
   call void @sub1.__module_recursion_01_sub2()
-  %18 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %18 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x, align 4
   store i32 %18, i32* %x, align 4
   call void @__module_recursion_01_sub1(i32* %x)
   br label %ifcont
@@ -75,11 +75,11 @@ define void @sub1.__module_recursion_01_sub2() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %1 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x, align 4
   %2 = add i32 %1, 1
-  store i32 %2, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %2, i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1__x)
+  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x)
   %5 = load i64, i64* %3, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
@@ -99,7 +99,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @__module_recursion_01_sub1(i32* @__module___lcompilers_created__nested_context__sub1__x)
+  call void @__module_recursion_01_sub1(i32* @__module___lcompilers_created__nested_context__recursion_01__sub1__x)
   br label %return
 
 return:                                           ; preds = %free_done

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "9232fab42cb620824631803cac16762b2cddf28d140333101ce1e435",
+    "stdout_hash": "6526ec03760fc34c015d50845cc345d1881010bc2bd31bb60a868495",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -4,7 +4,7 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__sub1__x = global i32 0
+@__module___lcompilers_created__nested_context__recursion_02__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
@@ -128,16 +128,16 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %4 = load i32, i32* %x, align 4
-  store i32 %4, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %4, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x, align 4
   %5 = call i32 @sub1.__module_recursion_02_getx()
   store i32 %5, i32* %tmp, align 4
-  %6 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %6 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x, align 4
   store i32 %6, i32* %x, align 4
   %7 = load i32, i32* %x, align 4
-  store i32 %7, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %7, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x, align 4
   %8 = call i32 @__module_recursion_02_solver(i32 ()* @sub1.__module_recursion_02_getx, i32* %iter)
   store i32 %8, i32* %sub1, align 4
-  %9 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %9 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x, align 4
   store i32 %9, i32* %x, align 4
   br label %return
 
@@ -155,7 +155,7 @@ define i32 @sub1.__module_recursion_02_getx() {
   %0 = call i8* @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__sub1__x)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -175,7 +175,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %12 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x, align 4
   store i32 %12, i32* %getx, align 4
   br label %return
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "508319cf165bb4d7fab359538ba157367a6ea3c12486bc061140eb1d",
+    "stdout_hash": "00fd686651e80d86d4bc211a839f459340e88355fd6f74f18bb24faf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -4,7 +4,7 @@ target datalayout = "..."
 
 %string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__sub1__x = global i32 0
+@__module___lcompilers_created__nested_context__recursion_03__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
@@ -145,16 +145,16 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %4 = load i32, i32* %x, align 4
-  store i32 %4, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %4, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x, align 4
   %5 = call i32 @sub1.__module_recursion_03_getx()
   store i32 %5, i32* %tmp, align 4
-  %6 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %6 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x, align 4
   store i32 %6, i32* %x, align 4
   %7 = load i32, i32* %x, align 4
-  store i32 %7, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %7, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x, align 4
   %8 = call i32 @__module_recursion_03_solver_caller(i32 ()* @sub1.__module_recursion_03_getx, i32* %iter)
   store i32 %8, i32* %sub1, align 4
-  %9 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %9 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x, align 4
   store i32 %9, i32* %x, align 4
   br label %return
 
@@ -172,7 +172,7 @@ define i32 @sub1.__module_recursion_03_getx() {
   %0 = call i8* @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__sub1__x)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -192,7 +192,7 @@ free_nonnull:                                     ; preds = %.entry
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %12 = load i32, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x, align 4
   store i32 %12, i32* %getx, align 4
   br label %return
 

--- a/tests/reference/pass_nested_vars-nested_call_filter_01-5a87413.json
+++ b/tests/reference/pass_nested_vars-nested_call_filter_01-5a87413.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_nested_vars-nested_call_filter_01-5a87413.stdout",
-    "stdout_hash": "86ef05c9f7fecfe5bad1a872de799907efca47b6960e0410af4a56f8",
+    "stdout_hash": "058f5a1cfb16327ddb212f53ffd430b26d152daf669121b0828a77d0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_nested_vars-nested_call_filter_01-5a87413.stdout
+++ b/tests/reference/pass_nested_vars-nested_call_filter_01-5a87413.stdout
@@ -2,7 +2,7 @@
     (SymbolTable
         1
         {
-            __lcompilers_created__nested_context__outer_:
+            __lcompilers_created__nested_context__nested_call_filter_01__outer_:
                 (Module
                     (SymbolTable
                         7
@@ -32,7 +32,7 @@
                                     []
                                 )
                         })
-                    __lcompilers_created__nested_context__outer_
+                    __lcompilers_created__nested_context__nested_call_filter_01__outer_
                     ()
                     []
                     .false.
@@ -88,7 +88,7 @@
                                                     5
                                                     a1
                                                     7 a
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_call_filter_01__outer_
                                                     []
                                                     a
                                                     Public
@@ -98,7 +98,7 @@
                                                     5
                                                     a2
                                                     7 a
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_call_filter_01__outer_
                                                     []
                                                     a
                                                     Public
@@ -108,7 +108,7 @@
                                                     5
                                                     a_nested_ctx
                                                     7 a
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_call_filter_01__outer_
                                                     []
                                                     a
                                                     Public
@@ -123,7 +123,7 @@
                                                                     6
                                                                     a
                                                                     7 a
-                                                                    __lcompilers_created__nested_context__outer_
+                                                                    __lcompilers_created__nested_context__nested_call_filter_01__outer_
                                                                     []
                                                                     a
                                                                     Public

--- a/tests/reference/pass_nested_vars-nested_external_dedup_01-94a5d6b.json
+++ b/tests/reference/pass_nested_vars-nested_external_dedup_01-94a5d6b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_nested_vars-nested_external_dedup_01-94a5d6b.stdout",
-    "stdout_hash": "4402a246ba4fd2b7c6b1b75889d98edf279781f3b441be6a44710b93",
+    "stdout_hash": "d9bda2662999bed13cfa366b1ec5dba7dd5557dc9196b66350333a1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_nested_vars-nested_external_dedup_01-94a5d6b.stdout
+++ b/tests/reference/pass_nested_vars-nested_external_dedup_01-94a5d6b.stdout
@@ -2,7 +2,7 @@
     (SymbolTable
         1
         {
-            __lcompilers_created__nested_context__outer_:
+            __lcompilers_created__nested_context__nested_external_dedup_01__outer_:
                 (Module
                     (SymbolTable
                         6
@@ -32,7 +32,7 @@
                                     []
                                 )
                         })
-                    __lcompilers_created__nested_context__outer_
+                    __lcompilers_created__nested_context__nested_external_dedup_01__outer_
                     ()
                     []
                     .false.
@@ -78,7 +78,7 @@
                                                     3
                                                     a1
                                                     6 a
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_external_dedup_01__outer_
                                                     []
                                                     a
                                                     Public
@@ -88,7 +88,7 @@
                                                     3
                                                     a_nested_ctx
                                                     6 a
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_external_dedup_01__outer_
                                                     []
                                                     a
                                                     Public
@@ -103,7 +103,7 @@
                                                                     4
                                                                     a
                                                                     6 a
-                                                                    __lcompilers_created__nested_context__outer_
+                                                                    __lcompilers_created__nested_context__nested_external_dedup_01__outer_
                                                                     []
                                                                     a
                                                                     Public
@@ -155,7 +155,7 @@
                                                                     5
                                                                     a
                                                                     6 a
-                                                                    __lcompilers_created__nested_context__outer_
+                                                                    __lcompilers_created__nested_context__nested_external_dedup_01__outer_
                                                                     []
                                                                     a
                                                                     Public

--- a/tests/reference/pass_nested_vars-nested_namelist_01-c1be094.json
+++ b/tests/reference/pass_nested_vars-nested_namelist_01-c1be094.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_nested_vars-nested_namelist_01-c1be094.stdout",
-    "stdout_hash": "4566f2ba96cd8ff19790bb59d26ef97daa8116a6124166afd930b467",
+    "stdout_hash": "27bf2fbfc0bb60768789be6438ff64d33fafd3e653a4a137c40a52cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_nested_vars-nested_namelist_01-c1be094.stdout
+++ b/tests/reference/pass_nested_vars-nested_namelist_01-c1be094.stdout
@@ -2,7 +2,7 @@
     (SymbolTable
         1
         {
-            __lcompilers_created__nested_context__outer_:
+            __lcompilers_created__nested_context__nested_namelist_01_mod__outer_:
                 (Module
                     (SymbolTable
                         6
@@ -63,7 +63,7 @@
                                     []
                                 )
                         })
-                    __lcompilers_created__nested_context__outer_
+                    __lcompilers_created__nested_context__nested_namelist_01_mod__outer_
                     ()
                     []
                     .false.
@@ -135,7 +135,7 @@
                                                     3
                                                     i_nested_ctx
                                                     6 i
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_namelist_01_mod__outer_
                                                     []
                                                     i
                                                     Public
@@ -174,7 +174,7 @@
                                                                     4
                                                                     nml
                                                                     6 nml
-                                                                    __lcompilers_created__nested_context__outer_
+                                                                    __lcompilers_created__nested_context__nested_namelist_01_mod__outer_
                                                                     []
                                                                     nml
                                                                     Public
@@ -255,7 +255,7 @@
                                                     3
                                                     x_nested_ctx
                                                     6 x
-                                                    __lcompilers_created__nested_context__outer_
+                                                    __lcompilers_created__nested_context__nested_namelist_01_mod__outer_
                                                     []
                                                     x
                                                     Public


### PR DESCRIPTION
Fixes #12157