### PR TITLE
LLVM: Fix ICE in pointer bounds remapping for rank-reduced array sections

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -956,6 +956,7 @@ RUN(NAME arrays_124 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_125 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME arrays_126 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME array_128 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME arrays_131 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_131.f90
+++ b/integration_tests/arrays_131.f90
@@ -1,0 +1,22 @@
+program main
+  implicit none
+
+  integer, target :: x(10, 10)
+  integer, pointer :: p(:)
+
+  p(4:) => x(4:7:3, 5)
+
+  call check(p)
+  print *, "passed"
+
+contains
+
+  subroutine check(a)
+    integer, pointer, intent(in) :: a(:)
+
+    if (lbound(a, 1) /= 4) error stop
+    if (ubound(a, 1) /= 5) error stop
+    if (size(a) /= 2) error stop
+  end subroutine check
+
+end program main

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -16,7 +16,6 @@
 #include <lfortran/semantics/asr_implicit_cast_rules.h>
 #include <libasr/pass/instantiate_template.h>
 #include <libasr/runtime/lfortran_float128_quadmath.h>
-#include <complex>
 #include <string>
 #include <sstream>
 #include <set>
@@ -175,7 +174,6 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
     ASR::expr_t* value;
     ASR::ttype_t* type;
     diag::Diagnostics& diag;
-    int64_t element_idx;
     const std::map<ASRUtils::IntrinsicElementalFunctions, size_t> name2signature_varargs = {
         // max0 can accept any arbitrary number of arguments 2<=x<=100
         {ASRUtils::IntrinsicElementalFunctions::Max, 100},
@@ -194,7 +192,6 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
         {ASRUtils::IntrinsicElementalFunctions::SelectedRealKind, 3},
         {ASRUtils::IntrinsicElementalFunctions::Ishftc, 3},
         {ASRUtils::IntrinsicElementalFunctions::Ichar, 2},
-        {ASRUtils::IntrinsicElementalFunctions::Iachar, 2},
         {ASRUtils::IntrinsicElementalFunctions::Char, 2},
         {ASRUtils::IntrinsicElementalFunctions::Achar, 2},
         {ASRUtils::IntrinsicElementalFunctions::Logical, 2},
@@ -208,7 +205,7 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
 
     ImpliedDoLoopValuesVisitor(Allocator& al, std::vector<ASR::symbol_t*>& loop_vars, std::vector<int>& loop_indices, ASR::expr_t* value_,
         ASR::ttype_t* type, diag::Diagnostics& diag) :
-        al(al), loop_vars(loop_vars), loop_indices(loop_indices), value(value_), type(type), diag(diag), element_idx(-1) {}
+        al(al), loop_vars(loop_vars), loop_indices(loop_indices), value(value_), type(type), diag(diag) {}
 
     void visit_Var(const ASR::Var_t &x) {
         int loop_var_index = std::find(loop_vars.begin(), loop_vars.end(), x.m_v) - loop_vars.begin();
@@ -412,7 +409,9 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
     }
 
     void visit_ComplexConstant(const ASR::ComplexConstant_t &x) {
-        value = ASRUtils::EXPR(ASR::make_ComplexConstant_t(al, x.base.base.loc, x.m_re, x.m_im, x.m_type));
+        diag.add(Diagnostic("Complex constant in compiletime evaluation implied do loop not supported",
+                            Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+        throw SemanticAbort();
     }
 
     void visit_StringConstant(const ASR::StringConstant_t &x) {
@@ -448,72 +447,35 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
             s2c(al, result), x.m_type));
     }
 
-
-
     void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
-        value = nullptr;
+        int left_val, right_val;
         this->visit_expr(*x.m_left);
-        ASR::expr_t* left_val = value;
-        value = nullptr;
+        left_val = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
         this->visit_expr(*x.m_right);
-        ASR::expr_t* right_val = value;
-
-        if (left_val && right_val) {
-            int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(left_val)->m_n;
-            int64_t b = ASR::down_cast<ASR::IntegerConstant_t>(right_val)->m_n;
-            int64_t res;
-
-            switch (x.m_op) {
-                case ASR::binopType::Mul: res = a * b; break;
-                case ASR::binopType::Add: res = a + b; break;
-                case ASR::binopType::Sub: res = a - b; break;
-                case ASR::binopType::Div: res = b != 0 ? a / b : 0; break;
-                case ASR::binopType::Pow: res = std::pow(a, b); break;
-                default:
-                    diag.add(Diagnostic("Unsupported binary operation in implied do loop",
-                                        Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                    throw SemanticAbort();
-            }
-            value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, res, x.m_type));
-        } else {
-            value = nullptr;
+        right_val = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
+        int res;
+        switch (x.m_op) {
+            case ASR::binopType::Mul:
+                res = left_val * right_val;
+                break;
+            case ASR::binopType::Add:
+                res = left_val + right_val;
+                break;
+            case ASR::binopType::Sub:
+                res = left_val - right_val;
+                break;
+            case ASR::binopType::Div:
+                res = left_val / right_val;
+                break;
+            case ASR::binopType::Pow:
+                res = std::pow(left_val, right_val);
+                break;
+            default:
+                diag.add(Diagnostic("Unsupported binary operation in implied do loop",
+                                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
         }
-    }
-
-    void visit_ArrayConstant(const ASR::ArrayConstant_t &x) {
-        if (element_idx != -1) {
-            ASR::ttype_t* base_type = ASRUtils::extract_type(x.m_type);
-            int kind = ASRUtils::extract_kind_from_ttype_t(base_type);
-            if (ASRUtils::is_integer(*base_type)) {
-                if (kind == 4) {
-                    int32_t val = ((int32_t*)x.m_data)[element_idx];
-                    value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, val, base_type));
-                } else if (kind == 8) {
-                    int64_t val = ((int64_t*)x.m_data)[element_idx];
-                    value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, val, base_type));
-                } else {
-                    LCOMPILERS_ASSERT(false);
-                }
-            } else if (ASRUtils::is_real(*base_type)) {
-                if (kind == 4) {
-                    float val = ((float*)x.m_data)[element_idx];
-                    value = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, val, base_type));
-                } else if (kind == 8) {
-                    double val = ((double*)x.m_data)[element_idx];
-                    value = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, val, base_type));
-                } else {
-                    LCOMPILERS_ASSERT(false);
-                }
-            } else {
-                value = nullptr;
-            }
-        } else {
-            value = const_cast<ASR::expr_t*>(&(x.base));
-        }
-    }
-
-    void visit_ArrayBroadcast(const ASR::ArrayBroadcast_t &x) {
-        this->visit_expr(*x.m_array);
+        value = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, res, x.m_type));
     }
 
     void visit_RealBinOp(const ASR::RealBinOp_t &x) {
@@ -791,14 +753,6 @@ static inline ASR::expr_t* evaluate_compiletime_values(Allocator &al, std::vecto
 
     if (compiletime_values.size() == 0) {
         ASR::ttype_t* logical_type = ASRUtils::type_get_past_array(type);
-        if (ASRUtils::is_array(type)) {
-            if (ASRUtils::get_fixed_size_of_array(type) == 0) {
-                return ASRUtils::EXPR(ASR::make_ArrayConstant_t(
-                    al, loc, 0, nullptr, type, ASR::arraystorageType::ColMajor));
-            } else {
-                return nullptr;
-            }
-        }
         return compare_helper(al, ASRUtils::expr_value(left), ASRUtils::expr_value(right), asr_op, logical_type, loc, diag);
     } else {
         ASR::ttype_t* logical_type = ASRUtils::type_get_past_array(type);
@@ -806,26 +760,9 @@ static inline ASR::expr_t* evaluate_compiletime_values(Allocator &al, std::vecto
         for (size_t i = 0; i < compiletime_values.size(); i++) {
             ASR::expr_t* left_val = compiletime_values[i].first;
             ASR::expr_t* right_val = compiletime_values[i].second;
-            if (ASRUtils::is_array(ASRUtils::expr_type(left_val)) || ASRUtils::is_array(ASRUtils::expr_type(right_val))) {
-                return nullptr;
-            }
-            ASR::expr_t* res = compare_helper(al, left_val, right_val, asr_op, logical_type, loc, diag);
-            if (!res) return nullptr;
-            args.push_back(al, res);
+            args.push_back(al, compare_helper(al, left_val, right_val, asr_op, logical_type, loc, diag));
         }
-        if (ASRUtils::is_array(type) && ASRUtils::extract_n_dims_from_ttype(type) > 1) {
-            Vec<ASR::expr_t*> values;
-            values.reserve(al, args.size());
-            for (size_t i = 0; i < args.size(); i++) {
-                values.push_back(al, ASRUtils::expr_value(args[i]));
-            }
-            ASR::Array_t* array_type =ASR::down_cast<ASR::Array_t>(ASRUtils::type_get_past_pointer(type));
-            void* data = ASRUtils::set_ArrayConstant_data(values.p, values.size(), array_type->m_type);
-            int64_t n_data = values.size() * ASRUtils::extract_kind_from_ttype_t(array_type->m_type);
-            return ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, loc, n_data, data, type, ASR::arraystorageType::ColMajor));
-        } else {
-            return ASRUtils::EXPR(ASRUtils::make_ArrayConstructor_t_util(al, loc, args.p, args.size(), type, ASR::arraystorageType::ColMajor));
-        }
+        return ASRUtils::EXPR(ASRUtils::make_ArrayConstructor_t_util(al, loc, args.p, args.size(), type, ASR::arraystorageType::ColMajor));
     }
 }
 
@@ -839,11 +776,6 @@ static inline void populate_compiletime_values(Allocator &al, std::vector<std::p
         for (size_t i=0; i<(size_t) ASRUtils::get_fixed_size_of_array(array->m_type); i++) {
             compiletime_values.push_back({ASRUtils::fetch_ArrayConstant_value(al, array, i), nullptr});
         }
-    } else if (ASR::is_a<ASR::ArrayConstructor_t>(*ASRUtils::expr_value(left))) {
-        ASR::ArrayConstructor_t* array = ASR::down_cast<ASR::ArrayConstructor_t>(ASRUtils::expr_value(left));
-        for (size_t i=0; i<array->n_args; i++) {
-            compiletime_values.push_back({array->m_args[i], nullptr});
-        }
     }
     if (ASR::is_a<ASR::ArrayConstant_t>(*ASRUtils::expr_value(right))) {
         ASR::ArrayConstant_t* array = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(right));
@@ -852,15 +784,6 @@ static inline void populate_compiletime_values(Allocator &al, std::vector<std::p
                 compiletime_values[i].second = ASRUtils::fetch_ArrayConstant_value(al, array, i);
             } else {
                 compiletime_values.push_back({nullptr, ASRUtils::fetch_ArrayConstant_value(al, array, i)});
-            }
-        }
-    } else if (ASR::is_a<ASR::ArrayConstructor_t>(*ASRUtils::expr_value(right))) {
-        ASR::ArrayConstructor_t* array = ASR::down_cast<ASR::ArrayConstructor_t>(ASRUtils::expr_value(right));
-        for (size_t i=0; i<array->n_args; i++) {
-            if(compiletime_values.size() > i) {
-                compiletime_values[i].second = array->m_args[i];
-            } else {
-                compiletime_values.push_back({nullptr, array->m_args[i]});
             }
         }
     }
@@ -1432,14 +1355,6 @@ static ASR::expr_t* eval_unary_array_const(Allocator& al, const Location& loc, A
                                             ASRUtils::expr_value(operand))->m_r;
                     value = ASR::down_cast<ASR::expr_t>(ASR::make_RealConstant_t(
                         al, x.base.base.loc, -op_value, operand_type));
