### PR TITLE
fix : ICE in nested_vars pass for locally-defined namelists

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1146,6 +1146,7 @@ RUN(NAME namelist_36 LABELS gfortran llvm)
 RUN(NAME namelist_37 LABELS gfortran llvm)
 
 RUN(NAME nested_namelist_01 LABELS gfortran llvm)
+RUN(NAME nested_namelist_02 LABELS gfortran llvm)
 
 RUN(NAME format_quotes_01 LABELS gfortran llvm)
 

--- a/integration_tests/nested_namelist_02.f90
+++ b/integration_tests/nested_namelist_02.f90
@@ -1,0 +1,22 @@
+! Test: namelist defined locally in a nested subroutine (contains block)
+! This previously caused an ICE (AssertFailed: scope.find(name) == scope.end())
+! in the nested_vars pass because the pass incorrectly tried to move a
+! locally-defined namelist into the parent's context module.
+program nested_namelist_02
+    implicit none
+
+    call test_foo()
+
+contains
+
+    subroutine test_foo()
+        real :: y
+        namelist /n/ y
+
+        y = 3.14
+        write(*, n)
+
+        if (abs(y - 3.14) > 1e-5) error stop
+    end subroutine test_foo
+
+end program nested_namelist_02

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -928,24 +928,9 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                 ASR::symbol_t *orig_sym = nml->m_var_list[i];
                 auto it_ext = nested_var_to_ext_var.find(orig_sym);
                 if (it_ext != nested_var_to_ext_var.end()) {
-                    std::string m_name = it_ext->second.first;
                     ASR::symbol_t *t = it_ext->second.second;
-                    std::string sym_name = ASRUtils::symbol_name(t);
-                    ASR::symbol_t *existing = current_scope->get_symbol(sym_name);
-                    ASR::symbol_t *ext_sym = nullptr;
-                    if (existing != nullptr &&
-                            ASR::is_a<ASR::ExternalSymbol_t>(*existing) &&
-                            ASRUtils::symbol_get_past_external(existing) == t) {
-                        ext_sym = existing;
-                    } else {
-                        std::string unique_name = sym_name;
-                        if (existing != nullptr) {
-                            unique_name = current_scope->get_unique_name(sym_name, false);
-                        }
-                        ext_sym = make_external_symbol(al, current_scope, t, unique_name,
-                            m_name, sym_name, ASR::accessType::Public);
-                    }
-                    nml->m_var_list[i] = ext_sym;
+                    std::string &m_name = it_ext->second.first;
+                    nml->m_var_list[i] = resolve_or_create_external_symbol(al, current_scope, t, m_name);
                 }
             }
         }

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -382,7 +382,10 @@ public:
             if (is_module_variable(v)) {
                 continue;
             }
-            nesting_map[par_func_sym].insert(nml->m_var_list[i]);
+            if (current_scope && par_func_sym &&
+                !is_sym_in_scope_chain(v->m_parent_symtab, current_scope)) {
+                nesting_map[par_func_sym].insert(nml->m_var_list[i]);
+            }
         }
     }
 
@@ -871,10 +874,11 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
         for (size_t i = 0; i < nml->n_var_list; i++) {
             ASR::symbol_t *orig_sym = nml->m_var_list[i];
             auto it_ext = nested_var_to_ext_var.find(orig_sym);
-            if (it_ext == nested_var_to_ext_var.end()) {
-                continue;
+            if (it_ext != nested_var_to_ext_var.end()) {
+                var_list.push_back(al, it_ext->second.second);
+            } else {
+                var_list.push_back(al, orig_sym);
             }
-            var_list.push_back(al, it_ext->second.second);
         }
 
         std::string nml_name = ASRUtils::symbol_name(nml_sym);
@@ -893,20 +897,58 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
             return;
         }
         (void)loc;
