### PR TITLE
fix : procedure pointer type mismatch in cross-struct association

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2529,6 +2529,7 @@ RUN(NAME derived_types_150 LABELS gfortran llvm) # SEQUENCE char(len>1) inline +
 # assignment(=) in one module breaks resolution under LFortran.
 RUN(NAME derived_types_151 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME derived_types_152 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME derived_types_153 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME defined_assignment_01 LABELS llvm flang)
 RUN(NAME defined_assignment_free_interface_01 LABELS gfortran llvm flang)
 

--- a/integration_tests/derived_types_153.f90
+++ b/integration_tests/derived_types_153.f90
@@ -1,0 +1,78 @@
+ Test: procedure pointer association between struct members with
+! different interfaces (concrete vs generic procedure()).
+! Verifies LLVM codegen bitcast when a typed procedure pointer
+! is associated to a generic procedure() pointer slot.
+
+module m_handler_153
+    implicit none
+    type :: handler
+        procedure(), nopass, pointer :: callback => null()
+    end type
+end module
+
+module m_dispatcher_153
+    use m_handler_153
+    implicit none
+
+    type :: dispatcher
+        procedure(), nopass, pointer :: callback => null()
+    contains
+        procedure, pass(this) :: set_callback
+        procedure, pass(this) :: dispatch
+    end type
+
+contains
+
+    subroutine set_callback(this, cb)
+        class(dispatcher), intent(inout) :: this
+        procedure() :: cb
+        this%callback => cb
+    end subroutine
+
+    subroutine dispatch(this, a, f)
+        class(dispatcher), intent(inout) :: this
+        class(*), intent(in) :: a
+        procedure() :: f
+        type(handler) :: h
+
+        ! This is the critical line: associating a typed procedure
+        ! pointer (this%callback) to a generic procedure() slot
+        ! (h%callback). Requires bitcast in LLVM codegen for typed
+        ! pointers (LLVM < 15).
+        if (associated(this%callback)) h%callback => this%callback
+        if (.not. associated(h%callback)) error stop "h%callback should be associated"
+    end subroutine
+
+end module
+
+program derived_types_153
+    use m_dispatcher_153
+    implicit none
+
+    interface
+        pure subroutine transform_str(str, res)
+            character(*), intent(in)            :: str
+            character(len(str)), intent(out)    :: res
+        end subroutine
+    end interface
+
+    type(dispatcher) :: d
+
+    ! Test 1: callback not set, should be null
+    if (associated(d%callback)) error stop "callback should be null initially"
+
+    ! Test 2: set callback and verify association
+    call d%set_callback(my_callback)
+    if (.not. associated(d%callback)) error stop "callback should be associated after set"
+
+    ! Test 3: dispatch exercises the cross-struct pointer association
+    call d%dispatch(42, my_callback)
+
+    print *, "PASS"
+
+contains
+    subroutine my_callback(f, a)
+        procedure(transform_str)    :: f
+        class(*), intent(in)        :: a
+    end subroutine
+end program

--- a/integration_tests/derived_types_153.f90
+++ b/integration_tests/derived_types_153.f90
@@ -1,4 +1,4 @@
- Test: procedure pointer association between struct members with
+!Test: procedure pointer association between struct members with
 ! different interfaces (concrete vs generic procedure()).
 ! Verifies LLVM codegen bitcast when a typed procedure pointer
 ! is associated to a generic procedure() pointer slot.

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10027,9 +10027,12 @@ public:
                 llvm::Type* llvm_value_type = llvm_utils->get_type_from_ttype_t_util(x.m_value, value_type, module.get());
                 llvm_value = llvm_utils->CreateLoad2(llvm_value_type, llvm_value);
                 // Bitcast procedure pointer if source and target LLVM types differ.