-                } else if (ASR::is_a<ASR::ArrayConstant_t>(*ASRUtils::expr_value(operand))) {
-                    ASR::ArrayConstant_t* arr_const = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(operand));
-                    int kind = ASRUtils::extract_kind_from_ttype_t(operand_type);
-                    if (kind == 4) {
-                        value = eval_unary_array_const<float>(al, x.base.base.loc, arr_const, operand_type, USubOp<float>());
-                    } else if (kind == 8) {
-                        value = eval_unary_array_const<double>(al, x.base.base.loc, arr_const, operand_type, USubOp<double>());
-                    }
                 }
             }
             asr = ASR::make_RealUnaryMinus_t(al, x.base.base.loc, operand,
@@ -1770,7 +1685,6 @@ template <class Derived>
 class CommonVisitor : public AST::BaseVisitor<Derived> {
 public:
     diag::Diagnostics &diag;
-    std::vector<ASR::Function_t*> implicit_interfaces_to_sync;
     std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
     std::map<std::string, int> assumed_rank_arrays;
     std::map<AST::operatorType, std::string> binop2str = {
@@ -1921,9 +1835,6 @@ public:
         {"system", IntrinsicSignature({"command"}, 1, 1)},
         {"sleep", IntrinsicSignature({"seconds"}, 1, 1)},
         {"co_sum", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
-        {"co_max", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
-        {"co_min", IntrinsicSignature({"a", "result_image", "stat", "errmsg"}, 1, 4)},
-        {"co_broadcast", IntrinsicSignature({"a", "source_image", "stat", "errmsg"}, 2, 4)},
         {"move_alloc", IntrinsicSignature({"from", "to"}, 2, 2)},
         {"mvbits", IntrinsicSignature({"from", "frompos", "len", "to", "topos"}, 5, 5)},
         {"modulo", IntrinsicSignature({"a", "p"}, 2, 2)},
@@ -2107,8 +2018,6 @@ public:
     ASR::presenceType dflt_presence = ASR::presenceType::Required;
     std::map<std::string, ASR::presenceType> assgnd_presence;
     std::set<std::string> assgnd_pointer;
-    std::set<std::string> assgnd_allocatable;
-    std::set<std::string> assgnd_target;
     // Current procedure arguments. Only non-empty for SymbolTableVisitor,
     // empty for BodyVisitor.
     std::vector<std::string> current_procedure_args;
@@ -3491,7 +3400,7 @@ public:
                 }
                 ASRUtils::make_ArrayBroadcast_t_util(al, x.base.base.loc, object, expression_value);
                 ASR::stmt_t* assignment_stmt = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(al, x.base.base.loc,
-                                                            object, expression_value, nullptr, compiler_options.po.realloc_lhs_arrays, false));
+                                            object, expression_value, nullptr, compiler_options.po.realloc_lhs_arrays, false));
                 current_body->push_back(al, assignment_stmt);
             } else {
                 diag.add(Diagnostic(
@@ -3505,18 +3414,12 @@ public:
             Vec<ASR::expr_t*> body;
             body.reserve(al, a->n_value);
             int size_of_array = 0;
-            
             if (ASR::is_a<ASR::ArraySection_t>(*object)) {
                 size_of_array = ASRUtils::get_fixed_size_of_ArraySection(ASR::down_cast<ASR::ArraySection_t>(object));
                 object = ASR::down_cast<ASR::ArraySection_t>(object)->m_v;
-            } else if (ASR::is_a<ASR::ArrayItem_t>(*object)) {
-                ASR::ArrayItem_t *item = ASR::down_cast<ASR::ArrayItem_t>(object);
-                size_of_array = a->n_value - curr_value; 
-                object = item->m_v; 
             } else {
                 size_of_array = ASRUtils::get_fixed_size_of_array(array_type->m_dims, array_type->n_dims);
             }
-
             if (size_of_array == -1) {
                 // For equivalenced arrays, the dimensions may not be available
                 // Use the number of DATA values as the array size
@@ -3610,21 +3513,13 @@ public:
             obj_type = ASRUtils::duplicate_type(al, obj_type, &dims);
             tmp = ASRUtils::make_ArrayConstructor_t_util(al, x.base.base.loc, body.p,
                 body.size(), obj_type, ASR::arraystorageType::ColMajor);
-            
             ASR::Variable_t* v2 = nullptr;
             if (ASR::is_a<ASR::StructInstanceMember_t>(*object)) {
                 ASR::StructInstanceMember_t *mem = ASR::down_cast<ASR::StructInstanceMember_t>(object);
                 v2 = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(mem->m_m));
-            } else if (ASR::is_a<ASR::Var_t>(*object)) {
+            } else {
                 ASR::Var_t *v = ASR::down_cast<ASR::Var_t>(object);
                 v2 = ASR::down_cast<ASR::Variable_t>(v->m_v);
-            } else {
-                diag.add(Diagnostic(
-                    "Internal Compiler Error: Unhandled AST node type in array data statement assignment",
-                    Level::Error, Stage::Semantic, {
-                        Label("",{x.base.base.loc})
-                    }));
-                throw SemanticAbort();
             }
             // For pointer types (e.g. equivalenced arrays), don't set m_value
             // as it causes issues in LLVM codegen - create assignment instead
@@ -4269,40 +4164,6 @@ public:
         return iterations * elements_per_iteration;
     }
 
-    // Returns the PARAMETER (named constant) Variable referenced by a
-    // DATA-statement object expression, walking through struct-member and
-    // array-index accessors and into the elements of a data implied-do-loop,
-    // or nullptr when the object does not refer to a named constant.
-    ASR::Variable_t* data_stmt_object_parameter(ASR::expr_t* expr) {
-        if (!expr) return nullptr;
-        if (ASR::is_a<ASR::Var_t>(*expr)) {
-            ASR::symbol_t* sym = ASRUtils::symbol_get_past_external(
-                ASR::down_cast<ASR::Var_t>(expr)->m_v);
-            if (ASR::is_a<ASR::Variable_t>(*sym)) {
-                ASR::Variable_t* v = ASR::down_cast<ASR::Variable_t>(sym);
-                return v->m_storage == ASR::storage_typeType::Parameter ? v
-                                                                       : nullptr;
-            }
-            return nullptr;
-        }
-        if (ASR::is_a<ASR::StructInstanceMember_t>(*expr)) {
-            return data_stmt_object_parameter(
-                ASR::down_cast<ASR::StructInstanceMember_t>(expr)->m_v);
-        }
-        if (ASR::is_a<ASR::ArrayItem_t>(*expr)) {
-            return data_stmt_object_parameter(
-                ASR::down_cast<ASR::ArrayItem_t>(expr)->m_v);
-        }
-        if (ASR::is_a<ASR::ImpliedDoLoop_t>(*expr)) {
-            ASR::ImpliedDoLoop_t* idl = ASR::down_cast<ASR::ImpliedDoLoop_t>(expr);
-            for (size_t i = 0; i < idl->n_values; i++) {
-                ASR::Variable_t* v = data_stmt_object_parameter(idl->m_values[i]);
-                if (v) return v;
-            }
-        }
-        return nullptr;
-    }
-
     void visit_DataStmt(const AST::DataStmt_t &x) {
         // The DataStmt is a statement, so it occurs in the BodyVisitor.
         // We add its contents into the symbol table here. This visitor
@@ -4338,24 +4199,6 @@ public:
             a->m_value = expanded_values.data();
             a->n_value = expanded_values.size();
             
-            // A PARAMETER (named constant) is initialized by its declaration
-            // and must not be (re-)initialized through a DATA statement, in
-            // whole or by component.
-            for (size_t j = 0; j < a->n_object; j++) {
-                this->visit_expr(*a->m_object[j]);
-                ASR::expr_t* object = ASRUtils::EXPR(tmp);
-                ASR::Variable_t* param_var = data_stmt_object_parameter(object);
-                if (param_var) {
-                    diag.add(Diagnostic(
-                        "PARAMETER '" + std::string(param_var->m_name)
-                        + "' shall not appear in a DATA statement",
-                        Level::Error, Stage::Semantic, {
-                            Label("", {object->base.loc})
-                        }));
-                    throw SemanticAbort();
-                }
-            }
-
             // Now we are dealing with just one item, there are four cases possible:
             // data x / 1, 2, 3 /       ! x must be an array
             // data x / 1 /             ! x must be a scalar (integer)
@@ -4517,7 +4360,7 @@ public:
             ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(make_Struct_t(
                 al, loc, struct_scope, s2c(al,common_block_name),
                 nullptr,
-                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false, false,
+                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false,
                 nullptr, 0, nullptr, nullptr, nullptr, 0));
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);
@@ -4828,10 +4671,9 @@ public:
                             al, loc, fn_scope, s2c(al, iface_name),
                             func_type,
                             nullptr, 0, nullptr, 0, nullptr, 0,
-                            nullptr, ASR::accessType::Private,
+                            nullptr, ASR::accessType::Public,
                             false, false, nullptr, nullptr, nullptr));
                     parent_scope->add_symbol(iface_name, iface_sym);
-                    implicit_interfaces_to_sync.push_back(ASR::down_cast<ASR::Function_t>(iface_sym));
                 }
                 ASR::ttype_t *ptr_type = ASRUtils::TYPE(
                     ASR::make_Pointer_t(al, loc, func_type));
@@ -4855,16 +4697,7 @@ public:
             SymbolTable *parent_scope = current_scope;
             current_scope = al.make_new<SymbolTable>(parent_scope);
             ASR::ttype_t *type = nullptr;
-            if (determined_type) {
-                // if explicit type provided, give preference to it.
-                type = determined_type;
-                if (sym_ && ASR::is_a<ASR::Function_t>(*sym_)) {
-                    ASR::Function_t* func_sym = ASR::down_cast<ASR::Function_t>(sym_);
-                    if (!func_sym->m_return_var) {
-                        is_subroutine = true;
-                    }
-                }
-            } else if (sym_) {
+            if (sym_) {
                 if (ASR::is_a<ASR::Function_t>(*sym_)) {
                     ASR::Function_t* func_sym = ASR::down_cast<ASR::Function_t>(sym_);
                     if (!func_sym->m_return_var) {
@@ -4874,6 +4707,9 @@ public:
                 if (!is_subroutine) {
                     type = ASRUtils::symbol_type(sym_);
                 }
+            } else if (determined_type) {
+                // if explicit type provided, give preference to it.
+                type = determined_type;
             } else if (compiler_options.implicit_typing) {
                 type = implicit_dictionary[std::string(1,sym[0])];
                 if (!type) {
@@ -5099,7 +4935,7 @@ public:
     }
 
     ASR::expr_t* adjust_array_character_length(ASR::expr_t* value, int64_t lhs_len, int64_t rhs_len, Allocator& al) {
-        ASR::ArrayConstant_t* array_constant = ASR::down_cast<ASR::ArrayConstant_t>(ASRUtils::expr_value(value));
+        ASR::ArrayConstant_t* array_constant = ASR::down_cast<ASR::ArrayConstant_t>(value);
         Vec<ASR::expr_t*> body;
         size_t array_size = ASRUtils::get_fixed_size_of_array(array_constant->m_type);
 
@@ -5126,7 +4962,7 @@ public:
                 body.p, body.size(), ASRUtils::extract_type(array_constant->m_type));
         array_constant->m_n_data = array_size * lhs_len;
 
-        return value;
+        return (ASR::expr_t*) array_constant;
     }
 
     ASR::expr_t* evaluate_parameter_array_section(
@@ -5853,31 +5689,8 @@ public:
                                     } else {
                                         assgnd_pointer.insert(sym);
                                     }
-                                } else if (sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
-                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
-                                    if (sym_) {
-                                        ASR::symbol_t* sym_past_external = ASRUtils::symbol_get_past_external(sym_);
-                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past_external);
-                                            if (!ASRUtils::is_allocatable(v->m_type)) {
-                                                v->m_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
-                                            }
-                                        }
-                                    } else {
-                                        assgnd_allocatable.insert(to_lower(sym));
-                                    }
-                                } else if (sa->m_attr == AST::simple_attributeType::AttrTarget) {
-                                    ASR::symbol_t* sym_ = current_scope->get_symbol(sym);
-                                    if (sym_) {
-                                        ASR::symbol_t* sym_past_external = ASRUtils::symbol_get_past_external(sym_);
-                                        if (ASR::is_a<ASR::Variable_t>(*sym_past_external)) {
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_past_external);
-                                            v->m_target_attr = true;
-                                        }
-                                    } else {
-                                        assgnd_target.insert(to_lower(sym));
-                                    }
-                                } else if (sa->m_attr == AST::simple_attributeType::AttrAsynchronous) {
+                                } else if (sa->m_attr == AST::simple_attributeType
+                                        ::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
                                 } else {
                                     diag.add(Diagnostic(
@@ -5904,12 +5717,6 @@ public:
                                                 v->m_type = ASRUtils::TYPE(
                                                     ASR::make_Pointer_t(al, x.base.base.loc, v->m_type));
                                             }
-                                        } else if (sym_ && sa->m_attr == AST::simple_attributeType::AttrAllocatable) {
-                                            ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(sym_);
-                                            if (!ASRUtils::is_allocatable(v->m_type)) {
-                                                v->m_type = ASRUtils::TYPE(
-                                                    ASR::make_Allocatable_t(al, x.base.base.loc, v->m_type));
-                                            }
                                         }
                                     }
                                 }
@@ -5927,19 +5734,24 @@ public:
                 AST::var_sym_t &s = x.m_syms[i];
                 dimension_variable(s, x.base.base.loc);
             }