-        ASR::symbol_t *parent_func_sym = func_stack[func_stack.size() - 2];
-        ASR::symbol_t *nml_new_sym = get_nested_namelist_symbol(parent_func_sym, nml_sym);
-        if (!nml_new_sym) {
-            return;
+        
+        ASR::symbol_t *nml_sym_past = ASRUtils::symbol_get_past_external(nml_sym);
+        if (!ASR::is_a<ASR::Namelist_t>(*nml_sym_past)) return;
+        ASR::Namelist_t *nml = ASR::down_cast<ASR::Namelist_t>(nml_sym_past);
+
+        bool is_local_namelist = is_sym_in_scope_chain(nml->m_parent_symtab, current_scope);
+        
+        if (!is_local_namelist) {
+            ASR::symbol_t *parent_func_sym = func_stack[func_stack.size() - 2];
+            ASR::symbol_t *nml_new_sym = get_nested_namelist_symbol(parent_func_sym, nml_sym);
+            if (!nml_new_sym) {
+                return;
+            }
+            std::string sym_name = ASRUtils::symbol_name(nml_sym);
+            ASR::symbol_t *ext_sym = current_scope->resolve_symbol(sym_name);
+            if (!ext_sym || !ASR::is_a<ASR::ExternalSymbol_t>(*ext_sym) ||
+                    ASRUtils::symbol_get_past_external(ext_sym) != nml_new_sym) {
+                std::string owner_name = ASRUtils::symbol_name(ASRUtils::get_asr_owner(nml_new_sym));
+                std::string unique_name = sym_name;
+                if (current_scope->get_symbol(sym_name)) {
+                    unique_name = current_scope->get_unique_name(sym_name, false);
+                }
+                ext_sym = make_external_symbol(al, current_scope, nml_new_sym, unique_name,
+                    owner_name, sym_name, ASR::accessType::Public);
+            }
+            nml_sym = ext_sym;
+        } else {
+            for (size_t i = 0; i < nml->n_var_list; i++) {
+                ASR::symbol_t *orig_sym = nml->m_var_list[i];
+                auto it_ext = nested_var_to_ext_var.find(orig_sym);
+                if (it_ext != nested_var_to_ext_var.end()) {
+                    std::string m_name = it_ext->second.first;
+                    ASR::symbol_t *t = it_ext->second.second;
+                    std::string sym_name = ASRUtils::symbol_name(t);
+                    ASR::symbol_t *existing = current_scope->get_symbol(sym_name);
+                    ASR::symbol_t *ext_sym = nullptr;
+                    if (existing != nullptr &&
+                            ASR::is_a<ASR::ExternalSymbol_t>(*existing) &&
+                            ASRUtils::symbol_get_past_external(existing) == t) {
+                        ext_sym = existing;
+                    } else {
+                        std::string unique_name = sym_name;
+                        if (existing != nullptr) {
+                            unique_name = current_scope->get_unique_name(sym_name, false);
+                        }
+                        ext_sym = make_external_symbol(al, current_scope, t, unique_name,
+                            m_name, sym_name, ASR::accessType::Public);
+                    }
+                    nml->m_var_list[i] = ext_sym;
+                }
+            }
         }
-        std::string sym_name = ASRUtils::symbol_name(nml_sym);
-        ASR::symbol_t *ext_sym = current_scope->resolve_symbol(sym_name);
-        if (!ext_sym || !ASR::is_a<ASR::ExternalSymbol_t>(*ext_sym) ||
-                ASRUtils::symbol_get_past_external(ext_sym) != nml_new_sym) {
-            std::string owner_name = ASRUtils::symbol_name(ASRUtils::get_asr_owner(nml_new_sym));
-            ext_sym = make_external_symbol(al, current_scope, nml_new_sym, sym_name,
-                owner_name, sym_name, ASR::accessType::Public);
-        }
-        nml_sym = ext_sym;
     }
 
     void visit_FileWrite(const ASR::FileWrite_t &x) {


### PR DESCRIPTION
fixes #12186


The nested_vars pass incorrectly tried to move locally-defined
namelists into the parent's context module, causing a duplicate
symbol assertion (scope.find(name) == scope.end()) when a namelist
was defined inside a nested subroutine.

The fix distinguishes local vs parent-scoped namelists:
- capture_namelist_vars now checks is_sym_in_scope_chain to skip
  variables that are local to the current scope.
- maybe_replace_namelist checks whether the namelist itself is local;
  local namelists have their captured vars replaced in-place, while
  parent-scoped namelists are moved to the context module as before.
- get_nested_namelist_symbol preserves non-captured variables instead
  of dropping them from the var_list.