-                // This happens when a typed procedure pointer (with concrete interface)
-                // is assigned to a generic procedure() pointer slot (void()*).
-                llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
+                // This happens under --implicit-interface when a typed procedure
+                // pointer (with concrete interface) is assigned to a generic
+                // procedure() pointer slot (void()*).
+                if (compiler_options.implicit_interface) {
+                    llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
+                }
                 builder->CreateStore(llvm_value, llvm_target);
             } else if (is_target_class &&
                        !ASRUtils::is_array(target_type) &&
@@ -10658,10 +10661,12 @@ public:
                     builder->CreateStore(llvm_value, loaded_target);
                 } else {
                     // Bitcast procedure pointer if source and target LLVM types
-                    // differ. This handles Pointer(FunctionType) associations where
-                    // the source has a concrete interface and the target has a
-                    // generic procedure() slot (void()*).
-                    llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
+                    // differ. This handles Pointer(FunctionType) associations under
+                    // --implicit-interface where the source has a concrete interface
+                    // and the target has a generic procedure() slot (void()*).
+                    if (compiler_options.implicit_interface) {
+                        llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
+                    }
                     builder->CreateStore(llvm_value, llvm_target);
                 }
             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10026,6 +10026,15 @@ public:
                         ASR::is_a<ASR::FunctionType_t>(*value_type)) {
                 llvm::Type* llvm_value_type = llvm_utils->get_type_from_ttype_t_util(x.m_value, value_type, module.get());
                 llvm_value = llvm_utils->CreateLoad2(llvm_value_type, llvm_value);
+                // Bitcast procedure pointer if source and target LLVM types differ.
+                // This happens when a typed procedure pointer (with concrete interface)
+                // is assigned to a generic procedure() pointer slot (void()*).
+#if LLVM_VERSION_MAJOR < 15
+                llvm::Type* llvm_target_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, target_type, module.get());
+                if (llvm_value->getType() != llvm_target_type) {
+                    llvm_value = builder->CreateBitCast(llvm_value, llvm_target_type);
+                }
+#endif
                 builder->CreateStore(llvm_value, llvm_target);
             } else if (is_target_class &&
                        !ASRUtils::is_array(target_type) &&
@@ -10653,6 +10662,24 @@ public:
                         llvm_target_contents_type->getPointerTo(), llvm_target);
                     builder->CreateStore(llvm_value, loaded_target);
                 } else {
+#if LLVM_VERSION_MAJOR < 15
+                    // Bitcast procedure pointer if source and target LLVM types
+                    // differ. This handles Pointer(FunctionType) associations where
+                    // the source has a concrete interface and the target has a
+                    // generic procedure() slot (void()*).
+                    if (ASR::is_a<ASR::Pointer_t>(*value_type) &&
+                        ASR::is_a<ASR::FunctionType_t>(
+                            *ASRUtils::type_get_past_pointer(value_type)) &&
+                        ASR::is_a<ASR::Pointer_t>(*target_type) &&
+                        ASR::is_a<ASR::FunctionType_t>(
+                            *ASRUtils::type_get_past_pointer(target_type))) {
+                        llvm::Type* llvm_target_el_type = llvm_utils->get_type_from_ttype_t_util(
+                            x.m_target, target_type, module.get());
+                        if (llvm_value->getType() != llvm_target_el_type) {
+                            llvm_value = builder->CreateBitCast(llvm_value, llvm_target_el_type);
+                        }
+                    }
+#endif
                     builder->CreateStore(llvm_value, llvm_target);
                 }
             }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10029,12 +10029,7 @@ public:
                 // Bitcast procedure pointer if source and target LLVM types differ.
                 // This happens when a typed procedure pointer (with concrete interface)
                 // is assigned to a generic procedure() pointer slot (void()*).
-#if LLVM_VERSION_MAJOR < 15
-                llvm::Type* llvm_target_type = llvm_utils->get_type_from_ttype_t_util(x.m_target, target_type, module.get());
-                if (llvm_value->getType() != llvm_target_type) {
-                    llvm_value = builder->CreateBitCast(llvm_value, llvm_target_type);
-                }
-#endif
+                llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
                 builder->CreateStore(llvm_value, llvm_target);
             } else if (is_target_class &&
                        !ASRUtils::is_array(target_type) &&
@@ -10662,24 +10657,11 @@ public:
                         llvm_target_contents_type->getPointerTo(), llvm_target);
                     builder->CreateStore(llvm_value, loaded_target);
                 } else {
-#if LLVM_VERSION_MAJOR < 15
                     // Bitcast procedure pointer if source and target LLVM types
                     // differ. This handles Pointer(FunctionType) associations where
                     // the source has a concrete interface and the target has a
                     // generic procedure() slot (void()*).
-                    if (ASR::is_a<ASR::Pointer_t>(*value_type) &&
-                        ASR::is_a<ASR::FunctionType_t>(
-                            *ASRUtils::type_get_past_pointer(value_type)) &&
-                        ASR::is_a<ASR::Pointer_t>(*target_type) &&
-                        ASR::is_a<ASR::FunctionType_t>(
-                            *ASRUtils::type_get_past_pointer(target_type))) {
-                        llvm::Type* llvm_target_el_type = llvm_utils->get_type_from_ttype_t_util(
-                            x.m_target, target_type, module.get());
-                        if (llvm_value->getType() != llvm_target_el_type) {
-                            llvm_value = builder->CreateBitCast(llvm_value, llvm_target_el_type);
-                        }
-                    }
-#endif
+                    llvm_value = llvm_utils->CreateBitCastForStore(llvm_value, llvm_target);
                     builder->CreateStore(llvm_value, llvm_target);
                 }
             }


### PR DESCRIPTION
fixes #12182
This pr is built on top of pr #11806 and pr #11975.
The test added will only give the same error when built on the top of above two prs.


When associating a typed procedure pointer from one struct member
to a generic procedure() pointer slot in another struct (e.g.
`mtd%caller => this%caller`), the LLVM codegen stored the value
without bitcasting, causing "Stored value type does not match
pointer operand type" verification failure on LLVM < 15 (typed
pointers).

The ASR type for procedure pointer members is Pointer(FunctionType),
which falls through to the generic else branch in visit_Associate.
Added a guarded bitcast (#if LLVM_VERSION_MAJOR < 15) to reconcile
the concrete function signature with the target's void()* slot.