-        } else if (AST::is_a<AST::AttrCommon_t>(*x.m_attributes[i])) {
-            AST::AttrCommon_t const & common_stmt =
-            *AST::down_cast<AST::AttrCommon_t>(x.m_attributes[i]);
-            constexpr char BLANK_BLOCK[] = "blank#block";
-            std::string common_block_name;
-            common_block_varsyms objs_by_blk;
-            for (size_t bi = 0; bi < common_stmt.n_blks; ++bi) {
-            AST::common_block_t const &cb = common_stmt.m_blks[bi];
-            if (cb.m_name) {
-                common_block_name = to_lower(cb.m_name);
-            } else {
-                common_block_name = BLANK_BLOCK;
-            }
+		} else if (AST::is_a<AST::AttrCommon_t>(*x.m_attributes[i])) {
+		    AST::AttrCommon_t const & common_stmt =
+			*AST::down_cast<AST::AttrCommon_t>(x.m_attributes[i]);
+		    constexpr char BLANK_BLOCK[] = "blank#block";
+		    std::string common_block_name;
+		    /* Local dictionary to aggregate objects into:
+		       "COMMON A /B1/ B, // C", will put "A" and "C"
+		       in the blank block.  This should be done for
+		       the entire declaration-construct. */
+		    common_block_varsyms objs_by_blk;
+		    for (size_t bi = 0; bi < common_stmt.n_blks; ++bi) {
+			AST::common_block_t const &cb = common_stmt.m_blks[bi];
+			if (cb.m_name) {
+			    common_block_name = to_lower(cb.m_name);
+			} else {
+			    common_block_name = BLANK_BLOCK;
+			}
+
 			// Aggregate the objects into their named common blocks
 			for (size_t oi = 0; oi < cb.n_objects; ++oi) {
 			    AST::var_sym_t const & vs = cb.m_objects[oi];
@@ -6070,27 +5882,9 @@ public:
                     auto emit_cptr_to_pointer = [&](const Location& loc,
                             ASR::asr_t* cptr_expr, ASR::expr_t* target_ref,
                             ASR::asr_t* shape_const) {
-                        bool is_module = in_module && !in_Subroutine;
-                        if (is_module) {
-                            ASR::expr_t* get_ptr_expr = nullptr;
-                            ASR::expr_t* cptr_expr_casted = ASRUtils::EXPR(cptr_expr);
-                            if (ASR::is_a<ASR::PointerToCPtr_t>(*cptr_expr_casted)) {
-                                get_ptr_expr = ASR::down_cast<ASR::PointerToCPtr_t>(cptr_expr_casted)->m_arg;
-                            }
-                            ASR::Variable_t* target_var = nullptr;
-                            if (ASR::is_a<ASR::Var_t>(*target_ref)) {
-                                target_var = ASRUtils::EXPR2VAR(target_ref);
-                            } else if (ASR::is_a<ASR::ArrayItem_t>(*target_ref)) {
-                                target_var = ASRUtils::EXPR2VAR(ASR::down_cast<ASR::ArrayItem_t>(target_ref)->m_v);
-                            }
-                            if (get_ptr_expr && target_var) {
-                                target_var->m_symbolic_value = get_ptr_expr;
-                                return;
-                            }
-                        }
                         ASR::asr_t* cfp = ASR::make_CPtrToPointer_t(
                             al, loc, ASRUtils::EXPR(cptr_expr), target_ref,
-                            shape_const ? ASRUtils::EXPR(shape_const) : nullptr, nullptr);
+                            ASRUtils::EXPR(shape_const), nullptr);
                         data_structure[current_scope->counter].push_back(
                             ASRUtils::STMT(cfp));
                     };
@@ -6267,17 +6061,12 @@ public:
                                         );
                                     }
                                     if (type != nullptr) {
-                                        if (!(in_module && !in_Subroutine)) {
-                                            ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
-                                            var__->m_type = ptr;
-                                        }
+                                        ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, type));
+                                        var__->m_type = ptr;
 
-                                        bool is_module = in_module && !in_Subroutine;
-                                        if (is_module) {
-                                            var__->m_symbolic_value = ASRUtils::EXPR(get_pointer);
-                                        } else {
-                                            emit_cptr_to_pointer(asr_eq1->base.loc, pointer_to_cptr, asr_eq2, nullptr);
-                                        }
+                                        ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(al, asr_eq1->base.loc, ASRUtils::EXPR(pointer_to_cptr),asr_eq2, nullptr, nullptr);
+                                        ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                        data_structure[current_scope->counter].push_back(stmt);
                                     }
                                 } else if (!AST::is_a<AST::FuncCallOrArray_t>(*eq1) && AST::is_a<AST::FuncCallOrArray_t>(*eq2)) {
                                     ASR::ttype_t* arg_type1 = ASRUtils::expr_type(asr_eq1);
@@ -6430,10 +6219,8 @@ public:
                                                 ASR::ttype_t* array_type2 = ASRUtils::make_Array_t_util(
                                                     al, asr_eq2->base.loc, pointer_type2_inner, dim2.p, dim2.size(),
                                                     ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
-                                                if (!(in_module && !in_Subroutine)) {
-                                                    ASR::ttype_t* ptr2 = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, array_type2));
-                                                    var2__->m_type = ptr2;
-                                                }
+                                                ASR::ttype_t* ptr2 = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, array_type2));
+                                                var2__->m_type = ptr2;
 
                                                 ASR::ttype_t* pointer_type_storage = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq2->base.loc, elem_type));
                                                 ASR::asr_t* get_pointer_storage = ASR::make_GetPointer_t(al, asr_eq2->base.loc, storage_at_1, pointer_type_storage, nullptr);
@@ -6448,7 +6235,9 @@ public:
                                                 ASR::asr_t* array_constant2 = ASRUtils::make_ArrayConstructor_t_util(al, asr_eq2->base.loc, args_shape2.p, args_shape2.size(), array_type_shape2, ASR::arraystorageType::ColMajor);
                                                 // Create var reference for ia2 (var2__ is already Variable_t*, cast to symbol_t*)
                                                 ASR::expr_t* var2_ref = ASRUtils::EXPR(ASR::make_Var_t(al, asr_eq2->base.loc, (ASR::symbol_t*)var2__));
-                                                emit_cptr_to_pointer(asr_eq2->base.loc, pointer_to_cptr2, var2_ref, array_constant2);
+                                                ASR::asr_t* c_f_pointer2 = ASR::make_CPtrToPointer_t(al, asr_eq2->base.loc, ASRUtils::EXPR(pointer_to_cptr2), var2_ref, ASRUtils::EXPR(array_constant2), nullptr);
+                                                ASR::stmt_t *stmt2 = ASRUtils::STMT(c_f_pointer2);
+                                                data_structure[current_scope->counter].push_back(stmt2);
 
                                                 // For ia1: point to storage(offset)
                                                 Vec<ASR::array_index_t> args1_idx;
@@ -6468,10 +6257,8 @@ public:
                                                 type1 = ASRUtils::make_Array_t_util(
                                                     al, asr_eq1->base.loc, type1, dim1.p, dim1.size(),
                                                     ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
-                                                if (!(in_module && !in_Subroutine)) {
-                                                    ASR::ttype_t* ptr1 = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type1));
-                                                    var1__->m_type = ptr1;
-                                                }
+                                                ASR::ttype_t* ptr1 = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type1));
+                                                var1__->m_type = ptr1;
 
                                                 ASR::asr_t* get_pointer_storage1 = ASR::make_GetPointer_t(al, asr_eq1->base.loc, storage_at_offset, pointer_type_storage, nullptr);
                                                 ASR::ttype_t *cptr1 = ASRUtils::TYPE(ASR::make_CPtr_t(al, asr_eq1->base.loc));
@@ -6483,16 +6270,16 @@ public:
 
                                                 ASR::ttype_t* array_type_shape1 = ASRUtils::TYPE(ASR::make_Array_t(al, asr_eq1->base.loc, int_type, dim.p, dim.size(), ASR::array_physical_typeType::PointerArray));
                                                 ASR::asr_t* array_constant1 = ASRUtils::make_ArrayConstructor_t_util(al, asr_eq1->base.loc, args_shape1.p, args_shape1.size(), array_type_shape1, ASR::arraystorageType::ColMajor);
-                                                emit_cptr_to_pointer(asr_eq1->base.loc, pointer_to_cptr1, asr_eq1, array_constant1);
+                                                ASR::asr_t* c_f_pointer1 = ASR::make_CPtrToPointer_t(al, asr_eq1->base.loc, ASRUtils::EXPR(pointer_to_cptr1), asr_eq1, ASRUtils::EXPR(array_constant1), nullptr);
+                                                ASR::stmt_t *stmt1 = ASRUtils::STMT(c_f_pointer1);
+                                                data_structure[current_scope->counter].push_back(stmt1);
                                             } else {
                                                 // No extension needed, use original approach
                                                 type1 = ASRUtils::make_Array_t_util(
                                                     al, asr_eq1->base.loc, type1, dim1.p, dim1.size(),
                                                     ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
-                                                if (!(in_module && !in_Subroutine)) {
-                                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type1));
-                                                    var1__->m_type = ptr;
-                                                }
+                                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type1));
+                                                var1__->m_type = ptr;
 
                                                 Vec<ASR::expr_t*> args_shape;
                                                 args_shape.reserve(al, array1->n_dims);
@@ -6516,7 +6303,12 @@ public:
                                                 ASR::ttype_t *cptr = ASRUtils::TYPE(ASR::make_CPtr_t(al, asr_eq2->base.loc));
                                                 ASR::asr_t* pointer_to_cptr = ASR::make_PointerToCPtr_t(
                                                     al, asr_eq2->base.loc, ASRUtils::EXPR(get_pointer2), cptr, nullptr);
-                                                emit_cptr_to_pointer(asr_eq2->base.loc, pointer_to_cptr, asr_eq1, array_constant);
+                                                ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(
+                                                    al, asr_eq2->base.loc, ASRUtils::EXPR(pointer_to_cptr),
+                                                    asr_eq1, ASRUtils::EXPR(array_constant), nullptr);
+
+                                                ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                                data_structure[current_scope->counter].push_back(stmt);
                                             }
                                         }
                                     } else {
@@ -6554,12 +6346,13 @@ public:
                                             );
                                         }
                                         if (type != nullptr) {
-                                            if (!(in_module && !in_Subroutine)) {
-                                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
-                                                var__->m_type = ptr;
-                                            }
+                                            ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
+                                            var__->m_type = ptr;
 
-                                            emit_cptr_to_pointer(asr_eq2->base.loc, pointer_to_cptr, asr_eq1, nullptr);
+                                            ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(
+                                                al, asr_eq2->base.loc, ASRUtils::EXPR(pointer_to_cptr), asr_eq1, nullptr, nullptr);
+                                            ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                            data_structure[current_scope->counter].push_back(stmt);
                                         }
                                     }
                                 } else if (AST::is_a<AST::FuncCallOrArray_t>(*eq2)) {
@@ -6595,17 +6388,12 @@ public:
                                         );
                                     }
                                     if (type != nullptr) {
-                                        if (!(in_module && !in_Subroutine)) {
-                                            ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
-                                            var__->m_type = ptr;
-                                        }
+                                        ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, asr_eq1->base.loc, type));
+                                        var__->m_type = ptr;
 
-                                        bool is_module = in_module && !in_Subroutine;
-                                        if (is_module) {
-                                            var__->m_symbolic_value = ASRUtils::EXPR(get_pointer);
-                                        } else {
-                                            emit_cptr_to_pointer(asr_eq2->base.loc, pointer_to_cptr, asr_eq1, nullptr);
-                                        }
+                                        ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(al, asr_eq2->base.loc, ASRUtils::EXPR(pointer_to_cptr),asr_eq1, nullptr, nullptr);
+                                        ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                        data_structure[current_scope->counter].push_back(stmt);
                                     }
                                 } else {
                                     ASR::ttype_t* arg_type1 = ASRUtils::expr_type(asr_eq1);
@@ -6709,10 +6497,8 @@ public:
                                                 ASR::ttype_t* arr_type = ASRUtils::make_Array_t_util(
                                                     al, alias_expr->base.loc, type, alias_dims.p, alias_dims.size(),
                                                     ASR::abiType::Source, false, ASR::array_physical_typeType::DescriptorArray, false, false);
-                                                if (!(in_module && !in_Subroutine)) {
-                                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, alias_expr->base.loc, arr_type));
-                                                    alias_var__->m_type = ptr;
-                                                }
+                                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, alias_expr->base.loc, arr_type));
+                                                alias_var__->m_type = ptr;
 
                                                 Vec<ASR::dimension_t> dim_one;
                                                 dim_one.reserve(al, 1);
@@ -6736,7 +6522,11 @@ public:
                                                     al, alias_expr->base.loc, shape_args.p, shape_args.size(),
                                                     shape_array_type, ASR::arraystorageType::ColMajor);
 
-                                                emit_cptr_to_pointer(alias_expr->base.loc, pointer_to_cptr, alias_expr, shape_constant);
+                                                ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(
+                                                    al, alias_expr->base.loc, ASRUtils::EXPR(pointer_to_cptr),
+                                                    alias_expr, ASRUtils::EXPR(shape_constant), nullptr);
+                                                ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                                data_structure[current_scope->counter].push_back(stmt);
                                             }
                                         } else {
                                             ASR::ttype_t* type = nullptr;
@@ -6761,12 +6551,14 @@ public:
                                                 );
                                             }
                                             if (type != nullptr) {
-                                                if (!(in_module && !in_Subroutine)) {
-                                                    ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, alias_expr->base.loc, type));
-                                                    alias_var__->m_type = ptr;
-                                                }
+                                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, alias_expr->base.loc, type));
+                                                alias_var__->m_type = ptr;
 
