### PR TITLE
fix : multiple definition linker errors for compiler-generated helpers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4509,6 +4509,7 @@ RUN(NAME separate_compilation_46 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compilation_47a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compilation_48a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/separate_compilation_50.f90
+++ b/integration_tests/separate_compilation_50.f90
@@ -1,0 +1,12 @@
+program separate_compilation_50
+    use separate_compilation_50a_mod
+    use separate_compilation_50b_mod
+    implicit none
+    real(8) :: x
+    integer :: r1, r2
+    x = 3.14d0
+    call get_exp_a(x, r1)
+    call get_exp_b(x, r2)
+    print *, r1, r2
+    if (r1 /= r2) error stop
+end program separate_compilation_50

--- a/integration_tests/separate_compilation_50a.f90
+++ b/integration_tests/separate_compilation_50a.f90
@@ -1,0 +1,9 @@
+module separate_compilation_50a_mod
+    implicit none
+contains
+    subroutine get_exp_a(x, r)
+        real(8), intent(in) :: x
+        integer, intent(out) :: r
+        r = exponent(x)
+    end subroutine get_exp_a
+end module separate_compilation_50a_mod

--- a/integration_tests/separate_compilation_50b.f90
+++ b/integration_tests/separate_compilation_50b.f90
@@ -1,0 +1,9 @@
+module separate_compilation_50b_mod
+    implicit none
+contains
+    subroutine get_exp_b(x, r)
+        real(8), intent(in) :: x
+        integer, intent(out) :: r
+        r = exponent(x)
+    end subroutine get_exp_b
+end module separate_compilation_50b_mod

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8126,6 +8126,14 @@ public:
                 llvm_symtab_fn_names[fn_name] = h;
                 F = llvm::Function::Create(function_type,
                     llvm::Function::ExternalLinkage, fn_name, module.get());
+                // Compiler-generated helper functions (e.g.
+                // _lcompiler_optimization_exponent_*) are emitted identically
+                // in every compilation unit that uses them.  Use
+                // LinkOnceODRLinkage so the linker keeps only one copy
+                // instead of erroring with "multiple definition".
+                if (fn_name.rfind("_lcompiler_", 0) == 0) {
+                    F->setLinkage(llvm::Function::LinkOnceODRLinkage);
+                }
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];


### PR DESCRIPTION
fixes #12173


Compiler-generated intrinsic helper functions (e.g.
_lcompiler_optimization_exponent_f64, _lcompilers_acos_f32, etc.)
were emitted with external linkage in every compilation unit that
used them. When linking multiple object files, this caused
"multiple definition" linker errors.

Fix by setting LinkOnceODRLinkage on functions whose names start
with "_lcompiler_". This tells the linker that all definitions are
identical and it may keep only one copy.

