### PR TITLE
ICE for findloc with mismatched character kinds and dim argument  

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -4757,6 +4757,11 @@ namespace FindLoc {
         ASRUtils::ASRBuilder b(al, loc);
         ASR::expr_t* array = nullptr;
         ASR::expr_t* value = nullptr;
+        if (is_character(*expr_type(args[0])) && is_character(*expr_type(args[1])) &&
+                extract_kind_from_ttype_t(expr_type(args[0])) != extract_kind_from_ttype_t(expr_type(args[1]))) {
+            append_error(diag, "`array` and `value` arguments of `findloc` must have the same character kind", loc);
+            return nullptr;
+        }
         if (extract_kind_from_ttype_t(expr_type(args[0])) != extract_kind_from_ttype_t(expr_type(args[1]))){
             Vec<ASR::expr_t*> args_;
             args_.reserve(al, 2);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -881,4 +881,9 @@ program continue_compilation_1
         integer :: items(:)
         consume_assumed_shape_function = size(items)
     end function
+    subroutine findloc_character_kind_mismatch()
+        character(kind=4) :: x(1)
+        character :: y
+        print *, findloc(x, y, 1)
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "3e2e12f7b0e2753cf191aae6b3b44596e04a212db2564f7121e5c600",
+    "infile_hash": "96506ab0d1c8546239853a0d5078c888fa1a133e269beef4b71e3d12",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "505f66db9533ed9702666c3cfbac4febfce8560b4c9631a4e650f846",
+    "stderr_hash": "b5a51024998f9a28a9a3bdad9a6bfc015cf2ae94c3dee58384158a9f",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1761,3 +1761,9 @@ semantic error: actual argument for 'items' cannot be an assumed-size array
     |
 877 |         print *, consume_assumed_shape_function(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
     |                                                 ^^^^^ 
+
+semantic error: `array` and `value` arguments of `findloc` must have the same character kind
+   --> tests/errors/continue_compilation_1.f90:887:18
+    |
+887 |         print *, findloc(x, y, 1)
+    |                  ^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
fixes #12171