-                                                emit_cptr_to_pointer(alias_expr->base.loc, pointer_to_cptr, alias_expr, nullptr);
+                                                ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(
+                                                    al, alias_expr->base.loc, ASRUtils::EXPR(pointer_to_cptr),
+                                                    alias_expr, nullptr, nullptr);
+                                                ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                                data_structure[current_scope->counter].push_back(stmt);
                                             }
                                         }
                                         }
@@ -6813,11 +6605,9 @@ public:
 
                                             bool src_has_value = candidate_src->m_value != nullptr;
                                             bool ptr_has_value = candidate_ptr->m_value != nullptr;
-                                            bool ptr_has_sym_value = candidate_ptr->m_symbolic_value != nullptr;
 
                                             if (equiv_sources.count(candidate_ptr) ||
-                                                (!src_has_value && ptr_has_value) ||
-                                                ptr_has_sym_value) {
+                                                (!src_has_value && ptr_has_value)) {
                                                 source_expr = asr_eq1;
                                                 pointer_expr = asr_eq2;
                                                 pointer_var = candidate_src;
@@ -6863,13 +6653,14 @@ public:
                                             );
                                         }
                                         if (type != nullptr) {
-                                            bool is_mod = in_module && !in_Subroutine;
-                                            if (!is_mod) {
-                                                ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, pointer_expr->base.loc, type));
-                                                pointer_var->m_type = ptr;
-                                            }
+                                            ASR::ttype_t* ptr = ASRUtils::TYPE(ASR::make_Pointer_t(al, pointer_expr->base.loc, type));
+                                            pointer_var->m_type = ptr;
 
-                                            emit_cptr_to_pointer(source_expr->base.loc, pointer_to_cptr, pointer_expr, nullptr);
+                                            ASR::asr_t* c_f_pointer = ASR::make_CPtrToPointer_t(
+                                                al, source_expr->base.loc, ASRUtils::EXPR(pointer_to_cptr),
+                                                pointer_expr, nullptr, nullptr);
+                                            ASR::stmt_t *stmt = ASRUtils::STMT(c_f_pointer);
+                                            data_structure[current_scope->counter].push_back(stmt);
 
                                             // Fix chained equivalences: if a previously emitted
                                             // CPtrToPointer uses GetPointer(pointer_var) as its
@@ -6950,31 +6741,28 @@ public:
                         orig_decl_variable->m_intent = s_intent;
                     }
                 } else if (AST::is_a<AST::AttrNamelist_t>(*x.m_attributes[0])) {
-                    AST::AttrNamelist_t* attr_namelist =
-                        AST::down_cast<AST::AttrNamelist_t>(x.m_attributes[0]);
-                    for (size_t j = 0; j < attr_namelist->n_groups; j++) {
-                        AST::namelist_group_t &group = attr_namelist->m_groups[j];
-                        std::string group_name = to_lower(group.m_name);
-                        Vec<ASR::symbol_t*> var_list;
-                        var_list.reserve(al, group.n_objects);
-                        if (current_scope->get_symbol(group_name) != nullptr) {
-                            ASR::Namelist_t* existing_namelist =
-                                ASR::down_cast<ASR::Namelist_t>(
-                                    current_scope->get_symbol(group_name));
-                            for (size_t i = 0; i < existing_namelist->n_var_list; i++) {
-                                var_list.push_back(al, existing_namelist->m_var_list[i]);
-                            }
+                    // namelist /EXAMPLE/ foo, bar
+                    AST::AttrNamelist_t* attr_namelist = AST::down_cast<AST::AttrNamelist_t>(x.m_attributes[0]);
+                    Vec<ASR::symbol_t*> var_list; var_list.reserve(al, x.n_syms);
+                    if (current_scope->get_symbol(to_lower(attr_namelist->m_name)) != nullptr) {
+                        ASR::Namelist_t* existing_namelist = ASR::down_cast<ASR::Namelist_t>(
+                            current_scope->get_symbol(to_lower(attr_namelist->m_name)));
+                        for (size_t i = 0; i < existing_namelist->n_var_list; i++) {
+                            var_list.push_back(al, existing_namelist->m_var_list[i]);   
                         }
-                        for (size_t i = 0; i < group.n_objects; i++) {
-                            var_list.push_back(al, current_scope->resolve_symbol(
-                                to_lower(group.m_objects[i].m_name)));
-                        }
-                        ASR::asr_t* namelist = ASR::make_Namelist_t(al,
-                            group.loc, current_scope, s2c(al, group_name),
-                            var_list.p, var_list.n);
-                        current_scope->add_or_overwrite_symbol(s2c(al, group_name),
-                            ASR::down_cast<ASR::symbol_t>(namelist));
                     }
+                    for (size_t i = 0; i < x.n_syms; i++) {
+                        var_list.push_back(al,
+                                           current_scope->resolve_symbol(to_lower(x.m_syms[i].m_name)));
+                    }
+                    ASR::asr_t* namelist = ASR::make_Namelist_t(al,
+                                               attr_namelist->base.base.loc,
+                                               current_scope,
+                                               s2c(al, to_lower(attr_namelist->m_name)),
+                                               var_list.p,
+                                               var_list.n);
+                    current_scope->add_or_overwrite_symbol(s2c(al, to_lower(attr_namelist->m_name)),
+                                              ASR::down_cast<ASR::symbol_t>(namelist));
                 } else if (AST::is_a<AST::AttrBind_t>(*x.m_attributes[i])) {
                     AST::AttrBind_t *attr_bind = AST::down_cast<AST::AttrBind_t>(x.m_attributes[i]);
                     ASR::abiType abi_type = ASR::abiType::Source;
@@ -7093,12 +6881,6 @@ public:
                 bool is_pointer = false;
                 if (assgnd_pointer.count(sym)) {
                     is_pointer = true;
-                }
-                if (assgnd_allocatable.count(sym)) {
-                    is_allocatable = true;
-                }
-                if (assgnd_target.count(sym)) {
-                    target_attr = true;
                 }
                 if (current_scope->get_symbol(sym) !=
                         nullptr) {
@@ -7569,14 +7351,7 @@ public:
                     } else {
                         lhs_type->m_len = char_length;
                     }
-                } else if (s.m_length) {
-                    diag.add(Diagnostic(
-                        "length specifier is only valid for character type",
-                        Level::Error, Stage::Semantic, {
-                            Label("", {s.loc})
-                        }));
-                    throw SemanticAbort();
-                }
+                }                
                 ASR::Variable_t* variable_added_to_symtab = nullptr;
                 if( std::find(excluded_from_symtab.begin(), excluded_from_symtab.end(), sym) == excluded_from_symtab.end() ) {
                     if ( !is_implicitly_declared && !is_external) {
@@ -7748,14 +7523,7 @@ public:
                                                 func_call->m_keywords, func_call->n_keywords,
                                                 sym_found, is_struct_const));
                             } else {
-                                std::string func_name = func_call->m_func ?
-                                    std::string(func_call->m_func) : "function";
-                                diag.add(Diagnostic(
-                                    "Function `" + func_name + "` is not permitted in an initialization expression",
-                                    Level::Error, Stage::Semantic, {
-                                        Label("", {x.base.base.loc})
-                                    }));
-                                throw SemanticAbort();
+                                LCOMPILERS_ASSERT(false);
                             }
                         }
                     } else if (AST::is_a<AST::Name_t>(*s.m_initializer)) {
@@ -7862,6 +7630,17 @@ public:
                                     Level::Error, Stage::Semantic, {
                                         Label("",{x.base.base.loc}),
                                         Label("declared here", {var->base.base.loc}, false)
+                                    }));
+                                throw SemanticAbort();
+                            }
+                            // Check if parameter is a scalar
+                            // TODO: Add support for arrays as well
+                            if (ASRUtils::is_array(var->m_type)) {
+                                diag.add(Diagnostic(
+                                    "Named initialization with array parameter `" + sym_name + "` is not supported yet",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("",{x.base.base.loc}),
+                                        Label("array parameter declared here", {var->base.base.loc}, false)
                                     }));
                                 throw SemanticAbort();
                             }
@@ -7983,8 +7762,7 @@ public:
                         }
                     }
                     if (storage_type == ASR::storage_typeType::Parameter &&
-                        init_expr && ASRUtils::is_array(type) &&
-                        ASRUtils::is_array(ASRUtils::expr_type(init_expr))) {
+                        init_expr && ASRUtils::is_array(type)) {
                         ASR::array_physical_typeType var_ptype = ASRUtils::extract_physical_type(type);
                         ASR::array_physical_typeType init_expr_ptype = ASRUtils::extract_physical_type(
                             ASRUtils::expr_type(init_expr));
@@ -8017,11 +7795,6 @@ public:
                         std::string init_name = to_lower(
                             AST::down_cast<AST::Name_t>(s.m_initializer)->m_id);
                         ASR::symbol_t *init_sym = current_scope->resolve_symbol(init_name);
-                        if (is_derived_type
-                                && init_sym == (ASR::symbol_t*)variable_added_to_symtab
-                                && current_scope->parent) {
-                            init_sym = current_scope->parent->resolve_symbol(init_name);
-                        }
                         bool is_pending_placeholder = false;
                         if (init_sym) {
                             ASR::symbol_t *init_sym_underlying =
@@ -8047,31 +7820,6 @@ public:
                                 init_name, variable_added_to_symtab,
                                 init_resolve_scope,
                                 s.m_initializer->base.loc});
-                            continue;
-                        }
-                        if (is_derived_type && init_sym && variable_added_to_symtab) {
-                            // At this point `init_sym` refers to a symbol in
-                            // the enclosing scope. Bind the component's
-                            // `m_symbolic_value` directly to it and skip the
-                            // generic `visit_expr` path below, which would
-                            // re-resolve `init_name` against `current_scope`
-                            // and pick up the component itself.
-                            ASR::expr_t *init_expr_direct = ASRUtils::EXPR(
-                                ASR::make_Var_t(al, s.m_initializer->base.loc, init_sym));
-                            variable_added_to_symtab->m_symbolic_value = init_expr_direct;
-                            variable_added_to_symtab->m_value = nullptr;
-                            SetChar variable_dependencies_vec;
-                            variable_dependencies_vec.reserve(al, 1);
-                            ASRUtils::collect_variable_dependencies(al,
-                                variable_dependencies_vec,
-                                variable_added_to_symtab->m_type,
-                                variable_added_to_symtab->m_symbolic_value,
-                                variable_added_to_symtab->m_value,
-                                variable_added_to_symtab->m_name);
-                            variable_added_to_symtab->m_dependencies =
-                                variable_dependencies_vec.p;
-                            variable_added_to_symtab->n_dependencies =
-                                variable_dependencies_vec.n;
                             continue;
                         }
                     }
@@ -8601,8 +8349,7 @@ public:
                         }
                     }
                     if (storage_type == ASR::storage_typeType::Parameter) {
-                        if( ASRUtils::is_array(type) && init_expr &&
-                            ASRUtils::is_array(ASRUtils::expr_type(init_expr)) ) {
+                        if( ASRUtils::is_array(type) ) {
                             ASR::array_physical_typeType var_ptype = ASRUtils::extract_physical_type(type);
                             ASR::array_physical_typeType init_expr_ptype = ASRUtils::extract_physical_type(
                                 ASRUtils::expr_type(init_expr));
@@ -9083,7 +8830,6 @@ public:
             new_data_member_names.p, new_data_member_names.size(),
             pdt_final_proc_names.p, pdt_final_proc_names.size(),
             ASR::abiType::Source, dflt_access, false, pdt_struct->m_is_abstract,
-            pdt_struct->m_is_sequence,
             nullptr, 0, nullptr, new_parent, nullptr, 0);
 
         ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(tmp);
@@ -9599,7 +9345,7 @@ public:
                         current_scope = al.make_new<SymbolTable>(parent_scope);
                         ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, current_scope,
                                                         s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
-                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true, false,
+                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
                                                         nullptr, 0, nullptr, nullptr, nullptr, 0);
                         ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
@@ -9868,7 +9614,7 @@ public:
                                 nullptr, nullptr, nullptr, 0, s2c(al, derived_type_name),
                                 ASR::accessType::Private));
                         type_declaration = v;
-                        type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, nullptr, 0, nullptr, 0, false, false));
+                        type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, nullptr, 0, nullptr, 0, true, false));
                         type = ASRUtils::make_Array_t_util(
                             al, loc, type, dims.p, dims.size(), abi, is_argument);
                         if (is_pointer) {
@@ -9904,7 +9650,7 @@ public:
                         SymbolTable *struct_symtab = al.make_new<SymbolTable>(target_scope);
                         ASR::asr_t* dtype = ASR::make_Struct_t(al, loc, struct_symtab,
                                                         s2c(al, to_lower(derived_type_name)), nullptr, nullptr, 0, nullptr, 0,
-                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true, false,
+                                                        nullptr, 0, ASR::abiType::Source, dflt_access, false, true,
                                                         nullptr, 0, nullptr, nullptr, nullptr, 0);
                         ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(dtype);
                         ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, false);
@@ -9996,7 +9742,7 @@ public:
                                 nullptr, 0,
                                 nullptr, 0,
                                 nullptr,
