### PR TITLE
README: add JupyterLite demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Website: https://lfortran.org/
 
 Try online: https://dev.lfortran.org/
 
+Try LFortran in a JupyterLite notebook:
+[![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://lfortran.github.io/lfortran/)
+
 # Documentation
 
 All documentation, installation instructions, motivation, design, ... is


### PR DESCRIPTION
It will be useful for users/contributors to try lfortran directly in their browser through Jupyterlite so adding the link in the README. Also it's the latest build as the deployment updates with every commit going into main.