### PR TITLE
fix: Missing semantic error for BOZ literal used as associate target

### DIFF
--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3042,6 +3042,14 @@ public:
         Vec<ASR::stmt_t*> body;
         body.reserve(al, x.n_body);
         for( size_t i = 0; i < x.n_syms; i++ ) {
+            if (AST::is_a<AST::BOZ_t>(*x.m_syms[i].m_initializer)) {
+                diag.add(Diagnostic(
+                    "Association target cannot be a BOZ literal constant",
+                    Level::Error, Stage::Semantic, {
+                        Label("", {x.m_syms[i].m_initializer->base.loc})
+                    }));
+                throw SemanticAbort();
+            }
             this->visit_expr(*x.m_syms[i].m_initializer);
             ASR::expr_t* tmp_expr = ASRUtils::EXPR(tmp);
             ASR::ttype_t* tmp_type = ASRUtils::expr_type(tmp_expr);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -881,4 +881,8 @@ program continue_compilation_1
         integer :: items(:)
         consume_assumed_shape_function = size(items)
     end function
+    subroutine associate_boz_target()
+        associate (y => z'1') 
+        end associate
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "3e2e12f7b0e2753cf191aae6b3b44596e04a212db2564f7121e5c600",
+    "infile_hash": "425f90283d1e923011184dfce4e33d8bbe47275fd7cbfc71cb1afa1f",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "505f66db9533ed9702666c3cfbac4febfce8560b4c9631a4e650f846",
+    "stderr_hash": "00d8628c0161ecfc640e08444b0b8ed9e8d5514a693624210698293b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1761,3 +1761,9 @@ semantic error: actual argument for 'items' cannot be an assumed-size array
     |
 877 |         print *, consume_assumed_shape_function(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
     |                                                 ^^^^^ 
+
+semantic error: Association target cannot be a BOZ literal constant
+   --> tests/errors/continue_compilation_1.f90:885:25
+    |
+885 |         associate (y => z'1') 
+    |                         ^^^^ 


### PR DESCRIPTION
fixes #12169