-                                ASR::accessType::Private,
+                                ASR::accessType::Public,
                                 false,
                                 false,
                                 nullptr,
@@ -10004,14 +9750,6 @@ public:
                             )
                         );
                         parent_scope->add_symbol(iface_name, existing);
-                        implicit_interfaces_to_sync.push_back(ASR::down_cast<ASR::Function_t>(existing));
-                    } else {
-                        // Reuse the existing iface function's FunctionType so that
-                        // all variables sharing this iface reference the same object.
-                        // In-place updates to the iface's arg_types will then
-                        // propagate to struct members and dummy arguments alike.
-                        existing = ASRUtils::symbol_get_past_external(existing);
-                        type = ASR::down_cast<ASR::Function_t>(existing)->m_function_signature;
                     }
                     type_declaration = existing;
                 } else {
@@ -11087,7 +10825,7 @@ public:
                 }
             }
             if (type == nullptr) {
-                type = ASRUtils::extract_type(expr_type);
+                type = expr_type;
                 extracted_type = ASRUtils::extract_type(type);
                 if (ASR::is_a<ASR::Tuple_t>(*extracted_type)) {
                      ASR::Tuple_t *t = ASR::down_cast<ASR::Tuple_t>(extracted_type);
@@ -11652,7 +11390,7 @@ public:
     }
 
     ASR::asr_t* create_GenericProcedureWithASTNode(const AST::FuncCallOrArray_t& x,
-                Vec<ASR::call_arg_t>& args, ASR::symbol_t *v, bool is_dt_present=false) {
+                Vec<ASR::call_arg_t>& args, ASR::symbol_t *v) {
         const Location& loc = x.base.base.loc;
         if (ASR::is_a<ASR::ExternalSymbol_t>(*v)) {
             return symbol_resolve_external_generic_procedure_with_ast_node(x, v,
@@ -11664,14 +11402,8 @@ public:
                             diag.add(Diagnostic(msg, Level::Error, Stage::Semantic, {Label("", {loc})}));
                             throw SemanticAbort();
                         },
-                    false, is_dt_present);
+                    false);
             if( idx == -1 ) {
-                ASR::symbol_t* tmp_v = current_scope->resolve_symbol(std::string(x.m_func));
-                if (tmp_v && ASR::is_a<ASR::Struct_t>(*ASRUtils::symbol_get_past_external(tmp_v))) {
-                    return create_DerivedTypeConstructor(x.base.base.loc, x.m_args, x.n_args,
-                        x.m_keywords, x.n_keywords, tmp_v);
-                }
-
                 bool is_function = true;
                 v = intrinsic_as_node(x, is_function);
                 if( !is_function ) {
@@ -11684,30 +11416,13 @@ public:
             ASR::ttype_t *type = nullptr;
             ASR::symbol_t *cp_s = nullptr;
             ASR::symbol_t *final_sym_past_ext = ASRUtils::symbol_get_past_external(final_sym);
-            bool is_nopass_method = false;
             if (ASR::is_a<ASR::StructMethodDeclaration_t>(*final_sym_past_ext)) {
-                is_nopass_method = ASR::down_cast<ASR::StructMethodDeclaration_t>(
-                    final_sym_past_ext)->m_is_nopass;
                 cp_s = ASRUtils::import_class_procedure(al, x.base.base.loc,
                     final_sym_past_ext, current_scope);
                 final_sym = ASR::down_cast<ASR::StructMethodDeclaration_t>(final_sym_past_ext)->m_proc;
             }
             LCOMPILERS_ASSERT(ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(final_sym)))
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(final_sym));
-            // For a `nopass` specific selected from a type-bound generic call,
-            // `args[0]` is the passed-object, which a nopass procedure does not
-            // accept as an argument. Drop it so the actual arguments line up
-            // with the procedure's dummy arguments.
-            ASR::expr_t* passed_object = nullptr;
-            if (is_nopass_method && is_dt_present && args.size() >= 1) {
-                passed_object = args[0].m_value;
-                Vec<ASR::call_arg_t> args_no_dt;
-                args_no_dt.reserve(al, args.size() - 1);
-                for (size_t i = 1; i < args.size(); i++) {
-                    args_no_dt.push_back(al, args[i]);
-                }
-                args = args_no_dt;
-            }
             ASR::expr_t* first_array_arg = ASRUtils::find_first_array_arg_if_elemental(func, args);
             if (first_array_arg) {
                 ASR::dimension_t* array_dims;
@@ -11728,16 +11443,6 @@ public:
                 }
                 ASRUtils::insert_module_dependency(cp_s, al, current_module_dependencies);
                 ASRUtils::insert_module_dependency(final_sym, al, current_module_dependencies);
-                if (is_nopass_method) {
-                    // The passed-object has already been dropped from `args`, so
-                    // the call arguments map directly onto the procedure's args.
-                    validate_missing_required_arguments(loc, args, func);
-                    ASRUtils::set_absent_optional_arguments_to_null(args, func, al);
-                    return ASRUtils::make_FunctionCall_t_util(al, loc,
-                        cp_s, nullptr, args.p, args.size(), type,
-                        nullptr, passed_object, current_scope, current_function_dependencies,
-                        compiler_options.implicit_argument_casting);
-                }
                 Vec<ASR::call_arg_t> args_without_dt; args_without_dt.reserve(al, args.size() - 1);
                 for (size_t i = 1; i < args.size(); i++) {
                     args_without_dt.push_back(al, args[i]);
@@ -12387,34 +12092,6 @@ public:
                 ASR::Variable_t* dummy_var = ASR::down_cast<ASR::Variable_t>(dummy_sym);
                 dummy_name = dummy_var->m_name;
                 is_required = dummy_var->m_presence != ASR::presenceType::Optional;
-                if (i < args.size() && args[i].m_value != nullptr) {
-                    ASR::ttype_t* dummy_type = dummy_var->m_type;
-                    ASR::ttype_t* actual_type = ASRUtils::expr_type(args[i].m_value);
-                    // An assumed-size actual has no extent for its last
-                    // dimension, so it cannot be associated with a dummy
-                    // that needs the full shape: a pointer/allocatable dummy
-                    // (covers assumed-rank pointer/allocatable, which has no
-                    // dimensions) or an assumed-shape dummy (empty dimensions
-                    // lowered to a descriptor). Empty dimensions alone are not
-                    // enough: assumed-size dummies and implicit-interface
-                    // dummies also carry empty dimensions but legally accept
-                    // assumed-size actuals, as do plain assumed-rank dummies.
-                    if (ASRUtils::is_array(actual_type) && ASRUtils::is_array(dummy_type) &&
-                            ASRUtils::extract_physical_type(actual_type) ==
-                                ASR::array_physical_typeType::UnboundedPointerArray &&
-                            (ASRUtils::is_pointer(dummy_type) ||
-                             ASRUtils::is_allocatable(dummy_type) ||
-                             (ASRUtils::is_dimension_empty(dummy_type) &&
-                              ASRUtils::extract_physical_type(dummy_type) ==
-                                  ASR::array_physical_typeType::DescriptorArray))) {
-                        diag.add(diag::Diagnostic(
-                            "actual argument for '" + dummy_name +
-                            "' cannot be an assumed-size array",
-                            diag::Level::Error, diag::Stage::Semantic, {
-                                diag::Label("", {args[i].m_value->base.loc})}));
-                        throw SemanticAbort();
-                    }
-                }
             } else if (ASR::is_a<ASR::Function_t>(*dummy_sym)) {
                 dummy_name = ASR::down_cast<ASR::Function_t>(dummy_sym)->m_name;
                 is_required = true;
@@ -12508,7 +12185,8 @@ public:
             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(f2);
             if (ASRUtils::is_intrinsic_procedure(f)) {
                 value = intrinsic_procedures.comptime_eval(f->m_name, al, loc, args, compiler_options);
-                char *mod = ASR::down_cast<ASR::ExternalSymbol_t>(v)->m_module_name;
+                char *mod = ASR::down_cast<ASR::ExternalSymbol_t>(
+                    current_scope->resolve_symbol(f->m_name))->m_module_name;
                 current_module_dependencies.push_back(al, mod);
             }
         }
@@ -12704,7 +12382,7 @@ public:
             return create_FunctionFromFunctionTypeVariable(x.base.base.loc, new_args, v, is_dt_present);
         } else {
             LCOMPILERS_ASSERT(ASR::is_a<ASR::GenericProcedure_t>(*f2));
-            return create_GenericProcedureWithASTNode(x, new_args, v, is_dt_present);
+            return create_GenericProcedureWithASTNode(x, new_args, v);
         }
     }
 
@@ -12783,39 +12461,6 @@ public:
             diag.add(Diagnostic("Variable '" + dt_name + "' not declared",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
-        }
-        if (ASR::is_a<ASR::Struct_t>(*ASRUtils::symbol_get_past_external(v))) {
-            // `dt_name` names a parent type accessed as a component, as in
-            // `obj%parent_type_name%member` where the enclosing derived type
-            // extends `parent_type_name`. Resolve `var_name` as a member of
-            // this derived type, searching its parent types as well.
-            ASR::Struct_t* par_der_type = ASR::down_cast<ASR::Struct_t>(
-                ASRUtils::symbol_get_past_external(v));
-            ASR::symbol_t* member = nullptr;
-            while( par_der_type != nullptr && member == nullptr ) {
-                scope = par_der_type->m_symtab;
-                member = par_der_type->m_symtab->get_symbol(var_name);
-                if( par_der_type->m_parent != nullptr ) {
-                    ASR::symbol_t* parent_sym = ASRUtils::symbol_get_past_external(par_der_type->m_parent);
-                    par_der_type = ASR::down_cast<ASR::Struct_t>(parent_sym);
-                    if (par_der_type->m_name == var_name) {
-                        member = parent_sym;
-                    }
-                } else {
-                    par_der_type = nullptr;
-                }
-            }
-            if( member == nullptr ) {
-                diag.add(Diagnostic("Variable '" + dt_name + "' doesn't have any member named, '" + var_name + "'.",
-                    Level::Error, Stage::Semantic, {Label("", {loc})}));
-                throw SemanticAbort();
-            }
-            ASR::asr_t* v_var = ASR::make_Var_t(al, loc, v);
-            ASR::asr_t* expr_ = (ASR::asr_t*) ASRUtils::getStructInstanceMember_t(
-                al, loc, v_var, nullptr, member, current_scope);
-            make_ArrayItem_from_struct_m_args(
-                member_struct_m_args, member_struct_n_args, ASRUtils::EXPR(expr_), expr_, loc);
-            return expr_;
         }
         ASR::Variable_t* v_variable = ASR::down_cast<ASR::Variable_t>(ASRUtils::symbol_get_past_external(v));
         ASR::ttype_t* v_variable_m_type = ASRUtils::duplicate_type(al, ASRUtils::extract_type(v_variable->m_type));
@@ -13113,15 +12758,6 @@ public:
             args.push_back(al, nullptr);
         }
         for( size_t i = 0; i < x.n_args; i++ ) {
-            if (x.m_args[i].m_end == nullptr && x.m_args[i].m_label != 0) {
-                diag.add(diag::Diagnostic(
-                    "Alternate return arguments are not permitted in calls to the '" +
-                    intrinsic_name + "' intrinsic.",
-                    diag::Level::Error, diag::Stage::Semantic, {
-                        diag::Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
-            }
-            LCOMPILERS_ASSERT(x.m_args[i].m_end != nullptr);
             // Handle BOZ constants in real() function
             ASR::ttype_t* temp_current_variable_type = current_variable_type_;
             if (intrinsic_name == "real" && i == 0 && x.m_args[i].m_end && 
@@ -13162,8 +12798,7 @@ public:
                         temp = ASRUtils::EXPR(array_cast);
                     } else if (!(intrinsic_name == "size" || intrinsic_name == "lbound" || intrinsic_name == "ubound" || 
                         intrinsic_name == "rank" || intrinsic_name == "shape" || intrinsic_name == "is_contiguous" || 
-                        intrinsic_name == "associated" || intrinsic_name == "allocated" || intrinsic_name == "present" ||
-                        intrinsic_name == "storage_size" || intrinsic_name == "same_type_as" || intrinsic_name == "extends_type_of")) {
+                        intrinsic_name == "associated" || intrinsic_name == "allocated" || intrinsic_name == "present")) {
                         diag.semantic_error_label("Assumed rank arrays cannot be used as arguments to intrinsics",
                             {arg_expr->base.loc}, "");
                         throw SemanticAbort();
@@ -14858,77 +14493,72 @@ public:
                 }
                 int64_t result_size = 64; // Fallback for runtime-sized sources
                 ASR::expr_t* result_size_expr = nullptr;
-                
-                // Declare our type safely once for this scope
-                ASR::ttype_t *local_int_type = ASRUtils::TYPE(ASR::make_Integer_t(
-                    al, x.base.base.loc, compiler_options.po.default_integer_kind));
-
-                // 1. Compute mold byte size or build an expression for it
-                ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
-                    ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
-                int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
-                ASR::expr_t* mold_bytes_expr = nullptr;
-
-                if (ASR::is_a<ASR::String_t>(*mold_elem_type)) {
-                    ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
-                    if (mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len)) {
-                        int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
-                            ASRUtils::expr_value(mold_str_type->m_len))->m_n;
-                        mold_bytes = mold_bytes * str_len;
-                    } else {
-                        mold_bytes = -1; // Runtime-sized string
-                        if (mold_str_type->m_len) {
-                            mold_bytes_expr = mold_str_type->m_len;
+                if( src_bytes > 0 ) {
+                    ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
+                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
+                    int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
+                    // For character types: mold_bytes = kind * length
+                    if( ASR::is_a<ASR::String_t>(*mold_elem_type) ) {
+                        ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
+                        if( mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len) ) {
+                            int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
+                                ASRUtils::expr_value(mold_str_type->m_len))->m_n;
+                            mold_bytes = mold_bytes * str_len;
                         } else {
-                            mold_bytes_expr = ASRUtils::EXPR(ASR::make_StringLen_t(
-                                al, x.base.base.loc, mold, local_int_type, nullptr));
+                            mold_bytes = -1; // Runtime-sized string
                         }
                     }
-                }
-
-                // 2. Ensure we have an expression for the source size if needed
-                if (src_bytes > 0 && !src_len_expr) {
-                    src_len_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x.base.base.loc, src_bytes, local_int_type));
-                }
-
-                // 3. Compute result_size (constant) or result_size_expr (runtime)
-                if (mold_bytes > 0) {
-                    mold_bytes_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x.base.base.loc, mold_bytes, local_int_type));
-                    if (src_bytes > 0) {
+                    if( mold_bytes > 0 ) {
                         result_size = (src_bytes + mold_bytes - 1) / mold_bytes;
                     }
+                } else if( src_len_expr ) {
+                    // For runtime-sized strings with known length expression, use it
+                    ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
+                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
+                    int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
+                    // For character types: mold_bytes = kind * length
+                    if( ASR::is_a<ASR::String_t>(*mold_elem_type) ) {
+                        ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
+                        if( mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len) ) {
+                            int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
+                                ASRUtils::expr_value(mold_str_type->m_len))->m_n;
+                            mold_bytes = mold_bytes * str_len;
+                        } else {
+                            mold_bytes = -1;
+                        }
+                    }
+                    if( mold_bytes > 0 ) {
+                        // Calculate: ceiling(src_len_expr / mold_bytes)
+                        // = (src_len_expr + mold_bytes - 1) / mold_bytes
+                        ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(
+                            al, x.base.base.loc, compiler_options.po.default_integer_kind));
+                        ASR::expr_t* mold_bytes_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                            al, x.base.base.loc, mold_bytes, int_type));
+                        ASR::expr_t* mold_bytes_minus_one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                            al, x.base.base.loc, mold_bytes - 1, int_type));
+                        ASR::expr_t* numerator = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                            al, x.base.base.loc, src_len_expr, ASR::binopType::Add,
+                            mold_bytes_minus_one, int_type, nullptr));
+                        result_size_expr = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                            al, x.base.base.loc, numerator, ASR::binopType::Div,
+                            mold_bytes_expr, int_type, nullptr));
+                    }
                 }
-
-                if ((src_bytes <= 0 || mold_bytes <= 0) && src_len_expr && mold_bytes_expr) {
-                    // Calculate runtime dimension: ceiling(src_len_expr / mold_bytes_expr)
-                    // = (src_len_expr + mold_bytes_expr - 1) / mold_bytes_expr
-                    ASR::expr_t* one_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x.base.base.loc, 1, local_int_type));
-                    ASR::expr_t* mold_bytes_minus_one = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                        al, x.base.base.loc, mold_bytes_expr, ASR::binopType::Sub,
-                        one_expr, local_int_type, nullptr));
-                    ASR::expr_t* numerator = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                        al, x.base.base.loc, src_len_expr, ASR::binopType::Add,
-                        mold_bytes_minus_one, local_int_type, nullptr));
-                    result_size_expr = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                        al, x.base.base.loc, numerator, ASR::binopType::Div,
-                        mold_bytes_expr, local_int_type, nullptr));
-                }
-
+                ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(
+                    al, x.base.base.loc, compiler_options.po.default_integer_kind));
                 ASR::dimension_t size_dim;
                 size_dim.loc = x.base.base.loc;
                 size_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                    al, x.base.base.loc, 1, local_int_type));
+                    al, x.base.base.loc, 1, int_type));
                 if( result_size_expr ) {
                     size_dim.m_length = result_size_expr;
                 } else {
                     size_dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x.base.base.loc, result_size, local_int_type));
+                        al, x.base.base.loc, result_size, int_type));
                 }
                 new_dims.push_back(al, size_dim);
-                
+            }
+        }
         ASR::ttype_t* type = ASRUtils::type_get_past_allocatable(ASRUtils::duplicate_type(al, ASRUtils::expr_type(mold), &new_dims));
         ASR::expr_t *transfer_value = nullptr, *source_value = ASRUtils::expr_value(source),
             *mold_value = ASRUtils::expr_value(mold), *size_value = nullptr;
@@ -15520,7 +15150,7 @@ public:
 
     void is_coarray_or_atomic(std::string intrinsic_name, const Location& loc){
         std::vector<std::string> coarray_intrinsics, atomic_intrinsics;
-        coarray_intrinsics = {"co_reduce", "lcobound", "ucobound", "failed_images",
+        coarray_intrinsics = {"co_broadcast", "co_max", "co_min", "co_reduce", "lcobound", "ucobound", "failed_images",
             "image_status", "get_team", "image_index", "stopped_images", "team_number", "coshape", "corank",
             "event_query"};
         atomic_intrinsics = {"atomic_add", "atomic_and", "atomic_cas", "atomic_define", "atomic_fetch_add", "atomic_fetch_and",
@@ -15559,39 +15189,6 @@ public:
     {
         ASR::expr_t* first_arg_ = ASRUtils::expr_value(args[array_indices_in_args[0]]);
         size_t max_array_size = ASRUtils::get_fixed_size_of_array(ASRUtils::expr_type(first_arg_));
-        if (max_array_size == 0) {
-            Vec<ASR::expr_t*> dummy_args;
-            dummy_args.reserve(al, args.size());
-            bool can_create_dummy = true;
-            for (size_t j = 0; j < args.size(); j++) {
-                if (std::find(array_indices_in_args.begin(), array_indices_in_args.end(), j) != array_indices_in_args.end()) {
-                    ASR::expr_t* arg_ = ASRUtils::expr_value(args[j]);
-                    ASR::ttype_t* s_type = ASRUtils::type_get_past_array(ASRUtils::expr_type(arg_));
-                    ASR::expr_t* dummy_val = ASRUtils::get_constant_zero_with_given_type(al, s_type);
-                    if (!dummy_val) {
-                        can_create_dummy = false;
-                        break;
-                    }
-                    dummy_args.push_back(al, dummy_val);
-                } else {
-                    dummy_args.push_back(al, args[j]);
-                }
-            }
-            if (can_create_dummy) {
-                ASR::asr_t* dummy_res = create_func(al, loc, dummy_args, diag);      
-                if (dummy_res) {
-                    ASR::expr_t* res_expr = ASRUtils::expr_value(ASRUtils::EXPR(dummy_res));
-                    ASR::ttype_t* res_type = ASRUtils::expr_type(res_expr);
-                    ASR::Array_t* orig_arr_type = ASR::down_cast<ASR::Array_t>((*result_array)->m_type);
-                    ASR::ttype_t* correct_type = ASRUtils::make_Array_t_util(al, orig_arr_type->base.base.loc,
-                                                res_type, orig_arr_type->m_dims,     
-                                                orig_arr_type->n_dims, ASR::abiType::Source, false,
-                                                orig_arr_type->m_physical_type);     
-                    (*result_array)->m_type = correct_type;
-                }
-            }
-            return;
-        }
         ASR::ttype_t* array_type = ASRUtils::expr_type(first_arg_);
         Vec<ASR::expr_t*> new_expr; new_expr.reserve(al, max_array_size);
 
@@ -15896,51 +15493,11 @@ public:
         return resolve_intrinsic_function(x.base.base.loc, var_name);
     }
 
-    bool struct_has_descriptor_string_member(ASR::expr_t* expr) {
-        ASR::ttype_t* type = ASRUtils::expr_type(expr);
-        type = ASRUtils::type_get_past_array(
-                   ASRUtils::type_get_past_allocatable(
-                       ASRUtils::type_get_past_pointer(type)));
-        if (!ASR::is_a<ASR::StructType_t>(*type)) return false;
-        ASR::symbol_t* struct_sym = ASRUtils::symbol_get_past_external(
-            ASRUtils::get_struct_sym_from_struct_expr(expr));
-        if (struct_sym && ASR::is_a<ASR::Struct_t>(*struct_sym)) {
-            ASR::Struct_t* st_sym = ASR::down_cast<ASR::Struct_t>(struct_sym);
-            // bind(C) and SEQUENCE types have a defined storage layout,
-            // so c_loc is allowed without warning.
-            if (st_sym->m_abi == ASR::abiType::BindC) return false;
-            if (st_sym->m_is_sequence) return false;
-        }
-        ASR::StructType_t* st = ASR::down_cast<ASR::StructType_t>(type);
-        for (size_t i = 0; i < st->n_data_member_types; i++) {
-            ASR::ttype_t* mt = ASRUtils::type_get_past_array(
-                                   ASRUtils::type_get_past_allocatable(
-                                       ASRUtils::type_get_past_pointer(
-                                           st->m_data_member_types[i])));
-            if (ASR::is_a<ASR::String_t>(*mt)) return true;
-        }
-        return false;
-    }
-
     ASR::asr_t* create_PointerToCptr(const AST::FuncCallOrArray_t& x) {
         Vec<ASR::expr_t*> args;
         std::vector<std::string> kwarg_names = {"X"};
         handle_intrinsic_node_args(x, args, kwarg_names, 1, 1, std::string("c_loc"));
         ASR::expr_t *v_Var = args[0];
-        if (struct_has_descriptor_string_member(v_Var)) {
-            diag.semantic_warning_label(
-                "c_loc() on a non-bind(C)/non-SEQUENCE derived type containing a "
-                "character component is not portable",
-                {x.base.base.loc},
-                "LFortran represents fixed-length character components as a "
-                "descriptor (pointer + length); the in-memory layout differs "
-                "from the standard inline layout used by gfortran/flang. "
-                "Code that relies on this layout (e.g. memcpy via storage_size, "
-                "raw bytewise transfer) will not behave portably. "
-                "Use SEQUENCE (or bind(C) with interoperable components) for "
-                "a defined contiguous layout."
-            );
-        }
         if( !ASR::is_a<ASR::GetPointer_t>(*v_Var) &&
             !ASRUtils::is_pointer(ASRUtils::expr_type(v_Var)) ) {
             ASR::ttype_t* ptr_type = ASRUtils::make_Pointer_t_util(al, x.base.base.loc,
@@ -16470,9 +16027,9 @@ public:
     }
 
     bool is_compiletime_implied_do_loop(ASR::ImpliedDoLoop_t* idl, std::vector<ASR::symbol_t*>& loop_vars) {
-        if ((!ASRUtils::is_value_constant(ASRUtils::expr_value(idl->m_start)) && !contains_loop_vars(idl->m_start, loop_vars)) ||
-            (!ASRUtils::is_value_constant(ASRUtils::expr_value(idl->m_end)) && !contains_loop_vars(idl->m_end, loop_vars)) ||
-            (idl->m_increment != nullptr && !ASRUtils::is_value_constant(ASRUtils::expr_value(idl->m_increment)) && !contains_loop_vars(idl->m_increment, loop_vars))) {
+        if ((!ASRUtils::is_value_constant(idl->m_start) && !contains_loop_vars(idl->m_start, loop_vars)) ||
+            (!ASRUtils::is_value_constant(idl->m_end) && !contains_loop_vars(idl->m_end, loop_vars)) ||
+            (idl->m_increment != nullptr && !ASRUtils::is_value_constant(idl->m_increment) && !contains_loop_vars(idl->m_increment, loop_vars))) {
             return false;
         }
 
@@ -16483,7 +16040,7 @@ public:
                     return false;
                 }
             }
-            if (!ASRUtils::is_value_constant(ASRUtils::expr_value(expr))) {
+            if (!ASRUtils::is_value_constant(expr)) {
                 // may be possible that it contains a loop variable
                 if (!contains_loop_vars(expr, loop_vars)) {
                     return false;
@@ -16516,11 +16073,6 @@ public:
             res = ASR::down_cast<ASR::IntegerConstant_t>(visitor.value)->m_n;
         } else if constexpr (std::is_same_v<T,float> || std::is_same_v<T,double>) {
             res = ASR::down_cast<ASR::RealConstant_t>(visitor.value)->m_r;
-        } else if constexpr (std::is_same_v<T,std::complex<float>>
-                || std::is_same_v<T,std::complex<double>>) {
-            ASR::ComplexConstant_t* cc =
-                ASR::down_cast<ASR::ComplexConstant_t>(visitor.value);
-            res = T(cc->m_re, cc->m_im);
         } else if constexpr (std::is_same_v<T,char*>) {
             res = ASR::down_cast<ASR::StringConstant_t>(visitor.value)->m_s;
         }
@@ -16574,18 +16126,6 @@ public:
                 if (ASR::is_a<ASR::ImpliedDoLoop_t>(*idl->m_values[i])) {
                     curr_nesting_level++;
                     populate_compiletime_array_for_idl(ASR::down_cast<ASR::ImpliedDoLoop_t>(idl->m_values[i]), array, loop_vars, loop_indices, curr_nesting_level, itr);
-                } else if (ASRUtils::is_array(ASRUtils::expr_type(idl->m_values[i]))) {
-                    int64_t n_elements = ASRUtils::get_fixed_size_of_array(ASRUtils::expr_type(idl->m_values[i]));
-                    if (n_elements <= 0) {
-                        n_elements = 1;
-                    }
-                    
-                    for (int64_t element_idx = 0; element_idx < n_elements; ++element_idx) {
-                        ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
-                        visitor.element_idx = element_idx;
-                        array.push_back(al, get_constant_value<T>(idl->m_values[i], visitor));
-                        itr++;
-                    }
                 } else {
                     ImpliedDoLoopValuesVisitor visitor(al, loop_vars, loop_indices, nullptr, idl->m_type, diag);
                     array.push_back(al, get_constant_value<T>(idl->m_values[i], visitor));
@@ -16748,26 +16288,6 @@ public:
                                         Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
                     throw SemanticAbort();
                 }
-            } else if (ASRUtils::is_complex(*type)) {
-                // Complex ArrayConstant stores elements as pairs [re, im] in
-                // contiguous memory (see set_data_complex in asr_utils.h and
-                // fetch_ArrayConstant_value). std::complex<T> is guaranteed to
-                // be layout-compatible with T[2] (C++11 [complex.numbers.general]),
-                // so we can feed the raw buffer directly to ArrayConstant.
-                int kind = ASRUtils::extract_kind_from_ttype_t(type);
-                if (kind == 4) {
-                    Vec<std::complex<float>> array; array.reserve(al, 1);
-                    populate_compiletime_array_for_idl(idl, array, loop_vars, loop_indices, curr_nesting_level, itr);
-                    data = &array.p[0];
-                } else if (kind == 8) {
-                    Vec<std::complex<double>> array; array.reserve(al, 1);
-                    populate_compiletime_array_for_idl(idl, array, loop_vars, loop_indices, curr_nesting_level, itr);
-                    data = &array.p[0];
-                } else {
-                    diag.add(Diagnostic("Unsupported kind for complex type in compiletime evaluation of implied do loop",
-                                        Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                    throw SemanticAbort();
-                }
             }
             // Add Support for Character Type in Implied Do Loop
             else if (ASRUtils::is_character(*type)){
@@ -16796,12 +16316,11 @@ public:
                 if (ASRUtils::is_character(*type)) {
                     physical_type = ASR::array_physical_typeType::PointerArray;
                 }
-                ASR::ttype_t* base_type = ASRUtils::extract_type(type);
-                ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, x.base.base.loc, base_type, dims.p, dims.n, physical_type));
-                int64_t n_data = itr * ASRUtils::extract_kind_from_ttype_t(base_type);
-                if (ASRUtils::is_character(*base_type)) {
+                ASR::ttype_t* array_type = ASRUtils::TYPE(ASR::make_Array_t(al, x.base.base.loc, type, dims.p, dims.n, physical_type));
+                int64_t n_data = itr * ASRUtils::extract_kind_from_ttype_t(type);
+                if (ASRUtils::is_character(*type)) {
                     int len;
-                    if(!ASRUtils::extract_value(ASR::down_cast<ASR::String_t>(base_type)->m_len, len)){
+                    if(!ASRUtils::extract_value(ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(type))->m_len, len)){
                         LCOMPILERS_ASSERT(false);
                     }
                     n_data = itr * len;
@@ -16985,9 +16504,8 @@ public:
             }
         }
         // if v is a function which has null pointer return type, give error
-        ASR::symbol_t *v_past_ext = v ? ASRUtils::symbol_get_past_external(v) : nullptr;
-        if (v_past_ext && ASR::is_a<ASR::Function_t>(*v_past_ext)){
-            ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(v_past_ext);
+        if (ASR::is_a<ASR::Function_t>(*v)){
+            ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(v);
             if (func->m_return_var == nullptr){
                 diag.add(Diagnostic("Subroutine `" + var_name + "` called as a function",
                                     Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
@@ -17210,15 +16728,14 @@ public:
         if (ASR::is_a<ASR::Function_t>(*f2)) {
             ASR::Function_t *f = ASR::down_cast<ASR::Function_t>(f2);
             if (ASRUtils::is_intrinsic_procedure(f)) {
-                std::string orig_name = f->m_name;
-                if (intrinsic_module_procedures_as_asr_nodes.find(orig_name) != intrinsic_module_procedures_as_asr_nodes.end()) {
-                    if (orig_name == "c_loc") {
+                if (intrinsic_module_procedures_as_asr_nodes.find(var_name) != intrinsic_module_procedures_as_asr_nodes.end()) {
+                    if (var_name == "c_loc") {
                         tmp = create_PointerToCptr(x);
-                    } else if (orig_name == "c_associated") {
+                    } else if (var_name == "c_associated") {
                         tmp = create_Associated(x);
-                    } else if (orig_name == "c_funloc") {
+                    } else if (var_name == "c_funloc") {
                         tmp = create_PointerToCptr(x);
-                    } else if (orig_name == "c_sizeof") {
+                    } else if (var_name == "c_sizeof") {
                         tmp = create_CSizeOf(x);
                     } else {
                         LCOMPILERS_ASSERT(false)
@@ -18188,8 +17705,8 @@ public:
                 if (ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(arg_type))) {
                     type_subs[param].second = type_declaration;
                 }
-            } else if (AST::is_a<AST::AttrName_t>(*args[i])) {
-                AST::AttrName_t *attr_name = AST::down_cast<AST::AttrName_t>(args[i]);
+            } else if (AST::is_a<AST::AttrNamelist_t>(*args[i])) {
+                AST::AttrNamelist_t *attr_name = AST::down_cast<AST::AttrNamelist_t>(args[i]);
                 std::string arg = to_lower(attr_name->m_name);
                 if (ASR::is_a<ASR::Function_t>(*param_sym)) {
                     // Handling functions passed as instantiate's arguments
@@ -19544,15 +19061,12 @@ public:
     // Create or update an implicit interface for a procedure variable.
     // If proc_var->m_type_declaration already points to a Function_t,
     // updates it in place; otherwise creates a new interface symbol.
-    // If owner_scope is provided, also updates the containing function's
-    // FunctionType arg_types to reflect the resolved procedure type.
     // Returns the resulting FunctionType.
     ASR::ttype_t* create_or_update_implicit_interface(
             ASR::Variable_t* proc_var, const Location& loc,
             ASR::ttype_t** arg_type_arr, size_t n_arg_types,
             ASR::ttype_t* return_type, SymbolTable* parent_scope,
-            const std::string& var_name,
-            SymbolTable* owner_scope = nullptr) {
+            const std::string& var_name) {
         bool update_existing = proc_var->m_type_declaration != nullptr &&
             ASR::is_a<ASR::Function_t>(*ASRUtils::symbol_get_past_external(
                 proc_var->m_type_declaration));
@@ -19602,29 +19116,18 @@ public:
             fn_scope->add_symbol(rv_name, rv_sym);
             return_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, rv_sym));
         }
-        ASR::ttype_t* iface_type;
+        ASR::ttype_t* iface_type = ASRUtils::TYPE(ASR::make_FunctionType_t(
+            al, loc, arg_types_vec.p, arg_types_vec.size(), return_type,
+            ASR::abiType::BindC, ASR::deftypeType::Interface, nullptr,
+            false, false, false, false, false, nullptr, 0, false));
         if (update_existing) {
-            // Update the existing FunctionType in-place and share the source
-            // arg_types array directly (not a copy). This is critical for
-            // cross-scope type propagation: when contained functions' bodies
-            // are processed after the calling scope's body, in-place updates
-            // to the source array elements propagate to the iface automatically.
             existing_fn->m_symtab = fn_scope;
             fn_scope->asr_owner = (ASR::asr_t*)existing_fn;
-            ASR::FunctionType_t* existing_ft = ASR::down_cast<ASR::FunctionType_t>(
-                existing_fn->m_function_signature);
-            existing_ft->m_arg_types = arg_type_arr;
-            existing_ft->n_arg_types = n_arg_types;
-            existing_ft->m_return_var_type = return_type;
-            iface_type = existing_fn->m_function_signature;
+            existing_fn->m_function_signature = iface_type;
             existing_fn->m_args = args.p;
             existing_fn->n_args = args.size();
             existing_fn->m_return_var = return_var;
         } else {
-            iface_type = ASRUtils::TYPE(ASR::make_FunctionType_t(
-                al, loc, arg_types_vec.p, arg_types_vec.size(), return_type,
-                ASR::abiType::BindC, ASR::deftypeType::Interface, nullptr,
-                false, false, false, false, false, nullptr, 0, false));
             ASR::symbol_t* iface = ASR::down_cast<ASR::symbol_t>(
                 ASR::make_Function_t(
                     al, loc, fn_scope, s2c(al, iface_name),
@@ -19633,38 +19136,12 @@ public:
                     nullptr, nullptr, nullptr));
             parent_scope->add_or_overwrite_symbol(iface_name, iface);
             proc_var->m_type_declaration = iface;
-            existing_fn = ASR::down_cast<ASR::Function_t>(iface);
         }
-        implicit_interfaces_to_sync.push_back(existing_fn);
         if (ASRUtils::is_pointer(proc_var->m_type)) {
             proc_var->m_type = ASRUtils::TYPE(
                 ASR::make_Pointer_t(al, loc, iface_type));
         } else {
             proc_var->m_type = iface_type;
-        }
-        // If owner_scope is provided, update the containing function's
-        // FunctionType arg_types so the resolved type propagates when
-        // the owner function is passed as an argument elsewhere.
-        if (owner_scope && owner_scope->asr_owner &&
-                ASR::is_a<ASR::symbol_t>(*owner_scope->asr_owner)) {
-            ASR::symbol_t* owner_sym = ASR::down_cast<ASR::symbol_t>(
-                owner_scope->asr_owner);
-            if (ASR::is_a<ASR::Function_t>(*owner_sym)) {
-                ASR::Function_t* owner_func = ASR::down_cast<ASR::Function_t>(owner_sym);
-                ASR::FunctionType_t* owner_ft = ASR::down_cast<ASR::FunctionType_t>(
-                    owner_func->m_function_signature);
-                ASR::symbol_t* proc_sym = owner_scope->get_symbol(proc_var->m_name);
-                for (size_t idx = 0; idx < owner_func->n_args; idx++) {
-                    if (ASR::is_a<ASR::Var_t>(*owner_func->m_args[idx])) {
-                        ASR::symbol_t* arg_sym = ASR::down_cast<ASR::Var_t>(
-                            owner_func->m_args[idx])->m_v;
-                        if (arg_sym == proc_sym) {
-                            owner_ft->m_arg_types[idx] = iface_type;
-                            break;
-                        }
-                    }
-                }
-            }
         }
         return iface_type;
     }
@@ -19682,8 +19159,27 @@ public:
         std::string var_name = proc_var->m_name;
         ASR::ttype_t* iface_type = create_or_update_implicit_interface(
             proc_var, loc, func_type->m_arg_types, func_type->n_arg_types,
-            return_type, parent_scope, var_name, current_scope);
-        (void)iface_type;
+            return_type, parent_scope, var_name);
+        // Update the arg type in the containing function's signature
+        ASR::symbol_t* proc_sym = current_scope->get_symbol(proc_var->m_name);
+        if (proc_sym && current_scope->asr_owner &&
+                ASR::is_a<ASR::symbol_t>(*current_scope->asr_owner) &&
+                ASR::is_a<ASR::Function_t>(*ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner))) {
+            ASR::Function_t* owner_func = ASR::down_cast<ASR::Function_t>(
+                ASR::down_cast<ASR::symbol_t>(current_scope->asr_owner));
+            ASR::FunctionType_t* owner_ft = ASR::down_cast<ASR::FunctionType_t>(
+                owner_func->m_function_signature);
+            for (size_t i = 0; i < owner_func->n_args; i++) {
+                if (ASR::is_a<ASR::Var_t>(*owner_func->m_args[i])) {
+                    ASR::symbol_t* arg_sym = ASR::down_cast<ASR::Var_t>(
+                        owner_func->m_args[i])->m_v;
+                    if (arg_sym == proc_sym) {
+                        owner_ft->m_arg_types[i] = iface_type;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     void visit_expr_list(AST::fnarg_t *ast_list, size_t n, Vec<ASR::call_arg_t>& call_args) {
@@ -20938,13 +20434,7 @@ public:
                 );
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));
         } else if (ASR::is_a<ASR::Variable_t>(*t)) {
-            ASR::symbol_t* existing = current_scope->get_symbol(local_sym);
-            if (existing != nullptr) {
-                existing = ASRUtils::symbol_get_past_external(existing);
-                ASR::symbol_t* incoming = ASRUtils::symbol_get_past_external(t);
-                if (existing == incoming) {
-                    return;
-                }
+            if (current_scope->get_symbol(local_sym) != nullptr) {
                 diag.add(Diagnostic(
                     "Symbol '" + local_sym + "' from module '" + m->m_name + "' shadows '" + local_sym + "' in the current scope",
                     Level::Warning, Stage::Semantic, {
@@ -21034,16 +20524,6 @@ public:
                 m->m_name, nullptr, 0, mtemp->m_name,
                 dflt_access);
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(temp));
-        } else if (ASR::is_a<ASR::Namelist_t>(*t)) {
-            ASR::Namelist_t *nml = ASR::down_cast<ASR::Namelist_t>(t);
-            ASR::asr_t *v = ASR::make_ExternalSymbol_t(
-                al, loc,
-                current_scope,
-                s2c(al, local_sym),
-                (ASR::symbol_t*) nml,
-                m->m_name, nullptr, 0, nml->m_group_name,
-                dflt_access);
-            current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(v));
         } else if (ASR::is_a<ASR::ExternalSymbol_t>(*t)) {
             ASR::ExternalSymbol_t* ext_sym = ASR::down_cast<ASR::ExternalSymbol_t>(t);
             ASR::asr_t* temp = ASR::make_ExternalSymbol_t(

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -14858,50 +14858,77 @@ public:
                 }
                 int64_t result_size = 64; // Fallback for runtime-sized sources
                 ASR::expr_t* result_size_expr = nullptr;
-                if( src_bytes > 0 ) {
-                    ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
-                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
-                    int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
-                    if( mold_bytes > 0 ) {
-                        result_size = (src_bytes + mold_bytes - 1) / mold_bytes;
-                    }
-                } else if( src_len_expr ) {
-                    // For runtime-sized strings with known length expression, use it
-                    ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
-                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
-                    int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
-                    if( mold_bytes > 0 ) {
-                        // Calculate: ceiling(src_len_expr / mold_bytes)
-                        // = (src_len_expr + mold_bytes - 1) / mold_bytes
-                        ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(
-                            al, x.base.base.loc, compiler_options.po.default_integer_kind));
-                        ASR::expr_t* mold_bytes_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                            al, x.base.base.loc, mold_bytes, int_type));
-                        ASR::expr_t* mold_bytes_minus_one = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                            al, x.base.base.loc, mold_bytes - 1, int_type));
-                        ASR::expr_t* numerator = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                            al, x.base.base.loc, src_len_expr, ASR::binopType::Add,
-                            mold_bytes_minus_one, int_type, nullptr));
-                        result_size_expr = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
-                            al, x.base.base.loc, numerator, ASR::binopType::Div,
-                            mold_bytes_expr, int_type, nullptr));
+                
+                // Declare our type safely once for this scope
+                ASR::ttype_t *local_int_type = ASRUtils::TYPE(ASR::make_Integer_t(
+                    al, x.base.base.loc, compiler_options.po.default_integer_kind));
+
+                // 1. Compute mold byte size or build an expression for it
+                ASR::ttype_t* mold_elem_type = ASRUtils::type_get_past_array(
+                    ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(mold)));
+                int64_t mold_bytes = ASRUtils::get_type_byte_size(mold_elem_type);
+                ASR::expr_t* mold_bytes_expr = nullptr;
+
+                if (ASR::is_a<ASR::String_t>(*mold_elem_type)) {
+                    ASR::String_t* mold_str_type = ASR::down_cast<ASR::String_t>(mold_elem_type);
+                    if (mold_str_type->m_len && ASRUtils::expr_value(mold_str_type->m_len)) {
+                        int64_t str_len = ASR::down_cast<ASR::IntegerConstant_t>(
+                            ASRUtils::expr_value(mold_str_type->m_len))->m_n;
+                        mold_bytes = mold_bytes * str_len;
+                    } else {
+                        mold_bytes = -1; // Runtime-sized string
+                        if (mold_str_type->m_len) {
+                            mold_bytes_expr = mold_str_type->m_len;
+                        } else {
+                            mold_bytes_expr = ASRUtils::EXPR(ASR::make_StringLen_t(
+                                al, x.base.base.loc, mold, local_int_type, nullptr));
+                        }
                     }
                 }
-                ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(
-                    al, x.base.base.loc, compiler_options.po.default_integer_kind));
+
+                // 2. Ensure we have an expression for the source size if needed
+                if (src_bytes > 0 && !src_len_expr) {
+                    src_len_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                        al, x.base.base.loc, src_bytes, local_int_type));
+                }
+
+                // 3. Compute result_size (constant) or result_size_expr (runtime)
+                if (mold_bytes > 0) {
+                    mold_bytes_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                        al, x.base.base.loc, mold_bytes, local_int_type));
+                    if (src_bytes > 0) {
+                        result_size = (src_bytes + mold_bytes - 1) / mold_bytes;
+                    }
+                }
+
+                if ((src_bytes <= 0 || mold_bytes <= 0) && src_len_expr && mold_bytes_expr) {
+                    // Calculate runtime dimension: ceiling(src_len_expr / mold_bytes_expr)
+                    // = (src_len_expr + mold_bytes_expr - 1) / mold_bytes_expr
+                    ASR::expr_t* one_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+                        al, x.base.base.loc, 1, local_int_type));
+                    ASR::expr_t* mold_bytes_minus_one = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                        al, x.base.base.loc, mold_bytes_expr, ASR::binopType::Sub,
+                        one_expr, local_int_type, nullptr));
+                    ASR::expr_t* numerator = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                        al, x.base.base.loc, src_len_expr, ASR::binopType::Add,
+                        mold_bytes_minus_one, local_int_type, nullptr));
+                    result_size_expr = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(
+                        al, x.base.base.loc, numerator, ASR::binopType::Div,
+                        mold_bytes_expr, local_int_type, nullptr));
+                }
+
                 ASR::dimension_t size_dim;
                 size_dim.loc = x.base.base.loc;
                 size_dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                    al, x.base.base.loc, 1, int_type));
+                    al, x.base.base.loc, 1, local_int_type));
                 if( result_size_expr ) {
                     size_dim.m_length = result_size_expr;
                 } else {
                     size_dim.m_length = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
-                        al, x.base.base.loc, result_size, int_type));
+                        al, x.base.base.loc, result_size, local_int_type));
                 }
                 new_dims.push_back(al, size_dim);
-            }
-        }
+                
         ASR::ttype_t* type = ASRUtils::type_get_past_allocatable(ASRUtils::duplicate_type(al, ASRUtils::expr_type(mold), &new_dims));
         ASR::expr_t *transfer_value = nullptr, *source_value = ASRUtils::expr_value(source),
             *mold_value = ASRUtils::expr_value(mold), *size_value = nullptr;

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11918,7 +11918,7 @@ public:
                 ASR::array_physical_typeType::DescriptorArray) {
                 visit_ArrayPhysicalCastUtil(
                     tmp, get_ptr->m_arg, ASRUtils::type_get_past_pointer(
-                        ASRUtils::type_get_past_allocatable(get_ptr->m_type)),
+                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(x.m_target))),
                         ASRUtils::expr_type(get_ptr->m_arg),
                     ASRUtils::extract_physical_type(ASRUtils::expr_type(get_ptr->m_arg)),
                     ASR::array_physical_typeType::DescriptorArray);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11904,22 +11904,30 @@ public:
             return;
         }
 
-        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+        // Extract base variable if the target is an ArraySection (e.g., p(4:) => ...)
+        ASR::expr_t* ptr_target_base = x.m_target;
+        if (ASR::is_a<ASR::ArraySection_t>(*ptr_target_base)) {
+            ptr_target_base = ASR::down_cast<ASR::ArraySection_t>(ptr_target_base)->m_v;
+        }
+
+        if( ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(ptr_target_base)) &&
             ASR::is_a<ASR::GetPointer_t>(*x.m_value) ) {
-            ASR::Variable_t *asr_target = EXPR2VAR(x.m_target);
+            ASR::Variable_t *asr_target = EXPR2VAR(ptr_target_base);
             ASR::GetPointer_t* get_ptr = ASR::down_cast<ASR::GetPointer_t>(x.m_value);
             uint32_t target_h = get_hash((ASR::asr_t*)asr_target);
             int ptr_loads_copy = ptr_loads;
             ptr_loads = 2 - LLVM::is_llvm_pointer(*ASRUtils::expr_type(get_ptr->m_arg));
             visit_expr_wrapper(get_ptr->m_arg, true);
             ptr_loads = ptr_loads_copy;
+            
             if( ASRUtils::is_array(ASRUtils::expr_type(get_ptr->m_arg)) &&
                 ASRUtils::extract_physical_type(ASRUtils::expr_type(get_ptr->m_arg)) !=
                 ASR::array_physical_typeType::DescriptorArray) {
+                
                 visit_ArrayPhysicalCastUtil(
                     tmp, get_ptr->m_arg, ASRUtils::type_get_past_pointer(
-                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(x.m_target))),
-                        ASRUtils::expr_type(get_ptr->m_arg),
+                        ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(ptr_target_base))),
+                        ASRUtils::expr_type(x.m_target), 
                     ASRUtils::extract_physical_type(ASRUtils::expr_type(get_ptr->m_arg)),
                     ASR::array_physical_typeType::DescriptorArray);
             }
@@ -12999,16 +13007,22 @@ public:
     }
 
     void PointerToData_to_Descriptor(ASR::expr_t* expr, ASR::ttype_t* m_type, ASR::ttype_t* m_type_for_dimensions) {
-        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(expr,
+        // Pass nullptr instead of expr to enforce returning a StructType descriptor
+        llvm::Type* target_type = llvm_utils->get_type_from_ttype_t_util(
+            nullptr, 
             ASRUtils::type_get_past_allocatable(
                 ASRUtils::type_get_past_pointer(m_type)), module.get());
+        
         llvm::Value *target = arr_descr->create_descriptor_alloca(
             target_type,
             "array_descriptor");
+            
         ASR::ttype_t* array_ttype = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(m_type));
+            
         llvm::Type* llvm_data_type = llvm_utils->get_el_type(
             expr, ASRUtils::extract_type(array_ttype), module.get());
+            
         llvm::Type* expected_data_ptr_type = llvm_data_type->getPointerTo();
         if (llvm::StructType* desc_struct = llvm::dyn_cast<llvm::StructType>(target_type)) {
             if (desc_struct->getNumElements() > 0 &&
@@ -13016,14 +13030,17 @@ public:
                 expected_data_ptr_type = desc_struct->getElementType(0);
             }
         }
+        
         llvm::Value* data_ptr = arr_descr->get_pointer_to_data(target_type, target);
         llvm::Value* tmp_cast = tmp;
         if (tmp_cast->getType() != expected_data_ptr_type) {
             tmp_cast = builder->CreateBitCast(tmp_cast, expected_data_ptr_type);
         }
         builder->CreateStore(tmp_cast, data_ptr);
+        
         ASR::dimension_t* m_dims = nullptr;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(m_type_for_dimensions, m_dims);
+        
         fill_array_details(target_type, target, llvm_data_type, m_dims, n_dims, false, false);
         
         // Set CFI descriptor fields (elem_len, type, attribute)
@@ -13031,6 +13048,7 @@ public:
         llvm::DataLayout data_layout(module->getDataLayout());
         uint64_t elem_size = data_layout.getTypeAllocSize(llvm_data_type);
         set_cfi_descriptor_fields(target_type, target, elem_asr_type, elem_size, m_type);
+        
         if( LLVM::is_llvm_pointer(*m_type) ) {
             llvm::AllocaInst* target_ptr = llvm_utils->CreateAlloca(
                 target_type->getPointerTo(), nullptr, "array_descriptor_ptr");

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -13024,9 +13024,8 @@ public:
         builder->CreateStore(tmp_cast, data_ptr);
         ASR::dimension_t* m_dims = nullptr;
         int n_dims = ASRUtils::extract_dimensions_from_ttype(m_type_for_dimensions, m_dims);
-        llvm::Type* llvm_typ = llvm_utils->get_type_from_ttype_t_util(expr,
-            ASRUtils::type_get_past_allocatable(m_type), module.get());
-        fill_array_details(llvm_typ, target, llvm_data_type, m_dims, n_dims, false, false);
+        fill_array_details(target_type, target, llvm_data_type, m_dims, n_dims, false, false);
+        
         // Set CFI descriptor fields (elem_len, type, attribute)
         ASR::ttype_t* elem_asr_type = ASRUtils::extract_type(array_ttype);
         llvm::DataLayout data_layout(module->getDataLayout());


### PR DESCRIPTION
Fixes #12177 