### PR TITLE
fix: set target triple on LLVM module during IR generation

### DIFF
--- a/build1.sh
+++ b/build1.sh
@@ -3,7 +3,11 @@
 set -e
 set -x
 
+BUILD_DIR="build-lfortran"
+
 cmake \
+    -S . \
+    -B "$BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DWITH_LLVM=yes \
     -DLFORTRAN_BUILD_ALL=yes \
@@ -17,6 +21,6 @@ cmake \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCMAKE_C_FLAGS="${CFLAGS} -fdiagnostics-color=always" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -fdiagnostics-color=always" \
-    -G Ninja \
-    .
-cmake --build .
+    -G Ninja
+
+cmake --build "$BUILD_DIR"

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1841,6 +1841,11 @@ public:
             } else {
                 module->setDataLayout("");
             }
+#if LLVM_VERSION_MAJOR >= 21
+            module->setTargetTriple(llvm::Triple(target_triple));
+#else
+            module->setTargetTriple(target_triple);
+#endif
         }
         llvm_utils->set_module(module.get());
 

--- a/tests/reference/llvm-abort_01-7212a3d.json
+++ b/tests/reference/llvm-abort_01-7212a3d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-abort_01-7212a3d.stdout",
-    "stdout_hash": "af197c3f92b3558b7df838df81d7def4c701eb5db5cace0c1c2b1daa",
+    "stdout_hash": "446c49125ace7969f51fdb77f4639d41cbc84ac9a6c0e20b4c043f72",
     "stderr": "llvm-abort_01-7212a3d.stderr",
     "stderr_hash": "132e12d6d59905849ec72f4c5e5303920f043e68e199519ab136643f",
     "returncode": 0

--- a/tests/reference/llvm-abort_01-7212a3d.stdout
+++ b/tests/reference/llvm-abort_01-7212a3d.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define void @_lcompilers_abort_() {
 .entry:
@@ -16,9 +17,9 @@ FINALIZE_SYMTABLE__lcompilers_abort_:             ; preds = %return
 
 declare void @_lfortran_abort()
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   br i1 false, label %then, label %else
 
 then:                                             ; preds = %.entry
@@ -39,6 +40,6 @@ FINALIZE_SYMTABLE_abort1:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-allocate_02-4f6b634.json
+++ b/tests/reference/llvm-allocate_02-4f6b634.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_02-4f6b634.stdout",
-    "stdout_hash": "5237e69b171150d54680e0d2e73c7ec50480653604afaab7d40c2d58",
+    "stdout_hash": "09e9464c4e6effc9678a18022f3cc8e3e8ef5798679721b20d217dbd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_02-4f6b634.stdout
+++ b/tests/reference/llvm-allocate_02-4f6b634.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%array.1 = type { i32*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%array.1 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
 
 @0 = private unnamed_addr constant [4 x i8] c"arr\00", align 1
@@ -14,37 +15,37 @@ target datalayout = "..."
 @6 = private unnamed_addr constant [53 x i8] c"Cannot allocate '%s' because it is already allocated\00", align 1
 @7 = private unnamed_addr constant [55 x i8] c"Attempting to allocate already allocated variable '%s'\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %arr_desc = alloca %array.1, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %arr = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %arr, align 8
-  %3 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 8
-  %4 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %3, i32 0, i32 0
-  %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 1, i64* %6, align 8
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
-  store i64 1, i64* %7, align 8
-  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 0, i64* %8, align 8
-  %9 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
-  store i8 1, i8* %9, align 1
-  %10 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %10, align 8
-  store %array.1* %arr_desc, %array.1** %arr, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %arr = alloca ptr, align 8
+  store ptr null, ptr %arr, align 8
+  %3 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 8
+  %4 = getelementptr [1 x %dimension_descriptor], ptr %3, i32 0, i32 0
+  %5 = getelementptr inbounds %dimension_descriptor, ptr %4, i32 0
+  %6 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 0
+  store i64 1, ptr %6, align 8
+  %7 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 1
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 2
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 3
+  store i8 1, ptr %9, align 1
+  %10 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %10, align 8
+  store ptr %arr_desc, ptr %arr, align 8
   %i = alloca i32, align 4
-  %11 = load %array.1*, %array.1** %arr, align 8
-  %12 = ptrtoint %array.1* %11 to i64
+  %11 = load ptr, ptr %arr, align 8
+  %12 = ptrtoint ptr %11 to i64
   %13 = icmp eq i64 %12, 0
   br i1 %13, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %14 = getelementptr %array.1, %array.1* %11, i32 0, i32 0
-  %15 = load i32*, i32** %14, align 8
-  %16 = ptrtoint i32* %15 to i64
+  %14 = getelementptr %array.1, ptr %11, i32 0, i32 0
+  %15 = load ptr, ptr %14, align 8
+  %16 = ptrtoint ptr %15 to i64
   %17 = icmp ne i64 %16, 0
   br label %merge_allocated
 
@@ -53,163 +54,160 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %is_allocated, label %then, label %ifcont
 
 then:                                             ; preds = %merge_allocated
-  %18 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %19 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %20 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 0
-  store i8* getelementptr inbounds ([22 x i8], [22 x i8]* @1, i32 0, i32 0), i8** %21, align 8
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 1
-  store i32 5, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 2
-  store i32 14, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 3
-  store i32 5, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 4
-  store i32 19, i32* %25, align 4
-  %26 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
-  %27 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
-  %28 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 2
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 0
-  store i1 true, i1* %30, align 1
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 1
-  store i8* %26, i8** %31, align 8
-  store { i8*, i32, i32, i32, i32 }* %28, { i8*, i32, i32, i32, i32 }** %29, align 8
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 3
-  store i32 1, i32* %32, align 4
-  %33 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %18, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %33, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
+  %18 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %19 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %20 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 0
+  store ptr @1, ptr %21, align 8
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 1
+  store i32 5, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 2
+  store i32 14, ptr %23, align 4
+  %24 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 3
+  store i32 5, ptr %24, align 4
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 4
+  store i32 19, ptr %25, align 4
+  %26 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2, ptr @0)
+  %27 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %18, i32 0, i32 0
+  %28 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 2
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 0
+  store i1 true, ptr %30, align 1
+  %31 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 1
+  store ptr %26, ptr %31, align 8
+  store ptr %28, ptr %29, align 8
+  %32 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 3
+  store i32 1, ptr %32, align 4
+  %33 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %18, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %33, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %merge_allocated
-  %34 = load %array.1*, %array.1** %arr, align 8
-  %35 = getelementptr %array.1, %array.1* %34, i32 0, i32 7
-  store i64 0, i64* %35, align 8
-  %36 = getelementptr %array.1, %array.1* %34, i32 0, i32 3
-  store i8 1, i8* %36, align 1
-  %37 = getelementptr %array.1, %array.1* %34, i32 0, i32 8
-  %38 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %37, i32 0, i32 0
-  %39 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %38, i32 0
-  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 2
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 0
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %39, i32 0, i32 1
-  store i64 1, i64* %40, align 8
-  store i64 1, i64* %41, align 8
-  store i64 1, i64* %42, align 8
-  %43 = getelementptr %array.1, %array.1* %34, i32 0, i32 0
-  %44 = call i8* @_lfortran_get_default_allocator()
-  %45 = call i8* @_lfortran_malloc_alloc(i8* %44, i64 4)
-  %46 = bitcast i8* %45 to i32*
-  store i32* %46, i32** %43, align 8
-  store i32 0, i32* %i, align 4
+  %34 = load ptr, ptr %arr, align 8
+  %35 = getelementptr %array.1, ptr %34, i32 0, i32 7
+  store i64 0, ptr %35, align 8
+  %36 = getelementptr %array.1, ptr %34, i32 0, i32 3
+  store i8 1, ptr %36, align 1
+  %37 = getelementptr %array.1, ptr %34, i32 0, i32 8
+  %38 = getelementptr [1 x %dimension_descriptor], ptr %37, i32 0, i32 0
+  %39 = getelementptr inbounds %dimension_descriptor, ptr %38, i32 0
+  %40 = getelementptr %dimension_descriptor, ptr %39, i32 0, i32 2
+  %41 = getelementptr %dimension_descriptor, ptr %39, i32 0, i32 0
+  %42 = getelementptr %dimension_descriptor, ptr %39, i32 0, i32 1
+  store i64 1, ptr %40, align 8
+  store i64 1, ptr %41, align 8
+  store i64 1, ptr %42, align 8
+  %43 = getelementptr %array.1, ptr %34, i32 0, i32 0
+  %44 = call ptr @_lfortran_get_default_allocator()
+  %45 = call ptr @_lfortran_malloc_alloc(ptr %44, i64 4)
+  store ptr %45, ptr %43, align 8
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont10, %ifcont
-  %47 = load i32, i32* %i, align 4
-  %48 = add i32 %47, 1
-  %49 = icmp sle i32 %48, 1000000
-  br i1 %49, label %loop.body, label %loop.end
+  %46 = load i32, ptr %i, align 4
+  %47 = add i32 %46, 1
+  %48 = icmp sle i32 %47, 1000000
+  br i1 %48, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %50 = load i32, i32* %i, align 4
-  %51 = add i32 %50, 1
-  store i32 %51, i32* %i, align 4
-  %52 = load %array.1*, %array.1** %arr, align 8
-  %53 = ptrtoint %array.1* %52 to i64
-  %54 = icmp eq i64 %53, 0
-  br i1 %54, label %merge_allocated2, label %check_data1
+  %49 = load i32, ptr %i, align 4
+  %50 = add i32 %49, 1
+  store i32 %50, ptr %i, align 4
+  %51 = load ptr, ptr %arr, align 8
+  %52 = ptrtoint ptr %51 to i64
+  %53 = icmp eq i64 %52, 0
+  br i1 %53, label %merge_allocated2, label %check_data1
 
 check_data1:                                      ; preds = %loop.body
-  %55 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
-  %56 = load i32*, i32** %55, align 8
-  %57 = ptrtoint i32* %56 to i64
-  %58 = icmp ne i64 %57, 0
+  %54 = getelementptr %array.1, ptr %51, i32 0, i32 0
+  %55 = load ptr, ptr %54, align 8
+  %56 = ptrtoint ptr %55 to i64
+  %57 = icmp ne i64 %56, 0
   br label %merge_allocated2
 
 merge_allocated2:                                 ; preds = %check_data1, %loop.body
-  %is_allocated3 = phi i1 [ false, %loop.body ], [ %58, %check_data1 ]
+  %is_allocated3 = phi i1 [ false, %loop.body ], [ %57, %check_data1 ]
   br i1 %is_allocated3, label %then4, label %else
 
 then4:                                            ; preds = %merge_allocated2
-  %59 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
-  %60 = load i32*, i32** %59, align 8
-  %61 = bitcast i32* %60 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %61)
-  %62 = getelementptr %array.1, %array.1* %52, i32 0, i32 0
-  store i32* null, i32** %62, align 8
+  %58 = getelementptr %array.1, ptr %51, i32 0, i32 0
+  %59 = load ptr, ptr %58, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %59)
+  %60 = getelementptr %array.1, ptr %51, i32 0, i32 0
+  store ptr null, ptr %60, align 8
   br label %ifcont5
 
 else:                                             ; preds = %merge_allocated2
   br label %ifcont5
 
 ifcont5:                                          ; preds = %else, %then4
-  %63 = load %array.1*, %array.1** %arr, align 8
-  %64 = ptrtoint %array.1* %63 to i64
-  %65 = icmp eq i64 %64, 0
-  br i1 %65, label %merge_allocated7, label %check_data6
+  %61 = load ptr, ptr %arr, align 8
+  %62 = ptrtoint ptr %61 to i64
+  %63 = icmp eq i64 %62, 0
+  br i1 %63, label %merge_allocated7, label %check_data6
 
 check_data6:                                      ; preds = %ifcont5
-  %66 = getelementptr %array.1, %array.1* %63, i32 0, i32 0
-  %67 = load i32*, i32** %66, align 8
-  %68 = ptrtoint i32* %67 to i64
-  %69 = icmp ne i64 %68, 0
+  %64 = getelementptr %array.1, ptr %61, i32 0, i32 0
+  %65 = load ptr, ptr %64, align 8
+  %66 = ptrtoint ptr %65 to i64
+  %67 = icmp ne i64 %66, 0
   br label %merge_allocated7
 
 merge_allocated7:                                 ; preds = %check_data6, %ifcont5
-  %is_allocated8 = phi i1 [ false, %ifcont5 ], [ %69, %check_data6 ]
+  %is_allocated8 = phi i1 [ false, %ifcont5 ], [ %67, %check_data6 ]
   br i1 %is_allocated8, label %then9, label %ifcont10
 
 then9:                                            ; preds = %merge_allocated7
-  %70 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %71 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %72 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 0
-  store i8* getelementptr inbounds ([22 x i8], [22 x i8]* @5, i32 0, i32 0), i8** %73, align 8
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 1
-  store i32 8, i32* %74, align 4
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 2
-  store i32 18, i32* %75, align 4
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 3
-  store i32 8, i32* %76, align 4
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 4
-  store i32 23, i32* %77, align 4
-  %78 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
-  %79 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
-  %80 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
-  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 2
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 0
-  store i1 true, i1* %82, align 1
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 1
-  store i8* %78, i8** %83, align 8
-  store { i8*, i32, i32, i32, i32 }* %80, { i8*, i32, i32, i32, i32 }** %81, align 8
-  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 3
-  store i32 1, i32* %84, align 4
-  %85 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %85, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
+  %68 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %69 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %70 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %69, i32 0, i32 0
+  %71 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 0
+  store ptr @5, ptr %71, align 8
+  %72 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 1
+  store i32 8, ptr %72, align 4
+  %73 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 2
+  store i32 18, ptr %73, align 4
+  %74 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 3
+  store i32 8, ptr %74, align 4
+  %75 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 4
+  store i32 23, ptr %75, align 4
+  %76 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6, ptr @4)
+  %77 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %68, i32 0, i32 0
+  %78 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %69, i32 0, i32 0
+  %79 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 2
+  %80 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 0
+  store i1 true, ptr %80, align 1
+  %81 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 1
+  store ptr %76, ptr %81, align 8
+  store ptr %78, ptr %79, align 8
+  %82 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 3
+  store i32 1, ptr %82, align 4
+  %83 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %68, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %83, i32 1, ptr @7, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %merge_allocated7
-  %86 = load %array.1*, %array.1** %arr, align 8
-  %87 = getelementptr %array.1, %array.1* %86, i32 0, i32 7
-  store i64 0, i64* %87, align 8
-  %88 = getelementptr %array.1, %array.1* %86, i32 0, i32 3
-  store i8 1, i8* %88, align 1
-  %89 = getelementptr %array.1, %array.1* %86, i32 0, i32 8
-  %90 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %89, i32 0, i32 0
-  %91 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %90, i32 0
-  %92 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 2
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 0
-  %94 = getelementptr %dimension_descriptor, %dimension_descriptor* %91, i32 0, i32 1
-  store i64 1, i64* %92, align 8
-  store i64 1, i64* %93, align 8
-  store i64 1, i64* %94, align 8
-  %95 = getelementptr %array.1, %array.1* %86, i32 0, i32 0
-  %96 = call i8* @_lfortran_get_default_allocator()
-  %97 = call i8* @_lfortran_malloc_alloc(i8* %96, i64 4)
-  %98 = bitcast i8* %97 to i32*
-  store i32* %98, i32** %95, align 8
+  %84 = load ptr, ptr %arr, align 8
+  %85 = getelementptr %array.1, ptr %84, i32 0, i32 7
+  store i64 0, ptr %85, align 8
+  %86 = getelementptr %array.1, ptr %84, i32 0, i32 3
+  store i8 1, ptr %86, align 1
+  %87 = getelementptr %array.1, ptr %84, i32 0, i32 8
+  %88 = getelementptr [1 x %dimension_descriptor], ptr %87, i32 0, i32 0
+  %89 = getelementptr inbounds %dimension_descriptor, ptr %88, i32 0
+  %90 = getelementptr %dimension_descriptor, ptr %89, i32 0, i32 2
+  %91 = getelementptr %dimension_descriptor, ptr %89, i32 0, i32 0
+  %92 = getelementptr %dimension_descriptor, ptr %89, i32 0, i32 1
+  store i64 1, ptr %90, align 8
+  store i64 1, ptr %91, align 8
+  store i64 1, ptr %92, align 8
+  %93 = getelementptr %array.1, ptr %84, i32 0, i32 0
+  %94 = call ptr @_lfortran_get_default_allocator()
+  %95 = call ptr @_lfortran_malloc_alloc(ptr %94, i64 4)
+  store ptr %95, ptr %93, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
@@ -222,33 +220,33 @@ FINALIZE_SYMTABLE_allocate_02:                    ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_allocate_02
-  %99 = load %array.1*, %array.1** %arr, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %99)
+  %96 = load ptr, ptr %arr, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %96)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define internal void @finalize_allocatable__Array_1_i32(%array.1* %0) {
+define internal void @finalize_allocatable__Array_1_i32(ptr %0) {
 entry:
-  %1 = icmp ne %array.1* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_1_i32(%array.1* %0)
+  call void @finalize_descriptorArray_Array_1_i32(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -258,18 +256,17 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_1_i32(%array.1* %0) {
+define internal void @finalize_descriptorArray_Array_1_i32(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.1, %array.1* %0, i32 0, i32 0
-  %3 = load i32*, i32** %2, align 8
-  %4 = ptrtoint i32* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.1, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = ptrtoint ptr %3 to i64
   %5 = icmp ne i64 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = bitcast i32* %3 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %3)
   br label %ifcont
 
 else:                                             ; preds = %entry

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "934b2bee5ecc9890b46ec3aff03c112054d106bdfdbeefab8b96c5c2",
+    "stdout_hash": "7dddc224cb2242b04bc4b410cf154cafd0a2c843b972d20128ace692",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -1,9 +1,10 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%array.3 = type { i32*, i64, i32, i8, i8, i8, i8, i64, [3 x %dimension_descriptor] }
+%string_descriptor = type <{ ptr, i64 }>
+%array.3 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [3 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
 
 @0 = private unnamed_addr constant [2 x i8] c"c\00", align 1
@@ -228,56 +229,56 @@ target datalayout = "..."
 @214 = private unnamed_addr constant [103 x i8] c"Array '%s' index out of bounds. Tried to access index %d of dimension %d, but valid range is %d to %d.\00", align 1
 @215 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %arr_desc = alloca %array.3, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c = alloca %array.3*, align 8
-  store %array.3* null, %array.3** %c, align 8
-  %3 = getelementptr %array.3, %array.3* %arr_desc, i32 0, i32 8
-  %4 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %3, i32 0, i32 0
-  %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 1, i64* %6, align 8
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
-  store i64 1, i64* %7, align 8
-  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 0, i64* %8, align 8
-  %9 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 1
-  %10 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 0
-  store i64 1, i64* %10, align 8
-  %11 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 1
-  store i64 1, i64* %11, align 8
-  %12 = getelementptr %dimension_descriptor, %dimension_descriptor* %9, i32 0, i32 2
-  store i64 0, i64* %12, align 8
-  %13 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 2
-  %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 0
-  store i64 1, i64* %14, align 8
-  %15 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 1
-  store i64 1, i64* %15, align 8
-  %16 = getelementptr %dimension_descriptor, %dimension_descriptor* %13, i32 0, i32 2
-  store i64 0, i64* %16, align 8
-  %17 = getelementptr %array.3, %array.3* %arr_desc, i32 0, i32 3
-  store i8 3, i8* %17, align 1
-  %18 = getelementptr %array.3, %array.3* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %18, align 8
-  store %array.3* %arr_desc, %array.3** %c, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %c = alloca ptr, align 8
+  store ptr null, ptr %c, align 8
+  %3 = getelementptr %array.3, ptr %arr_desc, i32 0, i32 8
+  %4 = getelementptr [3 x %dimension_descriptor], ptr %3, i32 0, i32 0
+  %5 = getelementptr inbounds %dimension_descriptor, ptr %4, i32 0
+  %6 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 0
+  store i64 1, ptr %6, align 8
+  %7 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 1
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 2
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr inbounds %dimension_descriptor, ptr %4, i32 1
+  %10 = getelementptr %dimension_descriptor, ptr %9, i32 0, i32 0
+  store i64 1, ptr %10, align 8
+  %11 = getelementptr %dimension_descriptor, ptr %9, i32 0, i32 1
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %dimension_descriptor, ptr %9, i32 0, i32 2
+  store i64 0, ptr %12, align 8
+  %13 = getelementptr inbounds %dimension_descriptor, ptr %4, i32 2
+  %14 = getelementptr %dimension_descriptor, ptr %13, i32 0, i32 0
+  store i64 1, ptr %14, align 8
+  %15 = getelementptr %dimension_descriptor, ptr %13, i32 0, i32 1
+  store i64 1, ptr %15, align 8
+  %16 = getelementptr %dimension_descriptor, ptr %13, i32 0, i32 2
+  store i64 0, ptr %16, align 8
+  %17 = getelementptr %array.3, ptr %arr_desc, i32 0, i32 3
+  store i8 3, ptr %17, align 1
+  %18 = getelementptr %array.3, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %18, align 8
+  store ptr %arr_desc, ptr %c, align 8
   %r = alloca i32, align 4
   %stat = alloca i32, align 4
-  store i32 1, i32* %stat, align 4
-  store i32 0, i32* %stat, align 4
-  %19 = load %array.3*, %array.3** %c, align 8
-  %20 = load %array.3*, %array.3** %c, align 8
-  %21 = ptrtoint %array.3* %20 to i64
+  store i32 1, ptr %stat, align 4
+  store i32 0, ptr %stat, align 4
+  %19 = load ptr, ptr %c, align 8
+  %20 = load ptr, ptr %c, align 8
+  %21 = ptrtoint ptr %20 to i64
   %22 = icmp eq i64 %21, 0
   br i1 %22, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %23 = getelementptr %array.3, %array.3* %20, i32 0, i32 0
-  %24 = load i32*, i32** %23, align 8
-  %25 = ptrtoint i32* %24 to i64
+  %23 = getelementptr %array.3, ptr %20, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = ptrtoint ptr %24 to i64
   %26 = icmp ne i64 %25, 0
   br label %merge_allocated
 
@@ -286,52 +287,51 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %is_allocated, label %then, label %else
 
 then:                                             ; preds = %merge_allocated
-  store i32 1, i32* %stat, align 4
+  store i32 1, ptr %stat, align 4
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated
-  %27 = load %array.3*, %array.3** %c, align 8
-  %28 = getelementptr %array.3, %array.3* %27, i32 0, i32 7
-  store i64 0, i64* %28, align 8
-  %29 = getelementptr %array.3, %array.3* %27, i32 0, i32 3
-  store i8 3, i8* %29, align 1
-  %30 = getelementptr %array.3, %array.3* %27, i32 0, i32 8
-  %31 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %30, i32 0, i32 0
-  %32 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 0
-  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 2
-  %34 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 0
-  %35 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 1
-  store i64 1, i64* %33, align 8
-  store i64 1, i64* %34, align 8
-  store i64 3, i64* %35, align 8
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 1
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  store i64 3, i64* %37, align 8
-  store i64 1, i64* %38, align 8
-  store i64 3, i64* %39, align 8
-  %40 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 2
-  %41 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 2
-  %42 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 0
-  %43 = getelementptr %dimension_descriptor, %dimension_descriptor* %40, i32 0, i32 1
-  store i64 9, i64* %41, align 8
-  store i64 1, i64* %42, align 8
-  store i64 3, i64* %43, align 8
-  %44 = getelementptr %array.3, %array.3* %27, i32 0, i32 0
-  %45 = call i8* @_lfortran_get_default_allocator()
-  %46 = call i8* @_lfortran_malloc_alloc(i8* %45, i64 108)
-  %47 = bitcast i8* %46 to i32*
-  store i32* %47, i32** %44, align 8
+  %27 = load ptr, ptr %c, align 8
+  %28 = getelementptr %array.3, ptr %27, i32 0, i32 7
+  store i64 0, ptr %28, align 8
+  %29 = getelementptr %array.3, ptr %27, i32 0, i32 3
+  store i8 3, ptr %29, align 1
+  %30 = getelementptr %array.3, ptr %27, i32 0, i32 8
+  %31 = getelementptr [3 x %dimension_descriptor], ptr %30, i32 0, i32 0
+  %32 = getelementptr inbounds %dimension_descriptor, ptr %31, i32 0
+  %33 = getelementptr %dimension_descriptor, ptr %32, i32 0, i32 2
+  %34 = getelementptr %dimension_descriptor, ptr %32, i32 0, i32 0
+  %35 = getelementptr %dimension_descriptor, ptr %32, i32 0, i32 1
+  store i64 1, ptr %33, align 8
+  store i64 1, ptr %34, align 8
+  store i64 3, ptr %35, align 8
+  %36 = getelementptr inbounds %dimension_descriptor, ptr %31, i32 1
+  %37 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 2
+  %38 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 0
+  %39 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 1
+  store i64 3, ptr %37, align 8
+  store i64 1, ptr %38, align 8
+  store i64 3, ptr %39, align 8
+  %40 = getelementptr inbounds %dimension_descriptor, ptr %31, i32 2
+  %41 = getelementptr %dimension_descriptor, ptr %40, i32 0, i32 2
+  %42 = getelementptr %dimension_descriptor, ptr %40, i32 0, i32 0
+  %43 = getelementptr %dimension_descriptor, ptr %40, i32 0, i32 1
+  store i64 9, ptr %41, align 8
+  store i64 1, ptr %42, align 8
+  store i64 3, ptr %43, align 8
+  %44 = getelementptr %array.3, ptr %27, i32 0, i32 0
+  %45 = call ptr @_lfortran_get_default_allocator()
+  %46 = call ptr @_lfortran_malloc_alloc(ptr %45, i64 108)
+  store ptr %46, ptr %44, align 8
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %48 = load i32, i32* %stat, align 4
-  %49 = icmp ne i32 %48, 0
-  br i1 %49, label %then1, label %else2
+  %47 = load i32, ptr %stat, align 4
+  %48 = icmp ne i32 %47, 0
+  br i1 %48, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @163, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @163, ptr @"ERROR STOP", ptr @162)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -340,416 +340,416 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %50 = load %array.3*, %array.3** %c, align 8
-  %51 = ptrtoint %array.3* %50 to i64
-  %52 = icmp eq i64 %51, 0
-  br i1 %52, label %merge_allocated5, label %check_data4
+  %49 = load ptr, ptr %c, align 8
+  %50 = ptrtoint ptr %49 to i64
+  %51 = icmp eq i64 %50, 0
+  br i1 %51, label %merge_allocated5, label %check_data4
 
 check_data4:                                      ; preds = %ifcont3
-  %53 = getelementptr %array.3, %array.3* %50, i32 0, i32 0
-  %54 = load i32*, i32** %53, align 8
-  %55 = ptrtoint i32* %54 to i64
-  %56 = icmp ne i64 %55, 0
+  %52 = getelementptr %array.3, ptr %49, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = ptrtoint ptr %53 to i64
+  %55 = icmp ne i64 %54, 0
   br label %merge_allocated5
 
 merge_allocated5:                                 ; preds = %check_data4, %ifcont3
-  %is_allocated6 = phi i1 [ false, %ifcont3 ], [ %56, %check_data4 ]
-  %57 = xor i1 %is_allocated6, true
-  br i1 %57, label %then7, label %ifcont8
+  %is_allocated6 = phi i1 [ false, %ifcont3 ], [ %55, %check_data4 ]
+  %56 = xor i1 %is_allocated6, true
+  br i1 %56, label %then7, label %ifcont8
 
 then7:                                            ; preds = %merge_allocated5
-  %58 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %59 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %60 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %59, i32 0, i32 0
-  %61 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @165, i32 0, i32 0), i8** %61, align 8
-  %62 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 1
-  store i32 10, i32* %62, align 4
-  %63 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 2
-  store i32 5, i32* %63, align 4
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 3
-  store i32 10, i32* %64, align 4
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 4
-  store i32 14, i32* %65, align 4
-  %66 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @166, i32 0, i32 0))
-  %67 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %58, i32 0, i32 0
-  %68 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %59, i32 0, i32 0
-  %69 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 2
-  %70 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 0
-  store i1 true, i1* %70, align 1
-  %71 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 1
-  store i8* %66, i8** %71, align 8
-  store { i8*, i32, i32, i32, i32 }* %68, { i8*, i32, i32, i32, i32 }** %69, align 8
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 3
-  store i32 1, i32* %72, align 4
-  %73 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %58, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %73, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @164, i32 0, i32 0))
+  %57 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %58 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %59 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %58, i32 0, i32 0
+  %60 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %59, i32 0, i32 0
+  store ptr @165, ptr %60, align 8
+  %61 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %59, i32 0, i32 1
+  store i32 10, ptr %61, align 4
+  %62 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %59, i32 0, i32 2
+  store i32 5, ptr %62, align 4
+  %63 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %59, i32 0, i32 3
+  store i32 10, ptr %63, align 4
+  %64 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %59, i32 0, i32 4
+  store i32 14, ptr %64, align 4
+  %65 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @166)
+  %66 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %57, i32 0, i32 0
+  %67 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %58, i32 0, i32 0
+  %68 = getelementptr { i1, ptr, ptr, i32 }, ptr %66, i32 0, i32 2
+  %69 = getelementptr { i1, ptr, ptr, i32 }, ptr %66, i32 0, i32 0
+  store i1 true, ptr %69, align 1
+  %70 = getelementptr { i1, ptr, ptr, i32 }, ptr %66, i32 0, i32 1
+  store ptr %65, ptr %70, align 8
+  store ptr %67, ptr %68, align 8
+  %71 = getelementptr { i1, ptr, ptr, i32 }, ptr %66, i32 0, i32 3
+  store i32 1, ptr %71, align 4
+  %72 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %57, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %72, i32 1, ptr @167, ptr @164)
   call void @exit(i32 1)
   unreachable
 
 ifcont8:                                          ; preds = %merge_allocated5
-  %74 = getelementptr %array.3, %array.3* %50, i32 0, i32 8
-  %75 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %74, i32 0, i32 0
-  %76 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %75, i32 0
-  %77 = getelementptr %dimension_descriptor, %dimension_descriptor* %76, i32 0, i32 0
-  %78 = load i64, i64* %77, align 8
-  %79 = getelementptr %dimension_descriptor, %dimension_descriptor* %76, i32 0, i32 1
-  %80 = load i64, i64* %79, align 8
-  %81 = sub i64 1, %78
-  %82 = add i64 %78, %80
-  %83 = sub i64 %82, 1
-  %84 = icmp slt i64 1, %78
-  %85 = icmp sgt i64 1, %83
-  %86 = or i1 %84, %85
-  br i1 %86, label %then9, label %ifcont10
+  %73 = getelementptr %array.3, ptr %49, i32 0, i32 8
+  %74 = getelementptr [3 x %dimension_descriptor], ptr %73, i32 0, i32 0
+  %75 = getelementptr inbounds %dimension_descriptor, ptr %74, i32 0
+  %76 = getelementptr %dimension_descriptor, ptr %75, i32 0, i32 0
+  %77 = load i64, ptr %76, align 8
+  %78 = getelementptr %dimension_descriptor, ptr %75, i32 0, i32 1
+  %79 = load i64, ptr %78, align 8
+  %80 = sub i64 1, %77
+  %81 = add i64 %77, %79
+  %82 = sub i64 %81, 1
+  %83 = icmp slt i64 1, %77
+  %84 = icmp sgt i64 1, %82
+  %85 = or i1 %83, %84
+  br i1 %85, label %then9, label %ifcont10
 
 then9:                                            ; preds = %ifcont8
-  %87 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %88 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %89 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %88, i32 0, i32 0
-  %90 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @169, i32 0, i32 0), i8** %90, align 8
-  %91 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 1
-  store i32 10, i32* %91, align 4
-  %92 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 2
-  store i32 5, i32* %92, align 4
-  %93 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 3
-  store i32 10, i32* %93, align 4
-  %94 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 4
-  store i32 14, i32* %94, align 4
-  %95 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
-  %96 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %87, i32 0, i32 0
-  %97 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %88, i32 0, i32 0
-  %98 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 2
-  %99 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 0
-  store i1 true, i1* %99, align 1
-  %100 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 1
-  store i8* %95, i8** %100, align 8
-  store { i8*, i32, i32, i32, i32 }* %97, { i8*, i32, i32, i32, i32 }** %98, align 8
-  %101 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 3
-  store i32 1, i32* %101, align 4
-  %102 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %87, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0), i64 1, i32 1, i64 %78, i64 %83)
+  %86 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %87 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %88 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %87, i32 0, i32 0
+  %89 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %88, i32 0, i32 0
+  store ptr @169, ptr %89, align 8
+  %90 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %88, i32 0, i32 1
+  store i32 10, ptr %90, align 4
+  %91 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %88, i32 0, i32 2
+  store i32 5, ptr %91, align 4
+  %92 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %88, i32 0, i32 3
+  store i32 10, ptr %92, align 4
+  %93 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %88, i32 0, i32 4
+  store i32 14, ptr %93, align 4
+  %94 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @170)
+  %95 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %86, i32 0, i32 0
+  %96 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %87, i32 0, i32 0
+  %97 = getelementptr { i1, ptr, ptr, i32 }, ptr %95, i32 0, i32 2
+  %98 = getelementptr { i1, ptr, ptr, i32 }, ptr %95, i32 0, i32 0
+  store i1 true, ptr %98, align 1
+  %99 = getelementptr { i1, ptr, ptr, i32 }, ptr %95, i32 0, i32 1
+  store ptr %94, ptr %99, align 8
+  store ptr %96, ptr %97, align 8
+  %100 = getelementptr { i1, ptr, ptr, i32 }, ptr %95, i32 0, i32 3
+  store i32 1, ptr %100, align 4
+  %101 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %86, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %101, i32 1, ptr @171, ptr @168, i64 1, i32 1, i64 %77, i64 %82)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
-  %103 = getelementptr %dimension_descriptor, %dimension_descriptor* %76, i32 0, i32 2
-  %104 = load i64, i64* %103, align 8
-  %105 = mul i64 %104, %81
-  %106 = add i64 0, %105
-  %107 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %75, i32 1
-  %108 = getelementptr %dimension_descriptor, %dimension_descriptor* %107, i32 0, i32 0
-  %109 = load i64, i64* %108, align 8
-  %110 = getelementptr %dimension_descriptor, %dimension_descriptor* %107, i32 0, i32 1
-  %111 = load i64, i64* %110, align 8
-  %112 = sub i64 1, %109
-  %113 = add i64 %109, %111
-  %114 = sub i64 %113, 1
-  %115 = icmp slt i64 1, %109
-  %116 = icmp sgt i64 1, %114
-  %117 = or i1 %115, %116
-  br i1 %117, label %then11, label %ifcont12
+  %102 = getelementptr %dimension_descriptor, ptr %75, i32 0, i32 2
+  %103 = load i64, ptr %102, align 8
+  %104 = mul i64 %103, %80
+  %105 = add i64 0, %104
+  %106 = getelementptr inbounds %dimension_descriptor, ptr %74, i32 1
+  %107 = getelementptr %dimension_descriptor, ptr %106, i32 0, i32 0
+  %108 = load i64, ptr %107, align 8
+  %109 = getelementptr %dimension_descriptor, ptr %106, i32 0, i32 1
+  %110 = load i64, ptr %109, align 8
+  %111 = sub i64 1, %108
+  %112 = add i64 %108, %110
+  %113 = sub i64 %112, 1
+  %114 = icmp slt i64 1, %108
+  %115 = icmp sgt i64 1, %113
+  %116 = or i1 %114, %115
+  br i1 %116, label %then11, label %ifcont12
 
 then11:                                           ; preds = %ifcont10
-  %118 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %119 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %120 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %119, i32 0, i32 0
-  %121 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %120, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @173, i32 0, i32 0), i8** %121, align 8
-  %122 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %120, i32 0, i32 1
-  store i32 10, i32* %122, align 4
-  %123 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %120, i32 0, i32 2
-  store i32 5, i32* %123, align 4
-  %124 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %120, i32 0, i32 3
-  store i32 10, i32* %124, align 4
-  %125 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %120, i32 0, i32 4
-  store i32 14, i32* %125, align 4
-  %126 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
-  %127 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %118, i32 0, i32 0
-  %128 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %119, i32 0, i32 0
-  %129 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %127, i32 0, i32 2
-  %130 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %127, i32 0, i32 0
-  store i1 true, i1* %130, align 1
-  %131 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %127, i32 0, i32 1
-  store i8* %126, i8** %131, align 8
-  store { i8*, i32, i32, i32, i32 }* %128, { i8*, i32, i32, i32, i32 }** %129, align 8
-  %132 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %127, i32 0, i32 3
-  store i32 1, i32* %132, align 4
-  %133 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %118, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %133, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i64 1, i32 2, i64 %109, i64 %114)
+  %117 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %118 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %119 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %118, i32 0, i32 0
+  %120 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 0
+  store ptr @173, ptr %120, align 8
+  %121 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 1
+  store i32 10, ptr %121, align 4
+  %122 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 2
+  store i32 5, ptr %122, align 4
+  %123 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 3
+  store i32 10, ptr %123, align 4
+  %124 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 4
+  store i32 14, ptr %124, align 4
+  %125 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @174)
+  %126 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %117, i32 0, i32 0
+  %127 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %118, i32 0, i32 0
+  %128 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 2
+  %129 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 0
+  store i1 true, ptr %129, align 1
+  %130 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 1
+  store ptr %125, ptr %130, align 8
+  store ptr %127, ptr %128, align 8
+  %131 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 3
+  store i32 1, ptr %131, align 4
+  %132 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %117, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %132, i32 1, ptr @175, ptr @172, i64 1, i32 2, i64 %108, i64 %113)
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %ifcont10
-  %134 = getelementptr %dimension_descriptor, %dimension_descriptor* %107, i32 0, i32 2
-  %135 = load i64, i64* %134, align 8
-  %136 = mul i64 %135, %112
-  %137 = add i64 %106, %136
-  %138 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %75, i32 2
-  %139 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 0
-  %140 = load i64, i64* %139, align 8
-  %141 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 1
-  %142 = load i64, i64* %141, align 8
-  %143 = sub i64 1, %140
-  %144 = add i64 %140, %142
-  %145 = sub i64 %144, 1
-  %146 = icmp slt i64 1, %140
-  %147 = icmp sgt i64 1, %145
-  %148 = or i1 %146, %147
-  br i1 %148, label %then13, label %ifcont14
+  %133 = getelementptr %dimension_descriptor, ptr %106, i32 0, i32 2
+  %134 = load i64, ptr %133, align 8
+  %135 = mul i64 %134, %111
+  %136 = add i64 %105, %135
+  %137 = getelementptr inbounds %dimension_descriptor, ptr %74, i32 2
+  %138 = getelementptr %dimension_descriptor, ptr %137, i32 0, i32 0
+  %139 = load i64, ptr %138, align 8
+  %140 = getelementptr %dimension_descriptor, ptr %137, i32 0, i32 1
+  %141 = load i64, ptr %140, align 8
+  %142 = sub i64 1, %139
+  %143 = add i64 %139, %141
+  %144 = sub i64 %143, 1
+  %145 = icmp slt i64 1, %139
+  %146 = icmp sgt i64 1, %144
+  %147 = or i1 %145, %146
+  br i1 %147, label %then13, label %ifcont14
 
 then13:                                           ; preds = %ifcont12
-  %149 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %150 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %151 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %150, i32 0, i32 0
-  %152 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %151, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @177, i32 0, i32 0), i8** %152, align 8
-  %153 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %151, i32 0, i32 1
-  store i32 10, i32* %153, align 4
-  %154 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %151, i32 0, i32 2
-  store i32 5, i32* %154, align 4
-  %155 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %151, i32 0, i32 3
-  store i32 10, i32* %155, align 4
-  %156 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %151, i32 0, i32 4
-  store i32 14, i32* %156, align 4
-  %157 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @178, i32 0, i32 0))
-  %158 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %149, i32 0, i32 0
-  %159 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %150, i32 0, i32 0
-  %160 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %158, i32 0, i32 2
-  %161 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %158, i32 0, i32 0
-  store i1 true, i1* %161, align 1
-  %162 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %158, i32 0, i32 1
-  store i8* %157, i8** %162, align 8
-  store { i8*, i32, i32, i32, i32 }* %159, { i8*, i32, i32, i32, i32 }** %160, align 8
-  %163 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %158, i32 0, i32 3
-  store i32 1, i32* %163, align 4
-  %164 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %149, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %164, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @179, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0), i64 1, i32 3, i64 %140, i64 %145)
+  %148 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %149 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %150 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %149, i32 0, i32 0
+  %151 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %150, i32 0, i32 0
+  store ptr @177, ptr %151, align 8
+  %152 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %150, i32 0, i32 1
+  store i32 10, ptr %152, align 4
+  %153 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %150, i32 0, i32 2
+  store i32 5, ptr %153, align 4
+  %154 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %150, i32 0, i32 3
+  store i32 10, ptr %154, align 4
+  %155 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %150, i32 0, i32 4
+  store i32 14, ptr %155, align 4
+  %156 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @178)
+  %157 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %148, i32 0, i32 0
+  %158 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %149, i32 0, i32 0
+  %159 = getelementptr { i1, ptr, ptr, i32 }, ptr %157, i32 0, i32 2
+  %160 = getelementptr { i1, ptr, ptr, i32 }, ptr %157, i32 0, i32 0
+  store i1 true, ptr %160, align 1
+  %161 = getelementptr { i1, ptr, ptr, i32 }, ptr %157, i32 0, i32 1
+  store ptr %156, ptr %161, align 8
+  store ptr %158, ptr %159, align 8
+  %162 = getelementptr { i1, ptr, ptr, i32 }, ptr %157, i32 0, i32 3
+  store i32 1, ptr %162, align 4
+  %163 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %148, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %163, i32 1, ptr @179, ptr @176, i64 1, i32 3, i64 %139, i64 %144)
   call void @exit(i32 1)
   unreachable
 
 ifcont14:                                         ; preds = %ifcont12
-  %165 = getelementptr %dimension_descriptor, %dimension_descriptor* %138, i32 0, i32 2
-  %166 = load i64, i64* %165, align 8
-  %167 = mul i64 %166, %143
-  %168 = add i64 %137, %167
-  %169 = getelementptr %array.3, %array.3* %50, i32 0, i32 7
-  %170 = load i64, i64* %169, align 8
-  %171 = add i64 %168, %170
-  %172 = getelementptr %array.3, %array.3* %50, i32 0, i32 0
-  %173 = load i32*, i32** %172, align 8
-  %174 = getelementptr inbounds i32, i32* %173, i64 %171
-  store i32 3, i32* %174, align 4
-  call void @h(%array.3** %c)
-  %175 = call i32 @g(%array.3** %c)
-  store i32 %175, i32* %r, align 4
-  %176 = load %array.3*, %array.3** %c, align 8
-  %177 = ptrtoint %array.3* %176 to i64
-  %178 = icmp eq i64 %177, 0
-  br i1 %178, label %merge_allocated16, label %check_data15
+  %164 = getelementptr %dimension_descriptor, ptr %137, i32 0, i32 2
+  %165 = load i64, ptr %164, align 8
+  %166 = mul i64 %165, %142
+  %167 = add i64 %136, %166
+  %168 = getelementptr %array.3, ptr %49, i32 0, i32 7
+  %169 = load i64, ptr %168, align 8
+  %170 = add i64 %167, %169
+  %171 = getelementptr %array.3, ptr %49, i32 0, i32 0
+  %172 = load ptr, ptr %171, align 8
+  %173 = getelementptr inbounds i32, ptr %172, i64 %170
+  store i32 3, ptr %173, align 4
+  call void @h(ptr %c)
+  %174 = call i32 @g(ptr %c)
+  store i32 %174, ptr %r, align 4
+  %175 = load ptr, ptr %c, align 8
+  %176 = ptrtoint ptr %175 to i64
+  %177 = icmp eq i64 %176, 0
+  br i1 %177, label %merge_allocated16, label %check_data15
 
 check_data15:                                     ; preds = %ifcont14
-  %179 = getelementptr %array.3, %array.3* %176, i32 0, i32 0
-  %180 = load i32*, i32** %179, align 8
-  %181 = ptrtoint i32* %180 to i64
-  %182 = icmp ne i64 %181, 0
+  %178 = getelementptr %array.3, ptr %175, i32 0, i32 0
+  %179 = load ptr, ptr %178, align 8
+  %180 = ptrtoint ptr %179 to i64
+  %181 = icmp ne i64 %180, 0
   br label %merge_allocated16
 
 merge_allocated16:                                ; preds = %check_data15, %ifcont14
-  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %182, %check_data15 ]
-  %183 = xor i1 %is_allocated17, true
-  br i1 %183, label %then18, label %ifcont19
+  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %181, %check_data15 ]
+  %182 = xor i1 %is_allocated17, true
+  br i1 %182, label %then18, label %ifcont19
 
 then18:                                           ; preds = %merge_allocated16
-  %184 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %185 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %186 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %185, i32 0, i32 0
-  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @181, i32 0, i32 0), i8** %187, align 8
-  %188 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 1
-  store i32 13, i32* %188, align 4
-  %189 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 2
-  store i32 9, i32* %189, align 4
-  %190 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 3
-  store i32 13, i32* %190, align 4
-  %191 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 4
-  store i32 18, i32* %191, align 4
-  %192 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @182, i32 0, i32 0))
-  %193 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %184, i32 0, i32 0
-  %194 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %185, i32 0, i32 0
-  %195 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 2
-  %196 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 0
-  store i1 true, i1* %196, align 1
-  %197 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 1
-  store i8* %192, i8** %197, align 8
-  store { i8*, i32, i32, i32, i32 }* %194, { i8*, i32, i32, i32, i32 }** %195, align 8
-  %198 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 3
-  store i32 1, i32* %198, align 4
-  %199 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %184, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @183, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @180, i32 0, i32 0))
+  %183 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %184 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %185 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %184, i32 0, i32 0
+  %186 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 0
+  store ptr @181, ptr %186, align 8
+  %187 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 1
+  store i32 13, ptr %187, align 4
+  %188 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 2
+  store i32 9, ptr %188, align 4
+  %189 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 3
+  store i32 13, ptr %189, align 4
+  %190 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 4
+  store i32 18, ptr %190, align 4
+  %191 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @182)
+  %192 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %183, i32 0, i32 0
+  %193 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %184, i32 0, i32 0
+  %194 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 2
+  %195 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 0
+  store i1 true, ptr %195, align 1
+  %196 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 1
+  store ptr %191, ptr %196, align 8
+  store ptr %193, ptr %194, align 8
+  %197 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 3
+  store i32 1, ptr %197, align 4
+  %198 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %183, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %198, i32 1, ptr @183, ptr @180)
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %merge_allocated16
-  %200 = getelementptr %array.3, %array.3* %176, i32 0, i32 8
-  %201 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %200, i32 0, i32 0
-  %202 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %201, i32 0
-  %203 = getelementptr %dimension_descriptor, %dimension_descriptor* %202, i32 0, i32 0
-  %204 = load i64, i64* %203, align 8
-  %205 = getelementptr %dimension_descriptor, %dimension_descriptor* %202, i32 0, i32 1
-  %206 = load i64, i64* %205, align 8
-  %207 = sub i64 1, %204
-  %208 = add i64 %204, %206
-  %209 = sub i64 %208, 1
-  %210 = icmp slt i64 1, %204
-  %211 = icmp sgt i64 1, %209
-  %212 = or i1 %210, %211
-  br i1 %212, label %then20, label %ifcont21
+  %199 = getelementptr %array.3, ptr %175, i32 0, i32 8
+  %200 = getelementptr [3 x %dimension_descriptor], ptr %199, i32 0, i32 0
+  %201 = getelementptr inbounds %dimension_descriptor, ptr %200, i32 0
+  %202 = getelementptr %dimension_descriptor, ptr %201, i32 0, i32 0
+  %203 = load i64, ptr %202, align 8
+  %204 = getelementptr %dimension_descriptor, ptr %201, i32 0, i32 1
+  %205 = load i64, ptr %204, align 8
+  %206 = sub i64 1, %203
+  %207 = add i64 %203, %205
+  %208 = sub i64 %207, 1
+  %209 = icmp slt i64 1, %203
+  %210 = icmp sgt i64 1, %208
+  %211 = or i1 %209, %210
+  br i1 %211, label %then20, label %ifcont21
 
 then20:                                           ; preds = %ifcont19
-  %213 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %214 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %215 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %214, i32 0, i32 0
-  %216 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @185, i32 0, i32 0), i8** %216, align 8
-  %217 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 1
-  store i32 13, i32* %217, align 4
-  %218 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 2
-  store i32 9, i32* %218, align 4
-  %219 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 3
-  store i32 13, i32* %219, align 4
-  %220 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 4
-  store i32 18, i32* %220, align 4
-  %221 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @186, i32 0, i32 0))
-  %222 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %213, i32 0, i32 0
-  %223 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %214, i32 0, i32 0
-  %224 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 2
-  %225 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 0
-  store i1 true, i1* %225, align 1
-  %226 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 1
-  store i8* %221, i8** %226, align 8
-  store { i8*, i32, i32, i32, i32 }* %223, { i8*, i32, i32, i32, i32 }** %224, align 8
-  %227 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 3
-  store i32 1, i32* %227, align 4
-  %228 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %213, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %228, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @184, i32 0, i32 0), i64 1, i32 1, i64 %204, i64 %209)
+  %212 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %213 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %214 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %213, i32 0, i32 0
+  %215 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %214, i32 0, i32 0
+  store ptr @185, ptr %215, align 8
+  %216 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %214, i32 0, i32 1
+  store i32 13, ptr %216, align 4
+  %217 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %214, i32 0, i32 2
+  store i32 9, ptr %217, align 4
+  %218 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %214, i32 0, i32 3
+  store i32 13, ptr %218, align 4
+  %219 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %214, i32 0, i32 4
+  store i32 18, ptr %219, align 4
+  %220 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @186)
+  %221 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %212, i32 0, i32 0
+  %222 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %213, i32 0, i32 0
+  %223 = getelementptr { i1, ptr, ptr, i32 }, ptr %221, i32 0, i32 2
+  %224 = getelementptr { i1, ptr, ptr, i32 }, ptr %221, i32 0, i32 0
+  store i1 true, ptr %224, align 1
+  %225 = getelementptr { i1, ptr, ptr, i32 }, ptr %221, i32 0, i32 1
+  store ptr %220, ptr %225, align 8
+  store ptr %222, ptr %223, align 8
+  %226 = getelementptr { i1, ptr, ptr, i32 }, ptr %221, i32 0, i32 3
+  store i32 1, ptr %226, align 4
+  %227 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %212, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %227, i32 1, ptr @187, ptr @184, i64 1, i32 1, i64 %203, i64 %208)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %229 = getelementptr %dimension_descriptor, %dimension_descriptor* %202, i32 0, i32 2
-  %230 = load i64, i64* %229, align 8
-  %231 = mul i64 %230, %207
-  %232 = add i64 0, %231
-  %233 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %201, i32 1
-  %234 = getelementptr %dimension_descriptor, %dimension_descriptor* %233, i32 0, i32 0
-  %235 = load i64, i64* %234, align 8
-  %236 = getelementptr %dimension_descriptor, %dimension_descriptor* %233, i32 0, i32 1
-  %237 = load i64, i64* %236, align 8
-  %238 = sub i64 1, %235
-  %239 = add i64 %235, %237
-  %240 = sub i64 %239, 1
-  %241 = icmp slt i64 1, %235
-  %242 = icmp sgt i64 1, %240
-  %243 = or i1 %241, %242
-  br i1 %243, label %then22, label %ifcont23
+  %228 = getelementptr %dimension_descriptor, ptr %201, i32 0, i32 2
+  %229 = load i64, ptr %228, align 8
+  %230 = mul i64 %229, %206
+  %231 = add i64 0, %230
+  %232 = getelementptr inbounds %dimension_descriptor, ptr %200, i32 1
+  %233 = getelementptr %dimension_descriptor, ptr %232, i32 0, i32 0
+  %234 = load i64, ptr %233, align 8
+  %235 = getelementptr %dimension_descriptor, ptr %232, i32 0, i32 1
+  %236 = load i64, ptr %235, align 8
+  %237 = sub i64 1, %234
+  %238 = add i64 %234, %236
+  %239 = sub i64 %238, 1
+  %240 = icmp slt i64 1, %234
+  %241 = icmp sgt i64 1, %239
+  %242 = or i1 %240, %241
+  br i1 %242, label %then22, label %ifcont23
 
 then22:                                           ; preds = %ifcont21
-  %244 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %245 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %246 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %245, i32 0, i32 0
-  %247 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %246, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @189, i32 0, i32 0), i8** %247, align 8
-  %248 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %246, i32 0, i32 1
-  store i32 13, i32* %248, align 4
-  %249 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %246, i32 0, i32 2
-  store i32 9, i32* %249, align 4
-  %250 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %246, i32 0, i32 3
-  store i32 13, i32* %250, align 4
-  %251 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %246, i32 0, i32 4
-  store i32 18, i32* %251, align 4
-  %252 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @190, i32 0, i32 0))
-  %253 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %244, i32 0, i32 0
-  %254 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %245, i32 0, i32 0
-  %255 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 0, i32 2
-  %256 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 0, i32 0
-  store i1 true, i1* %256, align 1
-  %257 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 0, i32 1
-  store i8* %252, i8** %257, align 8
-  store { i8*, i32, i32, i32, i32 }* %254, { i8*, i32, i32, i32, i32 }** %255, align 8
-  %258 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 0, i32 3
-  store i32 1, i32* %258, align 4
-  %259 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %244, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %259, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @191, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @188, i32 0, i32 0), i64 1, i32 2, i64 %235, i64 %240)
+  %243 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %244 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %245 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %244, i32 0, i32 0
+  %246 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 0
+  store ptr @189, ptr %246, align 8
+  %247 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 1
+  store i32 13, ptr %247, align 4
+  %248 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 2
+  store i32 9, ptr %248, align 4
+  %249 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 3
+  store i32 13, ptr %249, align 4
+  %250 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 4
+  store i32 18, ptr %250, align 4
+  %251 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @190)
+  %252 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %243, i32 0, i32 0
+  %253 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %244, i32 0, i32 0
+  %254 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 2
+  %255 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 0
+  store i1 true, ptr %255, align 1
+  %256 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 1
+  store ptr %251, ptr %256, align 8
+  store ptr %253, ptr %254, align 8
+  %257 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 3
+  store i32 1, ptr %257, align 4
+  %258 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %243, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %258, i32 1, ptr @191, ptr @188, i64 1, i32 2, i64 %234, i64 %239)
   call void @exit(i32 1)
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %260 = getelementptr %dimension_descriptor, %dimension_descriptor* %233, i32 0, i32 2
-  %261 = load i64, i64* %260, align 8
-  %262 = mul i64 %261, %238
-  %263 = add i64 %232, %262
-  %264 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %201, i32 2
-  %265 = getelementptr %dimension_descriptor, %dimension_descriptor* %264, i32 0, i32 0
-  %266 = load i64, i64* %265, align 8
-  %267 = getelementptr %dimension_descriptor, %dimension_descriptor* %264, i32 0, i32 1
-  %268 = load i64, i64* %267, align 8
-  %269 = sub i64 1, %266
-  %270 = add i64 %266, %268
-  %271 = sub i64 %270, 1
-  %272 = icmp slt i64 1, %266
-  %273 = icmp sgt i64 1, %271
-  %274 = or i1 %272, %273
-  br i1 %274, label %then24, label %ifcont25
+  %259 = getelementptr %dimension_descriptor, ptr %232, i32 0, i32 2
+  %260 = load i64, ptr %259, align 8
+  %261 = mul i64 %260, %237
+  %262 = add i64 %231, %261
+  %263 = getelementptr inbounds %dimension_descriptor, ptr %200, i32 2
+  %264 = getelementptr %dimension_descriptor, ptr %263, i32 0, i32 0
+  %265 = load i64, ptr %264, align 8
+  %266 = getelementptr %dimension_descriptor, ptr %263, i32 0, i32 1
+  %267 = load i64, ptr %266, align 8
+  %268 = sub i64 1, %265
+  %269 = add i64 %265, %267
+  %270 = sub i64 %269, 1
+  %271 = icmp slt i64 1, %265
+  %272 = icmp sgt i64 1, %270
+  %273 = or i1 %271, %272
+  br i1 %273, label %then24, label %ifcont25
 
 then24:                                           ; preds = %ifcont23
-  %275 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %276 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %277 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %276, i32 0, i32 0
-  %278 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @193, i32 0, i32 0), i8** %278, align 8
-  %279 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 1
-  store i32 13, i32* %279, align 4
-  %280 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 2
-  store i32 9, i32* %280, align 4
-  %281 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 3
-  store i32 13, i32* %281, align 4
-  %282 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 4
-  store i32 18, i32* %282, align 4
-  %283 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @194, i32 0, i32 0))
-  %284 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %275, i32 0, i32 0
-  %285 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %276, i32 0, i32 0
-  %286 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 2
-  %287 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 0
-  store i1 true, i1* %287, align 1
-  %288 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 1
-  store i8* %283, i8** %288, align 8
-  store { i8*, i32, i32, i32, i32 }* %285, { i8*, i32, i32, i32, i32 }** %286, align 8
-  %289 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 3
-  store i32 1, i32* %289, align 4
-  %290 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %275, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %290, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @195, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @192, i32 0, i32 0), i64 1, i32 3, i64 %266, i64 %271)
+  %274 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %275 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %276 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %275, i32 0, i32 0
+  %277 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %276, i32 0, i32 0
+  store ptr @193, ptr %277, align 8
+  %278 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %276, i32 0, i32 1
+  store i32 13, ptr %278, align 4
+  %279 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %276, i32 0, i32 2
+  store i32 9, ptr %279, align 4
+  %280 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %276, i32 0, i32 3
+  store i32 13, ptr %280, align 4
+  %281 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %276, i32 0, i32 4
+  store i32 18, ptr %281, align 4
+  %282 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @194)
+  %283 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %274, i32 0, i32 0
+  %284 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %275, i32 0, i32 0
+  %285 = getelementptr { i1, ptr, ptr, i32 }, ptr %283, i32 0, i32 2
+  %286 = getelementptr { i1, ptr, ptr, i32 }, ptr %283, i32 0, i32 0
+  store i1 true, ptr %286, align 1
+  %287 = getelementptr { i1, ptr, ptr, i32 }, ptr %283, i32 0, i32 1
+  store ptr %282, ptr %287, align 8
+  store ptr %284, ptr %285, align 8
+  %288 = getelementptr { i1, ptr, ptr, i32 }, ptr %283, i32 0, i32 3
+  store i32 1, ptr %288, align 4
+  %289 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %274, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %289, i32 1, ptr @195, ptr @192, i64 1, i32 3, i64 %265, i64 %270)
   call void @exit(i32 1)
   unreachable
 
 ifcont25:                                         ; preds = %ifcont23
-  %291 = getelementptr %dimension_descriptor, %dimension_descriptor* %264, i32 0, i32 2
-  %292 = load i64, i64* %291, align 8
-  %293 = mul i64 %292, %269
-  %294 = add i64 %263, %293
-  %295 = getelementptr %array.3, %array.3* %176, i32 0, i32 7
-  %296 = load i64, i64* %295, align 8
-  %297 = add i64 %294, %296
-  %298 = getelementptr %array.3, %array.3* %176, i32 0, i32 0
-  %299 = load i32*, i32** %298, align 8
-  %300 = getelementptr inbounds i32, i32* %299, i64 %297
-  %301 = load i32, i32* %300, align 4
-  %302 = icmp ne i32 %301, 8
-  br i1 %302, label %then26, label %else27
+  %290 = getelementptr %dimension_descriptor, ptr %263, i32 0, i32 2
+  %291 = load i64, ptr %290, align 8
+  %292 = mul i64 %291, %268
+  %293 = add i64 %262, %292
+  %294 = getelementptr %array.3, ptr %175, i32 0, i32 7
+  %295 = load i64, ptr %294, align 8
+  %296 = add i64 %293, %295
+  %297 = getelementptr %array.3, ptr %175, i32 0, i32 0
+  %298 = load ptr, ptr %297, align 8
+  %299 = getelementptr inbounds i32, ptr %298, i64 %296
+  %300 = load i32, ptr %299, align 4
+  %301 = icmp ne i32 %300, 8
+  br i1 %301, label %then26, label %else27
 
 then26:                                           ; preds = %ifcont25
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @197, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @196, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @197, ptr @"ERROR STOP", ptr @196)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont28
@@ -758,227 +758,227 @@ else27:                                           ; preds = %ifcont25
   br label %ifcont28
 
 ifcont28:                                         ; preds = %else27, %then26
-  %303 = alloca i64, align 8
-  %304 = load %array.3*, %array.3** %c, align 8
-  %305 = ptrtoint %array.3* %304 to i64
-  %306 = icmp eq i64 %305, 0
-  br i1 %306, label %merge_allocated30, label %check_data29
+  %302 = alloca i64, align 8
+  %303 = load ptr, ptr %c, align 8
+  %304 = ptrtoint ptr %303 to i64
+  %305 = icmp eq i64 %304, 0
+  br i1 %305, label %merge_allocated30, label %check_data29
 
 check_data29:                                     ; preds = %ifcont28
-  %307 = getelementptr %array.3, %array.3* %304, i32 0, i32 0
-  %308 = load i32*, i32** %307, align 8
-  %309 = ptrtoint i32* %308 to i64
-  %310 = icmp ne i64 %309, 0
+  %306 = getelementptr %array.3, ptr %303, i32 0, i32 0
+  %307 = load ptr, ptr %306, align 8
+  %308 = ptrtoint ptr %307 to i64
+  %309 = icmp ne i64 %308, 0
   br label %merge_allocated30
 
 merge_allocated30:                                ; preds = %check_data29, %ifcont28
-  %is_allocated31 = phi i1 [ false, %ifcont28 ], [ %310, %check_data29 ]
-  %311 = xor i1 %is_allocated31, true
-  br i1 %311, label %then32, label %ifcont33
+  %is_allocated31 = phi i1 [ false, %ifcont28 ], [ %309, %check_data29 ]
+  %310 = xor i1 %is_allocated31, true
+  br i1 %310, label %then32, label %ifcont33
 
 then32:                                           ; preds = %merge_allocated30
-  %312 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %313 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %314 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %313, i32 0, i32 0
-  %315 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %314, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @200, i32 0, i32 0), i8** %315, align 8
-  %316 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %314, i32 0, i32 1
-  store i32 14, i32* %316, align 4
-  %317 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %314, i32 0, i32 2
-  store i32 14, i32* %317, align 4
-  %318 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %314, i32 0, i32 3
-  store i32 14, i32* %318, align 4
-  %319 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %314, i32 0, i32 4
-  store i32 23, i32* %319, align 4
-  %320 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @201, i32 0, i32 0))
-  %321 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %312, i32 0, i32 0
-  %322 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %313, i32 0, i32 0
-  %323 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %321, i32 0, i32 2
-  %324 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %321, i32 0, i32 0
-  store i1 true, i1* %324, align 1
-  %325 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %321, i32 0, i32 1
-  store i8* %320, i8** %325, align 8
-  store { i8*, i32, i32, i32, i32 }* %322, { i8*, i32, i32, i32, i32 }** %323, align 8
-  %326 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %321, i32 0, i32 3
-  store i32 1, i32* %326, align 4
-  %327 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %312, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %327, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @202, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @199, i32 0, i32 0))
+  %311 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %312 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %313 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %312, i32 0, i32 0
+  %314 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %313, i32 0, i32 0
+  store ptr @200, ptr %314, align 8
+  %315 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %313, i32 0, i32 1
+  store i32 14, ptr %315, align 4
+  %316 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %313, i32 0, i32 2
+  store i32 14, ptr %316, align 4
+  %317 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %313, i32 0, i32 3
+  store i32 14, ptr %317, align 4
+  %318 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %313, i32 0, i32 4
+  store i32 23, ptr %318, align 4
+  %319 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @201)
+  %320 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %311, i32 0, i32 0
+  %321 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %312, i32 0, i32 0
+  %322 = getelementptr { i1, ptr, ptr, i32 }, ptr %320, i32 0, i32 2
+  %323 = getelementptr { i1, ptr, ptr, i32 }, ptr %320, i32 0, i32 0
+  store i1 true, ptr %323, align 1
+  %324 = getelementptr { i1, ptr, ptr, i32 }, ptr %320, i32 0, i32 1
+  store ptr %319, ptr %324, align 8
+  store ptr %321, ptr %322, align 8
+  %325 = getelementptr { i1, ptr, ptr, i32 }, ptr %320, i32 0, i32 3
+  store i32 1, ptr %325, align 4
+  %326 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %311, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %326, i32 1, ptr @202, ptr @199)
   call void @exit(i32 1)
   unreachable
 
 ifcont33:                                         ; preds = %merge_allocated30
-  %328 = getelementptr %array.3, %array.3* %304, i32 0, i32 8
-  %329 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %328, i32 0, i32 0
-  %330 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %329, i32 0
-  %331 = getelementptr %dimension_descriptor, %dimension_descriptor* %330, i32 0, i32 0
-  %332 = load i64, i64* %331, align 8
-  %333 = getelementptr %dimension_descriptor, %dimension_descriptor* %330, i32 0, i32 1
-  %334 = load i64, i64* %333, align 8
-  %335 = sub i64 1, %332
-  %336 = add i64 %332, %334
-  %337 = sub i64 %336, 1
-  %338 = icmp slt i64 1, %332
-  %339 = icmp sgt i64 1, %337
-  %340 = or i1 %338, %339
-  br i1 %340, label %then34, label %ifcont35
+  %327 = getelementptr %array.3, ptr %303, i32 0, i32 8
+  %328 = getelementptr [3 x %dimension_descriptor], ptr %327, i32 0, i32 0
+  %329 = getelementptr inbounds %dimension_descriptor, ptr %328, i32 0
+  %330 = getelementptr %dimension_descriptor, ptr %329, i32 0, i32 0
+  %331 = load i64, ptr %330, align 8
+  %332 = getelementptr %dimension_descriptor, ptr %329, i32 0, i32 1
+  %333 = load i64, ptr %332, align 8
+  %334 = sub i64 1, %331
+  %335 = add i64 %331, %333
+  %336 = sub i64 %335, 1
+  %337 = icmp slt i64 1, %331
+  %338 = icmp sgt i64 1, %336
+  %339 = or i1 %337, %338
+  br i1 %339, label %then34, label %ifcont35
 
 then34:                                           ; preds = %ifcont33
-  %341 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %342 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %343 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %342, i32 0, i32 0
-  %344 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %343, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @204, i32 0, i32 0), i8** %344, align 8
-  %345 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %343, i32 0, i32 1
-  store i32 14, i32* %345, align 4
-  %346 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %343, i32 0, i32 2
-  store i32 14, i32* %346, align 4
-  %347 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %343, i32 0, i32 3
-  store i32 14, i32* %347, align 4
-  %348 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %343, i32 0, i32 4
-  store i32 23, i32* %348, align 4
-  %349 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @205, i32 0, i32 0))
-  %350 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %341, i32 0, i32 0
-  %351 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %342, i32 0, i32 0
-  %352 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %350, i32 0, i32 2
-  %353 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %350, i32 0, i32 0
-  store i1 true, i1* %353, align 1
-  %354 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %350, i32 0, i32 1
-  store i8* %349, i8** %354, align 8
-  store { i8*, i32, i32, i32, i32 }* %351, { i8*, i32, i32, i32, i32 }** %352, align 8
-  %355 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %350, i32 0, i32 3
-  store i32 1, i32* %355, align 4
-  %356 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %341, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %356, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @206, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @203, i32 0, i32 0), i64 1, i32 1, i64 %332, i64 %337)
+  %340 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %341 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %342 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %341, i32 0, i32 0
+  %343 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %342, i32 0, i32 0
+  store ptr @204, ptr %343, align 8
+  %344 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %342, i32 0, i32 1
+  store i32 14, ptr %344, align 4
+  %345 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %342, i32 0, i32 2
+  store i32 14, ptr %345, align 4
+  %346 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %342, i32 0, i32 3
+  store i32 14, ptr %346, align 4
+  %347 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %342, i32 0, i32 4
+  store i32 23, ptr %347, align 4
+  %348 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @205)
+  %349 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %340, i32 0, i32 0
+  %350 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %341, i32 0, i32 0
+  %351 = getelementptr { i1, ptr, ptr, i32 }, ptr %349, i32 0, i32 2
+  %352 = getelementptr { i1, ptr, ptr, i32 }, ptr %349, i32 0, i32 0
+  store i1 true, ptr %352, align 1
+  %353 = getelementptr { i1, ptr, ptr, i32 }, ptr %349, i32 0, i32 1
+  store ptr %348, ptr %353, align 8
+  store ptr %350, ptr %351, align 8
+  %354 = getelementptr { i1, ptr, ptr, i32 }, ptr %349, i32 0, i32 3
+  store i32 1, ptr %354, align 4
+  %355 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %340, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %355, i32 1, ptr @206, ptr @203, i64 1, i32 1, i64 %331, i64 %336)
   call void @exit(i32 1)
   unreachable
 
 ifcont35:                                         ; preds = %ifcont33
-  %357 = getelementptr %dimension_descriptor, %dimension_descriptor* %330, i32 0, i32 2
-  %358 = load i64, i64* %357, align 8
-  %359 = mul i64 %358, %335
-  %360 = add i64 0, %359
-  %361 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %329, i32 1
-  %362 = getelementptr %dimension_descriptor, %dimension_descriptor* %361, i32 0, i32 0
-  %363 = load i64, i64* %362, align 8
-  %364 = getelementptr %dimension_descriptor, %dimension_descriptor* %361, i32 0, i32 1
-  %365 = load i64, i64* %364, align 8
-  %366 = sub i64 1, %363
-  %367 = add i64 %363, %365
-  %368 = sub i64 %367, 1
-  %369 = icmp slt i64 1, %363
-  %370 = icmp sgt i64 1, %368
-  %371 = or i1 %369, %370
-  br i1 %371, label %then36, label %ifcont37
+  %356 = getelementptr %dimension_descriptor, ptr %329, i32 0, i32 2
+  %357 = load i64, ptr %356, align 8
+  %358 = mul i64 %357, %334
+  %359 = add i64 0, %358
+  %360 = getelementptr inbounds %dimension_descriptor, ptr %328, i32 1
+  %361 = getelementptr %dimension_descriptor, ptr %360, i32 0, i32 0
+  %362 = load i64, ptr %361, align 8
+  %363 = getelementptr %dimension_descriptor, ptr %360, i32 0, i32 1
+  %364 = load i64, ptr %363, align 8
+  %365 = sub i64 1, %362
+  %366 = add i64 %362, %364
+  %367 = sub i64 %366, 1
+  %368 = icmp slt i64 1, %362
+  %369 = icmp sgt i64 1, %367
+  %370 = or i1 %368, %369
+  br i1 %370, label %then36, label %ifcont37
 
 then36:                                           ; preds = %ifcont35
-  %372 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %373 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %374 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %373, i32 0, i32 0
-  %375 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %374, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @208, i32 0, i32 0), i8** %375, align 8
-  %376 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %374, i32 0, i32 1
-  store i32 14, i32* %376, align 4
-  %377 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %374, i32 0, i32 2
-  store i32 14, i32* %377, align 4
-  %378 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %374, i32 0, i32 3
-  store i32 14, i32* %378, align 4
-  %379 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %374, i32 0, i32 4
-  store i32 23, i32* %379, align 4
-  %380 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @209, i32 0, i32 0))
-  %381 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %372, i32 0, i32 0
-  %382 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %373, i32 0, i32 0
-  %383 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %381, i32 0, i32 2
-  %384 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %381, i32 0, i32 0
-  store i1 true, i1* %384, align 1
-  %385 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %381, i32 0, i32 1
-  store i8* %380, i8** %385, align 8
-  store { i8*, i32, i32, i32, i32 }* %382, { i8*, i32, i32, i32, i32 }** %383, align 8
-  %386 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %381, i32 0, i32 3
-  store i32 1, i32* %386, align 4
-  %387 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %372, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %387, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @210, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @207, i32 0, i32 0), i64 1, i32 2, i64 %363, i64 %368)
+  %371 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %372 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %373 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %372, i32 0, i32 0
+  %374 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %373, i32 0, i32 0
+  store ptr @208, ptr %374, align 8
+  %375 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %373, i32 0, i32 1
+  store i32 14, ptr %375, align 4
+  %376 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %373, i32 0, i32 2
+  store i32 14, ptr %376, align 4
+  %377 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %373, i32 0, i32 3
+  store i32 14, ptr %377, align 4
+  %378 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %373, i32 0, i32 4
+  store i32 23, ptr %378, align 4
+  %379 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @209)
+  %380 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %371, i32 0, i32 0
+  %381 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %372, i32 0, i32 0
+  %382 = getelementptr { i1, ptr, ptr, i32 }, ptr %380, i32 0, i32 2
+  %383 = getelementptr { i1, ptr, ptr, i32 }, ptr %380, i32 0, i32 0
+  store i1 true, ptr %383, align 1
+  %384 = getelementptr { i1, ptr, ptr, i32 }, ptr %380, i32 0, i32 1
+  store ptr %379, ptr %384, align 8
+  store ptr %381, ptr %382, align 8
+  %385 = getelementptr { i1, ptr, ptr, i32 }, ptr %380, i32 0, i32 3
+  store i32 1, ptr %385, align 4
+  %386 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %371, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %386, i32 1, ptr @210, ptr @207, i64 1, i32 2, i64 %362, i64 %367)
   call void @exit(i32 1)
   unreachable
 
 ifcont37:                                         ; preds = %ifcont35
-  %388 = getelementptr %dimension_descriptor, %dimension_descriptor* %361, i32 0, i32 2
-  %389 = load i64, i64* %388, align 8
-  %390 = mul i64 %389, %366
-  %391 = add i64 %360, %390
-  %392 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %329, i32 2
-  %393 = getelementptr %dimension_descriptor, %dimension_descriptor* %392, i32 0, i32 0
-  %394 = load i64, i64* %393, align 8
-  %395 = getelementptr %dimension_descriptor, %dimension_descriptor* %392, i32 0, i32 1
-  %396 = load i64, i64* %395, align 8
-  %397 = sub i64 1, %394
-  %398 = add i64 %394, %396
-  %399 = sub i64 %398, 1
-  %400 = icmp slt i64 1, %394
-  %401 = icmp sgt i64 1, %399
-  %402 = or i1 %400, %401
-  br i1 %402, label %then38, label %ifcont39
+  %387 = getelementptr %dimension_descriptor, ptr %360, i32 0, i32 2
+  %388 = load i64, ptr %387, align 8
+  %389 = mul i64 %388, %365
+  %390 = add i64 %359, %389
+  %391 = getelementptr inbounds %dimension_descriptor, ptr %328, i32 2
+  %392 = getelementptr %dimension_descriptor, ptr %391, i32 0, i32 0
+  %393 = load i64, ptr %392, align 8
+  %394 = getelementptr %dimension_descriptor, ptr %391, i32 0, i32 1
+  %395 = load i64, ptr %394, align 8
+  %396 = sub i64 1, %393
+  %397 = add i64 %393, %395
+  %398 = sub i64 %397, 1
+  %399 = icmp slt i64 1, %393
+  %400 = icmp sgt i64 1, %398
+  %401 = or i1 %399, %400
+  br i1 %401, label %then38, label %ifcont39
 
 then38:                                           ; preds = %ifcont37
-  %403 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %404 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %405 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %404, i32 0, i32 0
-  %406 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %405, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @212, i32 0, i32 0), i8** %406, align 8
-  %407 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %405, i32 0, i32 1
-  store i32 14, i32* %407, align 4
-  %408 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %405, i32 0, i32 2
-  store i32 14, i32* %408, align 4
-  %409 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %405, i32 0, i32 3
-  store i32 14, i32* %409, align 4
-  %410 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %405, i32 0, i32 4
-  store i32 23, i32* %410, align 4
-  %411 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @213, i32 0, i32 0))
-  %412 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %403, i32 0, i32 0
-  %413 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %404, i32 0, i32 0
-  %414 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %412, i32 0, i32 2
-  %415 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %412, i32 0, i32 0
-  store i1 true, i1* %415, align 1
-  %416 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %412, i32 0, i32 1
-  store i8* %411, i8** %416, align 8
-  store { i8*, i32, i32, i32, i32 }* %413, { i8*, i32, i32, i32, i32 }** %414, align 8
-  %417 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %412, i32 0, i32 3
-  store i32 1, i32* %417, align 4
-  %418 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %403, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %418, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @214, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @211, i32 0, i32 0), i64 1, i32 3, i64 %394, i64 %399)
+  %402 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %403 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %404 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %403, i32 0, i32 0
+  %405 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %404, i32 0, i32 0
+  store ptr @212, ptr %405, align 8
+  %406 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %404, i32 0, i32 1
+  store i32 14, ptr %406, align 4
+  %407 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %404, i32 0, i32 2
+  store i32 14, ptr %407, align 4
+  %408 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %404, i32 0, i32 3
+  store i32 14, ptr %408, align 4
+  %409 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %404, i32 0, i32 4
+  store i32 23, ptr %409, align 4
+  %410 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @213)
+  %411 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %402, i32 0, i32 0
+  %412 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %403, i32 0, i32 0
+  %413 = getelementptr { i1, ptr, ptr, i32 }, ptr %411, i32 0, i32 2
+  %414 = getelementptr { i1, ptr, ptr, i32 }, ptr %411, i32 0, i32 0
+  store i1 true, ptr %414, align 1
+  %415 = getelementptr { i1, ptr, ptr, i32 }, ptr %411, i32 0, i32 1
+  store ptr %410, ptr %415, align 8
+  store ptr %412, ptr %413, align 8
+  %416 = getelementptr { i1, ptr, ptr, i32 }, ptr %411, i32 0, i32 3
+  store i32 1, ptr %416, align 4
+  %417 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %402, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %417, i32 1, ptr @214, ptr @211, i64 1, i32 3, i64 %393, i64 %398)
   call void @exit(i32 1)
   unreachable
 
 ifcont39:                                         ; preds = %ifcont37
-  %419 = getelementptr %dimension_descriptor, %dimension_descriptor* %392, i32 0, i32 2
-  %420 = load i64, i64* %419, align 8
-  %421 = mul i64 %420, %397
-  %422 = add i64 %391, %421
-  %423 = getelementptr %array.3, %array.3* %304, i32 0, i32 7
-  %424 = load i64, i64* %423, align 8
-  %425 = add i64 %422, %424
-  %426 = getelementptr %array.3, %array.3* %304, i32 0, i32 0
-  %427 = load i32*, i32** %426, align 8
-  %428 = getelementptr inbounds i32, i32* %427, i64 %425
-  %429 = load i32, i32* %428, align 4
-  %430 = alloca i32, align 4
-  store i32 %429, i32* %430, align 4
-  %431 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %303, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %430)
-  %432 = load i64, i64* %303, align 8
-  %433 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %431, i8** %433, align 8
-  %434 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %432, i64* %434, align 8
-  %435 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %436 = load i8*, i8** %435, align 8
-  %437 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %438 = load i64, i64* %437, align 8
-  %439 = trunc i64 %438 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @215, i32 0, i32 0), i8* %436, i32 %439, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @198, i32 0, i32 0), i32 1)
-  %440 = icmp eq i8* %431, null
-  br i1 %440, label %free_done, label %free_nonnull
+  %418 = getelementptr %dimension_descriptor, ptr %391, i32 0, i32 2
+  %419 = load i64, ptr %418, align 8
+  %420 = mul i64 %419, %396
+  %421 = add i64 %390, %420
+  %422 = getelementptr %array.3, ptr %303, i32 0, i32 7
+  %423 = load i64, ptr %422, align 8
+  %424 = add i64 %421, %423
+  %425 = getelementptr %array.3, ptr %303, i32 0, i32 0
+  %426 = load ptr, ptr %425, align 8
+  %427 = getelementptr inbounds i32, ptr %426, i64 %424
+  %428 = load i32, ptr %427, align 4
+  %429 = alloca i32, align 4
+  store i32 %428, ptr %429, align 4
+  %430 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %302, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %429)
+  %431 = load i64, ptr %302, align 8
+  %432 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %430, ptr %432, align 8
+  %433 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %431, ptr %433, align 8
+  %434 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %435 = load ptr, ptr %434, align 8
+  %436 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %437 = load i64, ptr %436, align 8
+  %438 = trunc i64 %437 to i32
+  call void @_lfortran_printf(ptr @215, ptr %435, i32 %438, ptr @198, i32 1)
+  %439 = icmp eq ptr %430, null
+  br i1 %439, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont39
-  call void @_lfortran_free_alloc(i8* %2, i8* %431)
+  call void @_lfortran_free_alloc(ptr %2, ptr %430)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont39
@@ -991,25 +991,25 @@ FINALIZE_SYMTABLE_allocate_03:                    ; preds = %return
   br label %Finalize_Variable_c
 
 Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_allocate_03
-  %441 = load %array.3*, %array.3** %c, align 8
-  call void @finalize_allocatable__Array_3_i32(%array.3* %441)
+  %440 = load ptr, ptr %c, align 8
+  call void @finalize_allocatable__Array_3_i32(ptr %440)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-define void @f(%array.3** %c) {
+define void @f(ptr %c) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load %array.3*, %array.3** %c, align 8
-  %2 = load %array.3*, %array.3** %c, align 8
-  %3 = ptrtoint %array.3* %2 to i64
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load ptr, ptr %c, align 8
+  %2 = load ptr, ptr %c, align 8
+  %3 = ptrtoint ptr %2 to i64
   %4 = icmp eq i64 %3, 0
   br i1 %4, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %5 = getelementptr %array.3, %array.3* %2, i32 0, i32 0
-  %6 = load i32*, i32** %5, align 8
-  %7 = ptrtoint i32* %6 to i64
+  %5 = getelementptr %array.3, ptr %2, i32 0, i32 0
+  %6 = load ptr, ptr %5, align 8
+  %7 = ptrtoint ptr %6 to i64
   %8 = icmp ne i64 %7, 0
   br label %merge_allocated
 
@@ -1018,15 +1018,15 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %is_allocated, label %then, label %else5
 
 then:                                             ; preds = %merge_allocated
-  %9 = load %array.3*, %array.3** %c, align 8
-  %10 = ptrtoint %array.3* %9 to i64
+  %9 = load ptr, ptr %c, align 8
+  %10 = ptrtoint ptr %9 to i64
   %11 = icmp eq i64 %10, 0
   br i1 %11, label %merge_allocated2, label %check_data1
 
 check_data1:                                      ; preds = %then
-  %12 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  %13 = load i32*, i32** %12, align 8
-  %14 = ptrtoint i32* %13 to i64
+  %12 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  %13 = load ptr, ptr %12, align 8
+  %14 = ptrtoint ptr %13 to i64
   %15 = icmp ne i64 %14, 0
   br label %merge_allocated2
 
@@ -1035,12 +1035,11 @@ merge_allocated2:                                 ; preds = %check_data1, %then
   br i1 %is_allocated3, label %then4, label %else
 
 then4:                                            ; preds = %merge_allocated2
-  %16 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  %17 = load i32*, i32** %16, align 8
-  %18 = bitcast i32* %17 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %18)
-  %19 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  store i32* null, i32** %19, align 8
+  %16 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %17)
+  %18 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  store ptr null, ptr %18, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated2
@@ -1053,307 +1052,305 @@ else5:                                            ; preds = %merge_allocated
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont
-  %20 = load %array.3*, %array.3** %c, align 8
-  %21 = ptrtoint %array.3* %20 to i64
-  %22 = icmp eq i64 %21, 0
-  br i1 %22, label %merge_allocated8, label %check_data7
+  %19 = load ptr, ptr %c, align 8
+  %20 = ptrtoint ptr %19 to i64
+  %21 = icmp eq i64 %20, 0
+  br i1 %21, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %ifcont6
-  %23 = getelementptr %array.3, %array.3* %20, i32 0, i32 0
-  %24 = load i32*, i32** %23, align 8
-  %25 = ptrtoint i32* %24 to i64
-  %26 = icmp ne i64 %25, 0
+  %22 = getelementptr %array.3, ptr %19, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = ptrtoint ptr %23 to i64
+  %25 = icmp ne i64 %24, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %26, %check_data7 ]
+  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %25, %check_data7 ]
   br i1 %is_allocated9, label %then10, label %ifcont11
 
 then10:                                           ; preds = %merge_allocated8
-  %27 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %28 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %29 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %28, i32 0, i32 0
-  %30 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %29, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @1, i32 0, i32 0), i8** %30, align 8
-  %31 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %29, i32 0, i32 1
-  store i32 20, i32* %31, align 4
-  %32 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %29, i32 0, i32 2
-  store i32 14, i32* %32, align 4
-  %33 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %29, i32 0, i32 3
-  store i32 20, i32* %33, align 4
-  %34 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %29, i32 0, i32 4
-  store i32 23, i32* %34, align 4
-  %35 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %36 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %27, i32 0, i32 0
-  %37 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %28, i32 0, i32 0
-  %38 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %36, i32 0, i32 2
-  %39 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %36, i32 0, i32 0
-  store i1 true, i1* %39, align 1
-  %40 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %36, i32 0, i32 1
-  store i8* %35, i8** %40, align 8
-  store { i8*, i32, i32, i32, i32 }* %37, { i8*, i32, i32, i32, i32 }** %38, align 8
-  %41 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %36, i32 0, i32 3
-  store i32 1, i32* %41, align 4
-  %42 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %27, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %26 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %27 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %28 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %27, i32 0, i32 0
+  %29 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %28, i32 0, i32 0
+  store ptr @1, ptr %29, align 8
+  %30 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %28, i32 0, i32 1
+  store i32 20, ptr %30, align 4
+  %31 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %28, i32 0, i32 2
+  store i32 14, ptr %31, align 4
+  %32 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %28, i32 0, i32 3
+  store i32 20, ptr %32, align 4
+  %33 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %28, i32 0, i32 4
+  store i32 23, ptr %33, align 4
+  %34 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @2, ptr @0)
+  %35 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %26, i32 0, i32 0
+  %36 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %27, i32 0, i32 0
+  %37 = getelementptr { i1, ptr, ptr, i32 }, ptr %35, i32 0, i32 2
+  %38 = getelementptr { i1, ptr, ptr, i32 }, ptr %35, i32 0, i32 0
+  store i1 true, ptr %38, align 1
+  %39 = getelementptr { i1, ptr, ptr, i32 }, ptr %35, i32 0, i32 1
+  store ptr %34, ptr %39, align 8
+  store ptr %36, ptr %37, align 8
+  %40 = getelementptr { i1, ptr, ptr, i32 }, ptr %35, i32 0, i32 3
+  store i32 1, ptr %40, align 4
+  %41 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %26, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %41, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %merge_allocated8
-  %43 = load %array.3*, %array.3** %c, align 8
-  %44 = ptrtoint %array.3* %43 to i64
-  %45 = icmp eq i64 %44, 0
-  br i1 %45, label %then12, label %else13
+  %42 = load ptr, ptr %c, align 8
+  %43 = ptrtoint ptr %42 to i64
+  %44 = icmp eq i64 %43, 0
+  br i1 %44, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont11
-  %46 = call i8* @_lfortran_get_default_allocator()
-  %47 = call i8* @_lfortran_malloc_alloc(i8* %46, i64 104)
-  %48 = bitcast i8* %47 to %array.3*
-  %49 = getelementptr %array.3, %array.3* %48, i32 0, i32 3
-  store i8 3, i8* %49, align 1
-  %50 = getelementptr %array.3, %array.3* %48, i32 0, i32 0
-  store i32* null, i32** %50, align 8
-  store %array.3* %48, %array.3** %c, align 8
+  %45 = call ptr @_lfortran_get_default_allocator()
+  %46 = call ptr @_lfortran_malloc_alloc(ptr %45, i64 104)
+  %47 = getelementptr %array.3, ptr %46, i32 0, i32 3
+  store i8 3, ptr %47, align 1
+  %48 = getelementptr %array.3, ptr %46, i32 0, i32 0
+  store ptr null, ptr %48, align 8
+  store ptr %46, ptr %c, align 8
   br label %ifcont14
 
 else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  %51 = load %array.3*, %array.3** %c, align 8
-  %52 = getelementptr %array.3, %array.3* %51, i32 0, i32 7
-  store i64 0, i64* %52, align 8
-  %53 = getelementptr %array.3, %array.3* %51, i32 0, i32 3
-  store i8 3, i8* %53, align 1
-  %54 = getelementptr %array.3, %array.3* %51, i32 0, i32 8
-  %55 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %54, i32 0, i32 0
-  %56 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 0
-  %57 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 2
-  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 0
-  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %56, i32 0, i32 1
-  store i64 1, i64* %57, align 8
-  store i64 1, i64* %58, align 8
-  store i64 3, i64* %59, align 8
-  %60 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 1
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 2
-  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 0
-  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %60, i32 0, i32 1
-  store i64 3, i64* %61, align 8
-  store i64 1, i64* %62, align 8
-  store i64 3, i64* %63, align 8
-  %64 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %55, i32 2
-  %65 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 2
-  %66 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 0
-  %67 = getelementptr %dimension_descriptor, %dimension_descriptor* %64, i32 0, i32 1
-  store i64 9, i64* %65, align 8
-  store i64 1, i64* %66, align 8
-  store i64 3, i64* %67, align 8
-  %68 = getelementptr %array.3, %array.3* %51, i32 0, i32 0
-  %69 = call i8* @_lfortran_get_default_allocator()
-  %70 = call i8* @_lfortran_malloc_alloc(i8* %69, i64 108)
-  %71 = bitcast i8* %70 to i32*
-  store i32* %71, i32** %68, align 8
-  %72 = load %array.3*, %array.3** %c, align 8
-  %73 = ptrtoint %array.3* %72 to i64
-  %74 = icmp eq i64 %73, 0
-  br i1 %74, label %merge_allocated16, label %check_data15
+  %49 = load ptr, ptr %c, align 8
+  %50 = getelementptr %array.3, ptr %49, i32 0, i32 7
+  store i64 0, ptr %50, align 8
+  %51 = getelementptr %array.3, ptr %49, i32 0, i32 3
+  store i8 3, ptr %51, align 1
+  %52 = getelementptr %array.3, ptr %49, i32 0, i32 8
+  %53 = getelementptr [3 x %dimension_descriptor], ptr %52, i32 0, i32 0
+  %54 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 0
+  %55 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 2
+  %56 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 0
+  %57 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 1
+  store i64 1, ptr %55, align 8
+  store i64 1, ptr %56, align 8
+  store i64 3, ptr %57, align 8
+  %58 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 1
+  %59 = getelementptr %dimension_descriptor, ptr %58, i32 0, i32 2
+  %60 = getelementptr %dimension_descriptor, ptr %58, i32 0, i32 0
+  %61 = getelementptr %dimension_descriptor, ptr %58, i32 0, i32 1
+  store i64 3, ptr %59, align 8
+  store i64 1, ptr %60, align 8
+  store i64 3, ptr %61, align 8
+  %62 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 2
+  %63 = getelementptr %dimension_descriptor, ptr %62, i32 0, i32 2
+  %64 = getelementptr %dimension_descriptor, ptr %62, i32 0, i32 0
+  %65 = getelementptr %dimension_descriptor, ptr %62, i32 0, i32 1
+  store i64 9, ptr %63, align 8
+  store i64 1, ptr %64, align 8
+  store i64 3, ptr %65, align 8
+  %66 = getelementptr %array.3, ptr %49, i32 0, i32 0
+  %67 = call ptr @_lfortran_get_default_allocator()
+  %68 = call ptr @_lfortran_malloc_alloc(ptr %67, i64 108)
+  store ptr %68, ptr %66, align 8
+  %69 = load ptr, ptr %c, align 8
+  %70 = ptrtoint ptr %69 to i64
+  %71 = icmp eq i64 %70, 0
+  br i1 %71, label %merge_allocated16, label %check_data15
 
 check_data15:                                     ; preds = %ifcont14
-  %75 = getelementptr %array.3, %array.3* %72, i32 0, i32 0
-  %76 = load i32*, i32** %75, align 8
-  %77 = ptrtoint i32* %76 to i64
-  %78 = icmp ne i64 %77, 0
+  %72 = getelementptr %array.3, ptr %69, i32 0, i32 0
+  %73 = load ptr, ptr %72, align 8
+  %74 = ptrtoint ptr %73 to i64
+  %75 = icmp ne i64 %74, 0
   br label %merge_allocated16
 
 merge_allocated16:                                ; preds = %check_data15, %ifcont14
-  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %78, %check_data15 ]
-  %79 = xor i1 %is_allocated17, true
-  br i1 %79, label %then18, label %ifcont19
+  %is_allocated17 = phi i1 [ false, %ifcont14 ], [ %75, %check_data15 ]
+  %76 = xor i1 %is_allocated17, true
+  br i1 %76, label %then18, label %ifcont19
 
 then18:                                           ; preds = %merge_allocated16
-  %80 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %81 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %82 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @5, i32 0, i32 0), i8** %83, align 8
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 1
-  store i32 21, i32* %84, align 4
-  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 2
-  store i32 5, i32* %85, align 4
-  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 3
-  store i32 21, i32* %86, align 4
-  %87 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 4
-  store i32 14, i32* %87, align 4
-  %88 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %89 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
-  %90 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 2
-  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 0
-  store i1 true, i1* %92, align 1
-  %93 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 1
-  store i8* %88, i8** %93, align 8
-  store { i8*, i32, i32, i32, i32 }* %90, { i8*, i32, i32, i32, i32 }** %91, align 8
-  %94 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 3
-  store i32 1, i32* %94, align 4
-  %95 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %95, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %77 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %78 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %79 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %78, i32 0, i32 0
+  %80 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 0
+  store ptr @5, ptr %80, align 8
+  %81 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 1
+  store i32 21, ptr %81, align 4
+  %82 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 2
+  store i32 5, ptr %82, align 4
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 3
+  store i32 21, ptr %83, align 4
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 4
+  store i32 14, ptr %84, align 4
+  %85 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @6)
+  %86 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %77, i32 0, i32 0
+  %87 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %78, i32 0, i32 0
+  %88 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 2
+  %89 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 0
+  store i1 true, ptr %89, align 1
+  %90 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 1
+  store ptr %85, ptr %90, align 8
+  store ptr %87, ptr %88, align 8
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 3
+  store i32 1, ptr %91, align 4
+  %92 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %77, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %92, i32 1, ptr @7, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %merge_allocated16
-  %96 = getelementptr %array.3, %array.3* %72, i32 0, i32 8
-  %97 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %96, i32 0, i32 0
-  %98 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 0
-  %99 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 0
-  %100 = load i64, i64* %99, align 8
-  %101 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 1
-  %102 = load i64, i64* %101, align 8
-  %103 = sub i64 1, %100
-  %104 = add i64 %100, %102
-  %105 = sub i64 %104, 1
-  %106 = icmp slt i64 1, %100
-  %107 = icmp sgt i64 1, %105
-  %108 = or i1 %106, %107
-  br i1 %108, label %then20, label %ifcont21
+  %93 = getelementptr %array.3, ptr %69, i32 0, i32 8
+  %94 = getelementptr [3 x %dimension_descriptor], ptr %93, i32 0, i32 0
+  %95 = getelementptr inbounds %dimension_descriptor, ptr %94, i32 0
+  %96 = getelementptr %dimension_descriptor, ptr %95, i32 0, i32 0
+  %97 = load i64, ptr %96, align 8
+  %98 = getelementptr %dimension_descriptor, ptr %95, i32 0, i32 1
+  %99 = load i64, ptr %98, align 8
+  %100 = sub i64 1, %97
+  %101 = add i64 %97, %99
+  %102 = sub i64 %101, 1
+  %103 = icmp slt i64 1, %97
+  %104 = icmp sgt i64 1, %102
+  %105 = or i1 %103, %104
+  br i1 %105, label %then20, label %ifcont21
 
 then20:                                           ; preds = %ifcont19
-  %109 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %110 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %111 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @9, i32 0, i32 0), i8** %112, align 8
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 1
-  store i32 21, i32* %113, align 4
-  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 2
-  store i32 5, i32* %114, align 4
-  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 3
-  store i32 21, i32* %115, align 4
-  %116 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %111, i32 0, i32 4
-  store i32 14, i32* %116, align 4
-  %117 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %118 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
-  %119 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %110, i32 0, i32 0
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 2
-  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 0
-  store i1 true, i1* %121, align 1
-  %122 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 1
-  store i8* %117, i8** %122, align 8
-  store { i8*, i32, i32, i32, i32 }* %119, { i8*, i32, i32, i32, i32 }** %120, align 8
-  %123 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %118, i32 0, i32 3
-  store i32 1, i32* %123, align 4
-  %124 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %109, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i64 1, i32 1, i64 %100, i64 %105)
+  %106 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %107 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %108 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %107, i32 0, i32 0
+  %109 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 0
+  store ptr @9, ptr %109, align 8
+  %110 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 1
+  store i32 21, ptr %110, align 4
+  %111 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 2
+  store i32 5, ptr %111, align 4
+  %112 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 3
+  store i32 21, ptr %112, align 4
+  %113 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 4
+  store i32 14, ptr %113, align 4
+  %114 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @10)
+  %115 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %106, i32 0, i32 0
+  %116 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %107, i32 0, i32 0
+  %117 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 2
+  %118 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 0
+  store i1 true, ptr %118, align 1
+  %119 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 1
+  store ptr %114, ptr %119, align 8
+  store ptr %116, ptr %117, align 8
+  %120 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 3
+  store i32 1, ptr %120, align 4
+  %121 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %106, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %121, i32 1, ptr @11, ptr @8, i64 1, i32 1, i64 %97, i64 %102)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %125 = getelementptr %dimension_descriptor, %dimension_descriptor* %98, i32 0, i32 2
-  %126 = load i64, i64* %125, align 8
-  %127 = mul i64 %126, %103
-  %128 = add i64 0, %127
-  %129 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 1
-  %130 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 0
-  %131 = load i64, i64* %130, align 8
-  %132 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 1
-  %133 = load i64, i64* %132, align 8
-  %134 = sub i64 1, %131
-  %135 = add i64 %131, %133
-  %136 = sub i64 %135, 1
-  %137 = icmp slt i64 1, %131
-  %138 = icmp sgt i64 1, %136
-  %139 = or i1 %137, %138
-  br i1 %139, label %then22, label %ifcont23
+  %122 = getelementptr %dimension_descriptor, ptr %95, i32 0, i32 2
+  %123 = load i64, ptr %122, align 8
+  %124 = mul i64 %123, %100
+  %125 = add i64 0, %124
+  %126 = getelementptr inbounds %dimension_descriptor, ptr %94, i32 1
+  %127 = getelementptr %dimension_descriptor, ptr %126, i32 0, i32 0
+  %128 = load i64, ptr %127, align 8
+  %129 = getelementptr %dimension_descriptor, ptr %126, i32 0, i32 1
+  %130 = load i64, ptr %129, align 8
+  %131 = sub i64 1, %128
+  %132 = add i64 %128, %130
+  %133 = sub i64 %132, 1
+  %134 = icmp slt i64 1, %128
+  %135 = icmp sgt i64 1, %133
+  %136 = or i1 %134, %135
+  br i1 %136, label %then22, label %ifcont23
 
 then22:                                           ; preds = %ifcont21
-  %140 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %141 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %142 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %141, i32 0, i32 0
-  %143 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @13, i32 0, i32 0), i8** %143, align 8
-  %144 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 1
-  store i32 21, i32* %144, align 4
-  %145 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 2
-  store i32 5, i32* %145, align 4
-  %146 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 3
-  store i32 21, i32* %146, align 4
-  %147 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %142, i32 0, i32 4
-  store i32 14, i32* %147, align 4
-  %148 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
-  %149 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %140, i32 0, i32 0
-  %150 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %141, i32 0, i32 0
-  %151 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 2
-  %152 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 0
-  store i1 true, i1* %152, align 1
-  %153 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 1
-  store i8* %148, i8** %153, align 8
-  store { i8*, i32, i32, i32, i32 }* %150, { i8*, i32, i32, i32, i32 }** %151, align 8
-  %154 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %149, i32 0, i32 3
-  store i32 1, i32* %154, align 4
-  %155 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %140, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %155, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i64 1, i32 2, i64 %131, i64 %136)
+  %137 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %138 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %139 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %138, i32 0, i32 0
+  %140 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 0
+  store ptr @13, ptr %140, align 8
+  %141 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 1
+  store i32 21, ptr %141, align 4
+  %142 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 2
+  store i32 5, ptr %142, align 4
+  %143 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 3
+  store i32 21, ptr %143, align 4
+  %144 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 4
+  store i32 14, ptr %144, align 4
+  %145 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @14)
+  %146 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %137, i32 0, i32 0
+  %147 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %138, i32 0, i32 0
+  %148 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 2
+  %149 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 0
+  store i1 true, ptr %149, align 1
+  %150 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 1
+  store ptr %145, ptr %150, align 8
+  store ptr %147, ptr %148, align 8
+  %151 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 3
+  store i32 1, ptr %151, align 4
+  %152 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %137, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %152, i32 1, ptr @15, ptr @12, i64 1, i32 2, i64 %128, i64 %133)
   call void @exit(i32 1)
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %156 = getelementptr %dimension_descriptor, %dimension_descriptor* %129, i32 0, i32 2
-  %157 = load i64, i64* %156, align 8
-  %158 = mul i64 %157, %134
-  %159 = add i64 %128, %158
-  %160 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %97, i32 2
-  %161 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 0
-  %162 = load i64, i64* %161, align 8
-  %163 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 1
-  %164 = load i64, i64* %163, align 8
-  %165 = sub i64 1, %162
-  %166 = add i64 %162, %164
-  %167 = sub i64 %166, 1
-  %168 = icmp slt i64 1, %162
-  %169 = icmp sgt i64 1, %167
-  %170 = or i1 %168, %169
-  br i1 %170, label %then24, label %ifcont25
+  %153 = getelementptr %dimension_descriptor, ptr %126, i32 0, i32 2
+  %154 = load i64, ptr %153, align 8
+  %155 = mul i64 %154, %131
+  %156 = add i64 %125, %155
+  %157 = getelementptr inbounds %dimension_descriptor, ptr %94, i32 2
+  %158 = getelementptr %dimension_descriptor, ptr %157, i32 0, i32 0
+  %159 = load i64, ptr %158, align 8
+  %160 = getelementptr %dimension_descriptor, ptr %157, i32 0, i32 1
+  %161 = load i64, ptr %160, align 8
+  %162 = sub i64 1, %159
+  %163 = add i64 %159, %161
+  %164 = sub i64 %163, 1
+  %165 = icmp slt i64 1, %159
+  %166 = icmp sgt i64 1, %164
+  %167 = or i1 %165, %166
+  br i1 %167, label %then24, label %ifcont25
 
 then24:                                           ; preds = %ifcont23
-  %171 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %172 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %173 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
-  %174 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @17, i32 0, i32 0), i8** %174, align 8
-  %175 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 1
-  store i32 21, i32* %175, align 4
-  %176 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 2
-  store i32 5, i32* %176, align 4
-  %177 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 3
-  store i32 21, i32* %177, align 4
-  %178 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 4
-  store i32 14, i32* %178, align 4
-  %179 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %180 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
-  %181 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
-  %182 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 2
-  %183 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 0
-  store i1 true, i1* %183, align 1
-  %184 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 1
-  store i8* %179, i8** %184, align 8
-  store { i8*, i32, i32, i32, i32 }* %181, { i8*, i32, i32, i32, i32 }** %182, align 8
-  %185 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 3
-  store i32 1, i32* %185, align 4
-  %186 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %186, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 1, i32 3, i64 %162, i64 %167)
+  %168 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %169 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %170 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %169, i32 0, i32 0
+  %171 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 0
+  store ptr @17, ptr %171, align 8
+  %172 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 1
+  store i32 21, ptr %172, align 4
+  %173 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 2
+  store i32 5, ptr %173, align 4
+  %174 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 3
+  store i32 21, ptr %174, align 4
+  %175 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 4
+  store i32 14, ptr %175, align 4
+  %176 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @18)
+  %177 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %168, i32 0, i32 0
+  %178 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %169, i32 0, i32 0
+  %179 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 2
+  %180 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 0
+  store i1 true, ptr %180, align 1
+  %181 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 1
+  store ptr %176, ptr %181, align 8
+  store ptr %178, ptr %179, align 8
+  %182 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 3
+  store i32 1, ptr %182, align 4
+  %183 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %168, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %183, i32 1, ptr @19, ptr @16, i64 1, i32 3, i64 %159, i64 %164)
   call void @exit(i32 1)
   unreachable
 
 ifcont25:                                         ; preds = %ifcont23
-  %187 = getelementptr %dimension_descriptor, %dimension_descriptor* %160, i32 0, i32 2
-  %188 = load i64, i64* %187, align 8
-  %189 = mul i64 %188, %165
-  %190 = add i64 %159, %189
-  %191 = getelementptr %array.3, %array.3* %72, i32 0, i32 7
-  %192 = load i64, i64* %191, align 8
-  %193 = add i64 %190, %192
-  %194 = getelementptr %array.3, %array.3* %72, i32 0, i32 0
-  %195 = load i32*, i32** %194, align 8
-  %196 = getelementptr inbounds i32, i32* %195, i64 %193
-  store i32 99, i32* %196, align 4
+  %184 = getelementptr %dimension_descriptor, ptr %157, i32 0, i32 2
+  %185 = load i64, ptr %184, align 8
+  %186 = mul i64 %185, %162
+  %187 = add i64 %156, %186
+  %188 = getelementptr %array.3, ptr %69, i32 0, i32 7
+  %189 = load i64, ptr %188, align 8
+  %190 = add i64 %187, %189
+  %191 = getelementptr %array.3, ptr %69, i32 0, i32 0
+  %192 = load ptr, ptr %191, align 8
+  %193 = getelementptr inbounds i32, ptr %192, i64 %190
+  store i32 99, ptr %193, align 4
   br label %return
 
 return:                                           ; preds = %ifcont25
@@ -1363,22 +1360,22 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
   ret void
 }
 
-define i32 @g(%array.3** %x) {
+define i32 @g(ptr %x) {
 .entry:
   %stringFormat_desc31 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %r = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = load %array.3*, %array.3** %x, align 8
-  %3 = ptrtoint %array.3* %2 to i64
+  %2 = load ptr, ptr %x, align 8
+  %3 = ptrtoint ptr %2 to i64
   %4 = icmp eq i64 %3, 0
   br i1 %4, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %5 = getelementptr %array.3, %array.3* %2, i32 0, i32 0
-  %6 = load i32*, i32** %5, align 8
-  %7 = ptrtoint i32* %6 to i64
+  %5 = getelementptr %array.3, ptr %2, i32 0, i32 0
+  %6 = load ptr, ptr %5, align 8
+  %7 = ptrtoint ptr %6 to i64
   %8 = icmp ne i64 %7, 0
   br label %merge_allocated
 
@@ -1388,43 +1385,43 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %9, label %then, label %ifcont
 
 then:                                             ; preds = %merge_allocated
-  %10 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %11 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %12 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %11, i32 0, i32 0
-  %13 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @22, i32 0, i32 0), i8** %13, align 8
-  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 1
-  store i32 27, i32* %14, align 4
-  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 2
-  store i32 14, i32* %15, align 4
-  %16 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 3
-  store i32 27, i32* %16, align 4
-  %17 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %12, i32 0, i32 4
-  store i32 23, i32* %17, align 4
-  %18 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @23, i32 0, i32 0))
-  %19 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %10, i32 0, i32 0
-  %20 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %11, i32 0, i32 0
-  %21 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 2
-  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 0
-  store i1 true, i1* %22, align 1
-  %23 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 1
-  store i8* %18, i8** %23, align 8
-  store { i8*, i32, i32, i32, i32 }* %20, { i8*, i32, i32, i32, i32 }** %21, align 8
-  %24 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %19, i32 0, i32 3
-  store i32 1, i32* %24, align 4
-  %25 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %10, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @24, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @21, i32 0, i32 0))
+  %10 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %11 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %12 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %11, i32 0, i32 0
+  %13 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %12, i32 0, i32 0
+  store ptr @22, ptr %13, align 8
+  %14 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %12, i32 0, i32 1
+  store i32 27, ptr %14, align 4
+  %15 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %12, i32 0, i32 2
+  store i32 14, ptr %15, align 4
+  %16 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %12, i32 0, i32 3
+  store i32 27, ptr %16, align 4
+  %17 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %12, i32 0, i32 4
+  store i32 23, ptr %17, align 4
+  %18 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @23)
+  %19 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %10, i32 0, i32 0
+  %20 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %11, i32 0, i32 0
+  %21 = getelementptr { i1, ptr, ptr, i32 }, ptr %19, i32 0, i32 2
+  %22 = getelementptr { i1, ptr, ptr, i32 }, ptr %19, i32 0, i32 0
+  store i1 true, ptr %22, align 1
+  %23 = getelementptr { i1, ptr, ptr, i32 }, ptr %19, i32 0, i32 1
+  store ptr %18, ptr %23, align 8
+  store ptr %20, ptr %21, align 8
+  %24 = getelementptr { i1, ptr, ptr, i32 }, ptr %19, i32 0, i32 3
+  store i32 1, ptr %24, align 4
+  %25 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %10, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %25, i32 1, ptr @24, ptr @21)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %merge_allocated
-  %26 = getelementptr %array.3, %array.3* %2, i32 0, i32 8
-  %27 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %26, i32 0, i32 0
-  %28 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 0
-  %29 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 0
-  %30 = load i64, i64* %29, align 8
-  %31 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 1
-  %32 = load i64, i64* %31, align 8
+  %26 = getelementptr %array.3, ptr %2, i32 0, i32 8
+  %27 = getelementptr [3 x %dimension_descriptor], ptr %26, i32 0, i32 0
+  %28 = getelementptr inbounds %dimension_descriptor, ptr %27, i32 0
+  %29 = getelementptr %dimension_descriptor, ptr %28, i32 0, i32 0
+  %30 = load i64, ptr %29, align 8
+  %31 = getelementptr %dimension_descriptor, ptr %28, i32 0, i32 1
+  %32 = load i64, ptr %31, align 8
   %33 = sub i64 1, %30
   %34 = add i64 %30, %32
   %35 = sub i64 %34, 1
@@ -1434,45 +1431,45 @@ ifcont:                                           ; preds = %merge_allocated
   br i1 %38, label %then1, label %ifcont2
 
 then1:                                            ; preds = %ifcont
-  %39 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %40 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %41 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @26, i32 0, i32 0), i8** %42, align 8
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 1
-  store i32 27, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 2
-  store i32 14, i32* %44, align 4
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 3
-  store i32 27, i32* %45, align 4
-  %46 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 4
-  store i32 23, i32* %46, align 4
-  %47 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @27, i32 0, i32 0))
-  %48 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  %49 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 2
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 0
-  store i1 true, i1* %51, align 1
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 1
-  store i8* %47, i8** %52, align 8
-  store { i8*, i32, i32, i32, i32 }* %49, { i8*, i32, i32, i32, i32 }** %50, align 8
-  %53 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 3
-  store i32 1, i32* %53, align 4
-  %54 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @25, i32 0, i32 0), i64 1, i32 1, i64 %30, i64 %35)
+  %39 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %40 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %41 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %40, i32 0, i32 0
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 0
+  store ptr @26, ptr %42, align 8
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 1
+  store i32 27, ptr %43, align 4
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 2
+  store i32 14, ptr %44, align 4
+  %45 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 3
+  store i32 27, ptr %45, align 4
+  %46 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 4
+  store i32 23, ptr %46, align 4
+  %47 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @27)
+  %48 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %39, i32 0, i32 0
+  %49 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %40, i32 0, i32 0
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 2
+  %51 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 0
+  store i1 true, ptr %51, align 1
+  %52 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 1
+  store ptr %47, ptr %52, align 8
+  store ptr %49, ptr %50, align 8
+  %53 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 3
+  store i32 1, ptr %53, align 4
+  %54 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %39, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %54, i32 1, ptr @28, ptr @25, i64 1, i32 1, i64 %30, i64 %35)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %28, i32 0, i32 2
-  %56 = load i64, i64* %55, align 8
+  %55 = getelementptr %dimension_descriptor, ptr %28, i32 0, i32 2
+  %56 = load i64, ptr %55, align 8
   %57 = mul i64 %56, %33
   %58 = add i64 0, %57
-  %59 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 1
-  %60 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 0
-  %61 = load i64, i64* %60, align 8
-  %62 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 1
-  %63 = load i64, i64* %62, align 8
+  %59 = getelementptr inbounds %dimension_descriptor, ptr %27, i32 1
+  %60 = getelementptr %dimension_descriptor, ptr %59, i32 0, i32 0
+  %61 = load i64, ptr %60, align 8
+  %62 = getelementptr %dimension_descriptor, ptr %59, i32 0, i32 1
+  %63 = load i64, ptr %62, align 8
   %64 = sub i64 1, %61
   %65 = add i64 %61, %63
   %66 = sub i64 %65, 1
@@ -1482,45 +1479,45 @@ ifcont2:                                          ; preds = %ifcont
   br i1 %69, label %then3, label %ifcont4
 
 then3:                                            ; preds = %ifcont2
-  %70 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %71 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %72 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @30, i32 0, i32 0), i8** %73, align 8
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 1
-  store i32 27, i32* %74, align 4
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 2
-  store i32 14, i32* %75, align 4
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 3
-  store i32 27, i32* %76, align 4
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %72, i32 0, i32 4
-  store i32 23, i32* %77, align 4
-  %78 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @31, i32 0, i32 0))
-  %79 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
-  %80 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %71, i32 0, i32 0
-  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 2
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 0
-  store i1 true, i1* %82, align 1
-  %83 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 1
-  store i8* %78, i8** %83, align 8
-  store { i8*, i32, i32, i32, i32 }* %80, { i8*, i32, i32, i32, i32 }** %81, align 8
-  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %79, i32 0, i32 3
-  store i32 1, i32* %84, align 4
-  %85 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %70, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %85, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @29, i32 0, i32 0), i64 1, i32 2, i64 %61, i64 %66)
+  %70 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %71 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %72 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %71, i32 0, i32 0
+  %73 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %72, i32 0, i32 0
+  store ptr @30, ptr %73, align 8
+  %74 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %72, i32 0, i32 1
+  store i32 27, ptr %74, align 4
+  %75 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %72, i32 0, i32 2
+  store i32 14, ptr %75, align 4
+  %76 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %72, i32 0, i32 3
+  store i32 27, ptr %76, align 4
+  %77 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %72, i32 0, i32 4
+  store i32 23, ptr %77, align 4
+  %78 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @31)
+  %79 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %70, i32 0, i32 0
+  %80 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %71, i32 0, i32 0
+  %81 = getelementptr { i1, ptr, ptr, i32 }, ptr %79, i32 0, i32 2
+  %82 = getelementptr { i1, ptr, ptr, i32 }, ptr %79, i32 0, i32 0
+  store i1 true, ptr %82, align 1
+  %83 = getelementptr { i1, ptr, ptr, i32 }, ptr %79, i32 0, i32 1
+  store ptr %78, ptr %83, align 8
+  store ptr %80, ptr %81, align 8
+  %84 = getelementptr { i1, ptr, ptr, i32 }, ptr %79, i32 0, i32 3
+  store i32 1, ptr %84, align 4
+  %85 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %70, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %85, i32 1, ptr @32, ptr @29, i64 1, i32 2, i64 %61, i64 %66)
   call void @exit(i32 1)
   unreachable
 
 ifcont4:                                          ; preds = %ifcont2
-  %86 = getelementptr %dimension_descriptor, %dimension_descriptor* %59, i32 0, i32 2
-  %87 = load i64, i64* %86, align 8
+  %86 = getelementptr %dimension_descriptor, ptr %59, i32 0, i32 2
+  %87 = load i64, ptr %86, align 8
   %88 = mul i64 %87, %64
   %89 = add i64 %58, %88
-  %90 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %27, i32 2
-  %91 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 0
-  %92 = load i64, i64* %91, align 8
-  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 1
-  %94 = load i64, i64* %93, align 8
+  %90 = getelementptr inbounds %dimension_descriptor, ptr %27, i32 2
+  %91 = getelementptr %dimension_descriptor, ptr %90, i32 0, i32 0
+  %92 = load i64, ptr %91, align 8
+  %93 = getelementptr %dimension_descriptor, ptr %90, i32 0, i32 1
+  %94 = load i64, ptr %93, align 8
   %95 = sub i64 1, %92
   %96 = add i64 %92, %94
   %97 = sub i64 %96, 1
@@ -1530,78 +1527,78 @@ ifcont4:                                          ; preds = %ifcont2
   br i1 %100, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %101 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %102 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %103 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @34, i32 0, i32 0), i8** %104, align 8
-  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 1
-  store i32 27, i32* %105, align 4
-  %106 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 2
-  store i32 14, i32* %106, align 4
-  %107 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 3
-  store i32 27, i32* %107, align 4
-  %108 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %103, i32 0, i32 4
-  store i32 23, i32* %108, align 4
-  %109 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @35, i32 0, i32 0))
-  %110 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
-  %111 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %102, i32 0, i32 0
-  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 2
-  %113 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 0
-  store i1 true, i1* %113, align 1
-  %114 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 1
-  store i8* %109, i8** %114, align 8
-  store { i8*, i32, i32, i32, i32 }* %111, { i8*, i32, i32, i32, i32 }** %112, align 8
-  %115 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 0, i32 3
-  store i32 1, i32* %115, align 4
-  %116 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %101, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @36, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @33, i32 0, i32 0), i64 1, i32 3, i64 %92, i64 %97)
+  %101 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %102 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %103 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %102, i32 0, i32 0
+  %104 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %103, i32 0, i32 0
+  store ptr @34, ptr %104, align 8
+  %105 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %103, i32 0, i32 1
+  store i32 27, ptr %105, align 4
+  %106 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %103, i32 0, i32 2
+  store i32 14, ptr %106, align 4
+  %107 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %103, i32 0, i32 3
+  store i32 27, ptr %107, align 4
+  %108 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %103, i32 0, i32 4
+  store i32 23, ptr %108, align 4
+  %109 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @35)
+  %110 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %101, i32 0, i32 0
+  %111 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %102, i32 0, i32 0
+  %112 = getelementptr { i1, ptr, ptr, i32 }, ptr %110, i32 0, i32 2
+  %113 = getelementptr { i1, ptr, ptr, i32 }, ptr %110, i32 0, i32 0
+  store i1 true, ptr %113, align 1
+  %114 = getelementptr { i1, ptr, ptr, i32 }, ptr %110, i32 0, i32 1
+  store ptr %109, ptr %114, align 8
+  store ptr %111, ptr %112, align 8
+  %115 = getelementptr { i1, ptr, ptr, i32 }, ptr %110, i32 0, i32 3
+  store i32 1, ptr %115, align 4
+  %116 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %101, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %116, i32 1, ptr @36, ptr @33, i64 1, i32 3, i64 %92, i64 %97)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %117 = getelementptr %dimension_descriptor, %dimension_descriptor* %90, i32 0, i32 2
-  %118 = load i64, i64* %117, align 8
+  %117 = getelementptr %dimension_descriptor, ptr %90, i32 0, i32 2
+  %118 = load i64, ptr %117, align 8
   %119 = mul i64 %118, %95
   %120 = add i64 %89, %119
-  %121 = getelementptr %array.3, %array.3* %2, i32 0, i32 7
-  %122 = load i64, i64* %121, align 8
+  %121 = getelementptr %array.3, ptr %2, i32 0, i32 7
+  %122 = load i64, ptr %121, align 8
   %123 = add i64 %120, %122
-  %124 = getelementptr %array.3, %array.3* %2, i32 0, i32 0
-  %125 = load i32*, i32** %124, align 8
-  %126 = getelementptr inbounds i32, i32* %125, i64 %123
-  %127 = load i32, i32* %126, align 4
+  %124 = getelementptr %array.3, ptr %2, i32 0, i32 0
+  %125 = load ptr, ptr %124, align 8
+  %126 = getelementptr inbounds i32, ptr %125, i64 %123
+  %127 = load i32, ptr %126, align 4
   %128 = alloca i32, align 4
-  store i32 %127, i32* %128, align 4
-  %129 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %128)
-  %130 = load i64, i64* %1, align 8
-  %131 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %129, i8** %131, align 8
-  %132 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %130, i64* %132, align 8
-  %133 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %134 = load i8*, i8** %133, align 8
-  %135 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %136 = load i64, i64* %135, align 8
+  store i32 %127, ptr %128, align 4
+  %129 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %128)
+  %130 = load i64, ptr %1, align 8
+  %131 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %129, ptr %131, align 8
+  %132 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %130, ptr %132, align 8
+  %133 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %134 = load ptr, ptr %133, align 8
+  %135 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %136 = load i64, ptr %135, align 8
   %137 = trunc i64 %136 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %134, i32 %137, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
-  %138 = icmp eq i8* %129, null
+  call void @_lfortran_printf(ptr @37, ptr %134, i32 %137, ptr @20, i32 1)
+  %138 = icmp eq ptr %129, null
   br i1 %138, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont6
-  call void @_lfortran_free_alloc(i8* %0, i8* %129)
+  call void @_lfortran_free_alloc(ptr %0, ptr %129)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
-  %139 = load %array.3*, %array.3** %x, align 8
-  %140 = ptrtoint %array.3* %139 to i64
+  %139 = load ptr, ptr %x, align 8
+  %140 = ptrtoint ptr %139 to i64
   %141 = icmp eq i64 %140, 0
   br i1 %141, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %free_done
-  %142 = getelementptr %array.3, %array.3* %139, i32 0, i32 0
-  %143 = load i32*, i32** %142, align 8
-  %144 = ptrtoint i32* %143 to i64
+  %142 = getelementptr %array.3, ptr %139, i32 0, i32 0
+  %143 = load ptr, ptr %142, align 8
+  %144 = ptrtoint ptr %143 to i64
   %145 = icmp ne i64 %144, 0
   br label %merge_allocated8
 
@@ -1611,43 +1608,43 @@ merge_allocated8:                                 ; preds = %check_data7, %free_
   br i1 %146, label %then10, label %ifcont11
 
 then10:                                           ; preds = %merge_allocated8
-  %147 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %148 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %149 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %148, i32 0, i32 0
-  %150 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @39, i32 0, i32 0), i8** %150, align 8
-  %151 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 1
-  store i32 28, i32* %151, align 4
-  %152 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 2
-  store i32 9, i32* %152, align 4
-  %153 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 3
-  store i32 28, i32* %153, align 4
-  %154 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %149, i32 0, i32 4
-  store i32 18, i32* %154, align 4
-  %155 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %156 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %147, i32 0, i32 0
-  %157 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %148, i32 0, i32 0
-  %158 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 2
-  %159 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 0
-  store i1 true, i1* %159, align 1
-  %160 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 1
-  store i8* %155, i8** %160, align 8
-  store { i8*, i32, i32, i32, i32 }* %157, { i8*, i32, i32, i32, i32 }** %158, align 8
-  %161 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %156, i32 0, i32 3
-  store i32 1, i32* %161, align 4
-  %162 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %147, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %162, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
+  %147 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %148 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %149 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %148, i32 0, i32 0
+  %150 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %149, i32 0, i32 0
+  store ptr @39, ptr %150, align 8
+  %151 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %149, i32 0, i32 1
+  store i32 28, ptr %151, align 4
+  %152 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %149, i32 0, i32 2
+  store i32 9, ptr %152, align 4
+  %153 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %149, i32 0, i32 3
+  store i32 28, ptr %153, align 4
+  %154 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %149, i32 0, i32 4
+  store i32 18, ptr %154, align 4
+  %155 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @40)
+  %156 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %147, i32 0, i32 0
+  %157 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %148, i32 0, i32 0
+  %158 = getelementptr { i1, ptr, ptr, i32 }, ptr %156, i32 0, i32 2
+  %159 = getelementptr { i1, ptr, ptr, i32 }, ptr %156, i32 0, i32 0
+  store i1 true, ptr %159, align 1
+  %160 = getelementptr { i1, ptr, ptr, i32 }, ptr %156, i32 0, i32 1
+  store ptr %155, ptr %160, align 8
+  store ptr %157, ptr %158, align 8
+  %161 = getelementptr { i1, ptr, ptr, i32 }, ptr %156, i32 0, i32 3
+  store i32 1, ptr %161, align 4
+  %162 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %147, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %162, i32 1, ptr @41, ptr @38)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %merge_allocated8
-  %163 = getelementptr %array.3, %array.3* %139, i32 0, i32 8
-  %164 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %163, i32 0, i32 0
-  %165 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 0
-  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 0
-  %167 = load i64, i64* %166, align 8
-  %168 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 1
-  %169 = load i64, i64* %168, align 8
+  %163 = getelementptr %array.3, ptr %139, i32 0, i32 8
+  %164 = getelementptr [3 x %dimension_descriptor], ptr %163, i32 0, i32 0
+  %165 = getelementptr inbounds %dimension_descriptor, ptr %164, i32 0
+  %166 = getelementptr %dimension_descriptor, ptr %165, i32 0, i32 0
+  %167 = load i64, ptr %166, align 8
+  %168 = getelementptr %dimension_descriptor, ptr %165, i32 0, i32 1
+  %169 = load i64, ptr %168, align 8
   %170 = sub i64 1, %167
   %171 = add i64 %167, %169
   %172 = sub i64 %171, 1
@@ -1657,45 +1654,45 @@ ifcont11:                                         ; preds = %merge_allocated8
   br i1 %175, label %then12, label %ifcont13
 
 then12:                                           ; preds = %ifcont11
-  %176 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %177 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %178 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
-  %179 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @43, i32 0, i32 0), i8** %179, align 8
-  %180 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 1
-  store i32 28, i32* %180, align 4
-  %181 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 2
-  store i32 9, i32* %181, align 4
-  %182 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 3
-  store i32 28, i32* %182, align 4
-  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 4
-  store i32 18, i32* %183, align 4
-  %184 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @44, i32 0, i32 0))
-  %185 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
-  %186 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
-  %187 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 2
-  %188 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 0
-  store i1 true, i1* %188, align 1
-  %189 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 1
-  store i8* %184, i8** %189, align 8
-  store { i8*, i32, i32, i32, i32 }* %186, { i8*, i32, i32, i32, i32 }** %187, align 8
-  %190 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 3
-  store i32 1, i32* %190, align 4
-  %191 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %191, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i64 1, i32 1, i64 %167, i64 %172)
+  %176 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %177 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %178 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %177, i32 0, i32 0
+  %179 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %178, i32 0, i32 0
+  store ptr @43, ptr %179, align 8
+  %180 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %178, i32 0, i32 1
+  store i32 28, ptr %180, align 4
+  %181 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %178, i32 0, i32 2
+  store i32 9, ptr %181, align 4
+  %182 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %178, i32 0, i32 3
+  store i32 28, ptr %182, align 4
+  %183 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %178, i32 0, i32 4
+  store i32 18, ptr %183, align 4
+  %184 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @44)
+  %185 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %176, i32 0, i32 0
+  %186 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %177, i32 0, i32 0
+  %187 = getelementptr { i1, ptr, ptr, i32 }, ptr %185, i32 0, i32 2
+  %188 = getelementptr { i1, ptr, ptr, i32 }, ptr %185, i32 0, i32 0
+  store i1 true, ptr %188, align 1
+  %189 = getelementptr { i1, ptr, ptr, i32 }, ptr %185, i32 0, i32 1
+  store ptr %184, ptr %189, align 8
+  store ptr %186, ptr %187, align 8
+  %190 = getelementptr { i1, ptr, ptr, i32 }, ptr %185, i32 0, i32 3
+  store i32 1, ptr %190, align 4
+  %191 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %176, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %191, i32 1, ptr @45, ptr @42, i64 1, i32 1, i64 %167, i64 %172)
   call void @exit(i32 1)
   unreachable
 
 ifcont13:                                         ; preds = %ifcont11
-  %192 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 2
-  %193 = load i64, i64* %192, align 8
+  %192 = getelementptr %dimension_descriptor, ptr %165, i32 0, i32 2
+  %193 = load i64, ptr %192, align 8
   %194 = mul i64 %193, %170
   %195 = add i64 0, %194
-  %196 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 1
-  %197 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 0
-  %198 = load i64, i64* %197, align 8
-  %199 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 1
-  %200 = load i64, i64* %199, align 8
+  %196 = getelementptr inbounds %dimension_descriptor, ptr %164, i32 1
+  %197 = getelementptr %dimension_descriptor, ptr %196, i32 0, i32 0
+  %198 = load i64, ptr %197, align 8
+  %199 = getelementptr %dimension_descriptor, ptr %196, i32 0, i32 1
+  %200 = load i64, ptr %199, align 8
   %201 = sub i64 1, %198
   %202 = add i64 %198, %200
   %203 = sub i64 %202, 1
@@ -1705,45 +1702,45 @@ ifcont13:                                         ; preds = %ifcont11
   br i1 %206, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  %207 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %208 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %209 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %208, i32 0, i32 0
-  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @47, i32 0, i32 0), i8** %210, align 8
-  %211 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 1
-  store i32 28, i32* %211, align 4
-  %212 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 2
-  store i32 9, i32* %212, align 4
-  %213 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 3
-  store i32 28, i32* %213, align 4
-  %214 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %209, i32 0, i32 4
-  store i32 18, i32* %214, align 4
-  %215 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @48, i32 0, i32 0))
-  %216 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %207, i32 0, i32 0
-  %217 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %208, i32 0, i32 0
-  %218 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 2
-  %219 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 0
-  store i1 true, i1* %219, align 1
-  %220 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 1
-  store i8* %215, i8** %220, align 8
-  store { i8*, i32, i32, i32, i32 }* %217, { i8*, i32, i32, i32, i32 }** %218, align 8
-  %221 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %216, i32 0, i32 3
-  store i32 1, i32* %221, align 4
-  %222 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %207, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i64 1, i32 2, i64 %198, i64 %203)
+  %207 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %208 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %209 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %208, i32 0, i32 0
+  %210 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %209, i32 0, i32 0
+  store ptr @47, ptr %210, align 8
+  %211 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %209, i32 0, i32 1
+  store i32 28, ptr %211, align 4
+  %212 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %209, i32 0, i32 2
+  store i32 9, ptr %212, align 4
+  %213 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %209, i32 0, i32 3
+  store i32 28, ptr %213, align 4
+  %214 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %209, i32 0, i32 4
+  store i32 18, ptr %214, align 4
+  %215 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @48)
+  %216 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %207, i32 0, i32 0
+  %217 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %208, i32 0, i32 0
+  %218 = getelementptr { i1, ptr, ptr, i32 }, ptr %216, i32 0, i32 2
+  %219 = getelementptr { i1, ptr, ptr, i32 }, ptr %216, i32 0, i32 0
+  store i1 true, ptr %219, align 1
+  %220 = getelementptr { i1, ptr, ptr, i32 }, ptr %216, i32 0, i32 1
+  store ptr %215, ptr %220, align 8
+  store ptr %217, ptr %218, align 8
+  %221 = getelementptr { i1, ptr, ptr, i32 }, ptr %216, i32 0, i32 3
+  store i32 1, ptr %221, align 4
+  %222 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %207, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %222, i32 1, ptr @49, ptr @46, i64 1, i32 2, i64 %198, i64 %203)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %223 = getelementptr %dimension_descriptor, %dimension_descriptor* %196, i32 0, i32 2
-  %224 = load i64, i64* %223, align 8
+  %223 = getelementptr %dimension_descriptor, ptr %196, i32 0, i32 2
+  %224 = load i64, ptr %223, align 8
   %225 = mul i64 %224, %201
   %226 = add i64 %195, %225
-  %227 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %164, i32 2
-  %228 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 0
-  %229 = load i64, i64* %228, align 8
-  %230 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 1
-  %231 = load i64, i64* %230, align 8
+  %227 = getelementptr inbounds %dimension_descriptor, ptr %164, i32 2
+  %228 = getelementptr %dimension_descriptor, ptr %227, i32 0, i32 0
+  %229 = load i64, ptr %228, align 8
+  %230 = getelementptr %dimension_descriptor, ptr %227, i32 0, i32 1
+  %231 = load i64, ptr %230, align 8
   %232 = sub i64 1, %229
   %233 = add i64 %229, %231
   %234 = sub i64 %233, 1
@@ -1753,52 +1750,52 @@ ifcont15:                                         ; preds = %ifcont13
   br i1 %237, label %then16, label %ifcont17
 
 then16:                                           ; preds = %ifcont15
-  %238 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %239 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %240 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @51, i32 0, i32 0), i8** %241, align 8
-  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 1
-  store i32 28, i32* %242, align 4
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 2
-  store i32 9, i32* %243, align 4
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 3
-  store i32 28, i32* %244, align 4
-  %245 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 4
-  store i32 18, i32* %245, align 4
-  %246 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
-  %247 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  %248 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 2
-  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 0
-  store i1 true, i1* %250, align 1
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 1
-  store i8* %246, i8** %251, align 8
-  store { i8*, i32, i32, i32, i32 }* %248, { i8*, i32, i32, i32, i32 }** %249, align 8
-  %252 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 3
-  store i32 1, i32* %252, align 4
-  %253 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i64 1, i32 3, i64 %229, i64 %234)
+  %238 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %239 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %240 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %239, i32 0, i32 0
+  %241 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 0
+  store ptr @51, ptr %241, align 8
+  %242 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 1
+  store i32 28, ptr %242, align 4
+  %243 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 2
+  store i32 9, ptr %243, align 4
+  %244 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 3
+  store i32 28, ptr %244, align 4
+  %245 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 4
+  store i32 18, ptr %245, align 4
+  %246 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @52)
+  %247 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %238, i32 0, i32 0
+  %248 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %239, i32 0, i32 0
+  %249 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 2
+  %250 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 0
+  store i1 true, ptr %250, align 1
+  %251 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 1
+  store ptr %246, ptr %251, align 8
+  store ptr %248, ptr %249, align 8
+  %252 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 3
+  store i32 1, ptr %252, align 4
+  %253 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %238, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %253, i32 1, ptr @53, ptr @50, i64 1, i32 3, i64 %229, i64 %234)
   call void @exit(i32 1)
   unreachable
 
 ifcont17:                                         ; preds = %ifcont15
-  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %227, i32 0, i32 2
-  %255 = load i64, i64* %254, align 8
+  %254 = getelementptr %dimension_descriptor, ptr %227, i32 0, i32 2
+  %255 = load i64, ptr %254, align 8
   %256 = mul i64 %255, %232
   %257 = add i64 %226, %256
-  %258 = getelementptr %array.3, %array.3* %139, i32 0, i32 7
-  %259 = load i64, i64* %258, align 8
+  %258 = getelementptr %array.3, ptr %139, i32 0, i32 7
+  %259 = load i64, ptr %258, align 8
   %260 = add i64 %257, %259
-  %261 = getelementptr %array.3, %array.3* %139, i32 0, i32 0
-  %262 = load i32*, i32** %261, align 8
-  %263 = getelementptr inbounds i32, i32* %262, i64 %260
-  %264 = load i32, i32* %263, align 4
+  %261 = getelementptr %array.3, ptr %139, i32 0, i32 0
+  %262 = load ptr, ptr %261, align 8
+  %263 = getelementptr inbounds i32, ptr %262, i64 %260
+  %264 = load i32, ptr %263, align 4
   %265 = icmp ne i32 %264, 8
   br i1 %265, label %then18, label %else
 
 then18:                                           ; preds = %ifcont17
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @55, ptr @"ERROR STOP", ptr @54)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont19
@@ -1807,17 +1804,17 @@ else:                                             ; preds = %ifcont17
   br label %ifcont19
 
 ifcont19:                                         ; preds = %else, %then18
-  call void @f(%array.3** %x)
+  call void @f(ptr %x)
   %266 = alloca i64, align 8
-  %267 = load %array.3*, %array.3** %x, align 8
-  %268 = ptrtoint %array.3* %267 to i64
+  %267 = load ptr, ptr %x, align 8
+  %268 = ptrtoint ptr %267 to i64
   %269 = icmp eq i64 %268, 0
   br i1 %269, label %merge_allocated21, label %check_data20
 
 check_data20:                                     ; preds = %ifcont19
-  %270 = getelementptr %array.3, %array.3* %267, i32 0, i32 0
-  %271 = load i32*, i32** %270, align 8
-  %272 = ptrtoint i32* %271 to i64
+  %270 = getelementptr %array.3, ptr %267, i32 0, i32 0
+  %271 = load ptr, ptr %270, align 8
+  %272 = ptrtoint ptr %271 to i64
   %273 = icmp ne i64 %272, 0
   br label %merge_allocated21
 
@@ -1827,43 +1824,43 @@ merge_allocated21:                                ; preds = %check_data20, %ifco
   br i1 %274, label %then23, label %ifcont24
 
 then23:                                           ; preds = %merge_allocated21
-  %275 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %276 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %277 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %276, i32 0, i32 0
-  %278 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @58, i32 0, i32 0), i8** %278, align 8
-  %279 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 1
-  store i32 30, i32* %279, align 4
-  %280 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 2
-  store i32 14, i32* %280, align 4
-  %281 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 3
-  store i32 30, i32* %281, align 4
-  %282 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %277, i32 0, i32 4
-  store i32 23, i32* %282, align 4
-  %283 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @59, i32 0, i32 0))
-  %284 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %275, i32 0, i32 0
-  %285 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %276, i32 0, i32 0
-  %286 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 2
-  %287 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 0
-  store i1 true, i1* %287, align 1
-  %288 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 1
-  store i8* %283, i8** %288, align 8
-  store { i8*, i32, i32, i32, i32 }* %285, { i8*, i32, i32, i32, i32 }** %286, align 8
-  %289 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %284, i32 0, i32 3
-  store i32 1, i32* %289, align 4
-  %290 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %275, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %290, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @60, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @57, i32 0, i32 0))
+  %275 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %276 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %277 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %276, i32 0, i32 0
+  %278 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %277, i32 0, i32 0
+  store ptr @58, ptr %278, align 8
+  %279 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %277, i32 0, i32 1
+  store i32 30, ptr %279, align 4
+  %280 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %277, i32 0, i32 2
+  store i32 14, ptr %280, align 4
+  %281 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %277, i32 0, i32 3
+  store i32 30, ptr %281, align 4
+  %282 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %277, i32 0, i32 4
+  store i32 23, ptr %282, align 4
+  %283 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @59)
+  %284 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %275, i32 0, i32 0
+  %285 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %276, i32 0, i32 0
+  %286 = getelementptr { i1, ptr, ptr, i32 }, ptr %284, i32 0, i32 2
+  %287 = getelementptr { i1, ptr, ptr, i32 }, ptr %284, i32 0, i32 0
+  store i1 true, ptr %287, align 1
+  %288 = getelementptr { i1, ptr, ptr, i32 }, ptr %284, i32 0, i32 1
+  store ptr %283, ptr %288, align 8
+  store ptr %285, ptr %286, align 8
+  %289 = getelementptr { i1, ptr, ptr, i32 }, ptr %284, i32 0, i32 3
+  store i32 1, ptr %289, align 4
+  %290 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %275, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %290, i32 1, ptr @60, ptr @57)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %merge_allocated21
-  %291 = getelementptr %array.3, %array.3* %267, i32 0, i32 8
-  %292 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %291, i32 0, i32 0
-  %293 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 0
-  %294 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 0
-  %295 = load i64, i64* %294, align 8
-  %296 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 1
-  %297 = load i64, i64* %296, align 8
+  %291 = getelementptr %array.3, ptr %267, i32 0, i32 8
+  %292 = getelementptr [3 x %dimension_descriptor], ptr %291, i32 0, i32 0
+  %293 = getelementptr inbounds %dimension_descriptor, ptr %292, i32 0
+  %294 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 0
+  %295 = load i64, ptr %294, align 8
+  %296 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 1
+  %297 = load i64, ptr %296, align 8
   %298 = sub i64 1, %295
   %299 = add i64 %295, %297
   %300 = sub i64 %299, 1
@@ -1873,45 +1870,45 @@ ifcont24:                                         ; preds = %merge_allocated21
   br i1 %303, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %304 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %305 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %306 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %305, i32 0, i32 0
-  %307 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %306, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @62, i32 0, i32 0), i8** %307, align 8
-  %308 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %306, i32 0, i32 1
-  store i32 30, i32* %308, align 4
-  %309 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %306, i32 0, i32 2
-  store i32 14, i32* %309, align 4
-  %310 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %306, i32 0, i32 3
-  store i32 30, i32* %310, align 4
-  %311 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %306, i32 0, i32 4
-  store i32 23, i32* %311, align 4
-  %312 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @63, i32 0, i32 0))
-  %313 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %304, i32 0, i32 0
-  %314 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %305, i32 0, i32 0
-  %315 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %313, i32 0, i32 2
-  %316 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %313, i32 0, i32 0
-  store i1 true, i1* %316, align 1
-  %317 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %313, i32 0, i32 1
-  store i8* %312, i8** %317, align 8
-  store { i8*, i32, i32, i32, i32 }* %314, { i8*, i32, i32, i32, i32 }** %315, align 8
-  %318 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %313, i32 0, i32 3
-  store i32 1, i32* %318, align 4
-  %319 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %304, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %319, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @64, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @61, i32 0, i32 0), i64 1, i32 1, i64 %295, i64 %300)
+  %304 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %305 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %306 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %305, i32 0, i32 0
+  %307 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %306, i32 0, i32 0
+  store ptr @62, ptr %307, align 8
+  %308 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %306, i32 0, i32 1
+  store i32 30, ptr %308, align 4
+  %309 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %306, i32 0, i32 2
+  store i32 14, ptr %309, align 4
+  %310 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %306, i32 0, i32 3
+  store i32 30, ptr %310, align 4
+  %311 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %306, i32 0, i32 4
+  store i32 23, ptr %311, align 4
+  %312 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @63)
+  %313 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %304, i32 0, i32 0
+  %314 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %305, i32 0, i32 0
+  %315 = getelementptr { i1, ptr, ptr, i32 }, ptr %313, i32 0, i32 2
+  %316 = getelementptr { i1, ptr, ptr, i32 }, ptr %313, i32 0, i32 0
+  store i1 true, ptr %316, align 1
+  %317 = getelementptr { i1, ptr, ptr, i32 }, ptr %313, i32 0, i32 1
+  store ptr %312, ptr %317, align 8
+  store ptr %314, ptr %315, align 8
+  %318 = getelementptr { i1, ptr, ptr, i32 }, ptr %313, i32 0, i32 3
+  store i32 1, ptr %318, align 4
+  %319 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %304, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %319, i32 1, ptr @64, ptr @61, i64 1, i32 1, i64 %295, i64 %300)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %293, i32 0, i32 2
-  %321 = load i64, i64* %320, align 8
+  %320 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 2
+  %321 = load i64, ptr %320, align 8
   %322 = mul i64 %321, %298
   %323 = add i64 0, %322
-  %324 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 1
-  %325 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 0
-  %326 = load i64, i64* %325, align 8
-  %327 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 1
-  %328 = load i64, i64* %327, align 8
+  %324 = getelementptr inbounds %dimension_descriptor, ptr %292, i32 1
+  %325 = getelementptr %dimension_descriptor, ptr %324, i32 0, i32 0
+  %326 = load i64, ptr %325, align 8
+  %327 = getelementptr %dimension_descriptor, ptr %324, i32 0, i32 1
+  %328 = load i64, ptr %327, align 8
   %329 = sub i64 1, %326
   %330 = add i64 %326, %328
   %331 = sub i64 %330, 1
@@ -1921,45 +1918,45 @@ ifcont26:                                         ; preds = %ifcont24
   br i1 %334, label %then27, label %ifcont28
 
 then27:                                           ; preds = %ifcont26
-  %335 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %336 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %337 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %336, i32 0, i32 0
-  %338 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %337, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @66, i32 0, i32 0), i8** %338, align 8
-  %339 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %337, i32 0, i32 1
-  store i32 30, i32* %339, align 4
-  %340 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %337, i32 0, i32 2
-  store i32 14, i32* %340, align 4
-  %341 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %337, i32 0, i32 3
-  store i32 30, i32* %341, align 4
-  %342 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %337, i32 0, i32 4
-  store i32 23, i32* %342, align 4
-  %343 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @67, i32 0, i32 0))
-  %344 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %335, i32 0, i32 0
-  %345 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %336, i32 0, i32 0
-  %346 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %344, i32 0, i32 2
-  %347 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %344, i32 0, i32 0
-  store i1 true, i1* %347, align 1
-  %348 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %344, i32 0, i32 1
-  store i8* %343, i8** %348, align 8
-  store { i8*, i32, i32, i32, i32 }* %345, { i8*, i32, i32, i32, i32 }** %346, align 8
-  %349 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %344, i32 0, i32 3
-  store i32 1, i32* %349, align 4
-  %350 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %335, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %350, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @68, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @65, i32 0, i32 0), i64 1, i32 2, i64 %326, i64 %331)
+  %335 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %336 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %337 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %336, i32 0, i32 0
+  %338 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %337, i32 0, i32 0
+  store ptr @66, ptr %338, align 8
+  %339 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %337, i32 0, i32 1
+  store i32 30, ptr %339, align 4
+  %340 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %337, i32 0, i32 2
+  store i32 14, ptr %340, align 4
+  %341 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %337, i32 0, i32 3
+  store i32 30, ptr %341, align 4
+  %342 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %337, i32 0, i32 4
+  store i32 23, ptr %342, align 4
+  %343 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @67)
+  %344 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %335, i32 0, i32 0
+  %345 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %336, i32 0, i32 0
+  %346 = getelementptr { i1, ptr, ptr, i32 }, ptr %344, i32 0, i32 2
+  %347 = getelementptr { i1, ptr, ptr, i32 }, ptr %344, i32 0, i32 0
+  store i1 true, ptr %347, align 1
+  %348 = getelementptr { i1, ptr, ptr, i32 }, ptr %344, i32 0, i32 1
+  store ptr %343, ptr %348, align 8
+  store ptr %345, ptr %346, align 8
+  %349 = getelementptr { i1, ptr, ptr, i32 }, ptr %344, i32 0, i32 3
+  store i32 1, ptr %349, align 4
+  %350 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %335, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %350, i32 1, ptr @68, ptr @65, i64 1, i32 2, i64 %326, i64 %331)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %ifcont26
-  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %324, i32 0, i32 2
-  %352 = load i64, i64* %351, align 8
+  %351 = getelementptr %dimension_descriptor, ptr %324, i32 0, i32 2
+  %352 = load i64, ptr %351, align 8
   %353 = mul i64 %352, %329
   %354 = add i64 %323, %353
-  %355 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %292, i32 2
-  %356 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 0
-  %357 = load i64, i64* %356, align 8
-  %358 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 1
-  %359 = load i64, i64* %358, align 8
+  %355 = getelementptr inbounds %dimension_descriptor, ptr %292, i32 2
+  %356 = getelementptr %dimension_descriptor, ptr %355, i32 0, i32 0
+  %357 = load i64, ptr %356, align 8
+  %358 = getelementptr %dimension_descriptor, ptr %355, i32 0, i32 1
+  %359 = load i64, ptr %358, align 8
   %360 = sub i64 1, %357
   %361 = add i64 %357, %359
   %362 = sub i64 %361, 1
@@ -1969,78 +1966,78 @@ ifcont28:                                         ; preds = %ifcont26
   br i1 %365, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %366 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %367 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %368 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %367, i32 0, i32 0
-  %369 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %368, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @70, i32 0, i32 0), i8** %369, align 8
-  %370 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %368, i32 0, i32 1
-  store i32 30, i32* %370, align 4
-  %371 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %368, i32 0, i32 2
-  store i32 14, i32* %371, align 4
-  %372 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %368, i32 0, i32 3
-  store i32 30, i32* %372, align 4
-  %373 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %368, i32 0, i32 4
-  store i32 23, i32* %373, align 4
-  %374 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @71, i32 0, i32 0))
-  %375 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %366, i32 0, i32 0
-  %376 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %367, i32 0, i32 0
-  %377 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %375, i32 0, i32 2
-  %378 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %375, i32 0, i32 0
-  store i1 true, i1* %378, align 1
-  %379 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %375, i32 0, i32 1
-  store i8* %374, i8** %379, align 8
-  store { i8*, i32, i32, i32, i32 }* %376, { i8*, i32, i32, i32, i32 }** %377, align 8
-  %380 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %375, i32 0, i32 3
-  store i32 1, i32* %380, align 4
-  %381 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %366, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %381, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @72, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @69, i32 0, i32 0), i64 1, i32 3, i64 %357, i64 %362)
+  %366 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %367 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %368 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %367, i32 0, i32 0
+  %369 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %368, i32 0, i32 0
+  store ptr @70, ptr %369, align 8
+  %370 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %368, i32 0, i32 1
+  store i32 30, ptr %370, align 4
+  %371 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %368, i32 0, i32 2
+  store i32 14, ptr %371, align 4
+  %372 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %368, i32 0, i32 3
+  store i32 30, ptr %372, align 4
+  %373 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %368, i32 0, i32 4
+  store i32 23, ptr %373, align 4
+  %374 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @71)
+  %375 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %366, i32 0, i32 0
+  %376 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %367, i32 0, i32 0
+  %377 = getelementptr { i1, ptr, ptr, i32 }, ptr %375, i32 0, i32 2
+  %378 = getelementptr { i1, ptr, ptr, i32 }, ptr %375, i32 0, i32 0
+  store i1 true, ptr %378, align 1
+  %379 = getelementptr { i1, ptr, ptr, i32 }, ptr %375, i32 0, i32 1
+  store ptr %374, ptr %379, align 8
+  store ptr %376, ptr %377, align 8
+  %380 = getelementptr { i1, ptr, ptr, i32 }, ptr %375, i32 0, i32 3
+  store i32 1, ptr %380, align 4
+  %381 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %366, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %381, i32 1, ptr @72, ptr @69, i64 1, i32 3, i64 %357, i64 %362)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %355, i32 0, i32 2
-  %383 = load i64, i64* %382, align 8
+  %382 = getelementptr %dimension_descriptor, ptr %355, i32 0, i32 2
+  %383 = load i64, ptr %382, align 8
   %384 = mul i64 %383, %360
   %385 = add i64 %354, %384
-  %386 = getelementptr %array.3, %array.3* %267, i32 0, i32 7
-  %387 = load i64, i64* %386, align 8
+  %386 = getelementptr %array.3, ptr %267, i32 0, i32 7
+  %387 = load i64, ptr %386, align 8
   %388 = add i64 %385, %387
-  %389 = getelementptr %array.3, %array.3* %267, i32 0, i32 0
-  %390 = load i32*, i32** %389, align 8
-  %391 = getelementptr inbounds i32, i32* %390, i64 %388
-  %392 = load i32, i32* %391, align 4
+  %389 = getelementptr %array.3, ptr %267, i32 0, i32 0
+  %390 = load ptr, ptr %389, align 8
+  %391 = getelementptr inbounds i32, ptr %390, i64 %388
+  %392 = load i32, ptr %391, align 4
   %393 = alloca i32, align 4
-  store i32 %392, i32* %393, align 4
-  %394 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %266, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %393)
-  %395 = load i64, i64* %266, align 8
-  %396 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
-  store i8* %394, i8** %396, align 8
-  %397 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
-  store i64 %395, i64* %397, align 8
-  %398 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 0
-  %399 = load i8*, i8** %398, align 8
-  %400 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
-  %401 = load i64, i64* %400, align 8
+  store i32 %392, ptr %393, align 4
+  %394 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %266, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %393)
+  %395 = load i64, ptr %266, align 8
+  %396 = getelementptr %string_descriptor, ptr %stringFormat_desc31, i32 0, i32 0
+  store ptr %394, ptr %396, align 8
+  %397 = getelementptr %string_descriptor, ptr %stringFormat_desc31, i32 0, i32 1
+  store i64 %395, ptr %397, align 8
+  %398 = getelementptr %string_descriptor, ptr %stringFormat_desc31, i32 0, i32 0
+  %399 = load ptr, ptr %398, align 8
+  %400 = getelementptr %string_descriptor, ptr %stringFormat_desc31, i32 0, i32 1
+  %401 = load i64, ptr %400, align 8
   %402 = trunc i64 %401 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* %399, i32 %402, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
-  %403 = icmp eq i8* %394, null
+  call void @_lfortran_printf(ptr @73, ptr %399, i32 %402, ptr @56, i32 1)
+  %403 = icmp eq ptr %394, null
   br i1 %403, label %free_done33, label %free_nonnull32
 
 free_nonnull32:                                   ; preds = %ifcont30
-  call void @_lfortran_free_alloc(i8* %0, i8* %394)
+  call void @_lfortran_free_alloc(ptr %0, ptr %394)
   br label %free_done33
 
 free_done33:                                      ; preds = %free_nonnull32, %ifcont30
-  %404 = load %array.3*, %array.3** %x, align 8
-  %405 = ptrtoint %array.3* %404 to i64
+  %404 = load ptr, ptr %x, align 8
+  %405 = ptrtoint ptr %404 to i64
   %406 = icmp eq i64 %405, 0
   br i1 %406, label %merge_allocated35, label %check_data34
 
 check_data34:                                     ; preds = %free_done33
-  %407 = getelementptr %array.3, %array.3* %404, i32 0, i32 0
-  %408 = load i32*, i32** %407, align 8
-  %409 = ptrtoint i32* %408 to i64
+  %407 = getelementptr %array.3, ptr %404, i32 0, i32 0
+  %408 = load ptr, ptr %407, align 8
+  %409 = ptrtoint ptr %408 to i64
   %410 = icmp ne i64 %409, 0
   br label %merge_allocated35
 
@@ -2050,43 +2047,43 @@ merge_allocated35:                                ; preds = %check_data34, %free
   br i1 %411, label %then37, label %ifcont38
 
 then37:                                           ; preds = %merge_allocated35
-  %412 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %413 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %414 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %413, i32 0, i32 0
-  %415 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %414, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @75, i32 0, i32 0), i8** %415, align 8
-  %416 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %414, i32 0, i32 1
-  store i32 31, i32* %416, align 4
-  %417 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %414, i32 0, i32 2
-  store i32 9, i32* %417, align 4
-  %418 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %414, i32 0, i32 3
-  store i32 31, i32* %418, align 4
-  %419 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %414, i32 0, i32 4
-  store i32 18, i32* %419, align 4
-  %420 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @76, i32 0, i32 0))
-  %421 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %412, i32 0, i32 0
-  %422 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %413, i32 0, i32 0
-  %423 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 0, i32 2
-  %424 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 0, i32 0
-  store i1 true, i1* %424, align 1
-  %425 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 0, i32 1
-  store i8* %420, i8** %425, align 8
-  store { i8*, i32, i32, i32, i32 }* %422, { i8*, i32, i32, i32, i32 }** %423, align 8
-  %426 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 0, i32 3
-  store i32 1, i32* %426, align 4
-  %427 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %412, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %427, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
+  %412 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %413 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %414 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %413, i32 0, i32 0
+  %415 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %414, i32 0, i32 0
+  store ptr @75, ptr %415, align 8
+  %416 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %414, i32 0, i32 1
+  store i32 31, ptr %416, align 4
+  %417 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %414, i32 0, i32 2
+  store i32 9, ptr %417, align 4
+  %418 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %414, i32 0, i32 3
+  store i32 31, ptr %418, align 4
+  %419 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %414, i32 0, i32 4
+  store i32 18, ptr %419, align 4
+  %420 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @76)
+  %421 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %412, i32 0, i32 0
+  %422 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %413, i32 0, i32 0
+  %423 = getelementptr { i1, ptr, ptr, i32 }, ptr %421, i32 0, i32 2
+  %424 = getelementptr { i1, ptr, ptr, i32 }, ptr %421, i32 0, i32 0
+  store i1 true, ptr %424, align 1
+  %425 = getelementptr { i1, ptr, ptr, i32 }, ptr %421, i32 0, i32 1
+  store ptr %420, ptr %425, align 8
+  store ptr %422, ptr %423, align 8
+  %426 = getelementptr { i1, ptr, ptr, i32 }, ptr %421, i32 0, i32 3
+  store i32 1, ptr %426, align 4
+  %427 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %412, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %427, i32 1, ptr @77, ptr @74)
   call void @exit(i32 1)
   unreachable
 
 ifcont38:                                         ; preds = %merge_allocated35
-  %428 = getelementptr %array.3, %array.3* %404, i32 0, i32 8
-  %429 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %428, i32 0, i32 0
-  %430 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 0
-  %431 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 0
-  %432 = load i64, i64* %431, align 8
-  %433 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 1
-  %434 = load i64, i64* %433, align 8
+  %428 = getelementptr %array.3, ptr %404, i32 0, i32 8
+  %429 = getelementptr [3 x %dimension_descriptor], ptr %428, i32 0, i32 0
+  %430 = getelementptr inbounds %dimension_descriptor, ptr %429, i32 0
+  %431 = getelementptr %dimension_descriptor, ptr %430, i32 0, i32 0
+  %432 = load i64, ptr %431, align 8
+  %433 = getelementptr %dimension_descriptor, ptr %430, i32 0, i32 1
+  %434 = load i64, ptr %433, align 8
   %435 = sub i64 1, %432
   %436 = add i64 %432, %434
   %437 = sub i64 %436, 1
@@ -2096,45 +2093,45 @@ ifcont38:                                         ; preds = %merge_allocated35
   br i1 %440, label %then39, label %ifcont40
 
 then39:                                           ; preds = %ifcont38
-  %441 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %442 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %443 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %442, i32 0, i32 0
-  %444 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @79, i32 0, i32 0), i8** %444, align 8
-  %445 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 1
-  store i32 31, i32* %445, align 4
-  %446 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 2
-  store i32 9, i32* %446, align 4
-  %447 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 3
-  store i32 31, i32* %447, align 4
-  %448 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 4
-  store i32 18, i32* %448, align 4
-  %449 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @80, i32 0, i32 0))
-  %450 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %441, i32 0, i32 0
-  %451 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %442, i32 0, i32 0
-  %452 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 2
-  %453 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 0
-  store i1 true, i1* %453, align 1
-  %454 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 1
-  store i8* %449, i8** %454, align 8
-  store { i8*, i32, i32, i32, i32 }* %451, { i8*, i32, i32, i32, i32 }** %452, align 8
-  %455 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 3
-  store i32 1, i32* %455, align 4
-  %456 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %441, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %456, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @81, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0), i64 1, i32 1, i64 %432, i64 %437)
+  %441 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %442 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %443 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %442, i32 0, i32 0
+  %444 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 0
+  store ptr @79, ptr %444, align 8
+  %445 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 1
+  store i32 31, ptr %445, align 4
+  %446 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 2
+  store i32 9, ptr %446, align 4
+  %447 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 3
+  store i32 31, ptr %447, align 4
+  %448 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 4
+  store i32 18, ptr %448, align 4
+  %449 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @80)
+  %450 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %441, i32 0, i32 0
+  %451 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %442, i32 0, i32 0
+  %452 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 2
+  %453 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 0
+  store i1 true, ptr %453, align 1
+  %454 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 1
+  store ptr %449, ptr %454, align 8
+  store ptr %451, ptr %452, align 8
+  %455 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 3
+  store i32 1, ptr %455, align 4
+  %456 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %441, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %456, i32 1, ptr @81, ptr @78, i64 1, i32 1, i64 %432, i64 %437)
   call void @exit(i32 1)
   unreachable
 
 ifcont40:                                         ; preds = %ifcont38
-  %457 = getelementptr %dimension_descriptor, %dimension_descriptor* %430, i32 0, i32 2
-  %458 = load i64, i64* %457, align 8
+  %457 = getelementptr %dimension_descriptor, ptr %430, i32 0, i32 2
+  %458 = load i64, ptr %457, align 8
   %459 = mul i64 %458, %435
   %460 = add i64 0, %459
-  %461 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 1
-  %462 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 0
-  %463 = load i64, i64* %462, align 8
-  %464 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 1
-  %465 = load i64, i64* %464, align 8
+  %461 = getelementptr inbounds %dimension_descriptor, ptr %429, i32 1
+  %462 = getelementptr %dimension_descriptor, ptr %461, i32 0, i32 0
+  %463 = load i64, ptr %462, align 8
+  %464 = getelementptr %dimension_descriptor, ptr %461, i32 0, i32 1
+  %465 = load i64, ptr %464, align 8
   %466 = sub i64 1, %463
   %467 = add i64 %463, %465
   %468 = sub i64 %467, 1
@@ -2144,45 +2141,45 @@ ifcont40:                                         ; preds = %ifcont38
   br i1 %471, label %then41, label %ifcont42
 
 then41:                                           ; preds = %ifcont40
-  %472 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %473 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %474 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %473, i32 0, i32 0
-  %475 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %474, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @83, i32 0, i32 0), i8** %475, align 8
-  %476 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %474, i32 0, i32 1
-  store i32 31, i32* %476, align 4
-  %477 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %474, i32 0, i32 2
-  store i32 9, i32* %477, align 4
-  %478 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %474, i32 0, i32 3
-  store i32 31, i32* %478, align 4
-  %479 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %474, i32 0, i32 4
-  store i32 18, i32* %479, align 4
-  %480 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @84, i32 0, i32 0))
-  %481 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %472, i32 0, i32 0
-  %482 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %473, i32 0, i32 0
-  %483 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %481, i32 0, i32 2
-  %484 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %481, i32 0, i32 0
-  store i1 true, i1* %484, align 1
-  %485 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %481, i32 0, i32 1
-  store i8* %480, i8** %485, align 8
-  store { i8*, i32, i32, i32, i32 }* %482, { i8*, i32, i32, i32, i32 }** %483, align 8
-  %486 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %481, i32 0, i32 3
-  store i32 1, i32* %486, align 4
-  %487 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %472, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %487, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @82, i32 0, i32 0), i64 1, i32 2, i64 %463, i64 %468)
+  %472 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %473 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %474 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %473, i32 0, i32 0
+  %475 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %474, i32 0, i32 0
+  store ptr @83, ptr %475, align 8
+  %476 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %474, i32 0, i32 1
+  store i32 31, ptr %476, align 4
+  %477 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %474, i32 0, i32 2
+  store i32 9, ptr %477, align 4
+  %478 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %474, i32 0, i32 3
+  store i32 31, ptr %478, align 4
+  %479 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %474, i32 0, i32 4
+  store i32 18, ptr %479, align 4
+  %480 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @84)
+  %481 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %472, i32 0, i32 0
+  %482 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %473, i32 0, i32 0
+  %483 = getelementptr { i1, ptr, ptr, i32 }, ptr %481, i32 0, i32 2
+  %484 = getelementptr { i1, ptr, ptr, i32 }, ptr %481, i32 0, i32 0
+  store i1 true, ptr %484, align 1
+  %485 = getelementptr { i1, ptr, ptr, i32 }, ptr %481, i32 0, i32 1
+  store ptr %480, ptr %485, align 8
+  store ptr %482, ptr %483, align 8
+  %486 = getelementptr { i1, ptr, ptr, i32 }, ptr %481, i32 0, i32 3
+  store i32 1, ptr %486, align 4
+  %487 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %472, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %487, i32 1, ptr @85, ptr @82, i64 1, i32 2, i64 %463, i64 %468)
   call void @exit(i32 1)
   unreachable
 
 ifcont42:                                         ; preds = %ifcont40
-  %488 = getelementptr %dimension_descriptor, %dimension_descriptor* %461, i32 0, i32 2
-  %489 = load i64, i64* %488, align 8
+  %488 = getelementptr %dimension_descriptor, ptr %461, i32 0, i32 2
+  %489 = load i64, ptr %488, align 8
   %490 = mul i64 %489, %466
   %491 = add i64 %460, %490
-  %492 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %429, i32 2
-  %493 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 0
-  %494 = load i64, i64* %493, align 8
-  %495 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 1
-  %496 = load i64, i64* %495, align 8
+  %492 = getelementptr inbounds %dimension_descriptor, ptr %429, i32 2
+  %493 = getelementptr %dimension_descriptor, ptr %492, i32 0, i32 0
+  %494 = load i64, ptr %493, align 8
+  %495 = getelementptr %dimension_descriptor, ptr %492, i32 0, i32 1
+  %496 = load i64, ptr %495, align 8
   %497 = sub i64 1, %494
   %498 = add i64 %494, %496
   %499 = sub i64 %498, 1
@@ -2192,52 +2189,52 @@ ifcont42:                                         ; preds = %ifcont40
   br i1 %502, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  %503 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %504 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %505 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %504, i32 0, i32 0
-  %506 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %505, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @87, i32 0, i32 0), i8** %506, align 8
-  %507 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %505, i32 0, i32 1
-  store i32 31, i32* %507, align 4
-  %508 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %505, i32 0, i32 2
-  store i32 9, i32* %508, align 4
-  %509 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %505, i32 0, i32 3
-  store i32 31, i32* %509, align 4
-  %510 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %505, i32 0, i32 4
-  store i32 18, i32* %510, align 4
-  %511 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @88, i32 0, i32 0))
-  %512 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %503, i32 0, i32 0
-  %513 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %504, i32 0, i32 0
-  %514 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %512, i32 0, i32 2
-  %515 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %512, i32 0, i32 0
-  store i1 true, i1* %515, align 1
-  %516 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %512, i32 0, i32 1
-  store i8* %511, i8** %516, align 8
-  store { i8*, i32, i32, i32, i32 }* %513, { i8*, i32, i32, i32, i32 }** %514, align 8
-  %517 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %512, i32 0, i32 3
-  store i32 1, i32* %517, align 4
-  %518 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %503, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %518, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i64 1, i32 3, i64 %494, i64 %499)
+  %503 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %504 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %505 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %504, i32 0, i32 0
+  %506 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %505, i32 0, i32 0
+  store ptr @87, ptr %506, align 8
+  %507 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %505, i32 0, i32 1
+  store i32 31, ptr %507, align 4
+  %508 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %505, i32 0, i32 2
+  store i32 9, ptr %508, align 4
+  %509 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %505, i32 0, i32 3
+  store i32 31, ptr %509, align 4
+  %510 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %505, i32 0, i32 4
+  store i32 18, ptr %510, align 4
+  %511 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @88)
+  %512 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %503, i32 0, i32 0
+  %513 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %504, i32 0, i32 0
+  %514 = getelementptr { i1, ptr, ptr, i32 }, ptr %512, i32 0, i32 2
+  %515 = getelementptr { i1, ptr, ptr, i32 }, ptr %512, i32 0, i32 0
+  store i1 true, ptr %515, align 1
+  %516 = getelementptr { i1, ptr, ptr, i32 }, ptr %512, i32 0, i32 1
+  store ptr %511, ptr %516, align 8
+  store ptr %513, ptr %514, align 8
+  %517 = getelementptr { i1, ptr, ptr, i32 }, ptr %512, i32 0, i32 3
+  store i32 1, ptr %517, align 4
+  %518 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %503, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %518, i32 1, ptr @89, ptr @86, i64 1, i32 3, i64 %494, i64 %499)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %519 = getelementptr %dimension_descriptor, %dimension_descriptor* %492, i32 0, i32 2
-  %520 = load i64, i64* %519, align 8
+  %519 = getelementptr %dimension_descriptor, ptr %492, i32 0, i32 2
+  %520 = load i64, ptr %519, align 8
   %521 = mul i64 %520, %497
   %522 = add i64 %491, %521
-  %523 = getelementptr %array.3, %array.3* %404, i32 0, i32 7
-  %524 = load i64, i64* %523, align 8
+  %523 = getelementptr %array.3, ptr %404, i32 0, i32 7
+  %524 = load i64, ptr %523, align 8
   %525 = add i64 %522, %524
-  %526 = getelementptr %array.3, %array.3* %404, i32 0, i32 0
-  %527 = load i32*, i32** %526, align 8
-  %528 = getelementptr inbounds i32, i32* %527, i64 %525
-  %529 = load i32, i32* %528, align 4
+  %526 = getelementptr %array.3, ptr %404, i32 0, i32 0
+  %527 = load ptr, ptr %526, align 8
+  %528 = getelementptr inbounds i32, ptr %527, i64 %525
+  %529 = load i32, ptr %528, align 4
   %530 = icmp ne i32 %529, 99
   br i1 %530, label %then45, label %else46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @91, ptr @"ERROR STOP", ptr @90)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -2246,15 +2243,15 @@ else46:                                           ; preds = %ifcont44
   br label %ifcont47
 
 ifcont47:                                         ; preds = %else46, %then45
-  %531 = load %array.3*, %array.3** %x, align 8
-  %532 = ptrtoint %array.3* %531 to i64
+  %531 = load ptr, ptr %x, align 8
+  %532 = ptrtoint ptr %531 to i64
   %533 = icmp eq i64 %532, 0
   br i1 %533, label %merge_allocated49, label %check_data48
 
 check_data48:                                     ; preds = %ifcont47
-  %534 = getelementptr %array.3, %array.3* %531, i32 0, i32 0
-  %535 = load i32*, i32** %534, align 8
-  %536 = ptrtoint i32* %535 to i64
+  %534 = getelementptr %array.3, ptr %531, i32 0, i32 0
+  %535 = load ptr, ptr %534, align 8
+  %536 = ptrtoint ptr %535 to i64
   %537 = icmp ne i64 %536, 0
   br label %merge_allocated49
 
@@ -2264,43 +2261,43 @@ merge_allocated49:                                ; preds = %check_data48, %ifco
   br i1 %538, label %then51, label %ifcont52
 
 then51:                                           ; preds = %merge_allocated49
-  %539 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %540 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %541 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %540, i32 0, i32 0
-  %542 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %541, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @93, i32 0, i32 0), i8** %542, align 8
-  %543 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %541, i32 0, i32 1
-  store i32 32, i32* %543, align 4
-  %544 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %541, i32 0, i32 2
-  store i32 5, i32* %544, align 4
-  %545 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %541, i32 0, i32 3
-  store i32 32, i32* %545, align 4
-  %546 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %541, i32 0, i32 4
-  store i32 14, i32* %546, align 4
-  %547 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %548 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %539, i32 0, i32 0
-  %549 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %540, i32 0, i32 0
-  %550 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %548, i32 0, i32 2
-  %551 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %548, i32 0, i32 0
-  store i1 true, i1* %551, align 1
-  %552 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %548, i32 0, i32 1
-  store i8* %547, i8** %552, align 8
-  store { i8*, i32, i32, i32, i32 }* %549, { i8*, i32, i32, i32, i32 }** %550, align 8
-  %553 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %548, i32 0, i32 3
-  store i32 1, i32* %553, align 4
-  %554 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %539, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %554, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0))
+  %539 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %540 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %541 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %540, i32 0, i32 0
+  %542 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %541, i32 0, i32 0
+  store ptr @93, ptr %542, align 8
+  %543 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %541, i32 0, i32 1
+  store i32 32, ptr %543, align 4
+  %544 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %541, i32 0, i32 2
+  store i32 5, ptr %544, align 4
+  %545 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %541, i32 0, i32 3
+  store i32 32, ptr %545, align 4
+  %546 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %541, i32 0, i32 4
+  store i32 14, ptr %546, align 4
+  %547 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @94)
+  %548 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %539, i32 0, i32 0
+  %549 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %540, i32 0, i32 0
+  %550 = getelementptr { i1, ptr, ptr, i32 }, ptr %548, i32 0, i32 2
+  %551 = getelementptr { i1, ptr, ptr, i32 }, ptr %548, i32 0, i32 0
+  store i1 true, ptr %551, align 1
+  %552 = getelementptr { i1, ptr, ptr, i32 }, ptr %548, i32 0, i32 1
+  store ptr %547, ptr %552, align 8
+  store ptr %549, ptr %550, align 8
+  %553 = getelementptr { i1, ptr, ptr, i32 }, ptr %548, i32 0, i32 3
+  store i32 1, ptr %553, align 4
+  %554 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %539, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %554, i32 1, ptr @95, ptr @92)
   call void @exit(i32 1)
   unreachable
 
 ifcont52:                                         ; preds = %merge_allocated49
-  %555 = getelementptr %array.3, %array.3* %531, i32 0, i32 8
-  %556 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %555, i32 0, i32 0
-  %557 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 0
-  %558 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 0
-  %559 = load i64, i64* %558, align 8
-  %560 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 1
-  %561 = load i64, i64* %560, align 8
+  %555 = getelementptr %array.3, ptr %531, i32 0, i32 8
+  %556 = getelementptr [3 x %dimension_descriptor], ptr %555, i32 0, i32 0
+  %557 = getelementptr inbounds %dimension_descriptor, ptr %556, i32 0
+  %558 = getelementptr %dimension_descriptor, ptr %557, i32 0, i32 0
+  %559 = load i64, ptr %558, align 8
+  %560 = getelementptr %dimension_descriptor, ptr %557, i32 0, i32 1
+  %561 = load i64, ptr %560, align 8
   %562 = sub i64 1, %559
   %563 = add i64 %559, %561
   %564 = sub i64 %563, 1
@@ -2310,45 +2307,45 @@ ifcont52:                                         ; preds = %merge_allocated49
   br i1 %567, label %then53, label %ifcont54
 
 then53:                                           ; preds = %ifcont52
-  %568 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %569 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %570 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %569, i32 0, i32 0
-  %571 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %570, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @97, i32 0, i32 0), i8** %571, align 8
-  %572 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %570, i32 0, i32 1
-  store i32 32, i32* %572, align 4
-  %573 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %570, i32 0, i32 2
-  store i32 5, i32* %573, align 4
-  %574 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %570, i32 0, i32 3
-  store i32 32, i32* %574, align 4
-  %575 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %570, i32 0, i32 4
-  store i32 14, i32* %575, align 4
-  %576 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %577 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %568, i32 0, i32 0
-  %578 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %569, i32 0, i32 0
-  %579 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %577, i32 0, i32 2
-  %580 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %577, i32 0, i32 0
-  store i1 true, i1* %580, align 1
-  %581 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %577, i32 0, i32 1
-  store i8* %576, i8** %581, align 8
-  store { i8*, i32, i32, i32, i32 }* %578, { i8*, i32, i32, i32, i32 }** %579, align 8
-  %582 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %577, i32 0, i32 3
-  store i32 1, i32* %582, align 4
-  %583 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %568, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %583, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 1, i32 1, i64 %559, i64 %564)
+  %568 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %569 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %570 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %569, i32 0, i32 0
+  %571 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %570, i32 0, i32 0
+  store ptr @97, ptr %571, align 8
+  %572 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %570, i32 0, i32 1
+  store i32 32, ptr %572, align 4
+  %573 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %570, i32 0, i32 2
+  store i32 5, ptr %573, align 4
+  %574 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %570, i32 0, i32 3
+  store i32 32, ptr %574, align 4
+  %575 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %570, i32 0, i32 4
+  store i32 14, ptr %575, align 4
+  %576 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @98)
+  %577 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %568, i32 0, i32 0
+  %578 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %569, i32 0, i32 0
+  %579 = getelementptr { i1, ptr, ptr, i32 }, ptr %577, i32 0, i32 2
+  %580 = getelementptr { i1, ptr, ptr, i32 }, ptr %577, i32 0, i32 0
+  store i1 true, ptr %580, align 1
+  %581 = getelementptr { i1, ptr, ptr, i32 }, ptr %577, i32 0, i32 1
+  store ptr %576, ptr %581, align 8
+  store ptr %578, ptr %579, align 8
+  %582 = getelementptr { i1, ptr, ptr, i32 }, ptr %577, i32 0, i32 3
+  store i32 1, ptr %582, align 4
+  %583 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %568, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %583, i32 1, ptr @99, ptr @96, i64 1, i32 1, i64 %559, i64 %564)
   call void @exit(i32 1)
   unreachable
 
 ifcont54:                                         ; preds = %ifcont52
-  %584 = getelementptr %dimension_descriptor, %dimension_descriptor* %557, i32 0, i32 2
-  %585 = load i64, i64* %584, align 8
+  %584 = getelementptr %dimension_descriptor, ptr %557, i32 0, i32 2
+  %585 = load i64, ptr %584, align 8
   %586 = mul i64 %585, %562
   %587 = add i64 0, %586
-  %588 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 1
-  %589 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 0
-  %590 = load i64, i64* %589, align 8
-  %591 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 1
-  %592 = load i64, i64* %591, align 8
+  %588 = getelementptr inbounds %dimension_descriptor, ptr %556, i32 1
+  %589 = getelementptr %dimension_descriptor, ptr %588, i32 0, i32 0
+  %590 = load i64, ptr %589, align 8
+  %591 = getelementptr %dimension_descriptor, ptr %588, i32 0, i32 1
+  %592 = load i64, ptr %591, align 8
   %593 = sub i64 1, %590
   %594 = add i64 %590, %592
   %595 = sub i64 %594, 1
@@ -2358,45 +2355,45 @@ ifcont54:                                         ; preds = %ifcont52
   br i1 %598, label %then55, label %ifcont56
 
 then55:                                           ; preds = %ifcont54
-  %599 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %600 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %601 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %600, i32 0, i32 0
-  %602 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %601, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @101, i32 0, i32 0), i8** %602, align 8
-  %603 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %601, i32 0, i32 1
-  store i32 32, i32* %603, align 4
-  %604 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %601, i32 0, i32 2
-  store i32 5, i32* %604, align 4
-  %605 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %601, i32 0, i32 3
-  store i32 32, i32* %605, align 4
-  %606 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %601, i32 0, i32 4
-  store i32 14, i32* %606, align 4
-  %607 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @102, i32 0, i32 0))
-  %608 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %599, i32 0, i32 0
-  %609 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %600, i32 0, i32 0
-  %610 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %608, i32 0, i32 2
-  %611 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %608, i32 0, i32 0
-  store i1 true, i1* %611, align 1
-  %612 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %608, i32 0, i32 1
-  store i8* %607, i8** %612, align 8
-  store { i8*, i32, i32, i32, i32 }* %609, { i8*, i32, i32, i32, i32 }** %610, align 8
-  %613 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %608, i32 0, i32 3
-  store i32 1, i32* %613, align 4
-  %614 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %599, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %614, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0), i64 1, i32 2, i64 %590, i64 %595)
+  %599 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %600 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %601 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %600, i32 0, i32 0
+  %602 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %601, i32 0, i32 0
+  store ptr @101, ptr %602, align 8
+  %603 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %601, i32 0, i32 1
+  store i32 32, ptr %603, align 4
+  %604 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %601, i32 0, i32 2
+  store i32 5, ptr %604, align 4
+  %605 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %601, i32 0, i32 3
+  store i32 32, ptr %605, align 4
+  %606 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %601, i32 0, i32 4
+  store i32 14, ptr %606, align 4
+  %607 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @102)
+  %608 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %599, i32 0, i32 0
+  %609 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %600, i32 0, i32 0
+  %610 = getelementptr { i1, ptr, ptr, i32 }, ptr %608, i32 0, i32 2
+  %611 = getelementptr { i1, ptr, ptr, i32 }, ptr %608, i32 0, i32 0
+  store i1 true, ptr %611, align 1
+  %612 = getelementptr { i1, ptr, ptr, i32 }, ptr %608, i32 0, i32 1
+  store ptr %607, ptr %612, align 8
+  store ptr %609, ptr %610, align 8
+  %613 = getelementptr { i1, ptr, ptr, i32 }, ptr %608, i32 0, i32 3
+  store i32 1, ptr %613, align 4
+  %614 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %599, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %614, i32 1, ptr @103, ptr @100, i64 1, i32 2, i64 %590, i64 %595)
   call void @exit(i32 1)
   unreachable
 
 ifcont56:                                         ; preds = %ifcont54
-  %615 = getelementptr %dimension_descriptor, %dimension_descriptor* %588, i32 0, i32 2
-  %616 = load i64, i64* %615, align 8
+  %615 = getelementptr %dimension_descriptor, ptr %588, i32 0, i32 2
+  %616 = load i64, ptr %615, align 8
   %617 = mul i64 %616, %593
   %618 = add i64 %587, %617
-  %619 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %556, i32 2
-  %620 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 0
-  %621 = load i64, i64* %620, align 8
-  %622 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 1
-  %623 = load i64, i64* %622, align 8
+  %619 = getelementptr inbounds %dimension_descriptor, ptr %556, i32 2
+  %620 = getelementptr %dimension_descriptor, ptr %619, i32 0, i32 0
+  %621 = load i64, ptr %620, align 8
+  %622 = getelementptr %dimension_descriptor, ptr %619, i32 0, i32 1
+  %623 = load i64, ptr %622, align 8
   %624 = sub i64 1, %621
   %625 = add i64 %621, %623
   %626 = sub i64 %625, 1
@@ -2406,72 +2403,72 @@ ifcont56:                                         ; preds = %ifcont54
   br i1 %629, label %then57, label %ifcont58
 
 then57:                                           ; preds = %ifcont56
-  %630 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %631 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %632 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %631, i32 0, i32 0
-  %633 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %632, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @105, i32 0, i32 0), i8** %633, align 8
-  %634 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %632, i32 0, i32 1
-  store i32 32, i32* %634, align 4
-  %635 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %632, i32 0, i32 2
-  store i32 5, i32* %635, align 4
-  %636 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %632, i32 0, i32 3
-  store i32 32, i32* %636, align 4
-  %637 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %632, i32 0, i32 4
-  store i32 14, i32* %637, align 4
-  %638 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @106, i32 0, i32 0))
-  %639 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %630, i32 0, i32 0
-  %640 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %631, i32 0, i32 0
-  %641 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %639, i32 0, i32 2
-  %642 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %639, i32 0, i32 0
-  store i1 true, i1* %642, align 1
-  %643 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %639, i32 0, i32 1
-  store i8* %638, i8** %643, align 8
-  store { i8*, i32, i32, i32, i32 }* %640, { i8*, i32, i32, i32, i32 }** %641, align 8
-  %644 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %639, i32 0, i32 3
-  store i32 1, i32* %644, align 4
-  %645 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %630, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %645, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i64 1, i32 3, i64 %621, i64 %626)
+  %630 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %631 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %632 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %631, i32 0, i32 0
+  %633 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %632, i32 0, i32 0
+  store ptr @105, ptr %633, align 8
+  %634 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %632, i32 0, i32 1
+  store i32 32, ptr %634, align 4
+  %635 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %632, i32 0, i32 2
+  store i32 5, ptr %635, align 4
+  %636 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %632, i32 0, i32 3
+  store i32 32, ptr %636, align 4
+  %637 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %632, i32 0, i32 4
+  store i32 14, ptr %637, align 4
+  %638 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @106)
+  %639 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %630, i32 0, i32 0
+  %640 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %631, i32 0, i32 0
+  %641 = getelementptr { i1, ptr, ptr, i32 }, ptr %639, i32 0, i32 2
+  %642 = getelementptr { i1, ptr, ptr, i32 }, ptr %639, i32 0, i32 0
+  store i1 true, ptr %642, align 1
+  %643 = getelementptr { i1, ptr, ptr, i32 }, ptr %639, i32 0, i32 1
+  store ptr %638, ptr %643, align 8
+  store ptr %640, ptr %641, align 8
+  %644 = getelementptr { i1, ptr, ptr, i32 }, ptr %639, i32 0, i32 3
+  store i32 1, ptr %644, align 4
+  %645 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %630, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %645, i32 1, ptr @107, ptr @104, i64 1, i32 3, i64 %621, i64 %626)
   call void @exit(i32 1)
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %646 = getelementptr %dimension_descriptor, %dimension_descriptor* %619, i32 0, i32 2
-  %647 = load i64, i64* %646, align 8
+  %646 = getelementptr %dimension_descriptor, ptr %619, i32 0, i32 2
+  %647 = load i64, ptr %646, align 8
   %648 = mul i64 %647, %624
   %649 = add i64 %618, %648
-  %650 = getelementptr %array.3, %array.3* %531, i32 0, i32 7
-  %651 = load i64, i64* %650, align 8
+  %650 = getelementptr %array.3, ptr %531, i32 0, i32 7
+  %651 = load i64, ptr %650, align 8
   %652 = add i64 %649, %651
-  %653 = getelementptr %array.3, %array.3* %531, i32 0, i32 0
-  %654 = load i32*, i32** %653, align 8
-  %655 = getelementptr inbounds i32, i32* %654, i64 %652
-  store i32 8, i32* %655, align 4
-  store i32 0, i32* %r, align 4
+  %653 = getelementptr %array.3, ptr %531, i32 0, i32 0
+  %654 = load ptr, ptr %653, align 8
+  %655 = getelementptr inbounds i32, ptr %654, i64 %652
+  store i32 8, ptr %655, align 4
+  store i32 0, ptr %r, align 4
   br label %return
 
 return:                                           ; preds = %ifcont58
   br label %FINALIZE_SYMTABLE_g
 
 FINALIZE_SYMTABLE_g:                              ; preds = %return
-  %656 = load i32, i32* %r, align 4
+  %656 = load i32, ptr %r, align 4
   ret i32 %656
 }
 
-define void @h(%array.3** %c) {
+define void @h(ptr %c) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load %array.3*, %array.3** %c, align 8
-  %2 = load %array.3*, %array.3** %c, align 8
-  %3 = ptrtoint %array.3* %2 to i64
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load ptr, ptr %c, align 8
+  %2 = load ptr, ptr %c, align 8
+  %3 = ptrtoint ptr %2 to i64
   %4 = icmp eq i64 %3, 0
   br i1 %4, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %5 = getelementptr %array.3, %array.3* %2, i32 0, i32 0
-  %6 = load i32*, i32** %5, align 8
-  %7 = ptrtoint i32* %6 to i64
+  %5 = getelementptr %array.3, ptr %2, i32 0, i32 0
+  %6 = load ptr, ptr %5, align 8
+  %7 = ptrtoint ptr %6 to i64
   %8 = icmp ne i64 %7, 0
   br label %merge_allocated
 
@@ -2480,15 +2477,15 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %is_allocated, label %then, label %else5
 
 then:                                             ; preds = %merge_allocated
-  %9 = load %array.3*, %array.3** %c, align 8
-  %10 = ptrtoint %array.3* %9 to i64
+  %9 = load ptr, ptr %c, align 8
+  %10 = ptrtoint ptr %9 to i64
   %11 = icmp eq i64 %10, 0
   br i1 %11, label %merge_allocated2, label %check_data1
 
 check_data1:                                      ; preds = %then
-  %12 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  %13 = load i32*, i32** %12, align 8
-  %14 = ptrtoint i32* %13 to i64
+  %12 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  %13 = load ptr, ptr %12, align 8
+  %14 = ptrtoint ptr %13 to i64
   %15 = icmp ne i64 %14, 0
   br label %merge_allocated2
 
@@ -2497,12 +2494,11 @@ merge_allocated2:                                 ; preds = %check_data1, %then
   br i1 %is_allocated3, label %then4, label %else
 
 then4:                                            ; preds = %merge_allocated2
-  %16 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  %17 = load i32*, i32** %16, align 8
-  %18 = bitcast i32* %17 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %18)
-  %19 = getelementptr %array.3, %array.3* %9, i32 0, i32 0
-  store i32* null, i32** %19, align 8
+  %16 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %17)
+  %18 = getelementptr %array.3, ptr %9, i32 0, i32 0
+  store ptr null, ptr %18, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated2
@@ -2515,25 +2511,25 @@ else5:                                            ; preds = %merge_allocated
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %ifcont
-  %20 = load %array.3*, %array.3** %c, align 8
-  %21 = load %array.3*, %array.3** %c, align 8
-  %22 = ptrtoint %array.3* %21 to i64
-  %23 = icmp eq i64 %22, 0
-  br i1 %23, label %merge_allocated8, label %check_data7
+  %19 = load ptr, ptr %c, align 8
+  %20 = load ptr, ptr %c, align 8
+  %21 = ptrtoint ptr %20 to i64
+  %22 = icmp eq i64 %21, 0
+  br i1 %22, label %merge_allocated8, label %check_data7
 
 check_data7:                                      ; preds = %ifcont6
-  %24 = getelementptr %array.3, %array.3* %21, i32 0, i32 0
-  %25 = load i32*, i32** %24, align 8
-  %26 = ptrtoint i32* %25 to i64
-  %27 = icmp ne i64 %26, 0
+  %23 = getelementptr %array.3, ptr %20, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = ptrtoint ptr %24 to i64
+  %26 = icmp ne i64 %25, 0
   br label %merge_allocated8
 
 merge_allocated8:                                 ; preds = %check_data7, %ifcont6
-  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %27, %check_data7 ]
+  %is_allocated9 = phi i1 [ false, %ifcont6 ], [ %26, %check_data7 ]
   br i1 %is_allocated9, label %then10, label %else11
 
 then10:                                           ; preds = %merge_allocated8
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @109, ptr @"ERROR STOP", ptr @108)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -2542,437 +2538,437 @@ else11:                                           ; preds = %merge_allocated8
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  call void @f(%array.3** %c)
-  %28 = alloca i64, align 8
-  %29 = load %array.3*, %array.3** %c, align 8
-  %30 = ptrtoint %array.3* %29 to i64
-  %31 = icmp eq i64 %30, 0
-  br i1 %31, label %merge_allocated14, label %check_data13
+  call void @f(ptr %c)
+  %27 = alloca i64, align 8
+  %28 = load ptr, ptr %c, align 8
+  %29 = ptrtoint ptr %28 to i64
+  %30 = icmp eq i64 %29, 0
+  br i1 %30, label %merge_allocated14, label %check_data13
 
 check_data13:                                     ; preds = %ifcont12
-  %32 = getelementptr %array.3, %array.3* %29, i32 0, i32 0
-  %33 = load i32*, i32** %32, align 8
-  %34 = ptrtoint i32* %33 to i64
-  %35 = icmp ne i64 %34, 0
+  %31 = getelementptr %array.3, ptr %28, i32 0, i32 0
+  %32 = load ptr, ptr %31, align 8
+  %33 = ptrtoint ptr %32 to i64
+  %34 = icmp ne i64 %33, 0
   br label %merge_allocated14
 
 merge_allocated14:                                ; preds = %check_data13, %ifcont12
-  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %35, %check_data13 ]
-  %36 = xor i1 %is_allocated15, true
-  br i1 %36, label %then16, label %ifcont17
+  %is_allocated15 = phi i1 [ false, %ifcont12 ], [ %34, %check_data13 ]
+  %35 = xor i1 %is_allocated15, true
+  br i1 %35, label %then16, label %ifcont17
 
 then16:                                           ; preds = %merge_allocated14
-  %37 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %38 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %39 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @112, i32 0, i32 0), i8** %40, align 8
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 1
-  store i32 40, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 2
-  store i32 14, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 3
-  store i32 40, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 4
-  store i32 23, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @113, i32 0, i32 0))
-  %46 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  %47 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 2
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 0
-  store i1 true, i1* %49, align 1
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 1
-  store i8* %45, i8** %50, align 8
-  store { i8*, i32, i32, i32, i32 }* %47, { i8*, i32, i32, i32, i32 }** %48, align 8
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 3
-  store i32 1, i32* %51, align 4
-  %52 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %52, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @114, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @111, i32 0, i32 0))
+  %36 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %37 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %38 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 0
+  store ptr @112, ptr %39, align 8
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 1
+  store i32 40, ptr %40, align 4
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 2
+  store i32 14, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 3
+  store i32 40, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 4
+  store i32 23, ptr %43, align 4
+  %44 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @113)
+  %45 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  %46 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 2
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 0
+  store i1 true, ptr %48, align 1
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 1
+  store ptr %44, ptr %49, align 8
+  store ptr %46, ptr %47, align 8
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 3
+  store i32 1, ptr %50, align 4
+  %51 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %51, i32 1, ptr @114, ptr @111)
   call void @exit(i32 1)
   unreachable
 
 ifcont17:                                         ; preds = %merge_allocated14
-  %53 = getelementptr %array.3, %array.3* %29, i32 0, i32 8
-  %54 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %53, i32 0, i32 0
-  %55 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 0
-  %56 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 0
-  %57 = load i64, i64* %56, align 8
-  %58 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 1
-  %59 = load i64, i64* %58, align 8
-  %60 = sub i64 1, %57
-  %61 = add i64 %57, %59
-  %62 = sub i64 %61, 1
-  %63 = icmp slt i64 1, %57
-  %64 = icmp sgt i64 1, %62
-  %65 = or i1 %63, %64
-  br i1 %65, label %then18, label %ifcont19
+  %52 = getelementptr %array.3, ptr %28, i32 0, i32 8
+  %53 = getelementptr [3 x %dimension_descriptor], ptr %52, i32 0, i32 0
+  %54 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 0
+  %55 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 0
+  %56 = load i64, ptr %55, align 8
+  %57 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 1
+  %58 = load i64, ptr %57, align 8
+  %59 = sub i64 1, %56
+  %60 = add i64 %56, %58
+  %61 = sub i64 %60, 1
+  %62 = icmp slt i64 1, %56
+  %63 = icmp sgt i64 1, %61
+  %64 = or i1 %62, %63
+  br i1 %64, label %then18, label %ifcont19
 
 then18:                                           ; preds = %ifcont17
-  %66 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %67 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %68 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %67, i32 0, i32 0
-  %69 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @116, i32 0, i32 0), i8** %69, align 8
-  %70 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 1
-  store i32 40, i32* %70, align 4
-  %71 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 2
-  store i32 14, i32* %71, align 4
-  %72 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 3
-  store i32 40, i32* %72, align 4
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 4
-  store i32 23, i32* %73, align 4
-  %74 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @117, i32 0, i32 0))
-  %75 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %66, i32 0, i32 0
-  %76 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %67, i32 0, i32 0
-  %77 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 2
-  %78 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 0
-  store i1 true, i1* %78, align 1
-  %79 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 1
-  store i8* %74, i8** %79, align 8
-  store { i8*, i32, i32, i32, i32 }* %76, { i8*, i32, i32, i32, i32 }** %77, align 8
-  %80 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 3
-  store i32 1, i32* %80, align 4
-  %81 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %66, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @118, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @115, i32 0, i32 0), i64 1, i32 1, i64 %57, i64 %62)
+  %65 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %66 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %67 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %66, i32 0, i32 0
+  %68 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 0
+  store ptr @116, ptr %68, align 8
+  %69 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 1
+  store i32 40, ptr %69, align 4
+  %70 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 2
+  store i32 14, ptr %70, align 4
+  %71 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 3
+  store i32 40, ptr %71, align 4
+  %72 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 4
+  store i32 23, ptr %72, align 4
+  %73 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @117)
+  %74 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %65, i32 0, i32 0
+  %75 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %66, i32 0, i32 0
+  %76 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 2
+  %77 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 0
+  store i1 true, ptr %77, align 1
+  %78 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 1
+  store ptr %73, ptr %78, align 8
+  store ptr %75, ptr %76, align 8
+  %79 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 3
+  store i32 1, ptr %79, align 4
+  %80 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %65, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %80, i32 1, ptr @118, ptr @115, i64 1, i32 1, i64 %56, i64 %61)
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %ifcont17
-  %82 = getelementptr %dimension_descriptor, %dimension_descriptor* %55, i32 0, i32 2
-  %83 = load i64, i64* %82, align 8
-  %84 = mul i64 %83, %60
-  %85 = add i64 0, %84
-  %86 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 1
-  %87 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 0
-  %88 = load i64, i64* %87, align 8
-  %89 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 1
-  %90 = load i64, i64* %89, align 8
-  %91 = sub i64 1, %88
-  %92 = add i64 %88, %90
-  %93 = sub i64 %92, 1
-  %94 = icmp slt i64 1, %88
-  %95 = icmp sgt i64 1, %93
-  %96 = or i1 %94, %95
-  br i1 %96, label %then20, label %ifcont21
+  %81 = getelementptr %dimension_descriptor, ptr %54, i32 0, i32 2
+  %82 = load i64, ptr %81, align 8
+  %83 = mul i64 %82, %59
+  %84 = add i64 0, %83
+  %85 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 1
+  %86 = getelementptr %dimension_descriptor, ptr %85, i32 0, i32 0
+  %87 = load i64, ptr %86, align 8
+  %88 = getelementptr %dimension_descriptor, ptr %85, i32 0, i32 1
+  %89 = load i64, ptr %88, align 8
+  %90 = sub i64 1, %87
+  %91 = add i64 %87, %89
+  %92 = sub i64 %91, 1
+  %93 = icmp slt i64 1, %87
+  %94 = icmp sgt i64 1, %92
+  %95 = or i1 %93, %94
+  br i1 %95, label %then20, label %ifcont21
 
 then20:                                           ; preds = %ifcont19
-  %97 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %98 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %99 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %98, i32 0, i32 0
-  %100 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %99, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @120, i32 0, i32 0), i8** %100, align 8
-  %101 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %99, i32 0, i32 1
-  store i32 40, i32* %101, align 4
-  %102 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %99, i32 0, i32 2
-  store i32 14, i32* %102, align 4
-  %103 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %99, i32 0, i32 3
-  store i32 40, i32* %103, align 4
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %99, i32 0, i32 4
-  store i32 23, i32* %104, align 4
-  %105 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @121, i32 0, i32 0))
-  %106 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %97, i32 0, i32 0
-  %107 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %98, i32 0, i32 0
-  %108 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 0, i32 2
-  %109 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 0, i32 0
-  store i1 true, i1* %109, align 1
-  %110 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 0, i32 1
-  store i8* %105, i8** %110, align 8
-  store { i8*, i32, i32, i32, i32 }* %107, { i8*, i32, i32, i32, i32 }** %108, align 8
-  %111 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 0, i32 3
-  store i32 1, i32* %111, align 4
-  %112 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %97, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %112, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @122, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @119, i32 0, i32 0), i64 1, i32 2, i64 %88, i64 %93)
+  %96 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %97 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %98 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %97, i32 0, i32 0
+  %99 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %98, i32 0, i32 0
+  store ptr @120, ptr %99, align 8
+  %100 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %98, i32 0, i32 1
+  store i32 40, ptr %100, align 4
+  %101 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %98, i32 0, i32 2
+  store i32 14, ptr %101, align 4
+  %102 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %98, i32 0, i32 3
+  store i32 40, ptr %102, align 4
+  %103 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %98, i32 0, i32 4
+  store i32 23, ptr %103, align 4
+  %104 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @121)
+  %105 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %96, i32 0, i32 0
+  %106 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %97, i32 0, i32 0
+  %107 = getelementptr { i1, ptr, ptr, i32 }, ptr %105, i32 0, i32 2
+  %108 = getelementptr { i1, ptr, ptr, i32 }, ptr %105, i32 0, i32 0
+  store i1 true, ptr %108, align 1
+  %109 = getelementptr { i1, ptr, ptr, i32 }, ptr %105, i32 0, i32 1
+  store ptr %104, ptr %109, align 8
+  store ptr %106, ptr %107, align 8
+  %110 = getelementptr { i1, ptr, ptr, i32 }, ptr %105, i32 0, i32 3
+  store i32 1, ptr %110, align 4
+  %111 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %96, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %111, i32 1, ptr @122, ptr @119, i64 1, i32 2, i64 %87, i64 %92)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %86, i32 0, i32 2
-  %114 = load i64, i64* %113, align 8
-  %115 = mul i64 %114, %91
-  %116 = add i64 %85, %115
-  %117 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %54, i32 2
-  %118 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 0
-  %119 = load i64, i64* %118, align 8
-  %120 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 1
-  %121 = load i64, i64* %120, align 8
-  %122 = sub i64 1, %119
-  %123 = add i64 %119, %121
-  %124 = sub i64 %123, 1
-  %125 = icmp slt i64 1, %119
-  %126 = icmp sgt i64 1, %124
-  %127 = or i1 %125, %126
-  br i1 %127, label %then22, label %ifcont23
+  %112 = getelementptr %dimension_descriptor, ptr %85, i32 0, i32 2
+  %113 = load i64, ptr %112, align 8
+  %114 = mul i64 %113, %90
+  %115 = add i64 %84, %114
+  %116 = getelementptr inbounds %dimension_descriptor, ptr %53, i32 2
+  %117 = getelementptr %dimension_descriptor, ptr %116, i32 0, i32 0
+  %118 = load i64, ptr %117, align 8
+  %119 = getelementptr %dimension_descriptor, ptr %116, i32 0, i32 1
+  %120 = load i64, ptr %119, align 8
+  %121 = sub i64 1, %118
+  %122 = add i64 %118, %120
+  %123 = sub i64 %122, 1
+  %124 = icmp slt i64 1, %118
+  %125 = icmp sgt i64 1, %123
+  %126 = or i1 %124, %125
+  br i1 %126, label %then22, label %ifcont23
 
 then22:                                           ; preds = %ifcont21
-  %128 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %129 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %130 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %129, i32 0, i32 0
-  %131 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @124, i32 0, i32 0), i8** %131, align 8
-  %132 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 1
-  store i32 40, i32* %132, align 4
-  %133 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 2
-  store i32 14, i32* %133, align 4
-  %134 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 3
-  store i32 40, i32* %134, align 4
-  %135 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 4
-  store i32 23, i32* %135, align 4
-  %136 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @125, i32 0, i32 0))
-  %137 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %128, i32 0, i32 0
-  %138 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %129, i32 0, i32 0
-  %139 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 2
-  %140 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 0
-  store i1 true, i1* %140, align 1
-  %141 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 1
-  store i8* %136, i8** %141, align 8
-  store { i8*, i32, i32, i32, i32 }* %138, { i8*, i32, i32, i32, i32 }** %139, align 8
-  %142 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 3
-  store i32 1, i32* %142, align 4
-  %143 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %128, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %143, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @126, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @123, i32 0, i32 0), i64 1, i32 3, i64 %119, i64 %124)
+  %127 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %128 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %129 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %128, i32 0, i32 0
+  %130 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %129, i32 0, i32 0
+  store ptr @124, ptr %130, align 8
+  %131 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %129, i32 0, i32 1
+  store i32 40, ptr %131, align 4
+  %132 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %129, i32 0, i32 2
+  store i32 14, ptr %132, align 4
+  %133 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %129, i32 0, i32 3
+  store i32 40, ptr %133, align 4
+  %134 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %129, i32 0, i32 4
+  store i32 23, ptr %134, align 4
+  %135 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @125)
+  %136 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %127, i32 0, i32 0
+  %137 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %128, i32 0, i32 0
+  %138 = getelementptr { i1, ptr, ptr, i32 }, ptr %136, i32 0, i32 2
+  %139 = getelementptr { i1, ptr, ptr, i32 }, ptr %136, i32 0, i32 0
+  store i1 true, ptr %139, align 1
+  %140 = getelementptr { i1, ptr, ptr, i32 }, ptr %136, i32 0, i32 1
+  store ptr %135, ptr %140, align 8
+  store ptr %137, ptr %138, align 8
+  %141 = getelementptr { i1, ptr, ptr, i32 }, ptr %136, i32 0, i32 3
+  store i32 1, ptr %141, align 4
+  %142 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %127, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %142, i32 1, ptr @126, ptr @123, i64 1, i32 3, i64 %118, i64 %123)
   call void @exit(i32 1)
   unreachable
 
 ifcont23:                                         ; preds = %ifcont21
-  %144 = getelementptr %dimension_descriptor, %dimension_descriptor* %117, i32 0, i32 2
-  %145 = load i64, i64* %144, align 8
-  %146 = mul i64 %145, %122
-  %147 = add i64 %116, %146
-  %148 = getelementptr %array.3, %array.3* %29, i32 0, i32 7
-  %149 = load i64, i64* %148, align 8
-  %150 = add i64 %147, %149
-  %151 = getelementptr %array.3, %array.3* %29, i32 0, i32 0
-  %152 = load i32*, i32** %151, align 8
-  %153 = getelementptr inbounds i32, i32* %152, i64 %150
-  %154 = load i32, i32* %153, align 4
-  %155 = alloca i32, align 4
-  store i32 %154, i32* %155, align 4
-  %156 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %28, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %155)
-  %157 = load i64, i64* %28, align 8
-  %158 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %156, i8** %158, align 8
-  %159 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %157, i64* %159, align 8
-  %160 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %161 = load i8*, i8** %160, align 8
-  %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %163 = load i64, i64* %162, align 8
-  %164 = trunc i64 %163 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @127, i32 0, i32 0), i8* %161, i32 %164, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
-  %165 = icmp eq i8* %156, null
-  br i1 %165, label %free_done, label %free_nonnull
+  %143 = getelementptr %dimension_descriptor, ptr %116, i32 0, i32 2
+  %144 = load i64, ptr %143, align 8
+  %145 = mul i64 %144, %121
+  %146 = add i64 %115, %145
+  %147 = getelementptr %array.3, ptr %28, i32 0, i32 7
+  %148 = load i64, ptr %147, align 8
+  %149 = add i64 %146, %148
+  %150 = getelementptr %array.3, ptr %28, i32 0, i32 0
+  %151 = load ptr, ptr %150, align 8
+  %152 = getelementptr inbounds i32, ptr %151, i64 %149
+  %153 = load i32, ptr %152, align 4
+  %154 = alloca i32, align 4
+  store i32 %153, ptr %154, align 4
+  %155 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.2, ptr %27, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %154)
+  %156 = load i64, ptr %27, align 8
+  %157 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %155, ptr %157, align 8
+  %158 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %156, ptr %158, align 8
+  %159 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %160 = load ptr, ptr %159, align 8
+  %161 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %162 = load i64, ptr %161, align 8
+  %163 = trunc i64 %162 to i32
+  call void @_lfortran_printf(ptr @127, ptr %160, i32 %163, ptr @110, i32 1)
+  %164 = icmp eq ptr %155, null
+  br i1 %164, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont23
-  call void @_lfortran_free_alloc(i8* %0, i8* %156)
+  call void @_lfortran_free_alloc(ptr %0, ptr %155)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont23
-  %166 = load %array.3*, %array.3** %c, align 8
-  %167 = ptrtoint %array.3* %166 to i64
-  %168 = icmp eq i64 %167, 0
-  br i1 %168, label %merge_allocated25, label %check_data24
+  %165 = load ptr, ptr %c, align 8
+  %166 = ptrtoint ptr %165 to i64
+  %167 = icmp eq i64 %166, 0
+  br i1 %167, label %merge_allocated25, label %check_data24
 
 check_data24:                                     ; preds = %free_done
-  %169 = getelementptr %array.3, %array.3* %166, i32 0, i32 0
-  %170 = load i32*, i32** %169, align 8
-  %171 = ptrtoint i32* %170 to i64
-  %172 = icmp ne i64 %171, 0
+  %168 = getelementptr %array.3, ptr %165, i32 0, i32 0
+  %169 = load ptr, ptr %168, align 8
+  %170 = ptrtoint ptr %169 to i64
+  %171 = icmp ne i64 %170, 0
   br label %merge_allocated25
 
 merge_allocated25:                                ; preds = %check_data24, %free_done
-  %is_allocated26 = phi i1 [ false, %free_done ], [ %172, %check_data24 ]
-  %173 = xor i1 %is_allocated26, true
-  br i1 %173, label %then27, label %ifcont28
+  %is_allocated26 = phi i1 [ false, %free_done ], [ %171, %check_data24 ]
+  %172 = xor i1 %is_allocated26, true
+  br i1 %172, label %then27, label %ifcont28
 
 then27:                                           ; preds = %merge_allocated25
-  %174 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %175 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %176 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %175, i32 0, i32 0
-  %177 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %176, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @129, i32 0, i32 0), i8** %177, align 8
-  %178 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %176, i32 0, i32 1
-  store i32 41, i32* %178, align 4
-  %179 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %176, i32 0, i32 2
-  store i32 9, i32* %179, align 4
-  %180 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %176, i32 0, i32 3
-  store i32 41, i32* %180, align 4
-  %181 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %176, i32 0, i32 4
-  store i32 18, i32* %181, align 4
-  %182 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @130, i32 0, i32 0))
-  %183 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %174, i32 0, i32 0
-  %184 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %175, i32 0, i32 0
-  %185 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %183, i32 0, i32 2
-  %186 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %183, i32 0, i32 0
-  store i1 true, i1* %186, align 1
-  %187 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %183, i32 0, i32 1
-  store i8* %182, i8** %187, align 8
-  store { i8*, i32, i32, i32, i32 }* %184, { i8*, i32, i32, i32, i32 }** %185, align 8
-  %188 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %183, i32 0, i32 3
-  store i32 1, i32* %188, align 4
-  %189 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %174, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %189, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @131, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @128, i32 0, i32 0))
+  %173 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %174 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %175 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %174, i32 0, i32 0
+  %176 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %175, i32 0, i32 0
+  store ptr @129, ptr %176, align 8
+  %177 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %175, i32 0, i32 1
+  store i32 41, ptr %177, align 4
+  %178 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %175, i32 0, i32 2
+  store i32 9, ptr %178, align 4
+  %179 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %175, i32 0, i32 3
+  store i32 41, ptr %179, align 4
+  %180 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %175, i32 0, i32 4
+  store i32 18, ptr %180, align 4
+  %181 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @130)
+  %182 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %173, i32 0, i32 0
+  %183 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %174, i32 0, i32 0
+  %184 = getelementptr { i1, ptr, ptr, i32 }, ptr %182, i32 0, i32 2
+  %185 = getelementptr { i1, ptr, ptr, i32 }, ptr %182, i32 0, i32 0
+  store i1 true, ptr %185, align 1
+  %186 = getelementptr { i1, ptr, ptr, i32 }, ptr %182, i32 0, i32 1
+  store ptr %181, ptr %186, align 8
+  store ptr %183, ptr %184, align 8
+  %187 = getelementptr { i1, ptr, ptr, i32 }, ptr %182, i32 0, i32 3
+  store i32 1, ptr %187, align 4
+  %188 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %173, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %188, i32 1, ptr @131, ptr @128)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %merge_allocated25
-  %190 = getelementptr %array.3, %array.3* %166, i32 0, i32 8
-  %191 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %190, i32 0, i32 0
-  %192 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 0
-  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 0
-  %194 = load i64, i64* %193, align 8
-  %195 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 1
-  %196 = load i64, i64* %195, align 8
-  %197 = sub i64 1, %194
-  %198 = add i64 %194, %196
-  %199 = sub i64 %198, 1
-  %200 = icmp slt i64 1, %194
-  %201 = icmp sgt i64 1, %199
-  %202 = or i1 %200, %201
-  br i1 %202, label %then29, label %ifcont30
+  %189 = getelementptr %array.3, ptr %165, i32 0, i32 8
+  %190 = getelementptr [3 x %dimension_descriptor], ptr %189, i32 0, i32 0
+  %191 = getelementptr inbounds %dimension_descriptor, ptr %190, i32 0
+  %192 = getelementptr %dimension_descriptor, ptr %191, i32 0, i32 0
+  %193 = load i64, ptr %192, align 8
+  %194 = getelementptr %dimension_descriptor, ptr %191, i32 0, i32 1
+  %195 = load i64, ptr %194, align 8
+  %196 = sub i64 1, %193
+  %197 = add i64 %193, %195
+  %198 = sub i64 %197, 1
+  %199 = icmp slt i64 1, %193
+  %200 = icmp sgt i64 1, %198
+  %201 = or i1 %199, %200
+  br i1 %201, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %203 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %204 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %205 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %204, i32 0, i32 0
-  %206 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %205, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @133, i32 0, i32 0), i8** %206, align 8
-  %207 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %205, i32 0, i32 1
-  store i32 41, i32* %207, align 4
-  %208 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %205, i32 0, i32 2
-  store i32 9, i32* %208, align 4
-  %209 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %205, i32 0, i32 3
-  store i32 41, i32* %209, align 4
-  %210 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %205, i32 0, i32 4
-  store i32 18, i32* %210, align 4
-  %211 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @134, i32 0, i32 0))
-  %212 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %203, i32 0, i32 0
-  %213 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %204, i32 0, i32 0
-  %214 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %212, i32 0, i32 2
-  %215 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %212, i32 0, i32 0
-  store i1 true, i1* %215, align 1
-  %216 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %212, i32 0, i32 1
-  store i8* %211, i8** %216, align 8
-  store { i8*, i32, i32, i32, i32 }* %213, { i8*, i32, i32, i32, i32 }** %214, align 8
-  %217 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %212, i32 0, i32 3
-  store i32 1, i32* %217, align 4
-  %218 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %203, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %218, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @135, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0), i64 1, i32 1, i64 %194, i64 %199)
+  %202 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %203 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %204 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %203, i32 0, i32 0
+  %205 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %204, i32 0, i32 0
+  store ptr @133, ptr %205, align 8
+  %206 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %204, i32 0, i32 1
+  store i32 41, ptr %206, align 4
+  %207 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %204, i32 0, i32 2
+  store i32 9, ptr %207, align 4
+  %208 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %204, i32 0, i32 3
+  store i32 41, ptr %208, align 4
+  %209 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %204, i32 0, i32 4
+  store i32 18, ptr %209, align 4
+  %210 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @134)
+  %211 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %202, i32 0, i32 0
+  %212 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %203, i32 0, i32 0
+  %213 = getelementptr { i1, ptr, ptr, i32 }, ptr %211, i32 0, i32 2
+  %214 = getelementptr { i1, ptr, ptr, i32 }, ptr %211, i32 0, i32 0
+  store i1 true, ptr %214, align 1
+  %215 = getelementptr { i1, ptr, ptr, i32 }, ptr %211, i32 0, i32 1
+  store ptr %210, ptr %215, align 8
+  store ptr %212, ptr %213, align 8
+  %216 = getelementptr { i1, ptr, ptr, i32 }, ptr %211, i32 0, i32 3
+  store i32 1, ptr %216, align 4
+  %217 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %202, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %217, i32 1, ptr @135, ptr @132, i64 1, i32 1, i64 %193, i64 %198)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %219 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 2
-  %220 = load i64, i64* %219, align 8
-  %221 = mul i64 %220, %197
-  %222 = add i64 0, %221
-  %223 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 1
-  %224 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 0
-  %225 = load i64, i64* %224, align 8
-  %226 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 1
-  %227 = load i64, i64* %226, align 8
-  %228 = sub i64 1, %225
-  %229 = add i64 %225, %227
-  %230 = sub i64 %229, 1
-  %231 = icmp slt i64 1, %225
-  %232 = icmp sgt i64 1, %230
-  %233 = or i1 %231, %232
-  br i1 %233, label %then31, label %ifcont32
+  %218 = getelementptr %dimension_descriptor, ptr %191, i32 0, i32 2
+  %219 = load i64, ptr %218, align 8
+  %220 = mul i64 %219, %196
+  %221 = add i64 0, %220
+  %222 = getelementptr inbounds %dimension_descriptor, ptr %190, i32 1
+  %223 = getelementptr %dimension_descriptor, ptr %222, i32 0, i32 0
+  %224 = load i64, ptr %223, align 8
+  %225 = getelementptr %dimension_descriptor, ptr %222, i32 0, i32 1
+  %226 = load i64, ptr %225, align 8
+  %227 = sub i64 1, %224
+  %228 = add i64 %224, %226
+  %229 = sub i64 %228, 1
+  %230 = icmp slt i64 1, %224
+  %231 = icmp sgt i64 1, %229
+  %232 = or i1 %230, %231
+  br i1 %232, label %then31, label %ifcont32
 
 then31:                                           ; preds = %ifcont30
-  %234 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %235 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %236 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %235, i32 0, i32 0
-  %237 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %236, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @137, i32 0, i32 0), i8** %237, align 8
-  %238 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %236, i32 0, i32 1
-  store i32 41, i32* %238, align 4
-  %239 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %236, i32 0, i32 2
-  store i32 9, i32* %239, align 4
-  %240 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %236, i32 0, i32 3
-  store i32 41, i32* %240, align 4
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %236, i32 0, i32 4
-  store i32 18, i32* %241, align 4
-  %242 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @138, i32 0, i32 0))
-  %243 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %234, i32 0, i32 0
-  %244 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %235, i32 0, i32 0
-  %245 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %243, i32 0, i32 2
-  %246 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %243, i32 0, i32 0
-  store i1 true, i1* %246, align 1
-  %247 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %243, i32 0, i32 1
-  store i8* %242, i8** %247, align 8
-  store { i8*, i32, i32, i32, i32 }* %244, { i8*, i32, i32, i32, i32 }** %245, align 8
-  %248 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %243, i32 0, i32 3
-  store i32 1, i32* %248, align 4
-  %249 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %234, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %249, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @139, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @136, i32 0, i32 0), i64 1, i32 2, i64 %225, i64 %230)
+  %233 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %234 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %235 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %234, i32 0, i32 0
+  %236 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 0
+  store ptr @137, ptr %236, align 8
+  %237 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 1
+  store i32 41, ptr %237, align 4
+  %238 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 2
+  store i32 9, ptr %238, align 4
+  %239 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 3
+  store i32 41, ptr %239, align 4
+  %240 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 4
+  store i32 18, ptr %240, align 4
+  %241 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @138)
+  %242 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %233, i32 0, i32 0
+  %243 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %234, i32 0, i32 0
+  %244 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 2
+  %245 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 0
+  store i1 true, ptr %245, align 1
+  %246 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 1
+  store ptr %241, ptr %246, align 8
+  store ptr %243, ptr %244, align 8
+  %247 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 3
+  store i32 1, ptr %247, align 4
+  %248 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %233, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %248, i32 1, ptr @139, ptr @136, i64 1, i32 2, i64 %224, i64 %229)
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %250 = getelementptr %dimension_descriptor, %dimension_descriptor* %223, i32 0, i32 2
-  %251 = load i64, i64* %250, align 8
-  %252 = mul i64 %251, %228
-  %253 = add i64 %222, %252
-  %254 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 2
-  %255 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 0
-  %256 = load i64, i64* %255, align 8
-  %257 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 1
-  %258 = load i64, i64* %257, align 8
-  %259 = sub i64 1, %256
-  %260 = add i64 %256, %258
-  %261 = sub i64 %260, 1
-  %262 = icmp slt i64 1, %256
-  %263 = icmp sgt i64 1, %261
-  %264 = or i1 %262, %263
-  br i1 %264, label %then33, label %ifcont34
+  %249 = getelementptr %dimension_descriptor, ptr %222, i32 0, i32 2
+  %250 = load i64, ptr %249, align 8
+  %251 = mul i64 %250, %227
+  %252 = add i64 %221, %251
+  %253 = getelementptr inbounds %dimension_descriptor, ptr %190, i32 2
+  %254 = getelementptr %dimension_descriptor, ptr %253, i32 0, i32 0
+  %255 = load i64, ptr %254, align 8
+  %256 = getelementptr %dimension_descriptor, ptr %253, i32 0, i32 1
+  %257 = load i64, ptr %256, align 8
+  %258 = sub i64 1, %255
+  %259 = add i64 %255, %257
+  %260 = sub i64 %259, 1
+  %261 = icmp slt i64 1, %255
+  %262 = icmp sgt i64 1, %260
+  %263 = or i1 %261, %262
+  br i1 %263, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  %265 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %266 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %267 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %266, i32 0, i32 0
-  %268 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @141, i32 0, i32 0), i8** %268, align 8
-  %269 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 1
-  store i32 41, i32* %269, align 4
-  %270 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 2
-  store i32 9, i32* %270, align 4
-  %271 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 3
-  store i32 41, i32* %271, align 4
-  %272 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 4
-  store i32 18, i32* %272, align 4
-  %273 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @142, i32 0, i32 0))
-  %274 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %265, i32 0, i32 0
-  %275 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %266, i32 0, i32 0
-  %276 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 2
-  %277 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 0
-  store i1 true, i1* %277, align 1
-  %278 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 1
-  store i8* %273, i8** %278, align 8
-  store { i8*, i32, i32, i32, i32 }* %275, { i8*, i32, i32, i32, i32 }** %276, align 8
-  %279 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 3
-  store i32 1, i32* %279, align 4
-  %280 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %265, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %280, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @140, i32 0, i32 0), i64 1, i32 3, i64 %256, i64 %261)
+  %264 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %265 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %266 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %265, i32 0, i32 0
+  %267 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %266, i32 0, i32 0
+  store ptr @141, ptr %267, align 8
+  %268 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %266, i32 0, i32 1
+  store i32 41, ptr %268, align 4
+  %269 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %266, i32 0, i32 2
+  store i32 9, ptr %269, align 4
+  %270 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %266, i32 0, i32 3
+  store i32 41, ptr %270, align 4
+  %271 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %266, i32 0, i32 4
+  store i32 18, ptr %271, align 4
+  %272 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @142)
+  %273 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %264, i32 0, i32 0
+  %274 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %265, i32 0, i32 0
+  %275 = getelementptr { i1, ptr, ptr, i32 }, ptr %273, i32 0, i32 2
+  %276 = getelementptr { i1, ptr, ptr, i32 }, ptr %273, i32 0, i32 0
+  store i1 true, ptr %276, align 1
+  %277 = getelementptr { i1, ptr, ptr, i32 }, ptr %273, i32 0, i32 1
+  store ptr %272, ptr %277, align 8
+  store ptr %274, ptr %275, align 8
+  %278 = getelementptr { i1, ptr, ptr, i32 }, ptr %273, i32 0, i32 3
+  store i32 1, ptr %278, align 4
+  %279 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %264, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %279, i32 1, ptr @143, ptr @140, i64 1, i32 3, i64 %255, i64 %260)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %281 = getelementptr %dimension_descriptor, %dimension_descriptor* %254, i32 0, i32 2
-  %282 = load i64, i64* %281, align 8
-  %283 = mul i64 %282, %259
-  %284 = add i64 %253, %283
-  %285 = getelementptr %array.3, %array.3* %166, i32 0, i32 7
-  %286 = load i64, i64* %285, align 8
-  %287 = add i64 %284, %286
-  %288 = getelementptr %array.3, %array.3* %166, i32 0, i32 0
-  %289 = load i32*, i32** %288, align 8
-  %290 = getelementptr inbounds i32, i32* %289, i64 %287
-  %291 = load i32, i32* %290, align 4
-  %292 = icmp ne i32 %291, 99
-  br i1 %292, label %then35, label %else36
+  %280 = getelementptr %dimension_descriptor, ptr %253, i32 0, i32 2
+  %281 = load i64, ptr %280, align 8
+  %282 = mul i64 %281, %258
+  %283 = add i64 %252, %282
+  %284 = getelementptr %array.3, ptr %165, i32 0, i32 7
+  %285 = load i64, ptr %284, align 8
+  %286 = add i64 %283, %285
+  %287 = getelementptr %array.3, ptr %165, i32 0, i32 0
+  %288 = load ptr, ptr %287, align 8
+  %289 = getelementptr inbounds i32, ptr %288, i64 %286
+  %290 = load i32, ptr %289, align 4
+  %291 = icmp ne i32 %290, 99
+  br i1 %291, label %then35, label %else36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @145, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @144, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @145, ptr @"ERROR STOP", ptr @144)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -2981,207 +2977,207 @@ else36:                                           ; preds = %ifcont34
   br label %ifcont37
 
 ifcont37:                                         ; preds = %else36, %then35
-  %293 = load %array.3*, %array.3** %c, align 8
-  %294 = ptrtoint %array.3* %293 to i64
-  %295 = icmp eq i64 %294, 0
-  br i1 %295, label %merge_allocated39, label %check_data38
+  %292 = load ptr, ptr %c, align 8
+  %293 = ptrtoint ptr %292 to i64
+  %294 = icmp eq i64 %293, 0
+  br i1 %294, label %merge_allocated39, label %check_data38
 
 check_data38:                                     ; preds = %ifcont37
-  %296 = getelementptr %array.3, %array.3* %293, i32 0, i32 0
-  %297 = load i32*, i32** %296, align 8
-  %298 = ptrtoint i32* %297 to i64
-  %299 = icmp ne i64 %298, 0
+  %295 = getelementptr %array.3, ptr %292, i32 0, i32 0
+  %296 = load ptr, ptr %295, align 8
+  %297 = ptrtoint ptr %296 to i64
+  %298 = icmp ne i64 %297, 0
   br label %merge_allocated39
 
 merge_allocated39:                                ; preds = %check_data38, %ifcont37
-  %is_allocated40 = phi i1 [ false, %ifcont37 ], [ %299, %check_data38 ]
-  %300 = xor i1 %is_allocated40, true
-  br i1 %300, label %then41, label %ifcont42
+  %is_allocated40 = phi i1 [ false, %ifcont37 ], [ %298, %check_data38 ]
+  %299 = xor i1 %is_allocated40, true
+  br i1 %299, label %then41, label %ifcont42
 
 then41:                                           ; preds = %merge_allocated39
-  %301 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %302 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %303 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %302, i32 0, i32 0
-  %304 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %303, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @147, i32 0, i32 0), i8** %304, align 8
-  %305 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %303, i32 0, i32 1
-  store i32 42, i32* %305, align 4
-  %306 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %303, i32 0, i32 2
-  store i32 5, i32* %306, align 4
-  %307 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %303, i32 0, i32 3
-  store i32 42, i32* %307, align 4
-  %308 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %303, i32 0, i32 4
-  store i32 14, i32* %308, align 4
-  %309 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @148, i32 0, i32 0))
-  %310 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %301, i32 0, i32 0
-  %311 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %302, i32 0, i32 0
-  %312 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %310, i32 0, i32 2
-  %313 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %310, i32 0, i32 0
-  store i1 true, i1* %313, align 1
-  %314 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %310, i32 0, i32 1
-  store i8* %309, i8** %314, align 8
-  store { i8*, i32, i32, i32, i32 }* %311, { i8*, i32, i32, i32, i32 }** %312, align 8
-  %315 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %310, i32 0, i32 3
-  store i32 1, i32* %315, align 4
-  %316 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %301, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %316, i32 1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @149, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @146, i32 0, i32 0))
+  %300 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %301 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %302 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %301, i32 0, i32 0
+  %303 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %302, i32 0, i32 0
+  store ptr @147, ptr %303, align 8
+  %304 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %302, i32 0, i32 1
+  store i32 42, ptr %304, align 4
+  %305 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %302, i32 0, i32 2
+  store i32 5, ptr %305, align 4
+  %306 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %302, i32 0, i32 3
+  store i32 42, ptr %306, align 4
+  %307 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %302, i32 0, i32 4
+  store i32 14, ptr %307, align 4
+  %308 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @148)
+  %309 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %300, i32 0, i32 0
+  %310 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %301, i32 0, i32 0
+  %311 = getelementptr { i1, ptr, ptr, i32 }, ptr %309, i32 0, i32 2
+  %312 = getelementptr { i1, ptr, ptr, i32 }, ptr %309, i32 0, i32 0
+  store i1 true, ptr %312, align 1
+  %313 = getelementptr { i1, ptr, ptr, i32 }, ptr %309, i32 0, i32 1
+  store ptr %308, ptr %313, align 8
+  store ptr %310, ptr %311, align 8
+  %314 = getelementptr { i1, ptr, ptr, i32 }, ptr %309, i32 0, i32 3
+  store i32 1, ptr %314, align 4
+  %315 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %300, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %315, i32 1, ptr @149, ptr @146)
   call void @exit(i32 1)
   unreachable
 
 ifcont42:                                         ; preds = %merge_allocated39
-  %317 = getelementptr %array.3, %array.3* %293, i32 0, i32 8
-  %318 = getelementptr [3 x %dimension_descriptor], [3 x %dimension_descriptor]* %317, i32 0, i32 0
-  %319 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 0
-  %320 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 0
-  %321 = load i64, i64* %320, align 8
-  %322 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 1
-  %323 = load i64, i64* %322, align 8
-  %324 = sub i64 1, %321
-  %325 = add i64 %321, %323
-  %326 = sub i64 %325, 1
-  %327 = icmp slt i64 1, %321
-  %328 = icmp sgt i64 1, %326
-  %329 = or i1 %327, %328
-  br i1 %329, label %then43, label %ifcont44
+  %316 = getelementptr %array.3, ptr %292, i32 0, i32 8
+  %317 = getelementptr [3 x %dimension_descriptor], ptr %316, i32 0, i32 0
+  %318 = getelementptr inbounds %dimension_descriptor, ptr %317, i32 0
+  %319 = getelementptr %dimension_descriptor, ptr %318, i32 0, i32 0
+  %320 = load i64, ptr %319, align 8
+  %321 = getelementptr %dimension_descriptor, ptr %318, i32 0, i32 1
+  %322 = load i64, ptr %321, align 8
+  %323 = sub i64 1, %320
+  %324 = add i64 %320, %322
+  %325 = sub i64 %324, 1
+  %326 = icmp slt i64 1, %320
+  %327 = icmp sgt i64 1, %325
+  %328 = or i1 %326, %327
+  br i1 %328, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  %330 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %331 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %332 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %331, i32 0, i32 0
-  %333 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @151, i32 0, i32 0), i8** %333, align 8
-  %334 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 1
-  store i32 42, i32* %334, align 4
-  %335 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 2
-  store i32 5, i32* %335, align 4
-  %336 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 3
-  store i32 42, i32* %336, align 4
-  %337 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 4
-  store i32 14, i32* %337, align 4
-  %338 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @152, i32 0, i32 0))
-  %339 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %330, i32 0, i32 0
-  %340 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %331, i32 0, i32 0
-  %341 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 2
-  %342 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 0
-  store i1 true, i1* %342, align 1
-  %343 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 1
-  store i8* %338, i8** %343, align 8
-  store { i8*, i32, i32, i32, i32 }* %340, { i8*, i32, i32, i32, i32 }** %341, align 8
-  %344 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 3
-  store i32 1, i32* %344, align 4
-  %345 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %330, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %345, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @153, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @150, i32 0, i32 0), i64 1, i32 1, i64 %321, i64 %326)
+  %329 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %330 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %331 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %330, i32 0, i32 0
+  %332 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %331, i32 0, i32 0
+  store ptr @151, ptr %332, align 8
+  %333 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %331, i32 0, i32 1
+  store i32 42, ptr %333, align 4
+  %334 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %331, i32 0, i32 2
+  store i32 5, ptr %334, align 4
+  %335 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %331, i32 0, i32 3
+  store i32 42, ptr %335, align 4
+  %336 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %331, i32 0, i32 4
+  store i32 14, ptr %336, align 4
+  %337 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @152)
+  %338 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %329, i32 0, i32 0
+  %339 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %330, i32 0, i32 0
+  %340 = getelementptr { i1, ptr, ptr, i32 }, ptr %338, i32 0, i32 2
+  %341 = getelementptr { i1, ptr, ptr, i32 }, ptr %338, i32 0, i32 0
+  store i1 true, ptr %341, align 1
+  %342 = getelementptr { i1, ptr, ptr, i32 }, ptr %338, i32 0, i32 1
+  store ptr %337, ptr %342, align 8
+  store ptr %339, ptr %340, align 8
+  %343 = getelementptr { i1, ptr, ptr, i32 }, ptr %338, i32 0, i32 3
+  store i32 1, ptr %343, align 4
+  %344 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %329, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %344, i32 1, ptr @153, ptr @150, i64 1, i32 1, i64 %320, i64 %325)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %346 = getelementptr %dimension_descriptor, %dimension_descriptor* %319, i32 0, i32 2
-  %347 = load i64, i64* %346, align 8
-  %348 = mul i64 %347, %324
-  %349 = add i64 0, %348
-  %350 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 1
-  %351 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 0
-  %352 = load i64, i64* %351, align 8
-  %353 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 1
-  %354 = load i64, i64* %353, align 8
-  %355 = sub i64 1, %352
-  %356 = add i64 %352, %354
-  %357 = sub i64 %356, 1
-  %358 = icmp slt i64 1, %352
-  %359 = icmp sgt i64 1, %357
-  %360 = or i1 %358, %359
-  br i1 %360, label %then45, label %ifcont46
+  %345 = getelementptr %dimension_descriptor, ptr %318, i32 0, i32 2
+  %346 = load i64, ptr %345, align 8
+  %347 = mul i64 %346, %323
+  %348 = add i64 0, %347
+  %349 = getelementptr inbounds %dimension_descriptor, ptr %317, i32 1
+  %350 = getelementptr %dimension_descriptor, ptr %349, i32 0, i32 0
+  %351 = load i64, ptr %350, align 8
+  %352 = getelementptr %dimension_descriptor, ptr %349, i32 0, i32 1
+  %353 = load i64, ptr %352, align 8
+  %354 = sub i64 1, %351
+  %355 = add i64 %351, %353
+  %356 = sub i64 %355, 1
+  %357 = icmp slt i64 1, %351
+  %358 = icmp sgt i64 1, %356
+  %359 = or i1 %357, %358
+  br i1 %359, label %then45, label %ifcont46
 
 then45:                                           ; preds = %ifcont44
-  %361 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %362 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %363 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %362, i32 0, i32 0
-  %364 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %363, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @155, i32 0, i32 0), i8** %364, align 8
-  %365 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %363, i32 0, i32 1
-  store i32 42, i32* %365, align 4
-  %366 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %363, i32 0, i32 2
-  store i32 5, i32* %366, align 4
-  %367 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %363, i32 0, i32 3
-  store i32 42, i32* %367, align 4
-  %368 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %363, i32 0, i32 4
-  store i32 14, i32* %368, align 4
-  %369 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @156, i32 0, i32 0))
-  %370 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %361, i32 0, i32 0
-  %371 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %362, i32 0, i32 0
-  %372 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %370, i32 0, i32 2
-  %373 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %370, i32 0, i32 0
-  store i1 true, i1* %373, align 1
-  %374 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %370, i32 0, i32 1
-  store i8* %369, i8** %374, align 8
-  store { i8*, i32, i32, i32, i32 }* %371, { i8*, i32, i32, i32, i32 }** %372, align 8
-  %375 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %370, i32 0, i32 3
-  store i32 1, i32* %375, align 4
-  %376 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %361, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %376, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @157, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @154, i32 0, i32 0), i64 1, i32 2, i64 %352, i64 %357)
+  %360 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %361 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %362 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %361, i32 0, i32 0
+  %363 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 0
+  store ptr @155, ptr %363, align 8
+  %364 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 1
+  store i32 42, ptr %364, align 4
+  %365 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 2
+  store i32 5, ptr %365, align 4
+  %366 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 3
+  store i32 42, ptr %366, align 4
+  %367 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 4
+  store i32 14, ptr %367, align 4
+  %368 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @156)
+  %369 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %360, i32 0, i32 0
+  %370 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %361, i32 0, i32 0
+  %371 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 2
+  %372 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 0
+  store i1 true, ptr %372, align 1
+  %373 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 1
+  store ptr %368, ptr %373, align 8
+  store ptr %370, ptr %371, align 8
+  %374 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 3
+  store i32 1, ptr %374, align 4
+  %375 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %360, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %375, i32 1, ptr @157, ptr @154, i64 1, i32 2, i64 %351, i64 %356)
   call void @exit(i32 1)
   unreachable
 
 ifcont46:                                         ; preds = %ifcont44
-  %377 = getelementptr %dimension_descriptor, %dimension_descriptor* %350, i32 0, i32 2
-  %378 = load i64, i64* %377, align 8
-  %379 = mul i64 %378, %355
-  %380 = add i64 %349, %379
-  %381 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %318, i32 2
-  %382 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 0
-  %383 = load i64, i64* %382, align 8
-  %384 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 1
-  %385 = load i64, i64* %384, align 8
-  %386 = sub i64 1, %383
-  %387 = add i64 %383, %385
-  %388 = sub i64 %387, 1
-  %389 = icmp slt i64 1, %383
-  %390 = icmp sgt i64 1, %388
-  %391 = or i1 %389, %390
-  br i1 %391, label %then47, label %ifcont48
+  %376 = getelementptr %dimension_descriptor, ptr %349, i32 0, i32 2
+  %377 = load i64, ptr %376, align 8
+  %378 = mul i64 %377, %354
+  %379 = add i64 %348, %378
+  %380 = getelementptr inbounds %dimension_descriptor, ptr %317, i32 2
+  %381 = getelementptr %dimension_descriptor, ptr %380, i32 0, i32 0
+  %382 = load i64, ptr %381, align 8
+  %383 = getelementptr %dimension_descriptor, ptr %380, i32 0, i32 1
+  %384 = load i64, ptr %383, align 8
+  %385 = sub i64 1, %382
+  %386 = add i64 %382, %384
+  %387 = sub i64 %386, 1
+  %388 = icmp slt i64 1, %382
+  %389 = icmp sgt i64 1, %387
+  %390 = or i1 %388, %389
+  br i1 %390, label %then47, label %ifcont48
 
 then47:                                           ; preds = %ifcont46
-  %392 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %393 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %394 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %393, i32 0, i32 0
-  %395 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %394, i32 0, i32 0
-  store i8* getelementptr inbounds ([43 x i8], [43 x i8]* @159, i32 0, i32 0), i8** %395, align 8
-  %396 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %394, i32 0, i32 1
-  store i32 42, i32* %396, align 4
-  %397 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %394, i32 0, i32 2
-  store i32 5, i32* %397, align 4
-  %398 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %394, i32 0, i32 3
-  store i32 42, i32* %398, align 4
-  %399 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %394, i32 0, i32 4
-  store i32 14, i32* %399, align 4
-  %400 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @160, i32 0, i32 0))
-  %401 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %392, i32 0, i32 0
-  %402 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %393, i32 0, i32 0
-  %403 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %401, i32 0, i32 2
-  %404 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %401, i32 0, i32 0
-  store i1 true, i1* %404, align 1
-  %405 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %401, i32 0, i32 1
-  store i8* %400, i8** %405, align 8
-  store { i8*, i32, i32, i32, i32 }* %402, { i8*, i32, i32, i32, i32 }** %403, align 8
-  %406 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %401, i32 0, i32 3
-  store i32 1, i32* %406, align 4
-  %407 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %392, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %407, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @161, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @158, i32 0, i32 0), i64 1, i32 3, i64 %383, i64 %388)
+  %391 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %392 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %393 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %392, i32 0, i32 0
+  %394 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %393, i32 0, i32 0
+  store ptr @159, ptr %394, align 8
+  %395 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %393, i32 0, i32 1
+  store i32 42, ptr %395, align 4
+  %396 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %393, i32 0, i32 2
+  store i32 5, ptr %396, align 4
+  %397 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %393, i32 0, i32 3
+  store i32 42, ptr %397, align 4
+  %398 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %393, i32 0, i32 4
+  store i32 14, ptr %398, align 4
+  %399 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @160)
+  %400 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %391, i32 0, i32 0
+  %401 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %392, i32 0, i32 0
+  %402 = getelementptr { i1, ptr, ptr, i32 }, ptr %400, i32 0, i32 2
+  %403 = getelementptr { i1, ptr, ptr, i32 }, ptr %400, i32 0, i32 0
+  store i1 true, ptr %403, align 1
+  %404 = getelementptr { i1, ptr, ptr, i32 }, ptr %400, i32 0, i32 1
+  store ptr %399, ptr %404, align 8
+  store ptr %401, ptr %402, align 8
+  %405 = getelementptr { i1, ptr, ptr, i32 }, ptr %400, i32 0, i32 3
+  store i32 1, ptr %405, align 4
+  %406 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %391, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %406, i32 1, ptr @161, ptr @158, i64 1, i32 3, i64 %382, i64 %387)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %ifcont46
-  %408 = getelementptr %dimension_descriptor, %dimension_descriptor* %381, i32 0, i32 2
-  %409 = load i64, i64* %408, align 8
-  %410 = mul i64 %409, %386
-  %411 = add i64 %380, %410
-  %412 = getelementptr %array.3, %array.3* %293, i32 0, i32 7
-  %413 = load i64, i64* %412, align 8
-  %414 = add i64 %411, %413
-  %415 = getelementptr %array.3, %array.3* %293, i32 0, i32 0
-  %416 = load i32*, i32** %415, align 8
-  %417 = getelementptr inbounds i32, i32* %416, i64 %414
-  store i32 8, i32* %417, align 4
+  %407 = getelementptr %dimension_descriptor, ptr %380, i32 0, i32 2
+  %408 = load i64, ptr %407, align 8
+  %409 = mul i64 %408, %385
+  %410 = add i64 %379, %409
+  %411 = getelementptr %array.3, ptr %292, i32 0, i32 7
+  %412 = load i64, ptr %411, align 8
+  %413 = add i64 %410, %412
+  %414 = getelementptr %array.3, ptr %292, i32 0, i32 0
+  %415 = load ptr, ptr %414, align 8
+  %416 = getelementptr inbounds i32, ptr %415, i64 %413
+  store i32 8, ptr %416, align 4
   br label %return
 
 return:                                           ; preds = %ifcont48
@@ -3191,35 +3187,35 @@ FINALIZE_SYMTABLE_h:                              ; preds = %return
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-define internal void @finalize_allocatable__Array_3_i32(%array.3* %0) {
+define internal void @finalize_allocatable__Array_3_i32(ptr %0) {
 entry:
-  %1 = icmp ne %array.3* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_3_i32(%array.3* %0)
+  call void @finalize_descriptorArray_Array_3_i32(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -3229,18 +3225,17 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_3_i32(%array.3* %0) {
+define internal void @finalize_descriptorArray_Array_3_i32(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.3, %array.3* %0, i32 0, i32 0
-  %3 = load i32*, i32** %2, align 8
-  %4 = ptrtoint i32* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.3, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = ptrtoint ptr %3 to i64
   %5 = icmp ne i64 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = bitcast i32* %3 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %3)
   br label %ifcont
 
 else:                                             ; preds = %entry

--- a/tests/reference/llvm-array2-4254183.json
+++ b/tests/reference/llvm-array2-4254183.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array2-4254183.stdout",
-    "stdout_hash": "f6bfd3d9f72c380281aea1dd07d1faf276bef83283d8a862f3142bc3",
+    "stdout_hash": "cdabaf8d4df16172aa917f22e1e397588931ad3cb68327458a537668",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array2-4254183.stdout
+++ b/tests/reference/llvm-array2-4254183.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [5 x float], align 4
   %b = alloca [5 x float], align 4
   %c = alloca [3 x i32], align 4
@@ -25,6 +26,6 @@ FINALIZE_SYMTABLE_array2:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "68867feda0934cf6db70b84ef1c11f045219d92ff9d08aa3d1b270cf",
+    "stdout_hash": "0836b31cb4499f97b730eb5a1d2961baeaf2e0301678223389c7cd27",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [9 x i8] c"I4,I4,I4\00", align 1
@@ -29,7 +30,7 @@ target datalayout = "..."
 @serialization_info.7 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
@@ -39,217 +40,217 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [196 x i32], align 4
   %b = alloca [96 x i32], align 4
   %c = alloca [35 x i32], align 4
   %d = alloca [4 x i32], align 4
   %3 = alloca i64, align 8
   %4 = alloca i32, align 4
-  store i32 2, i32* %4, align 4
+  store i32 2, ptr %4, align 4
   %5 = alloca i32, align 4
-  store i32 3, i32* %5, align 4
+  store i32 3, ptr %5, align 4
   %6 = alloca i32, align 4
-  store i32 1, i32* %6, align 4
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4, i32* %5, i32* %6)
-  %8 = load i64, i64* %3, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %7, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %8, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %14 = load i64, i64* %13, align 8
+  store i32 1, ptr %6, align 4
+  %7 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %4, ptr %5, ptr %6)
+  %8 = load i64, ptr %3, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %16 = icmp eq i8* %7, null
+  call void @_lfortran_printf(ptr @1, ptr %12, i32 %15, ptr @0, i32 1)
+  %16 = icmp eq ptr %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %7)
+  call void @_lfortran_free_alloc(ptr %2, ptr %7)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %17 = alloca i64, align 8
   %18 = alloca i32, align 4
-  store i32 5, i32* %18, align 4
+  store i32 5, ptr %18, align 4
   %19 = alloca i32, align 4
-  store i32 9, i32* %19, align 4
+  store i32 9, ptr %19, align 4
   %20 = alloca i32, align 4
-  store i32 7, i32* %20, align 4
-  %21 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %18, i32* %19, i32* %20)
-  %22 = load i64, i64* %17, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %21, i8** %23, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %22, i64* %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %26 = load i8*, i8** %25, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %28 = load i64, i64* %27, align 8
+  store i32 7, ptr %20, align 4
+  %21 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %18, ptr %19, ptr %20)
+  %22 = load i64, ptr %17, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %21, ptr %23, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %22, ptr %24, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %26 = load ptr, ptr %25, align 8
+  %27 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %28 = load i64, ptr %27, align 8
   %29 = trunc i64 %28 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %26, i32 %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %30 = icmp eq i8* %21, null
+  call void @_lfortran_printf(ptr @3, ptr %26, i32 %29, ptr @2, i32 1)
+  %30 = icmp eq ptr %21, null
   br i1 %30, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %21)
+  call void @_lfortran_free_alloc(ptr %2, ptr %21)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %31 = alloca i64, align 8
   %32 = alloca i32, align 4
-  store i32 1, i32* %32, align 4
+  store i32 1, ptr %32, align 4
   %33 = alloca i32, align 4
-  store i32 2, i32* %33, align 4
+  store i32 2, ptr %33, align 4
   %34 = alloca i32, align 4
-  store i32 3, i32* %34, align 4
+  store i32 3, ptr %34, align 4
   %35 = alloca i32, align 4
-  store i32 4, i32* %35, align 4
-  %36 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %32, i32* %33, i32* %34, i32* %35)
-  %37 = load i64, i64* %31, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %37, i64* %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %43 = load i64, i64* %42, align 8
+  store i32 4, ptr %35, align 4
+  %36 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %31, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %32, ptr %33, ptr %34, ptr %35)
+  %37 = load i64, ptr %31, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %36, ptr %38, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %41 = load ptr, ptr %40, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %43 = load i64, ptr %42, align 8
   %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %45 = icmp eq i8* %36, null
+  call void @_lfortran_printf(ptr @5, ptr %41, i32 %44, ptr @4, i32 1)
+  %45 = icmp eq ptr %36, null
   br i1 %45, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %36)
+  call void @_lfortran_free_alloc(ptr %2, ptr %36)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   %46 = alloca i64, align 8
   %47 = alloca i32, align 4
-  store i32 2, i32* %47, align 4
+  store i32 2, ptr %47, align 4
   %48 = alloca i32, align 4
-  store i32 4, i32* %48, align 4
+  store i32 4, ptr %48, align 4
   %49 = alloca i32, align 4
-  store i32 6, i32* %49, align 4
+  store i32 6, ptr %49, align 4
   %50 = alloca i32, align 4
-  store i32 7, i32* %50, align 4
-  %51 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.3, i32 0, i32 0), i64* %46, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %47, i32* %48, i32* %49, i32* %50)
-  %52 = load i64, i64* %46, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %51, i8** %53, align 8
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %52, i64* %54, align 8
-  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %56 = load i8*, i8** %55, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %58 = load i64, i64* %57, align 8
+  store i32 7, ptr %50, align 4
+  %51 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %46, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %47, ptr %48, ptr %49, ptr %50)
+  %52 = load i64, ptr %46, align 8
+  %53 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %51, ptr %53, align 8
+  %54 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %52, ptr %54, align 8
+  %55 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %56 = load ptr, ptr %55, align 8
+  %57 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %58 = load i64, ptr %57, align 8
   %59 = trunc i64 %58 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %56, i32 %59, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %60 = icmp eq i8* %51, null
+  call void @_lfortran_printf(ptr @7, ptr %56, i32 %59, ptr @6, i32 1)
+  %60 = icmp eq ptr %51, null
   br i1 %60, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %51)
+  call void @_lfortran_free_alloc(ptr %2, ptr %51)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
   %61 = alloca i64, align 8
   %62 = alloca i32, align 4
-  store i32 6, i32* %62, align 4
+  store i32 6, ptr %62, align 4
   %63 = alloca i32, align 4
-  store i32 1, i32* %63, align 4
-  %64 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.4, i32 0, i32 0), i64* %61, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %62, i32* %63)
-  %65 = load i64, i64* %61, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %64, i8** %66, align 8
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %65, i64* %67, align 8
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %69 = load i8*, i8** %68, align 8
-  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %71 = load i64, i64* %70, align 8
+  store i32 1, ptr %63, align 4
+  %64 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %61, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %62, ptr %63)
+  %65 = load i64, ptr %61, align 8
+  %66 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %64, ptr %66, align 8
+  %67 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %65, ptr %67, align 8
+  %68 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %69 = load ptr, ptr %68, align 8
+  %70 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %71 = load i64, ptr %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %73 = icmp eq i8* %64, null
+  call void @_lfortran_printf(ptr @9, ptr %69, i32 %72, ptr @8, i32 1)
+  %73 = icmp eq ptr %64, null
   br i1 %73, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free_alloc(i8* %2, i8* %64)
+  call void @_lfortran_free_alloc(ptr %2, ptr %64)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
   %74 = alloca i64, align 8
   %75 = alloca i32, align 4
-  store i32 10, i32* %75, align 4
+  store i32 10, ptr %75, align 4
   %76 = alloca i32, align 4
-  store i32 7, i32* %76, align 4
-  %77 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.5, i32 0, i32 0), i64* %74, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %75, i32* %76)
-  %78 = load i64, i64* %74, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %77, i8** %79, align 8
-  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %78, i64* %80, align 8
-  %81 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %82 = load i8*, i8** %81, align 8
-  %83 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %84 = load i64, i64* %83, align 8
+  store i32 7, ptr %76, align 4
+  %77 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.5, ptr %74, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %75, ptr %76)
+  %78 = load i64, ptr %74, align 8
+  %79 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %77, ptr %79, align 8
+  %80 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %78, ptr %80, align 8
+  %81 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %82 = load ptr, ptr %81, align 8
+  %83 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %84 = load i64, ptr %83, align 8
   %85 = trunc i64 %84 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %82, i32 %85, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %86 = icmp eq i8* %77, null
+  call void @_lfortran_printf(ptr @11, ptr %82, i32 %85, ptr @10, i32 1)
+  %86 = icmp eq ptr %77, null
   br i1 %86, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free_alloc(i8* %2, i8* %77)
+  call void @_lfortran_free_alloc(ptr %2, ptr %77)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
   %87 = alloca i64, align 8
   %88 = alloca i32, align 4
-  store i32 1, i32* %88, align 4
-  %89 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %87, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %88)
-  %90 = load i64, i64* %87, align 8
-  %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %89, i8** %91, align 8
-  %92 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %90, i64* %92, align 8
-  %93 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %94 = load i8*, i8** %93, align 8
-  %95 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %96 = load i64, i64* %95, align 8
+  store i32 1, ptr %88, align 4
+  %89 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.6, ptr %87, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %88)
+  %90 = load i64, ptr %87, align 8
+  %91 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %89, ptr %91, align 8
+  %92 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %90, ptr %92, align 8
+  %93 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %94 = load ptr, ptr %93, align 8
+  %95 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %96 = load i64, ptr %95, align 8
   %97 = trunc i64 %96 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %94, i32 %97, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %98 = icmp eq i8* %89, null
+  call void @_lfortran_printf(ptr @13, ptr %94, i32 %97, ptr @12, i32 1)
+  %98 = icmp eq ptr %89, null
   br i1 %98, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free_alloc(i8* %2, i8* %89)
+  call void @_lfortran_free_alloc(ptr %2, ptr %89)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
   %99 = alloca i64, align 8
   %100 = alloca i32, align 4
-  store i32 4, i32* %100, align 4
-  %101 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %99, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %100)
-  %102 = load i64, i64* %99, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %101, i8** %103, align 8
-  %104 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %102, i64* %104, align 8
-  %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %106 = load i8*, i8** %105, align 8
-  %107 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %108 = load i64, i64* %107, align 8
+  store i32 4, ptr %100, align 4
+  %101 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.7, ptr %99, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %100)
+  %102 = load i64, ptr %99, align 8
+  %103 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  store ptr %101, ptr %103, align 8
+  %104 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  store i64 %102, ptr %104, align 8
+  %105 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  %106 = load ptr, ptr %105, align 8
+  %107 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  %108 = load i64, ptr %107, align 8
   %109 = trunc i64 %108 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %106, i32 %109, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %110 = icmp eq i8* %101, null
+  call void @_lfortran_printf(ptr @15, ptr %106, i32 %109, ptr @14, i32 1)
+  %110 = icmp eq ptr %101, null
   br i1 %110, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %free_done18
-  call void @_lfortran_free_alloc(i8* %2, i8* %101)
+  call void @_lfortran_free_alloc(ptr %2, ptr %101)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
@@ -263,14 +264,14 @@ FINALIZE_SYMTABLE_array_bound_1:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01-91893af.json
+++ b/tests/reference/llvm-arrays_01-91893af.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01-91893af.stdout",
-    "stdout_hash": "59f5874dafb34f289bf6e87b5d87aaa547e059d167903900e0b6edb2",
+    "stdout_hash": "599eb3a8d5502d9481dd444053335889ab38743a103383681db2aec4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01-91893af.stdout
+++ b/tests/reference/llvm-arrays_01-91893af.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @0 = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @1 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/arrays_01.f90\00", align 1
@@ -120,27 +121,27 @@ target datalayout = "..."
 @114 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @115 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [3 x i32], align 4
   %b = alloca [4 x i32], align 4
   %i = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 3
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %7, ptr %i, align 4
+  %8 = load i32, ptr %i, align 4
   %9 = sext i32 %8 to i64
   %10 = sub i64 %9, 1
   %11 = mul i64 1, %10
@@ -151,83 +152,83 @@ loop.body:                                        ; preds = %loop.head
   br i1 %15, label %then, label %ifcont
 
 then:                                             ; preds = %loop.body
-  %16 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %17 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %18 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %19 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @1, i32 0, i32 0), i8** %19, align 8
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 1
-  store i32 5, i32* %20, align 4
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 2
-  store i32 5, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 3
-  store i32 5, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 4
-  store i32 8, i32* %23, align 4
-  %24 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
-  %25 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  %26 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 2
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 0
-  store i1 true, i1* %28, align 1
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 1
-  store i8* %24, i8** %29, align 8
-  store { i8*, i32, i32, i32, i32 }* %26, { i8*, i32, i32, i32, i32 }** %27, align 8
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 3
-  store i32 1, i32* %30, align 4
-  %31 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %9, i32 1, i64 1, i64 3)
+  %16 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %17 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %18 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %19 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 0
+  store ptr @1, ptr %19, align 8
+  %20 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 1
+  store i32 5, ptr %20, align 4
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 2
+  store i32 5, ptr %21, align 4
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 3
+  store i32 5, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 4
+  store i32 8, ptr %23, align 4
+  %24 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %25 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  %26 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %27 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 2
+  %28 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 0
+  store i1 true, ptr %28, align 1
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 1
+  store ptr %24, ptr %29, align 8
+  store ptr %26, ptr %27, align 8
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 3
+  store i32 1, ptr %30, align 4
+  %31 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %31, i32 1, ptr @3, ptr @0, i64 %9, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %loop.body
-  %32 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %12
-  %33 = load i32, i32* %i, align 4
+  %32 = getelementptr [3 x i32], ptr %a, i32 0, i64 %12
+  %33 = load i32, ptr %i, align 4
   %34 = add i32 %33, 10
-  store i32 %34, i32* %32, align 4
+  store i32 %34, ptr %32, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then1, label %ifcont2
 
 then1:                                            ; preds = %loop.end
-  %35 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %36 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %37 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %36, i32 0, i32 0
-  %38 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @5, i32 0, i32 0), i8** %38, align 8
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 1
-  store i32 7, i32* %39, align 4
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 2
-  store i32 5, i32* %40, align 4
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 3
-  store i32 7, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %37, i32 0, i32 4
-  store i32 8, i32* %42, align 4
-  %43 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %44 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %35, i32 0, i32 0
-  %45 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %36, i32 0, i32 0
-  %46 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 2
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 0
-  store i1 true, i1* %47, align 1
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 1
-  store i8* %43, i8** %48, align 8
-  store { i8*, i32, i32, i32, i32 }* %45, { i8*, i32, i32, i32, i32 }** %46, align 8
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %44, i32 0, i32 3
-  store i32 1, i32* %49, align 4
-  %50 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %35, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %35 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %36 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %37 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %36, i32 0, i32 0
+  %38 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %37, i32 0, i32 0
+  store ptr @5, ptr %38, align 8
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %37, i32 0, i32 1
+  store i32 7, ptr %39, align 4
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %37, i32 0, i32 2
+  store i32 5, ptr %40, align 4
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %37, i32 0, i32 3
+  store i32 7, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %37, i32 0, i32 4
+  store i32 8, ptr %42, align 4
+  %43 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %44 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %35, i32 0, i32 0
+  %45 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %36, i32 0, i32 0
+  %46 = getelementptr { i1, ptr, ptr, i32 }, ptr %44, i32 0, i32 2
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %44, i32 0, i32 0
+  store i1 true, ptr %47, align 1
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %44, i32 0, i32 1
+  store ptr %43, ptr %48, align 8
+  store ptr %45, ptr %46, align 8
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %44, i32 0, i32 3
+  store i32 1, ptr %49, align 4
+  %50 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %35, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %50, i32 1, ptr @7, ptr @4, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %loop.end
-  %51 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %52 = load i32, i32* %51, align 4
+  %51 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %52 = load i32, ptr %51, align 4
   %53 = icmp ne i32 %52, 11
   br i1 %53, label %then3, label %else
 
 then3:                                            ; preds = %ifcont2
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -239,43 +240,43 @@ ifcont4:                                          ; preds = %else, %then3
   br i1 false, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %54 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %55 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %56 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %55, i32 0, i32 0
-  %57 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %56, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @11, i32 0, i32 0), i8** %57, align 8
-  %58 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %56, i32 0, i32 1
-  store i32 8, i32* %58, align 4
-  %59 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %56, i32 0, i32 2
-  store i32 5, i32* %59, align 4
-  %60 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %56, i32 0, i32 3
-  store i32 8, i32* %60, align 4
-  %61 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %56, i32 0, i32 4
-  store i32 8, i32* %61, align 4
-  %62 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @12, i32 0, i32 0))
-  %63 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %54, i32 0, i32 0
-  %64 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %55, i32 0, i32 0
-  %65 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %63, i32 0, i32 2
-  %66 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %63, i32 0, i32 0
-  store i1 true, i1* %66, align 1
-  %67 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %63, i32 0, i32 1
-  store i8* %62, i8** %67, align 8
-  store { i8*, i32, i32, i32, i32 }* %64, { i8*, i32, i32, i32, i32 }** %65, align 8
-  %68 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %63, i32 0, i32 3
-  store i32 1, i32* %68, align 4
-  %69 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %54, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %69, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i64 2, i32 1, i64 1, i64 3)
+  %54 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %55 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %56 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %55, i32 0, i32 0
+  %57 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %56, i32 0, i32 0
+  store ptr @11, ptr %57, align 8
+  %58 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %56, i32 0, i32 1
+  store i32 8, ptr %58, align 4
+  %59 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %56, i32 0, i32 2
+  store i32 5, ptr %59, align 4
+  %60 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %56, i32 0, i32 3
+  store i32 8, ptr %60, align 4
+  %61 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %56, i32 0, i32 4
+  store i32 8, ptr %61, align 4
+  %62 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @12)
+  %63 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %54, i32 0, i32 0
+  %64 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %55, i32 0, i32 0
+  %65 = getelementptr { i1, ptr, ptr, i32 }, ptr %63, i32 0, i32 2
+  %66 = getelementptr { i1, ptr, ptr, i32 }, ptr %63, i32 0, i32 0
+  store i1 true, ptr %66, align 1
+  %67 = getelementptr { i1, ptr, ptr, i32 }, ptr %63, i32 0, i32 1
+  store ptr %62, ptr %67, align 8
+  store ptr %64, ptr %65, align 8
+  %68 = getelementptr { i1, ptr, ptr, i32 }, ptr %63, i32 0, i32 3
+  store i32 1, ptr %68, align 4
+  %69 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %54, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %69, i32 1, ptr @13, ptr @10, i64 2, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %70 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 1
-  %71 = load i32, i32* %70, align 4
+  %70 = getelementptr [3 x i32], ptr %a, i32 0, i64 1
+  %71 = load i32, ptr %70, align 4
   %72 = icmp ne i32 %71, 12
   br i1 %72, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -287,43 +288,43 @@ ifcont9:                                          ; preds = %else8, %then7
   br i1 false, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  %73 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %74 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %75 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %74, i32 0, i32 0
-  %76 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @17, i32 0, i32 0), i8** %76, align 8
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 1
-  store i32 9, i32* %77, align 4
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 2
-  store i32 5, i32* %78, align 4
-  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 3
-  store i32 9, i32* %79, align 4
-  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %75, i32 0, i32 4
-  store i32 8, i32* %80, align 4
-  %81 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %82 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %73, i32 0, i32 0
-  %83 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %74, i32 0, i32 0
-  %84 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 2
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 0
-  store i1 true, i1* %85, align 1
-  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 1
-  store i8* %81, i8** %86, align 8
-  store { i8*, i32, i32, i32, i32 }* %83, { i8*, i32, i32, i32, i32 }** %84, align 8
-  %87 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %82, i32 0, i32 3
-  store i32 1, i32* %87, align 4
-  %88 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %73, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 3, i32 1, i64 1, i64 3)
+  %73 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %74 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %75 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %74, i32 0, i32 0
+  %76 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 0
+  store ptr @17, ptr %76, align 8
+  %77 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 1
+  store i32 9, ptr %77, align 4
+  %78 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 2
+  store i32 5, ptr %78, align 4
+  %79 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 3
+  store i32 9, ptr %79, align 4
+  %80 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 4
+  store i32 8, ptr %80, align 4
+  %81 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @18)
+  %82 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %73, i32 0, i32 0
+  %83 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %74, i32 0, i32 0
+  %84 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 2
+  %85 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 0
+  store i1 true, ptr %85, align 1
+  %86 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 1
+  store ptr %81, ptr %86, align 8
+  store ptr %83, ptr %84, align 8
+  %87 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 3
+  store i32 1, ptr %87, align 4
+  %88 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %73, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %88, i32 1, ptr @19, ptr @16, i64 3, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %89 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 2
-  %90 = load i32, i32* %89, align 4
+  %89 = getelementptr [3 x i32], ptr %a, i32 0, i64 2
+  %90 = load i32, ptr %89, align 4
   %91 = icmp ne i32 %90, 13
   br i1 %91, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont11
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -332,20 +333,20 @@ else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  store i32 10, i32* %i, align 4
+  store i32 10, ptr %i, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %ifcont18, %ifcont14
-  %92 = load i32, i32* %i, align 4
+  %92 = load i32, ptr %i, align 4
   %93 = add i32 %92, 1
   %94 = icmp sle i32 %93, 14
   br i1 %94, label %loop.body16, label %loop.end19
 
 loop.body16:                                      ; preds = %loop.head15
-  %95 = load i32, i32* %i, align 4
+  %95 = load i32, ptr %i, align 4
   %96 = add i32 %95, 1
-  store i32 %96, i32* %i, align 4
-  %97 = load i32, i32* %i, align 4
+  store i32 %96, ptr %i, align 4
+  %97 = load i32, ptr %i, align 4
   %98 = sub i32 %97, 10
   %99 = sext i32 %98 to i64
   %100 = sub i64 %99, 1
@@ -357,82 +358,82 @@ loop.body16:                                      ; preds = %loop.head15
   br i1 %105, label %then17, label %ifcont18
 
 then17:                                           ; preds = %loop.body16
-  %106 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %107 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %108 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %107, i32 0, i32 0
-  %109 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @23, i32 0, i32 0), i8** %109, align 8
-  %110 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 1
-  store i32 12, i32* %110, align 4
-  %111 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 2
-  store i32 5, i32* %111, align 4
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 3
-  store i32 12, i32* %112, align 4
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 4
-  store i32 11, i32* %113, align 4
-  %114 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @24, i32 0, i32 0))
-  %115 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %106, i32 0, i32 0
-  %116 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %107, i32 0, i32 0
-  %117 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 2
-  %118 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 0
-  store i1 true, i1* %118, align 1
-  %119 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 1
-  store i8* %114, i8** %119, align 8
-  store { i8*, i32, i32, i32, i32 }* %116, { i8*, i32, i32, i32, i32 }** %117, align 8
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 3
-  store i32 1, i32* %120, align 4
-  %121 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %106, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i64 %99, i32 1, i64 1, i64 4)
+  %106 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %107 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %108 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %107, i32 0, i32 0
+  %109 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 0
+  store ptr @23, ptr %109, align 8
+  %110 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 1
+  store i32 12, ptr %110, align 4
+  %111 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 2
+  store i32 5, ptr %111, align 4
+  %112 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 3
+  store i32 12, ptr %112, align 4
+  %113 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %108, i32 0, i32 4
+  store i32 11, ptr %113, align 4
+  %114 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @24)
+  %115 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %106, i32 0, i32 0
+  %116 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %107, i32 0, i32 0
+  %117 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 2
+  %118 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 0
+  store i1 true, ptr %118, align 1
+  %119 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 1
+  store ptr %114, ptr %119, align 8
+  store ptr %116, ptr %117, align 8
+  %120 = getelementptr { i1, ptr, ptr, i32 }, ptr %115, i32 0, i32 3
+  store i32 1, ptr %120, align 4
+  %121 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %106, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %121, i32 1, ptr @25, ptr @22, i64 %99, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %loop.body16
-  %122 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %102
-  %123 = load i32, i32* %i, align 4
-  store i32 %123, i32* %122, align 4
+  %122 = getelementptr [4 x i32], ptr %b, i32 0, i64 %102
+  %123 = load i32, ptr %i, align 4
+  store i32 %123, ptr %122, align 4
   br label %loop.head15
 
 loop.end19:                                       ; preds = %loop.head15
   br i1 false, label %then20, label %ifcont21
 
 then20:                                           ; preds = %loop.end19
-  %124 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %125 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %126 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %125, i32 0, i32 0
-  %127 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %126, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @27, i32 0, i32 0), i8** %127, align 8
-  %128 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %126, i32 0, i32 1
-  store i32 14, i32* %128, align 4
-  %129 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %126, i32 0, i32 2
-  store i32 5, i32* %129, align 4
-  %130 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %126, i32 0, i32 3
-  store i32 14, i32* %130, align 4
-  %131 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %126, i32 0, i32 4
-  store i32 8, i32* %131, align 4
-  %132 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @28, i32 0, i32 0))
-  %133 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %124, i32 0, i32 0
-  %134 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %125, i32 0, i32 0
-  %135 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %133, i32 0, i32 2
-  %136 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %133, i32 0, i32 0
-  store i1 true, i1* %136, align 1
-  %137 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %133, i32 0, i32 1
-  store i8* %132, i8** %137, align 8
-  store { i8*, i32, i32, i32, i32 }* %134, { i8*, i32, i32, i32, i32 }** %135, align 8
-  %138 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %133, i32 0, i32 3
-  store i32 1, i32* %138, align 4
-  %139 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %124, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %139, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %124 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %125 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %126 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %125, i32 0, i32 0
+  %127 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 0
+  store ptr @27, ptr %127, align 8
+  %128 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 1
+  store i32 14, ptr %128, align 4
+  %129 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 2
+  store i32 5, ptr %129, align 4
+  %130 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 3
+  store i32 14, ptr %130, align 4
+  %131 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 4
+  store i32 8, ptr %131, align 4
+  %132 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @28)
+  %133 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %124, i32 0, i32 0
+  %134 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %125, i32 0, i32 0
+  %135 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 2
+  %136 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 0
+  store i1 true, ptr %136, align 1
+  %137 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 1
+  store ptr %132, ptr %137, align 8
+  store ptr %134, ptr %135, align 8
+  %138 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 3
+  store i32 1, ptr %138, align 4
+  %139 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %124, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %139, i32 1, ptr @29, ptr @26, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %loop.end19
-  %140 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %141 = load i32, i32* %140, align 4
+  %140 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %141 = load i32, ptr %140, align 4
   %142 = icmp ne i32 %141, 11
   br i1 %142, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @31, ptr @"ERROR STOP", ptr @30)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -444,43 +445,43 @@ ifcont24:                                         ; preds = %else23, %then22
   br i1 false, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %143 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %144 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %145 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %144, i32 0, i32 0
-  %146 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %145, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @33, i32 0, i32 0), i8** %146, align 8
-  %147 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %145, i32 0, i32 1
-  store i32 15, i32* %147, align 4
-  %148 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %145, i32 0, i32 2
-  store i32 5, i32* %148, align 4
-  %149 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %145, i32 0, i32 3
-  store i32 15, i32* %149, align 4
-  %150 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %145, i32 0, i32 4
-  store i32 8, i32* %150, align 4
-  %151 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @34, i32 0, i32 0))
-  %152 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %143, i32 0, i32 0
-  %153 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %144, i32 0, i32 0
-  %154 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %152, i32 0, i32 2
-  %155 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %152, i32 0, i32 0
-  store i1 true, i1* %155, align 1
-  %156 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %152, i32 0, i32 1
-  store i8* %151, i8** %156, align 8
-  store { i8*, i32, i32, i32, i32 }* %153, { i8*, i32, i32, i32, i32 }** %154, align 8
-  %157 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %152, i32 0, i32 3
-  store i32 1, i32* %157, align 4
-  %158 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %143, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %158, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %143 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %144 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %145 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %144, i32 0, i32 0
+  %146 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %145, i32 0, i32 0
+  store ptr @33, ptr %146, align 8
+  %147 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %145, i32 0, i32 1
+  store i32 15, ptr %147, align 4
+  %148 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %145, i32 0, i32 2
+  store i32 5, ptr %148, align 4
+  %149 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %145, i32 0, i32 3
+  store i32 15, ptr %149, align 4
+  %150 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %145, i32 0, i32 4
+  store i32 8, ptr %150, align 4
+  %151 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @34)
+  %152 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %143, i32 0, i32 0
+  %153 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %144, i32 0, i32 0
+  %154 = getelementptr { i1, ptr, ptr, i32 }, ptr %152, i32 0, i32 2
+  %155 = getelementptr { i1, ptr, ptr, i32 }, ptr %152, i32 0, i32 0
+  store i1 true, ptr %155, align 1
+  %156 = getelementptr { i1, ptr, ptr, i32 }, ptr %152, i32 0, i32 1
+  store ptr %151, ptr %156, align 8
+  store ptr %153, ptr %154, align 8
+  %157 = getelementptr { i1, ptr, ptr, i32 }, ptr %152, i32 0, i32 3
+  store i32 1, ptr %157, align 4
+  %158 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %143, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %158, i32 1, ptr @35, ptr @32, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %159 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %160 = load i32, i32* %159, align 4
+  %159 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %160 = load i32, ptr %159, align 4
   %161 = icmp ne i32 %160, 12
   br i1 %161, label %then27, label %else28
 
 then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @37, ptr @"ERROR STOP", ptr @36)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -492,43 +493,43 @@ ifcont29:                                         ; preds = %else28, %then27
   br i1 false, label %then30, label %ifcont31
 
 then30:                                           ; preds = %ifcont29
-  %162 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %163 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %164 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %163, i32 0, i32 0
-  %165 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %164, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @39, i32 0, i32 0), i8** %165, align 8
-  %166 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %164, i32 0, i32 1
-  store i32 16, i32* %166, align 4
-  %167 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %164, i32 0, i32 2
-  store i32 5, i32* %167, align 4
-  %168 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %164, i32 0, i32 3
-  store i32 16, i32* %168, align 4
-  %169 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %164, i32 0, i32 4
-  store i32 8, i32* %169, align 4
-  %170 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %171 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %162, i32 0, i32 0
-  %172 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %163, i32 0, i32 0
-  %173 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %171, i32 0, i32 2
-  %174 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %171, i32 0, i32 0
-  store i1 true, i1* %174, align 1
-  %175 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %171, i32 0, i32 1
-  store i8* %170, i8** %175, align 8
-  store { i8*, i32, i32, i32, i32 }* %172, { i8*, i32, i32, i32, i32 }** %173, align 8
-  %176 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %171, i32 0, i32 3
-  store i32 1, i32* %176, align 4
-  %177 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %162, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %177, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %162 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %163 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %164 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %163, i32 0, i32 0
+  %165 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %164, i32 0, i32 0
+  store ptr @39, ptr %165, align 8
+  %166 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %164, i32 0, i32 1
+  store i32 16, ptr %166, align 4
+  %167 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %164, i32 0, i32 2
+  store i32 5, ptr %167, align 4
+  %168 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %164, i32 0, i32 3
+  store i32 16, ptr %168, align 4
+  %169 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %164, i32 0, i32 4
+  store i32 8, ptr %169, align 4
+  %170 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @40)
+  %171 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %162, i32 0, i32 0
+  %172 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %163, i32 0, i32 0
+  %173 = getelementptr { i1, ptr, ptr, i32 }, ptr %171, i32 0, i32 2
+  %174 = getelementptr { i1, ptr, ptr, i32 }, ptr %171, i32 0, i32 0
+  store i1 true, ptr %174, align 1
+  %175 = getelementptr { i1, ptr, ptr, i32 }, ptr %171, i32 0, i32 1
+  store ptr %170, ptr %175, align 8
+  store ptr %172, ptr %173, align 8
+  %176 = getelementptr { i1, ptr, ptr, i32 }, ptr %171, i32 0, i32 3
+  store i32 1, ptr %176, align 4
+  %177 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %162, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %177, i32 1, ptr @41, ptr @38, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont31:                                         ; preds = %ifcont29
-  %178 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %179 = load i32, i32* %178, align 4
+  %178 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %179 = load i32, ptr %178, align 4
   %180 = icmp ne i32 %179, 13
   br i1 %180, label %then32, label %else33
 
 then32:                                           ; preds = %ifcont31
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @43, ptr @"ERROR STOP", ptr @42)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -540,43 +541,43 @@ ifcont34:                                         ; preds = %else33, %then32
   br i1 false, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  %181 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %182 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %183 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %182, i32 0, i32 0
-  %184 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @45, i32 0, i32 0), i8** %184, align 8
-  %185 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 1
-  store i32 17, i32* %185, align 4
-  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 2
-  store i32 5, i32* %186, align 4
-  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 3
-  store i32 17, i32* %187, align 4
-  %188 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %183, i32 0, i32 4
-  store i32 8, i32* %188, align 4
-  %189 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @46, i32 0, i32 0))
-  %190 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %181, i32 0, i32 0
-  %191 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %182, i32 0, i32 0
-  %192 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 2
-  %193 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 0
-  store i1 true, i1* %193, align 1
-  %194 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 1
-  store i8* %189, i8** %194, align 8
-  store { i8*, i32, i32, i32, i32 }* %191, { i8*, i32, i32, i32, i32 }** %192, align 8
-  %195 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %190, i32 0, i32 3
-  store i32 1, i32* %195, align 4
-  %196 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %181, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %196, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %181 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %182 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %183 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %182, i32 0, i32 0
+  %184 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %183, i32 0, i32 0
+  store ptr @45, ptr %184, align 8
+  %185 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %183, i32 0, i32 1
+  store i32 17, ptr %185, align 4
+  %186 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %183, i32 0, i32 2
+  store i32 5, ptr %186, align 4
+  %187 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %183, i32 0, i32 3
+  store i32 17, ptr %187, align 4
+  %188 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %183, i32 0, i32 4
+  store i32 8, ptr %188, align 4
+  %189 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @46)
+  %190 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %181, i32 0, i32 0
+  %191 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %182, i32 0, i32 0
+  %192 = getelementptr { i1, ptr, ptr, i32 }, ptr %190, i32 0, i32 2
+  %193 = getelementptr { i1, ptr, ptr, i32 }, ptr %190, i32 0, i32 0
+  store i1 true, ptr %193, align 1
+  %194 = getelementptr { i1, ptr, ptr, i32 }, ptr %190, i32 0, i32 1
+  store ptr %189, ptr %194, align 8
+  store ptr %191, ptr %192, align 8
+  %195 = getelementptr { i1, ptr, ptr, i32 }, ptr %190, i32 0, i32 3
+  store i32 1, ptr %195, align 4
+  %196 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %181, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %196, i32 1, ptr @47, ptr @44, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %197 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %198 = load i32, i32* %197, align 4
+  %197 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %198 = load i32, ptr %197, align 4
   %199 = icmp ne i32 %198, 14
   br i1 %199, label %then37, label %else38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @49, ptr @"ERROR STOP", ptr @48)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -585,20 +586,20 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head40
 
 loop.head40:                                      ; preds = %ifcont45, %ifcont39
-  %200 = load i32, i32* %i, align 4
+  %200 = load i32, ptr %i, align 4
   %201 = add i32 %200, 1
   %202 = icmp sle i32 %201, 3
   br i1 %202, label %loop.body41, label %loop.end46
 
 loop.body41:                                      ; preds = %loop.head40
-  %203 = load i32, i32* %i, align 4
+  %203 = load i32, ptr %i, align 4
   %204 = add i32 %203, 1
-  store i32 %204, i32* %i, align 4
-  %205 = load i32, i32* %i, align 4
+  store i32 %204, ptr %i, align 4
+  %205 = load i32, ptr %i, align 4
   %206 = sext i32 %205 to i64
   %207 = sub i64 %206, 1
   %208 = mul i64 1, %207
@@ -609,38 +610,38 @@ loop.body41:                                      ; preds = %loop.head40
   br i1 %212, label %then42, label %ifcont43
 
 then42:                                           ; preds = %loop.body41
-  %213 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %214 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %215 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %214, i32 0, i32 0
-  %216 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @51, i32 0, i32 0), i8** %216, align 8
-  %217 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 1
-  store i32 20, i32* %217, align 4
-  %218 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 2
-  store i32 5, i32* %218, align 4
-  %219 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 3
-  store i32 20, i32* %219, align 4
-  %220 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %215, i32 0, i32 4
-  store i32 8, i32* %220, align 4
-  %221 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
-  %222 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %213, i32 0, i32 0
-  %223 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %214, i32 0, i32 0
-  %224 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 2
-  %225 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 0
-  store i1 true, i1* %225, align 1
-  %226 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 1
-  store i8* %221, i8** %226, align 8
-  store { i8*, i32, i32, i32, i32 }* %223, { i8*, i32, i32, i32, i32 }** %224, align 8
-  %227 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %222, i32 0, i32 3
-  store i32 1, i32* %227, align 4
-  %228 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %213, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %228, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i64 %206, i32 1, i64 1, i64 4)
+  %213 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %214 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %215 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %214, i32 0, i32 0
+  %216 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %215, i32 0, i32 0
+  store ptr @51, ptr %216, align 8
+  %217 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %215, i32 0, i32 1
+  store i32 20, ptr %217, align 4
+  %218 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %215, i32 0, i32 2
+  store i32 5, ptr %218, align 4
+  %219 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %215, i32 0, i32 3
+  store i32 20, ptr %219, align 4
+  %220 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %215, i32 0, i32 4
+  store i32 8, ptr %220, align 4
+  %221 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @52)
+  %222 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %213, i32 0, i32 0
+  %223 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %214, i32 0, i32 0
+  %224 = getelementptr { i1, ptr, ptr, i32 }, ptr %222, i32 0, i32 2
+  %225 = getelementptr { i1, ptr, ptr, i32 }, ptr %222, i32 0, i32 0
+  store i1 true, ptr %225, align 1
+  %226 = getelementptr { i1, ptr, ptr, i32 }, ptr %222, i32 0, i32 1
+  store ptr %221, ptr %226, align 8
+  store ptr %223, ptr %224, align 8
+  %227 = getelementptr { i1, ptr, ptr, i32 }, ptr %222, i32 0, i32 3
+  store i32 1, ptr %227, align 4
+  %228 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %213, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %228, i32 1, ptr @53, ptr @50, i64 %206, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont43:                                         ; preds = %loop.body41
-  %229 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %209
-  %230 = load i32, i32* %i, align 4
+  %229 = getelementptr [4 x i32], ptr %b, i32 0, i64 %209
+  %230 = load i32, ptr %i, align 4
   %231 = sext i32 %230 to i64
   %232 = sub i64 %231, 1
   %233 = mul i64 1, %232
@@ -651,83 +652,83 @@ ifcont43:                                         ; preds = %loop.body41
   br i1 %237, label %then44, label %ifcont45
 
 then44:                                           ; preds = %ifcont43
-  %238 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %239 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %240 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @55, i32 0, i32 0), i8** %241, align 8
-  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 1
-  store i32 20, i32* %242, align 4
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 2
-  store i32 12, i32* %243, align 4
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 3
-  store i32 20, i32* %244, align 4
-  %245 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 4
-  store i32 15, i32* %245, align 4
-  %246 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @56, i32 0, i32 0))
-  %247 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  %248 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 2
-  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 0
-  store i1 true, i1* %250, align 1
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 1
-  store i8* %246, i8** %251, align 8
-  store { i8*, i32, i32, i32, i32 }* %248, { i8*, i32, i32, i32, i32 }** %249, align 8
-  %252 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 3
-  store i32 1, i32* %252, align 4
-  %253 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i64 %231, i32 1, i64 1, i64 3)
+  %238 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %239 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %240 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %239, i32 0, i32 0
+  %241 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 0
+  store ptr @55, ptr %241, align 8
+  %242 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 1
+  store i32 20, ptr %242, align 4
+  %243 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 2
+  store i32 12, ptr %243, align 4
+  %244 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 3
+  store i32 20, ptr %244, align 4
+  %245 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %240, i32 0, i32 4
+  store i32 15, ptr %245, align 4
+  %246 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @56)
+  %247 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %238, i32 0, i32 0
+  %248 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %239, i32 0, i32 0
+  %249 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 2
+  %250 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 0
+  store i1 true, ptr %250, align 1
+  %251 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 1
+  store ptr %246, ptr %251, align 8
+  store ptr %248, ptr %249, align 8
+  %252 = getelementptr { i1, ptr, ptr, i32 }, ptr %247, i32 0, i32 3
+  store i32 1, ptr %252, align 4
+  %253 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %238, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %253, i32 1, ptr @57, ptr @54, i64 %231, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont45:                                         ; preds = %ifcont43
-  %254 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %234
-  %255 = load i32, i32* %254, align 4
+  %254 = getelementptr [3 x i32], ptr %a, i32 0, i64 %234
+  %255 = load i32, ptr %254, align 4
   %256 = sub i32 %255, 10
-  store i32 %256, i32* %229, align 4
+  store i32 %256, ptr %229, align 4
   br label %loop.head40
 
 loop.end46:                                       ; preds = %loop.head40
   br i1 false, label %then47, label %ifcont48
 
 then47:                                           ; preds = %loop.end46
-  %257 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %258 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %259 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %258, i32 0, i32 0
-  %260 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %259, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @59, i32 0, i32 0), i8** %260, align 8
-  %261 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %259, i32 0, i32 1
-  store i32 22, i32* %261, align 4
-  %262 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %259, i32 0, i32 2
-  store i32 5, i32* %262, align 4
-  %263 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %259, i32 0, i32 3
-  store i32 22, i32* %263, align 4
-  %264 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %259, i32 0, i32 4
-  store i32 8, i32* %264, align 4
-  %265 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @60, i32 0, i32 0))
-  %266 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %257, i32 0, i32 0
-  %267 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %258, i32 0, i32 0
-  %268 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %266, i32 0, i32 2
-  %269 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %266, i32 0, i32 0
-  store i1 true, i1* %269, align 1
-  %270 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %266, i32 0, i32 1
-  store i8* %265, i8** %270, align 8
-  store { i8*, i32, i32, i32, i32 }* %267, { i8*, i32, i32, i32, i32 }** %268, align 8
-  %271 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %266, i32 0, i32 3
-  store i32 1, i32* %271, align 4
-  %272 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %257, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %272, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %257 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %258 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %259 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %258, i32 0, i32 0
+  %260 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %259, i32 0, i32 0
+  store ptr @59, ptr %260, align 8
+  %261 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %259, i32 0, i32 1
+  store i32 22, ptr %261, align 4
+  %262 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %259, i32 0, i32 2
+  store i32 5, ptr %262, align 4
+  %263 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %259, i32 0, i32 3
+  store i32 22, ptr %263, align 4
+  %264 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %259, i32 0, i32 4
+  store i32 8, ptr %264, align 4
+  %265 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @60)
+  %266 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %257, i32 0, i32 0
+  %267 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %258, i32 0, i32 0
+  %268 = getelementptr { i1, ptr, ptr, i32 }, ptr %266, i32 0, i32 2
+  %269 = getelementptr { i1, ptr, ptr, i32 }, ptr %266, i32 0, i32 0
+  store i1 true, ptr %269, align 1
+  %270 = getelementptr { i1, ptr, ptr, i32 }, ptr %266, i32 0, i32 1
+  store ptr %265, ptr %270, align 8
+  store ptr %267, ptr %268, align 8
+  %271 = getelementptr { i1, ptr, ptr, i32 }, ptr %266, i32 0, i32 3
+  store i32 1, ptr %271, align 4
+  %272 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %257, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %272, i32 1, ptr @61, ptr @58, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %loop.end46
-  %273 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %274 = load i32, i32* %273, align 4
+  %273 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %274 = load i32, ptr %273, align 4
   %275 = icmp ne i32 %274, 1
   br i1 %275, label %then49, label %else50
 
 then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @63, ptr @"ERROR STOP", ptr @62)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -739,43 +740,43 @@ ifcont51:                                         ; preds = %else50, %then49
   br i1 false, label %then52, label %ifcont53
 
 then52:                                           ; preds = %ifcont51
-  %276 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %277 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %278 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %277, i32 0, i32 0
-  %279 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %278, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @65, i32 0, i32 0), i8** %279, align 8
-  %280 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %278, i32 0, i32 1
-  store i32 23, i32* %280, align 4
-  %281 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %278, i32 0, i32 2
-  store i32 5, i32* %281, align 4
-  %282 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %278, i32 0, i32 3
-  store i32 23, i32* %282, align 4
-  %283 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %278, i32 0, i32 4
-  store i32 8, i32* %283, align 4
-  %284 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @66, i32 0, i32 0))
-  %285 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %276, i32 0, i32 0
-  %286 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %277, i32 0, i32 0
-  %287 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %285, i32 0, i32 2
-  %288 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %285, i32 0, i32 0
-  store i1 true, i1* %288, align 1
-  %289 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %285, i32 0, i32 1
-  store i8* %284, i8** %289, align 8
-  store { i8*, i32, i32, i32, i32 }* %286, { i8*, i32, i32, i32, i32 }** %287, align 8
-  %290 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %285, i32 0, i32 3
-  store i32 1, i32* %290, align 4
-  %291 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %276, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %291, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %276 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %277 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %278 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %277, i32 0, i32 0
+  %279 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %278, i32 0, i32 0
+  store ptr @65, ptr %279, align 8
+  %280 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %278, i32 0, i32 1
+  store i32 23, ptr %280, align 4
+  %281 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %278, i32 0, i32 2
+  store i32 5, ptr %281, align 4
+  %282 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %278, i32 0, i32 3
+  store i32 23, ptr %282, align 4
+  %283 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %278, i32 0, i32 4
+  store i32 8, ptr %283, align 4
+  %284 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @66)
+  %285 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %276, i32 0, i32 0
+  %286 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %277, i32 0, i32 0
+  %287 = getelementptr { i1, ptr, ptr, i32 }, ptr %285, i32 0, i32 2
+  %288 = getelementptr { i1, ptr, ptr, i32 }, ptr %285, i32 0, i32 0
+  store i1 true, ptr %288, align 1
+  %289 = getelementptr { i1, ptr, ptr, i32 }, ptr %285, i32 0, i32 1
+  store ptr %284, ptr %289, align 8
+  store ptr %286, ptr %287, align 8
+  %290 = getelementptr { i1, ptr, ptr, i32 }, ptr %285, i32 0, i32 3
+  store i32 1, ptr %290, align 4
+  %291 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %276, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %291, i32 1, ptr @67, ptr @64, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont53:                                         ; preds = %ifcont51
-  %292 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %293 = load i32, i32* %292, align 4
+  %292 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %293 = load i32, ptr %292, align 4
   %294 = icmp ne i32 %293, 2
   br i1 %294, label %then54, label %else55
 
 then54:                                           ; preds = %ifcont53
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @69, ptr @"ERROR STOP", ptr @68)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -787,43 +788,43 @@ ifcont56:                                         ; preds = %else55, %then54
   br i1 false, label %then57, label %ifcont58
 
 then57:                                           ; preds = %ifcont56
-  %295 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %296 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %297 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %296, i32 0, i32 0
-  %298 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %297, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @71, i32 0, i32 0), i8** %298, align 8
-  %299 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %297, i32 0, i32 1
-  store i32 24, i32* %299, align 4
-  %300 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %297, i32 0, i32 2
-  store i32 5, i32* %300, align 4
-  %301 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %297, i32 0, i32 3
-  store i32 24, i32* %301, align 4
-  %302 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %297, i32 0, i32 4
-  store i32 8, i32* %302, align 4
-  %303 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @72, i32 0, i32 0))
-  %304 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %295, i32 0, i32 0
-  %305 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %296, i32 0, i32 0
-  %306 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %304, i32 0, i32 2
-  %307 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %304, i32 0, i32 0
-  store i1 true, i1* %307, align 1
-  %308 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %304, i32 0, i32 1
-  store i8* %303, i8** %308, align 8
-  store { i8*, i32, i32, i32, i32 }* %305, { i8*, i32, i32, i32, i32 }** %306, align 8
-  %309 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %304, i32 0, i32 3
-  store i32 1, i32* %309, align 4
-  %310 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %295, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %310, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %295 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %296 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %297 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %296, i32 0, i32 0
+  %298 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %297, i32 0, i32 0
+  store ptr @71, ptr %298, align 8
+  %299 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %297, i32 0, i32 1
+  store i32 24, ptr %299, align 4
+  %300 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %297, i32 0, i32 2
+  store i32 5, ptr %300, align 4
+  %301 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %297, i32 0, i32 3
+  store i32 24, ptr %301, align 4
+  %302 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %297, i32 0, i32 4
+  store i32 8, ptr %302, align 4
+  %303 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @72)
+  %304 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %295, i32 0, i32 0
+  %305 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %296, i32 0, i32 0
+  %306 = getelementptr { i1, ptr, ptr, i32 }, ptr %304, i32 0, i32 2
+  %307 = getelementptr { i1, ptr, ptr, i32 }, ptr %304, i32 0, i32 0
+  store i1 true, ptr %307, align 1
+  %308 = getelementptr { i1, ptr, ptr, i32 }, ptr %304, i32 0, i32 1
+  store ptr %303, ptr %308, align 8
+  store ptr %305, ptr %306, align 8
+  %309 = getelementptr { i1, ptr, ptr, i32 }, ptr %304, i32 0, i32 3
+  store i32 1, ptr %309, align 4
+  %310 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %295, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %310, i32 1, ptr @73, ptr @70, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %311 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %312 = load i32, i32* %311, align 4
+  %311 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %312 = load i32, ptr %311, align 4
   %313 = icmp ne i32 %312, 3
   br i1 %313, label %then59, label %else60
 
 then59:                                           ; preds = %ifcont58
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @75, ptr @"ERROR STOP", ptr @74)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -835,221 +836,221 @@ ifcont61:                                         ; preds = %else60, %then59
   br i1 false, label %then62, label %ifcont63
 
 then62:                                           ; preds = %ifcont61
-  %314 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %315 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %316 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %315, i32 0, i32 0
-  %317 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %316, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @77, i32 0, i32 0), i8** %317, align 8
-  %318 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %316, i32 0, i32 1
-  store i32 26, i32* %318, align 4
-  %319 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %316, i32 0, i32 2
-  store i32 1, i32* %319, align 4
-  %320 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %316, i32 0, i32 3
-  store i32 26, i32* %320, align 4
-  %321 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %316, i32 0, i32 4
-  store i32 4, i32* %321, align 4
-  %322 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @78, i32 0, i32 0))
-  %323 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %314, i32 0, i32 0
-  %324 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %315, i32 0, i32 0
-  %325 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %323, i32 0, i32 2
-  %326 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %323, i32 0, i32 0
-  store i1 true, i1* %326, align 1
-  %327 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %323, i32 0, i32 1
-  store i8* %322, i8** %327, align 8
-  store { i8*, i32, i32, i32, i32 }* %324, { i8*, i32, i32, i32, i32 }** %325, align 8
-  %328 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %323, i32 0, i32 3
-  store i32 1, i32* %328, align 4
-  %329 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %314, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %329, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %314 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %315 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %316 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %315, i32 0, i32 0
+  %317 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %316, i32 0, i32 0
+  store ptr @77, ptr %317, align 8
+  %318 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %316, i32 0, i32 1
+  store i32 26, ptr %318, align 4
+  %319 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %316, i32 0, i32 2
+  store i32 1, ptr %319, align 4
+  %320 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %316, i32 0, i32 3
+  store i32 26, ptr %320, align 4
+  %321 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %316, i32 0, i32 4
+  store i32 4, ptr %321, align 4
+  %322 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @78)
+  %323 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %314, i32 0, i32 0
+  %324 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %315, i32 0, i32 0
+  %325 = getelementptr { i1, ptr, ptr, i32 }, ptr %323, i32 0, i32 2
+  %326 = getelementptr { i1, ptr, ptr, i32 }, ptr %323, i32 0, i32 0
+  store i1 true, ptr %326, align 1
+  %327 = getelementptr { i1, ptr, ptr, i32 }, ptr %323, i32 0, i32 1
+  store ptr %322, ptr %327, align 8
+  store ptr %324, ptr %325, align 8
+  %328 = getelementptr { i1, ptr, ptr, i32 }, ptr %323, i32 0, i32 3
+  store i32 1, ptr %328, align 4
+  %329 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %314, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %329, i32 1, ptr @79, ptr @76, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont63:                                         ; preds = %ifcont61
-  %330 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %330 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then64, label %ifcont65
 
 then64:                                           ; preds = %ifcont63
-  %331 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %332 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %333 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %332, i32 0, i32 0
-  %334 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @81, i32 0, i32 0), i8** %334, align 8
-  %335 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 1
-  store i32 26, i32* %335, align 4
-  %336 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 2
-  store i32 8, i32* %336, align 4
-  %337 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 3
-  store i32 26, i32* %337, align 4
-  %338 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 4
-  store i32 11, i32* %338, align 4
-  %339 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @82, i32 0, i32 0))
-  %340 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %331, i32 0, i32 0
-  %341 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %332, i32 0, i32 0
-  %342 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 2
-  %343 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 0
-  store i1 true, i1* %343, align 1
-  %344 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 1
-  store i8* %339, i8** %344, align 8
-  store { i8*, i32, i32, i32, i32 }* %341, { i8*, i32, i32, i32, i32 }** %342, align 8
-  %345 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 3
-  store i32 1, i32* %345, align 4
-  %346 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %331, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %346, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %331 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %332 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %333 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %332, i32 0, i32 0
+  %334 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %333, i32 0, i32 0
+  store ptr @81, ptr %334, align 8
+  %335 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %333, i32 0, i32 1
+  store i32 26, ptr %335, align 4
+  %336 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %333, i32 0, i32 2
+  store i32 8, ptr %336, align 4
+  %337 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %333, i32 0, i32 3
+  store i32 26, ptr %337, align 4
+  %338 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %333, i32 0, i32 4
+  store i32 11, ptr %338, align 4
+  %339 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @82)
+  %340 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %331, i32 0, i32 0
+  %341 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %332, i32 0, i32 0
+  %342 = getelementptr { i1, ptr, ptr, i32 }, ptr %340, i32 0, i32 2
+  %343 = getelementptr { i1, ptr, ptr, i32 }, ptr %340, i32 0, i32 0
+  store i1 true, ptr %343, align 1
+  %344 = getelementptr { i1, ptr, ptr, i32 }, ptr %340, i32 0, i32 1
+  store ptr %339, ptr %344, align 8
+  store ptr %341, ptr %342, align 8
+  %345 = getelementptr { i1, ptr, ptr, i32 }, ptr %340, i32 0, i32 3
+  store i32 1, ptr %345, align 4
+  %346 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %331, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %346, i32 1, ptr @83, ptr @80, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont65:                                         ; preds = %ifcont63
-  %347 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %348 = load i32, i32* %347, align 4
+  %347 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %348 = load i32, ptr %347, align 4
   br i1 false, label %then66, label %ifcont67
 
 then66:                                           ; preds = %ifcont65
-  %349 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %350 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %351 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
-  %352 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @85, i32 0, i32 0), i8** %352, align 8
-  %353 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 1
-  store i32 26, i32* %353, align 4
-  %354 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 2
-  store i32 13, i32* %354, align 4
-  %355 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 3
-  store i32 26, i32* %355, align 4
-  %356 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 4
-  store i32 16, i32* %356, align 4
-  %357 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @86, i32 0, i32 0))
-  %358 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
-  %359 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
-  %360 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 2
-  %361 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 0
-  store i1 true, i1* %361, align 1
-  %362 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 1
-  store i8* %357, i8** %362, align 8
-  store { i8*, i32, i32, i32, i32 }* %359, { i8*, i32, i32, i32, i32 }** %360, align 8
-  %363 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 3
-  store i32 1, i32* %363, align 4
-  %364 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %349 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %350 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %351 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %350, i32 0, i32 0
+  %352 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 0
+  store ptr @85, ptr %352, align 8
+  %353 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 1
+  store i32 26, ptr %353, align 4
+  %354 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 2
+  store i32 13, ptr %354, align 4
+  %355 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 3
+  store i32 26, ptr %355, align 4
+  %356 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 4
+  store i32 16, ptr %356, align 4
+  %357 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @86)
+  %358 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %349, i32 0, i32 0
+  %359 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %350, i32 0, i32 0
+  %360 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 2
+  %361 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 0
+  store i1 true, ptr %361, align 1
+  %362 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 1
+  store ptr %357, ptr %362, align 8
+  store ptr %359, ptr %360, align 8
+  %363 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 3
+  store i32 1, ptr %363, align 4
+  %364 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %349, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %364, i32 1, ptr @87, ptr @84, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont67:                                         ; preds = %ifcont65
-  %365 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %366 = load i32, i32* %365, align 4
+  %365 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %366 = load i32, ptr %365, align 4
   %367 = add i32 %348, %366
   br i1 false, label %then68, label %ifcont69
 
 then68:                                           ; preds = %ifcont67
-  %368 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %369 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %370 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %369, i32 0, i32 0
-  %371 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @89, i32 0, i32 0), i8** %371, align 8
-  %372 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 1
-  store i32 26, i32* %372, align 4
-  %373 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 2
-  store i32 18, i32* %373, align 4
-  %374 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 3
-  store i32 26, i32* %374, align 4
-  %375 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 4
-  store i32 21, i32* %375, align 4
-  %376 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @90, i32 0, i32 0))
-  %377 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %368, i32 0, i32 0
-  %378 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %369, i32 0, i32 0
-  %379 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 2
-  %380 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 0
-  store i1 true, i1* %380, align 1
-  %381 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 1
-  store i8* %376, i8** %381, align 8
-  store { i8*, i32, i32, i32, i32 }* %378, { i8*, i32, i32, i32, i32 }** %379, align 8
-  %382 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 3
-  store i32 1, i32* %382, align 4
-  %383 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %368, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %368 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %369 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %370 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %369, i32 0, i32 0
+  %371 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 0
+  store ptr @89, ptr %371, align 8
+  %372 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 1
+  store i32 26, ptr %372, align 4
+  %373 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 2
+  store i32 18, ptr %373, align 4
+  %374 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 3
+  store i32 26, ptr %374, align 4
+  %375 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 4
+  store i32 21, ptr %375, align 4
+  %376 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @90)
+  %377 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %368, i32 0, i32 0
+  %378 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %369, i32 0, i32 0
+  %379 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 2
+  %380 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 0
+  store i1 true, ptr %380, align 1
+  %381 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 1
+  store ptr %376, ptr %381, align 8
+  store ptr %378, ptr %379, align 8
+  %382 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 3
+  store i32 1, ptr %382, align 4
+  %383 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %368, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %383, i32 1, ptr @91, ptr @88, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont69:                                         ; preds = %ifcont67
-  %384 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %385 = load i32, i32* %384, align 4
+  %384 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %385 = load i32, ptr %384, align 4
   %386 = add i32 %367, %385
   br i1 false, label %then70, label %ifcont71
 
 then70:                                           ; preds = %ifcont69
-  %387 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %388 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %389 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
-  %390 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @93, i32 0, i32 0), i8** %390, align 8
-  %391 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 1
-  store i32 26, i32* %391, align 4
-  %392 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 2
-  store i32 23, i32* %392, align 4
-  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 3
-  store i32 26, i32* %393, align 4
-  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 4
-  store i32 26, i32* %394, align 4
-  %395 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %396 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
-  %397 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
-  %398 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 2
-  %399 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 0
-  store i1 true, i1* %399, align 1
-  %400 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 1
-  store i8* %395, i8** %400, align 8
-  store { i8*, i32, i32, i32, i32 }* %397, { i8*, i32, i32, i32, i32 }** %398, align 8
-  %401 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 3
-  store i32 1, i32* %401, align 4
-  %402 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %402, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %387 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %388 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %389 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %388, i32 0, i32 0
+  %390 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 0
+  store ptr @93, ptr %390, align 8
+  %391 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 1
+  store i32 26, ptr %391, align 4
+  %392 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 2
+  store i32 23, ptr %392, align 4
+  %393 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 3
+  store i32 26, ptr %393, align 4
+  %394 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 4
+  store i32 26, ptr %394, align 4
+  %395 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @94)
+  %396 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %387, i32 0, i32 0
+  %397 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %388, i32 0, i32 0
+  %398 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 2
+  %399 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 0
+  store i1 true, ptr %399, align 1
+  %400 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 1
+  store ptr %395, ptr %400, align 8
+  store ptr %397, ptr %398, align 8
+  %401 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 3
+  store i32 1, ptr %401, align 4
+  %402 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %387, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %402, i32 1, ptr @95, ptr @92, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont71:                                         ; preds = %ifcont69
-  %403 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %404 = load i32, i32* %403, align 4
+  %403 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %404 = load i32, ptr %403, align 4
   %405 = add i32 %386, %404
-  store i32 %405, i32* %330, align 4
+  store i32 %405, ptr %330, align 4
   br i1 false, label %then72, label %ifcont73
 
 then72:                                           ; preds = %ifcont71
-  %406 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %407 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %408 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %407, i32 0, i32 0
-  %409 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @97, i32 0, i32 0), i8** %409, align 8
-  %410 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 1
-  store i32 27, i32* %410, align 4
-  %411 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 2
-  store i32 5, i32* %411, align 4
-  %412 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 3
-  store i32 27, i32* %412, align 4
-  %413 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 4
-  store i32 8, i32* %413, align 4
-  %414 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %415 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %406, i32 0, i32 0
-  %416 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %407, i32 0, i32 0
-  %417 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 2
-  %418 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 0
-  store i1 true, i1* %418, align 1
-  %419 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 1
-  store i8* %414, i8** %419, align 8
-  store { i8*, i32, i32, i32, i32 }* %416, { i8*, i32, i32, i32, i32 }** %417, align 8
-  %420 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 3
-  store i32 1, i32* %420, align 4
-  %421 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %406, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %406 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %407 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %408 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %407, i32 0, i32 0
+  %409 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 0
+  store ptr @97, ptr %409, align 8
+  %410 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 1
+  store i32 27, ptr %410, align 4
+  %411 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 2
+  store i32 5, ptr %411, align 4
+  %412 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 3
+  store i32 27, ptr %412, align 4
+  %413 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 4
+  store i32 8, ptr %413, align 4
+  %414 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @98)
+  %415 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %406, i32 0, i32 0
+  %416 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %407, i32 0, i32 0
+  %417 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 2
+  %418 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 0
+  store i1 true, ptr %418, align 1
+  %419 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 1
+  store ptr %414, ptr %419, align 8
+  store ptr %416, ptr %417, align 8
+  %420 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 3
+  store i32 1, ptr %420, align 4
+  %421 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %406, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %421, i32 1, ptr @99, ptr @96, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont73:                                         ; preds = %ifcont71
-  %422 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %423 = load i32, i32* %422, align 4
+  %422 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %423 = load i32, ptr %422, align 4
   %424 = icmp ne i32 %423, 17
   br i1 %424, label %then74, label %else75
 
 then74:                                           ; preds = %ifcont73
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @101, ptr @"ERROR STOP", ptr @100)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1061,113 +1062,113 @@ ifcont76:                                         ; preds = %else75, %then74
   br i1 false, label %then77, label %ifcont78
 
 then77:                                           ; preds = %ifcont76
-  %425 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %426 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %427 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %426, i32 0, i32 0
-  %428 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %427, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @103, i32 0, i32 0), i8** %428, align 8
-  %429 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %427, i32 0, i32 1
-  store i32 29, i32* %429, align 4
-  %430 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %427, i32 0, i32 2
-  store i32 1, i32* %430, align 4
-  %431 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %427, i32 0, i32 3
-  store i32 29, i32* %431, align 4
-  %432 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %427, i32 0, i32 4
-  store i32 4, i32* %432, align 4
-  %433 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @104, i32 0, i32 0))
-  %434 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %425, i32 0, i32 0
-  %435 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %426, i32 0, i32 0
-  %436 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %434, i32 0, i32 2
-  %437 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %434, i32 0, i32 0
-  store i1 true, i1* %437, align 1
-  %438 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %434, i32 0, i32 1
-  store i8* %433, i8** %438, align 8
-  store { i8*, i32, i32, i32, i32 }* %435, { i8*, i32, i32, i32, i32 }** %436, align 8
-  %439 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %434, i32 0, i32 3
-  store i32 1, i32* %439, align 4
-  %440 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %425, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %440, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %425 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %426 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %427 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %426, i32 0, i32 0
+  %428 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %427, i32 0, i32 0
+  store ptr @103, ptr %428, align 8
+  %429 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %427, i32 0, i32 1
+  store i32 29, ptr %429, align 4
+  %430 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %427, i32 0, i32 2
+  store i32 1, ptr %430, align 4
+  %431 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %427, i32 0, i32 3
+  store i32 29, ptr %431, align 4
+  %432 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %427, i32 0, i32 4
+  store i32 4, ptr %432, align 4
+  %433 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @104)
+  %434 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %425, i32 0, i32 0
+  %435 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %426, i32 0, i32 0
+  %436 = getelementptr { i1, ptr, ptr, i32 }, ptr %434, i32 0, i32 2
+  %437 = getelementptr { i1, ptr, ptr, i32 }, ptr %434, i32 0, i32 0
+  store i1 true, ptr %437, align 1
+  %438 = getelementptr { i1, ptr, ptr, i32 }, ptr %434, i32 0, i32 1
+  store ptr %433, ptr %438, align 8
+  store ptr %435, ptr %436, align 8
+  %439 = getelementptr { i1, ptr, ptr, i32 }, ptr %434, i32 0, i32 3
+  store i32 1, ptr %439, align 4
+  %440 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %425, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %440, i32 1, ptr @105, ptr @102, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont78:                                         ; preds = %ifcont76
-  %441 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %441 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then79, label %ifcont80
 
 then79:                                           ; preds = %ifcont78
-  %442 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %443 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %444 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %443, i32 0, i32 0
-  %445 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %444, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @107, i32 0, i32 0), i8** %445, align 8
-  %446 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %444, i32 0, i32 1
-  store i32 29, i32* %446, align 4
-  %447 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %444, i32 0, i32 2
-  store i32 8, i32* %447, align 4
-  %448 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %444, i32 0, i32 3
-  store i32 29, i32* %448, align 4
-  %449 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %444, i32 0, i32 4
-  store i32 11, i32* %449, align 4
-  %450 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @108, i32 0, i32 0))
-  %451 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %442, i32 0, i32 0
-  %452 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %443, i32 0, i32 0
-  %453 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %451, i32 0, i32 2
-  %454 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %451, i32 0, i32 0
-  store i1 true, i1* %454, align 1
-  %455 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %451, i32 0, i32 1
-  store i8* %450, i8** %455, align 8
-  store { i8*, i32, i32, i32, i32 }* %452, { i8*, i32, i32, i32, i32 }** %453, align 8
-  %456 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %451, i32 0, i32 3
-  store i32 1, i32* %456, align 4
-  %457 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %442, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %457, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %442 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %443 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %444 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %443, i32 0, i32 0
+  %445 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %444, i32 0, i32 0
+  store ptr @107, ptr %445, align 8
+  %446 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %444, i32 0, i32 1
+  store i32 29, ptr %446, align 4
+  %447 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %444, i32 0, i32 2
+  store i32 8, ptr %447, align 4
+  %448 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %444, i32 0, i32 3
+  store i32 29, ptr %448, align 4
+  %449 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %444, i32 0, i32 4
+  store i32 11, ptr %449, align 4
+  %450 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @108)
+  %451 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %442, i32 0, i32 0
+  %452 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %443, i32 0, i32 0
+  %453 = getelementptr { i1, ptr, ptr, i32 }, ptr %451, i32 0, i32 2
+  %454 = getelementptr { i1, ptr, ptr, i32 }, ptr %451, i32 0, i32 0
+  store i1 true, ptr %454, align 1
+  %455 = getelementptr { i1, ptr, ptr, i32 }, ptr %451, i32 0, i32 1
+  store ptr %450, ptr %455, align 8
+  store ptr %452, ptr %453, align 8
+  %456 = getelementptr { i1, ptr, ptr, i32 }, ptr %451, i32 0, i32 3
+  store i32 1, ptr %456, align 4
+  %457 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %442, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %457, i32 1, ptr @109, ptr @106, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont80:                                         ; preds = %ifcont78
-  %458 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %459 = load i32, i32* %458, align 4
-  store i32 %459, i32* %441, align 4
+  %458 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %459 = load i32, ptr %458, align 4
+  store i32 %459, ptr %441, align 4
   br i1 false, label %then81, label %ifcont82
 
 then81:                                           ; preds = %ifcont80
-  %460 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %461 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %462 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %461, i32 0, i32 0
-  %463 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @111, i32 0, i32 0), i8** %463, align 8
-  %464 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 1
-  store i32 30, i32* %464, align 4
-  %465 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 2
-  store i32 5, i32* %465, align 4
-  %466 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 3
-  store i32 30, i32* %466, align 4
-  %467 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 4
-  store i32 8, i32* %467, align 4
-  %468 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @112, i32 0, i32 0))
-  %469 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %460, i32 0, i32 0
-  %470 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %461, i32 0, i32 0
-  %471 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 2
-  %472 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 0
-  store i1 true, i1* %472, align 1
-  %473 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 1
-  store i8* %468, i8** %473, align 8
-  store { i8*, i32, i32, i32, i32 }* %470, { i8*, i32, i32, i32, i32 }** %471, align 8
-  %474 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 3
-  store i32 1, i32* %474, align 4
-  %475 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %460, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %475, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @113, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %460 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %461 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %462 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %461, i32 0, i32 0
+  %463 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 0
+  store ptr @111, ptr %463, align 8
+  %464 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 1
+  store i32 30, ptr %464, align 4
+  %465 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 2
+  store i32 5, ptr %465, align 4
+  %466 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 3
+  store i32 30, ptr %466, align 4
+  %467 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 4
+  store i32 8, ptr %467, align 4
+  %468 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @112)
+  %469 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %460, i32 0, i32 0
+  %470 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %461, i32 0, i32 0
+  %471 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 2
+  %472 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 0
+  store i1 true, ptr %472, align 1
+  %473 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 1
+  store ptr %468, ptr %473, align 8
+  store ptr %470, ptr %471, align 8
+  %474 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 3
+  store i32 1, ptr %474, align 4
+  %475 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %460, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %475, i32 1, ptr @113, ptr @110, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont82:                                         ; preds = %ifcont80
-  %476 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %477 = load i32, i32* %476, align 4
+  %476 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %477 = load i32, ptr %476, align 4
   %478 = icmp ne i32 %477, 11
   br i1 %478, label %then83, label %else84
 
 then83:                                           ; preds = %ifcont82
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @115, ptr @"ERROR STOP", ptr @114)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1186,16 +1187,16 @@ FINALIZE_SYMTABLE_arrays_01:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.json
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_complex-c90dbdd.stdout",
-    "stdout_hash": "9169292ca46bfc786582326f122bdb1981b78b5577c45e1d2760d09a",
+    "stdout_hash": "52fe80bdf207e0755c6f341930dfb32607cf7b8cb0b0c1dd885f30de",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
+++ b/tests/reference/llvm-arrays_01_complex-c90dbdd.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %complex_4 = type <{ float, float }>
 
@@ -170,29 +171,29 @@ target datalayout = "..."
 @162 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @163 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [3 x %complex_4], align 8
   %b = alloca [4 x %complex_4], align 8
   %c = alloca [4 x %complex_4], align 8
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 3
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %7, ptr %i, align 4
+  %8 = load i32, ptr %i, align 4
   %9 = sext i32 %8 to i64
   %10 = sub i64 %9, 1
   %11 = mul i64 1, %10
@@ -203,81 +204,81 @@ loop.body:                                        ; preds = %loop.head
   br i1 %15, label %then, label %ifcont
 
 then:                                             ; preds = %loop.body
-  %16 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %17 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %18 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %19 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @1, i32 0, i32 0), i8** %19, align 8
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 1
-  store i32 6, i32* %20, align 4
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 2
-  store i32 5, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 3
-  store i32 6, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 4
-  store i32 8, i32* %23, align 4
-  %24 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
-  %25 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  %26 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 2
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 0
-  store i1 true, i1* %28, align 1
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 1
-  store i8* %24, i8** %29, align 8
-  store { i8*, i32, i32, i32, i32 }* %26, { i8*, i32, i32, i32, i32 }** %27, align 8
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 3
-  store i32 1, i32* %30, align 4
-  %31 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %9, i32 1, i64 1, i64 3)
+  %16 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %17 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %18 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %19 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 0
+  store ptr @1, ptr %19, align 8
+  %20 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 1
+  store i32 6, ptr %20, align 4
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 2
+  store i32 5, ptr %21, align 4
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 3
+  store i32 6, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 4
+  store i32 8, ptr %23, align 4
+  %24 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %25 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  %26 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %27 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 2
+  %28 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 0
+  store i1 true, ptr %28, align 1
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 1
+  store ptr %24, ptr %29, align 8
+  store ptr %26, ptr %27, align 8
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 3
+  store i32 1, ptr %30, align 4
+  %31 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %31, i32 1, ptr @3, ptr @0, i64 %9, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %loop.body
-  %32 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 %12
-  %33 = load i32, i32* %i, align 4
+  %32 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 %12
+  %33 = load i32, ptr %i, align 4
   %34 = add i32 %33, 10
   %35 = sitofp i32 %34 to float
   %36 = insertvalue %complex_4 undef, float %35, 0
   %37 = insertvalue %complex_4 %36, float 0.000000e+00, 1
-  store %complex_4 %37, %complex_4* %32, align 1
+  store %complex_4 %37, ptr %32, align 1
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then1, label %ifcont2
 
 then1:                                            ; preds = %loop.end
-  %38 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %39 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %40 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %39, i32 0, i32 0
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @5, i32 0, i32 0), i8** %41, align 8
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 1
-  store i32 8, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 2
-  store i32 5, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 3
-  store i32 8, i32* %44, align 4
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %40, i32 0, i32 4
-  store i32 8, i32* %45, align 4
-  %46 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %47 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %38, i32 0, i32 0
-  %48 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %39, i32 0, i32 0
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 2
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 0
-  store i1 true, i1* %50, align 1
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 1
-  store i8* %46, i8** %51, align 8
-  store { i8*, i32, i32, i32, i32 }* %48, { i8*, i32, i32, i32, i32 }** %49, align 8
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %47, i32 0, i32 3
-  store i32 1, i32* %52, align 4
-  %53 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %38, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %53, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %38 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %39 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %40 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %39, i32 0, i32 0
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %40, i32 0, i32 0
+  store ptr @5, ptr %41, align 8
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %40, i32 0, i32 1
+  store i32 8, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %40, i32 0, i32 2
+  store i32 5, ptr %43, align 4
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %40, i32 0, i32 3
+  store i32 8, ptr %44, align 4
+  %45 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %40, i32 0, i32 4
+  store i32 8, ptr %45, align 4
+  %46 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %47 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %38, i32 0, i32 0
+  %48 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %39, i32 0, i32 0
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %47, i32 0, i32 2
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %47, i32 0, i32 0
+  store i1 true, ptr %50, align 1
+  %51 = getelementptr { i1, ptr, ptr, i32 }, ptr %47, i32 0, i32 1
+  store ptr %46, ptr %51, align 8
+  store ptr %48, ptr %49, align 8
+  %52 = getelementptr { i1, ptr, ptr, i32 }, ptr %47, i32 0, i32 3
+  store i32 1, ptr %52, align 4
+  %53 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %38, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %53, i32 1, ptr @7, ptr @4, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %loop.end
-  %54 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 0
-  %55 = load %complex_4, %complex_4* %54, align 1
+  %54 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 0
+  %55 = load %complex_4, ptr %54, align 1
   %56 = extractvalue %complex_4 %55, 0
   %57 = extractvalue %complex_4 %55, 1
   %58 = fcmp one float %56, 1.100000e+01
@@ -286,7 +287,7 @@ ifcont2:                                          ; preds = %loop.end
   br i1 %60, label %then3, label %else
 
 then3:                                            ; preds = %ifcont2
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -298,38 +299,38 @@ ifcont4:                                          ; preds = %else, %then3
   br i1 false, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %61 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %62 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %63 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %62, i32 0, i32 0
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @11, i32 0, i32 0), i8** %64, align 8
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 1
-  store i32 9, i32* %65, align 4
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 2
-  store i32 5, i32* %66, align 4
-  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 3
-  store i32 9, i32* %67, align 4
-  %68 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 4
-  store i32 8, i32* %68, align 4
-  %69 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @12, i32 0, i32 0))
-  %70 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %61, i32 0, i32 0
-  %71 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %62, i32 0, i32 0
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 2
-  %73 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 0
-  store i1 true, i1* %73, align 1
-  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 1
-  store i8* %69, i8** %74, align 8
-  store { i8*, i32, i32, i32, i32 }* %71, { i8*, i32, i32, i32, i32 }** %72, align 8
-  %75 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 3
-  store i32 1, i32* %75, align 4
-  %76 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %61, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %76, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i64 2, i32 1, i64 1, i64 3)
+  %61 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %62 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %63 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %62, i32 0, i32 0
+  %64 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 0
+  store ptr @11, ptr %64, align 8
+  %65 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 1
+  store i32 9, ptr %65, align 4
+  %66 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 2
+  store i32 5, ptr %66, align 4
+  %67 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 3
+  store i32 9, ptr %67, align 4
+  %68 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 4
+  store i32 8, ptr %68, align 4
+  %69 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @12)
+  %70 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %61, i32 0, i32 0
+  %71 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %62, i32 0, i32 0
+  %72 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 2
+  %73 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 0
+  store i1 true, ptr %73, align 1
+  %74 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 1
+  store ptr %69, ptr %74, align 8
+  store ptr %71, ptr %72, align 8
+  %75 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 3
+  store i32 1, ptr %75, align 4
+  %76 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %61, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %76, i32 1, ptr @13, ptr @10, i64 2, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %77 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 1
-  %78 = load %complex_4, %complex_4* %77, align 1
+  %77 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 1
+  %78 = load %complex_4, ptr %77, align 1
   %79 = extractvalue %complex_4 %78, 0
   %80 = extractvalue %complex_4 %78, 1
   %81 = fcmp one float %79, 1.200000e+01
@@ -338,7 +339,7 @@ ifcont6:                                          ; preds = %ifcont4
   br i1 %83, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -350,38 +351,38 @@ ifcont9:                                          ; preds = %else8, %then7
   br i1 false, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  %84 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %85 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %86 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %85, i32 0, i32 0
-  %87 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %86, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @17, i32 0, i32 0), i8** %87, align 8
-  %88 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %86, i32 0, i32 1
-  store i32 10, i32* %88, align 4
-  %89 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %86, i32 0, i32 2
-  store i32 5, i32* %89, align 4
-  %90 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %86, i32 0, i32 3
-  store i32 10, i32* %90, align 4
-  %91 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %86, i32 0, i32 4
-  store i32 8, i32* %91, align 4
-  %92 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %93 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %84, i32 0, i32 0
-  %94 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %85, i32 0, i32 0
-  %95 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %93, i32 0, i32 2
-  %96 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %93, i32 0, i32 0
-  store i1 true, i1* %96, align 1
-  %97 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %93, i32 0, i32 1
-  store i8* %92, i8** %97, align 8
-  store { i8*, i32, i32, i32, i32 }* %94, { i8*, i32, i32, i32, i32 }** %95, align 8
-  %98 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %93, i32 0, i32 3
-  store i32 1, i32* %98, align 4
-  %99 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %84, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %99, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 3, i32 1, i64 1, i64 3)
+  %84 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %85 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %86 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %85, i32 0, i32 0
+  %87 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %86, i32 0, i32 0
+  store ptr @17, ptr %87, align 8
+  %88 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %86, i32 0, i32 1
+  store i32 10, ptr %88, align 4
+  %89 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %86, i32 0, i32 2
+  store i32 5, ptr %89, align 4
+  %90 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %86, i32 0, i32 3
+  store i32 10, ptr %90, align 4
+  %91 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %86, i32 0, i32 4
+  store i32 8, ptr %91, align 4
+  %92 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @18)
+  %93 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %84, i32 0, i32 0
+  %94 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %85, i32 0, i32 0
+  %95 = getelementptr { i1, ptr, ptr, i32 }, ptr %93, i32 0, i32 2
+  %96 = getelementptr { i1, ptr, ptr, i32 }, ptr %93, i32 0, i32 0
+  store i1 true, ptr %96, align 1
+  %97 = getelementptr { i1, ptr, ptr, i32 }, ptr %93, i32 0, i32 1
+  store ptr %92, ptr %97, align 8
+  store ptr %94, ptr %95, align 8
+  %98 = getelementptr { i1, ptr, ptr, i32 }, ptr %93, i32 0, i32 3
+  store i32 1, ptr %98, align 4
+  %99 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %84, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %99, i32 1, ptr @19, ptr @16, i64 3, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %100 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 2
-  %101 = load %complex_4, %complex_4* %100, align 1
+  %100 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 2
+  %101 = load %complex_4, ptr %100, align 1
   %102 = extractvalue %complex_4 %101, 0
   %103 = extractvalue %complex_4 %101, 1
   %104 = fcmp one float %102, 1.300000e+01
@@ -390,7 +391,7 @@ ifcont11:                                         ; preds = %ifcont9
   br i1 %106, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont11
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -399,20 +400,20 @@ else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  store i32 10, i32* %i, align 4
+  store i32 10, ptr %i, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %ifcont18, %ifcont14
-  %107 = load i32, i32* %i, align 4
+  %107 = load i32, ptr %i, align 4
   %108 = add i32 %107, 1
   %109 = icmp sle i32 %108, 14
   br i1 %109, label %loop.body16, label %loop.end19
 
 loop.body16:                                      ; preds = %loop.head15
-  %110 = load i32, i32* %i, align 4
+  %110 = load i32, ptr %i, align 4
   %111 = add i32 %110, 1
-  store i32 %111, i32* %i, align 4
-  %112 = load i32, i32* %i, align 4
+  store i32 %111, ptr %i, align 4
+  %112 = load i32, ptr %i, align 4
   %113 = sub i32 %112, 10
   %114 = sext i32 %113 to i64
   %115 = sub i64 %114, 1
@@ -424,80 +425,80 @@ loop.body16:                                      ; preds = %loop.head15
   br i1 %120, label %then17, label %ifcont18
 
 then17:                                           ; preds = %loop.body16
-  %121 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %122 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %123 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %122, i32 0, i32 0
-  %124 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %123, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @23, i32 0, i32 0), i8** %124, align 8
-  %125 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %123, i32 0, i32 1
-  store i32 13, i32* %125, align 4
-  %126 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %123, i32 0, i32 2
-  store i32 5, i32* %126, align 4
-  %127 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %123, i32 0, i32 3
-  store i32 13, i32* %127, align 4
-  %128 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %123, i32 0, i32 4
-  store i32 11, i32* %128, align 4
-  %129 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @24, i32 0, i32 0))
-  %130 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %121, i32 0, i32 0
-  %131 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %122, i32 0, i32 0
-  %132 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %130, i32 0, i32 2
-  %133 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %130, i32 0, i32 0
-  store i1 true, i1* %133, align 1
-  %134 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %130, i32 0, i32 1
-  store i8* %129, i8** %134, align 8
-  store { i8*, i32, i32, i32, i32 }* %131, { i8*, i32, i32, i32, i32 }** %132, align 8
-  %135 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %130, i32 0, i32 3
-  store i32 1, i32* %135, align 4
-  %136 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %121, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %136, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i64 %114, i32 1, i64 1, i64 4)
+  %121 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %122 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %123 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %122, i32 0, i32 0
+  %124 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %123, i32 0, i32 0
+  store ptr @23, ptr %124, align 8
+  %125 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %123, i32 0, i32 1
+  store i32 13, ptr %125, align 4
+  %126 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %123, i32 0, i32 2
+  store i32 5, ptr %126, align 4
+  %127 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %123, i32 0, i32 3
+  store i32 13, ptr %127, align 4
+  %128 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %123, i32 0, i32 4
+  store i32 11, ptr %128, align 4
+  %129 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @24)
+  %130 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %121, i32 0, i32 0
+  %131 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %122, i32 0, i32 0
+  %132 = getelementptr { i1, ptr, ptr, i32 }, ptr %130, i32 0, i32 2
+  %133 = getelementptr { i1, ptr, ptr, i32 }, ptr %130, i32 0, i32 0
+  store i1 true, ptr %133, align 1
+  %134 = getelementptr { i1, ptr, ptr, i32 }, ptr %130, i32 0, i32 1
+  store ptr %129, ptr %134, align 8
+  store ptr %131, ptr %132, align 8
+  %135 = getelementptr { i1, ptr, ptr, i32 }, ptr %130, i32 0, i32 3
+  store i32 1, ptr %135, align 4
+  %136 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %121, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %136, i32 1, ptr @25, ptr @22, i64 %114, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %loop.body16
-  %137 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 %117
-  %138 = load i32, i32* %i, align 4
+  %137 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 %117
+  %138 = load i32, ptr %i, align 4
   %139 = sitofp i32 %138 to float
   %140 = insertvalue %complex_4 undef, float %139, 0
   %141 = insertvalue %complex_4 %140, float 0.000000e+00, 1
-  store %complex_4 %141, %complex_4* %137, align 1
+  store %complex_4 %141, ptr %137, align 1
   br label %loop.head15
 
 loop.end19:                                       ; preds = %loop.head15
   br i1 false, label %then20, label %ifcont21
 
 then20:                                           ; preds = %loop.end19
-  %142 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %143 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %144 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %143, i32 0, i32 0
-  %145 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %144, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @27, i32 0, i32 0), i8** %145, align 8
-  %146 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %144, i32 0, i32 1
-  store i32 15, i32* %146, align 4
-  %147 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %144, i32 0, i32 2
-  store i32 5, i32* %147, align 4
-  %148 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %144, i32 0, i32 3
-  store i32 15, i32* %148, align 4
-  %149 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %144, i32 0, i32 4
-  store i32 8, i32* %149, align 4
-  %150 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @28, i32 0, i32 0))
-  %151 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %142, i32 0, i32 0
-  %152 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %143, i32 0, i32 0
-  %153 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %151, i32 0, i32 2
-  %154 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %151, i32 0, i32 0
-  store i1 true, i1* %154, align 1
-  %155 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %151, i32 0, i32 1
-  store i8* %150, i8** %155, align 8
-  store { i8*, i32, i32, i32, i32 }* %152, { i8*, i32, i32, i32, i32 }** %153, align 8
-  %156 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %151, i32 0, i32 3
-  store i32 1, i32* %156, align 4
-  %157 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %142, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %157, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %142 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %143 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %144 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %143, i32 0, i32 0
+  %145 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %144, i32 0, i32 0
+  store ptr @27, ptr %145, align 8
+  %146 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %144, i32 0, i32 1
+  store i32 15, ptr %146, align 4
+  %147 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %144, i32 0, i32 2
+  store i32 5, ptr %147, align 4
+  %148 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %144, i32 0, i32 3
+  store i32 15, ptr %148, align 4
+  %149 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %144, i32 0, i32 4
+  store i32 8, ptr %149, align 4
+  %150 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @28)
+  %151 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %142, i32 0, i32 0
+  %152 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %143, i32 0, i32 0
+  %153 = getelementptr { i1, ptr, ptr, i32 }, ptr %151, i32 0, i32 2
+  %154 = getelementptr { i1, ptr, ptr, i32 }, ptr %151, i32 0, i32 0
+  store i1 true, ptr %154, align 1
+  %155 = getelementptr { i1, ptr, ptr, i32 }, ptr %151, i32 0, i32 1
+  store ptr %150, ptr %155, align 8
+  store ptr %152, ptr %153, align 8
+  %156 = getelementptr { i1, ptr, ptr, i32 }, ptr %151, i32 0, i32 3
+  store i32 1, ptr %156, align 4
+  %157 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %142, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %157, i32 1, ptr @29, ptr @26, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %loop.end19
-  %158 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 0
-  %159 = load %complex_4, %complex_4* %158, align 1
+  %158 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 0
+  %159 = load %complex_4, ptr %158, align 1
   %160 = extractvalue %complex_4 %159, 0
   %161 = extractvalue %complex_4 %159, 1
   %162 = fcmp one float %160, 1.100000e+01
@@ -506,7 +507,7 @@ ifcont21:                                         ; preds = %loop.end19
   br i1 %164, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @31, ptr @"ERROR STOP", ptr @30)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -518,38 +519,38 @@ ifcont24:                                         ; preds = %else23, %then22
   br i1 false, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %165 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %166 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %167 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %166, i32 0, i32 0
-  %168 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %167, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @33, i32 0, i32 0), i8** %168, align 8
-  %169 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %167, i32 0, i32 1
-  store i32 16, i32* %169, align 4
-  %170 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %167, i32 0, i32 2
-  store i32 5, i32* %170, align 4
-  %171 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %167, i32 0, i32 3
-  store i32 16, i32* %171, align 4
-  %172 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %167, i32 0, i32 4
-  store i32 8, i32* %172, align 4
-  %173 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @34, i32 0, i32 0))
-  %174 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %165, i32 0, i32 0
-  %175 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %166, i32 0, i32 0
-  %176 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %174, i32 0, i32 2
-  %177 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %174, i32 0, i32 0
-  store i1 true, i1* %177, align 1
-  %178 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %174, i32 0, i32 1
-  store i8* %173, i8** %178, align 8
-  store { i8*, i32, i32, i32, i32 }* %175, { i8*, i32, i32, i32, i32 }** %176, align 8
-  %179 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %174, i32 0, i32 3
-  store i32 1, i32* %179, align 4
-  %180 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %165, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %165 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %166 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %167 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %166, i32 0, i32 0
+  %168 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 0
+  store ptr @33, ptr %168, align 8
+  %169 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 1
+  store i32 16, ptr %169, align 4
+  %170 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 2
+  store i32 5, ptr %170, align 4
+  %171 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 3
+  store i32 16, ptr %171, align 4
+  %172 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 4
+  store i32 8, ptr %172, align 4
+  %173 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @34)
+  %174 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %165, i32 0, i32 0
+  %175 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %166, i32 0, i32 0
+  %176 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 2
+  %177 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 0
+  store i1 true, ptr %177, align 1
+  %178 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 1
+  store ptr %173, ptr %178, align 8
+  store ptr %175, ptr %176, align 8
+  %179 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 3
+  store i32 1, ptr %179, align 4
+  %180 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %165, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %180, i32 1, ptr @35, ptr @32, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %181 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 1
-  %182 = load %complex_4, %complex_4* %181, align 1
+  %181 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 1
+  %182 = load %complex_4, ptr %181, align 1
   %183 = extractvalue %complex_4 %182, 0
   %184 = extractvalue %complex_4 %182, 1
   %185 = fcmp one float %183, 1.200000e+01
@@ -558,7 +559,7 @@ ifcont26:                                         ; preds = %ifcont24
   br i1 %187, label %then27, label %else28
 
 then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @37, ptr @"ERROR STOP", ptr @36)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -570,38 +571,38 @@ ifcont29:                                         ; preds = %else28, %then27
   br i1 false, label %then30, label %ifcont31
 
 then30:                                           ; preds = %ifcont29
-  %188 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %189 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %190 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %189, i32 0, i32 0
-  %191 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @39, i32 0, i32 0), i8** %191, align 8
-  %192 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 1
-  store i32 17, i32* %192, align 4
-  %193 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 2
-  store i32 5, i32* %193, align 4
-  %194 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 3
-  store i32 17, i32* %194, align 4
-  %195 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %190, i32 0, i32 4
-  store i32 8, i32* %195, align 4
-  %196 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %197 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %188, i32 0, i32 0
-  %198 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %189, i32 0, i32 0
-  %199 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 2
-  %200 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 0
-  store i1 true, i1* %200, align 1
-  %201 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 1
-  store i8* %196, i8** %201, align 8
-  store { i8*, i32, i32, i32, i32 }* %198, { i8*, i32, i32, i32, i32 }** %199, align 8
-  %202 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %197, i32 0, i32 3
-  store i32 1, i32* %202, align 4
-  %203 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %188, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %203, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %188 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %189 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %190 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %189, i32 0, i32 0
+  %191 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %190, i32 0, i32 0
+  store ptr @39, ptr %191, align 8
+  %192 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %190, i32 0, i32 1
+  store i32 17, ptr %192, align 4
+  %193 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %190, i32 0, i32 2
+  store i32 5, ptr %193, align 4
+  %194 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %190, i32 0, i32 3
+  store i32 17, ptr %194, align 4
+  %195 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %190, i32 0, i32 4
+  store i32 8, ptr %195, align 4
+  %196 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @40)
+  %197 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %188, i32 0, i32 0
+  %198 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %189, i32 0, i32 0
+  %199 = getelementptr { i1, ptr, ptr, i32 }, ptr %197, i32 0, i32 2
+  %200 = getelementptr { i1, ptr, ptr, i32 }, ptr %197, i32 0, i32 0
+  store i1 true, ptr %200, align 1
+  %201 = getelementptr { i1, ptr, ptr, i32 }, ptr %197, i32 0, i32 1
+  store ptr %196, ptr %201, align 8
+  store ptr %198, ptr %199, align 8
+  %202 = getelementptr { i1, ptr, ptr, i32 }, ptr %197, i32 0, i32 3
+  store i32 1, ptr %202, align 4
+  %203 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %188, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %203, i32 1, ptr @41, ptr @38, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont31:                                         ; preds = %ifcont29
-  %204 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 2
-  %205 = load %complex_4, %complex_4* %204, align 1
+  %204 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 2
+  %205 = load %complex_4, ptr %204, align 1
   %206 = extractvalue %complex_4 %205, 0
   %207 = extractvalue %complex_4 %205, 1
   %208 = fcmp one float %206, 1.300000e+01
@@ -610,7 +611,7 @@ ifcont31:                                         ; preds = %ifcont29
   br i1 %210, label %then32, label %else33
 
 then32:                                           ; preds = %ifcont31
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @43, ptr @"ERROR STOP", ptr @42)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -622,38 +623,38 @@ ifcont34:                                         ; preds = %else33, %then32
   br i1 false, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  %211 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %212 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %213 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %212, i32 0, i32 0
-  %214 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %213, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @45, i32 0, i32 0), i8** %214, align 8
-  %215 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %213, i32 0, i32 1
-  store i32 18, i32* %215, align 4
-  %216 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %213, i32 0, i32 2
-  store i32 5, i32* %216, align 4
-  %217 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %213, i32 0, i32 3
-  store i32 18, i32* %217, align 4
-  %218 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %213, i32 0, i32 4
-  store i32 8, i32* %218, align 4
-  %219 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @46, i32 0, i32 0))
-  %220 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %211, i32 0, i32 0
-  %221 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %212, i32 0, i32 0
-  %222 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %220, i32 0, i32 2
-  %223 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %220, i32 0, i32 0
-  store i1 true, i1* %223, align 1
-  %224 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %220, i32 0, i32 1
-  store i8* %219, i8** %224, align 8
-  store { i8*, i32, i32, i32, i32 }* %221, { i8*, i32, i32, i32, i32 }** %222, align 8
-  %225 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %220, i32 0, i32 3
-  store i32 1, i32* %225, align 4
-  %226 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %211, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %226, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %211 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %212 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %213 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %212, i32 0, i32 0
+  %214 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %213, i32 0, i32 0
+  store ptr @45, ptr %214, align 8
+  %215 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %213, i32 0, i32 1
+  store i32 18, ptr %215, align 4
+  %216 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %213, i32 0, i32 2
+  store i32 5, ptr %216, align 4
+  %217 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %213, i32 0, i32 3
+  store i32 18, ptr %217, align 4
+  %218 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %213, i32 0, i32 4
+  store i32 8, ptr %218, align 4
+  %219 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @46)
+  %220 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %211, i32 0, i32 0
+  %221 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %212, i32 0, i32 0
+  %222 = getelementptr { i1, ptr, ptr, i32 }, ptr %220, i32 0, i32 2
+  %223 = getelementptr { i1, ptr, ptr, i32 }, ptr %220, i32 0, i32 0
+  store i1 true, ptr %223, align 1
+  %224 = getelementptr { i1, ptr, ptr, i32 }, ptr %220, i32 0, i32 1
+  store ptr %219, ptr %224, align 8
+  store ptr %221, ptr %222, align 8
+  %225 = getelementptr { i1, ptr, ptr, i32 }, ptr %220, i32 0, i32 3
+  store i32 1, ptr %225, align 4
+  %226 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %211, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %226, i32 1, ptr @47, ptr @44, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %227 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 3
-  %228 = load %complex_4, %complex_4* %227, align 1
+  %227 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 3
+  %228 = load %complex_4, ptr %227, align 1
   %229 = extractvalue %complex_4 %228, 0
   %230 = extractvalue %complex_4 %228, 1
   %231 = fcmp one float %229, 1.400000e+01
@@ -662,7 +663,7 @@ ifcont36:                                         ; preds = %ifcont34
   br i1 %233, label %then37, label %else38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @49, ptr @"ERROR STOP", ptr @48)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -671,20 +672,20 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head40
 
 loop.head40:                                      ; preds = %ifcont45, %ifcont39
-  %234 = load i32, i32* %i, align 4
+  %234 = load i32, ptr %i, align 4
   %235 = add i32 %234, 1
   %236 = icmp sle i32 %235, 3
   br i1 %236, label %loop.body41, label %loop.end46
 
 loop.body41:                                      ; preds = %loop.head40
-  %237 = load i32, i32* %i, align 4
+  %237 = load i32, ptr %i, align 4
   %238 = add i32 %237, 1
-  store i32 %238, i32* %i, align 4
-  %239 = load i32, i32* %i, align 4
+  store i32 %238, ptr %i, align 4
+  %239 = load i32, ptr %i, align 4
   %240 = sext i32 %239 to i64
   %241 = sub i64 %240, 1
   %242 = mul i64 1, %241
@@ -695,38 +696,38 @@ loop.body41:                                      ; preds = %loop.head40
   br i1 %246, label %then42, label %ifcont43
 
 then42:                                           ; preds = %loop.body41
-  %247 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %248 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %249 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %248, i32 0, i32 0
-  %250 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %249, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @51, i32 0, i32 0), i8** %250, align 8
-  %251 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %249, i32 0, i32 1
-  store i32 21, i32* %251, align 4
-  %252 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %249, i32 0, i32 2
-  store i32 5, i32* %252, align 4
-  %253 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %249, i32 0, i32 3
-  store i32 21, i32* %253, align 4
-  %254 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %249, i32 0, i32 4
-  store i32 8, i32* %254, align 4
-  %255 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
-  %256 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %247, i32 0, i32 0
-  %257 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %248, i32 0, i32 0
-  %258 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %256, i32 0, i32 2
-  %259 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %256, i32 0, i32 0
-  store i1 true, i1* %259, align 1
-  %260 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %256, i32 0, i32 1
-  store i8* %255, i8** %260, align 8
-  store { i8*, i32, i32, i32, i32 }* %257, { i8*, i32, i32, i32, i32 }** %258, align 8
-  %261 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %256, i32 0, i32 3
-  store i32 1, i32* %261, align 4
-  %262 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %247, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %262, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i64 %240, i32 1, i64 1, i64 4)
+  %247 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %248 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %249 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %248, i32 0, i32 0
+  %250 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %249, i32 0, i32 0
+  store ptr @51, ptr %250, align 8
+  %251 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %249, i32 0, i32 1
+  store i32 21, ptr %251, align 4
+  %252 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %249, i32 0, i32 2
+  store i32 5, ptr %252, align 4
+  %253 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %249, i32 0, i32 3
+  store i32 21, ptr %253, align 4
+  %254 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %249, i32 0, i32 4
+  store i32 8, ptr %254, align 4
+  %255 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @52)
+  %256 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %247, i32 0, i32 0
+  %257 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %248, i32 0, i32 0
+  %258 = getelementptr { i1, ptr, ptr, i32 }, ptr %256, i32 0, i32 2
+  %259 = getelementptr { i1, ptr, ptr, i32 }, ptr %256, i32 0, i32 0
+  store i1 true, ptr %259, align 1
+  %260 = getelementptr { i1, ptr, ptr, i32 }, ptr %256, i32 0, i32 1
+  store ptr %255, ptr %260, align 8
+  store ptr %257, ptr %258, align 8
+  %261 = getelementptr { i1, ptr, ptr, i32 }, ptr %256, i32 0, i32 3
+  store i32 1, ptr %261, align 4
+  %262 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %247, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %262, i32 1, ptr @53, ptr @50, i64 %240, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont43:                                         ; preds = %loop.body41
-  %263 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 %243
-  %264 = load i32, i32* %i, align 4
+  %263 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 %243
+  %264 = load i32, ptr %i, align 4
   %265 = sext i32 %264 to i64
   %266 = sub i64 %265, 1
   %267 = mul i64 1, %266
@@ -737,83 +738,83 @@ ifcont43:                                         ; preds = %loop.body41
   br i1 %271, label %then44, label %ifcont45
 
 then44:                                           ; preds = %ifcont43
-  %272 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %273 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %274 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %273, i32 0, i32 0
-  %275 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @55, i32 0, i32 0), i8** %275, align 8
-  %276 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 1
-  store i32 21, i32* %276, align 4
-  %277 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 2
-  store i32 12, i32* %277, align 4
-  %278 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 3
-  store i32 21, i32* %278, align 4
-  %279 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 4
-  store i32 15, i32* %279, align 4
-  %280 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @56, i32 0, i32 0))
-  %281 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %272, i32 0, i32 0
-  %282 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %273, i32 0, i32 0
-  %283 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 2
-  %284 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 0
-  store i1 true, i1* %284, align 1
-  %285 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 1
-  store i8* %280, i8** %285, align 8
-  store { i8*, i32, i32, i32, i32 }* %282, { i8*, i32, i32, i32, i32 }** %283, align 8
-  %286 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 3
-  store i32 1, i32* %286, align 4
-  %287 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %272, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i64 %265, i32 1, i64 1, i64 3)
+  %272 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %273 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %274 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %273, i32 0, i32 0
+  %275 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 0
+  store ptr @55, ptr %275, align 8
+  %276 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 1
+  store i32 21, ptr %276, align 4
+  %277 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 2
+  store i32 12, ptr %277, align 4
+  %278 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 3
+  store i32 21, ptr %278, align 4
+  %279 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 4
+  store i32 15, ptr %279, align 4
+  %280 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @56)
+  %281 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %272, i32 0, i32 0
+  %282 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %273, i32 0, i32 0
+  %283 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 2
+  %284 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 0
+  store i1 true, ptr %284, align 1
+  %285 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 1
+  store ptr %280, ptr %285, align 8
+  store ptr %282, ptr %283, align 8
+  %286 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 3
+  store i32 1, ptr %286, align 4
+  %287 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %272, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %287, i32 1, ptr @57, ptr @54, i64 %265, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont45:                                         ; preds = %ifcont43
-  %288 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 %268
-  %289 = load %complex_4, %complex_4* %288, align 1
+  %288 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 %268
+  %289 = load %complex_4, ptr %288, align 1
   %290 = extractvalue %complex_4 %289, 0
   %291 = extractvalue %complex_4 %289, 1
   %292 = fsub float %290, 1.000000e+01
   %293 = fsub float %291, 0.000000e+00
   %294 = insertvalue %complex_4 undef, float %292, 0
   %295 = insertvalue %complex_4 %294, float %293, 1
-  store %complex_4 %295, %complex_4* %263, align 1
+  store %complex_4 %295, ptr %263, align 1
   br label %loop.head40
 
 loop.end46:                                       ; preds = %loop.head40
   br i1 false, label %then47, label %ifcont48
 
 then47:                                           ; preds = %loop.end46
-  %296 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %297 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %298 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %297, i32 0, i32 0
-  %299 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %298, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @59, i32 0, i32 0), i8** %299, align 8
-  %300 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %298, i32 0, i32 1
-  store i32 23, i32* %300, align 4
-  %301 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %298, i32 0, i32 2
-  store i32 5, i32* %301, align 4
-  %302 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %298, i32 0, i32 3
-  store i32 23, i32* %302, align 4
-  %303 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %298, i32 0, i32 4
-  store i32 8, i32* %303, align 4
-  %304 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @60, i32 0, i32 0))
-  %305 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %296, i32 0, i32 0
-  %306 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %297, i32 0, i32 0
-  %307 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %305, i32 0, i32 2
-  %308 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %305, i32 0, i32 0
-  store i1 true, i1* %308, align 1
-  %309 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %305, i32 0, i32 1
-  store i8* %304, i8** %309, align 8
-  store { i8*, i32, i32, i32, i32 }* %306, { i8*, i32, i32, i32, i32 }** %307, align 8
-  %310 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %305, i32 0, i32 3
-  store i32 1, i32* %310, align 4
-  %311 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %296, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %311, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %296 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %297 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %298 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %297, i32 0, i32 0
+  %299 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %298, i32 0, i32 0
+  store ptr @59, ptr %299, align 8
+  %300 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %298, i32 0, i32 1
+  store i32 23, ptr %300, align 4
+  %301 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %298, i32 0, i32 2
+  store i32 5, ptr %301, align 4
+  %302 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %298, i32 0, i32 3
+  store i32 23, ptr %302, align 4
+  %303 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %298, i32 0, i32 4
+  store i32 8, ptr %303, align 4
+  %304 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @60)
+  %305 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %296, i32 0, i32 0
+  %306 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %297, i32 0, i32 0
+  %307 = getelementptr { i1, ptr, ptr, i32 }, ptr %305, i32 0, i32 2
+  %308 = getelementptr { i1, ptr, ptr, i32 }, ptr %305, i32 0, i32 0
+  store i1 true, ptr %308, align 1
+  %309 = getelementptr { i1, ptr, ptr, i32 }, ptr %305, i32 0, i32 1
+  store ptr %304, ptr %309, align 8
+  store ptr %306, ptr %307, align 8
+  %310 = getelementptr { i1, ptr, ptr, i32 }, ptr %305, i32 0, i32 3
+  store i32 1, ptr %310, align 4
+  %311 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %296, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %311, i32 1, ptr @61, ptr @58, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %loop.end46
-  %312 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 0
-  %313 = load %complex_4, %complex_4* %312, align 1
+  %312 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 0
+  %313 = load %complex_4, ptr %312, align 1
   %314 = extractvalue %complex_4 %313, 0
   %315 = extractvalue %complex_4 %313, 1
   %316 = fcmp one float %314, 1.000000e+00
@@ -822,7 +823,7 @@ ifcont48:                                         ; preds = %loop.end46
   br i1 %318, label %then49, label %else50
 
 then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @63, ptr @"ERROR STOP", ptr @62)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -834,38 +835,38 @@ ifcont51:                                         ; preds = %else50, %then49
   br i1 false, label %then52, label %ifcont53
 
 then52:                                           ; preds = %ifcont51
-  %319 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %320 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %321 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %320, i32 0, i32 0
-  %322 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %321, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @65, i32 0, i32 0), i8** %322, align 8
-  %323 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %321, i32 0, i32 1
-  store i32 24, i32* %323, align 4
-  %324 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %321, i32 0, i32 2
-  store i32 5, i32* %324, align 4
-  %325 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %321, i32 0, i32 3
-  store i32 24, i32* %325, align 4
-  %326 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %321, i32 0, i32 4
-  store i32 8, i32* %326, align 4
-  %327 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @66, i32 0, i32 0))
-  %328 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %319, i32 0, i32 0
-  %329 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %320, i32 0, i32 0
-  %330 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %328, i32 0, i32 2
-  %331 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %328, i32 0, i32 0
-  store i1 true, i1* %331, align 1
-  %332 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %328, i32 0, i32 1
-  store i8* %327, i8** %332, align 8
-  store { i8*, i32, i32, i32, i32 }* %329, { i8*, i32, i32, i32, i32 }** %330, align 8
-  %333 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %328, i32 0, i32 3
-  store i32 1, i32* %333, align 4
-  %334 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %319, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %334, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %319 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %320 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %321 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %320, i32 0, i32 0
+  %322 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %321, i32 0, i32 0
+  store ptr @65, ptr %322, align 8
+  %323 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %321, i32 0, i32 1
+  store i32 24, ptr %323, align 4
+  %324 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %321, i32 0, i32 2
+  store i32 5, ptr %324, align 4
+  %325 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %321, i32 0, i32 3
+  store i32 24, ptr %325, align 4
+  %326 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %321, i32 0, i32 4
+  store i32 8, ptr %326, align 4
+  %327 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @66)
+  %328 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %319, i32 0, i32 0
+  %329 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %320, i32 0, i32 0
+  %330 = getelementptr { i1, ptr, ptr, i32 }, ptr %328, i32 0, i32 2
+  %331 = getelementptr { i1, ptr, ptr, i32 }, ptr %328, i32 0, i32 0
+  store i1 true, ptr %331, align 1
+  %332 = getelementptr { i1, ptr, ptr, i32 }, ptr %328, i32 0, i32 1
+  store ptr %327, ptr %332, align 8
+  store ptr %329, ptr %330, align 8
+  %333 = getelementptr { i1, ptr, ptr, i32 }, ptr %328, i32 0, i32 3
+  store i32 1, ptr %333, align 4
+  %334 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %319, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %334, i32 1, ptr @67, ptr @64, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont53:                                         ; preds = %ifcont51
-  %335 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 1
-  %336 = load %complex_4, %complex_4* %335, align 1
+  %335 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 1
+  %336 = load %complex_4, ptr %335, align 1
   %337 = extractvalue %complex_4 %336, 0
   %338 = extractvalue %complex_4 %336, 1
   %339 = fcmp one float %337, 2.000000e+00
@@ -874,7 +875,7 @@ ifcont53:                                         ; preds = %ifcont51
   br i1 %341, label %then54, label %else55
 
 then54:                                           ; preds = %ifcont53
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @69, ptr @"ERROR STOP", ptr @68)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -886,38 +887,38 @@ ifcont56:                                         ; preds = %else55, %then54
   br i1 false, label %then57, label %ifcont58
 
 then57:                                           ; preds = %ifcont56
-  %342 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %343 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %344 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %343, i32 0, i32 0
-  %345 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @71, i32 0, i32 0), i8** %345, align 8
-  %346 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 1
-  store i32 25, i32* %346, align 4
-  %347 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 2
-  store i32 5, i32* %347, align 4
-  %348 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 3
-  store i32 25, i32* %348, align 4
-  %349 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 4
-  store i32 8, i32* %349, align 4
-  %350 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @72, i32 0, i32 0))
-  %351 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %342, i32 0, i32 0
-  %352 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %343, i32 0, i32 0
-  %353 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 2
-  %354 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 0
-  store i1 true, i1* %354, align 1
-  %355 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 1
-  store i8* %350, i8** %355, align 8
-  store { i8*, i32, i32, i32, i32 }* %352, { i8*, i32, i32, i32, i32 }** %353, align 8
-  %356 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 3
-  store i32 1, i32* %356, align 4
-  %357 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %342, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %342 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %343 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %344 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %343, i32 0, i32 0
+  %345 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 0
+  store ptr @71, ptr %345, align 8
+  %346 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 1
+  store i32 25, ptr %346, align 4
+  %347 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 2
+  store i32 5, ptr %347, align 4
+  %348 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 3
+  store i32 25, ptr %348, align 4
+  %349 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 4
+  store i32 8, ptr %349, align 4
+  %350 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @72)
+  %351 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %342, i32 0, i32 0
+  %352 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %343, i32 0, i32 0
+  %353 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 2
+  %354 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 0
+  store i1 true, ptr %354, align 1
+  %355 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 1
+  store ptr %350, ptr %355, align 8
+  store ptr %352, ptr %353, align 8
+  %356 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 3
+  store i32 1, ptr %356, align 4
+  %357 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %342, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %357, i32 1, ptr @73, ptr @70, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %358 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 2
-  %359 = load %complex_4, %complex_4* %358, align 1
+  %358 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 2
+  %359 = load %complex_4, ptr %358, align 1
   %360 = extractvalue %complex_4 %359, 0
   %361 = extractvalue %complex_4 %359, 1
   %362 = fcmp one float %360, 3.000000e+00
@@ -926,7 +927,7 @@ ifcont58:                                         ; preds = %ifcont56
   br i1 %364, label %then59, label %else60
 
 then59:                                           ; preds = %ifcont58
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @75, ptr @"ERROR STOP", ptr @74)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -938,107 +939,107 @@ ifcont61:                                         ; preds = %else60, %then59
   br i1 false, label %then62, label %ifcont63
 
 then62:                                           ; preds = %ifcont61
-  %365 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %366 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %367 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %366, i32 0, i32 0
-  %368 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %367, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @77, i32 0, i32 0), i8** %368, align 8
-  %369 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %367, i32 0, i32 1
-  store i32 27, i32* %369, align 4
-  %370 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %367, i32 0, i32 2
-  store i32 1, i32* %370, align 4
-  %371 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %367, i32 0, i32 3
-  store i32 27, i32* %371, align 4
-  %372 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %367, i32 0, i32 4
-  store i32 4, i32* %372, align 4
-  %373 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @78, i32 0, i32 0))
-  %374 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %365, i32 0, i32 0
-  %375 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %366, i32 0, i32 0
-  %376 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %374, i32 0, i32 2
-  %377 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %374, i32 0, i32 0
-  store i1 true, i1* %377, align 1
-  %378 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %374, i32 0, i32 1
-  store i8* %373, i8** %378, align 8
-  store { i8*, i32, i32, i32, i32 }* %375, { i8*, i32, i32, i32, i32 }** %376, align 8
-  %379 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %374, i32 0, i32 3
-  store i32 1, i32* %379, align 4
-  %380 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %365, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %380, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %365 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %366 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %367 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %366, i32 0, i32 0
+  %368 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %367, i32 0, i32 0
+  store ptr @77, ptr %368, align 8
+  %369 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %367, i32 0, i32 1
+  store i32 27, ptr %369, align 4
+  %370 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %367, i32 0, i32 2
+  store i32 1, ptr %370, align 4
+  %371 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %367, i32 0, i32 3
+  store i32 27, ptr %371, align 4
+  %372 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %367, i32 0, i32 4
+  store i32 4, ptr %372, align 4
+  %373 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @78)
+  %374 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %365, i32 0, i32 0
+  %375 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %366, i32 0, i32 0
+  %376 = getelementptr { i1, ptr, ptr, i32 }, ptr %374, i32 0, i32 2
+  %377 = getelementptr { i1, ptr, ptr, i32 }, ptr %374, i32 0, i32 0
+  store i1 true, ptr %377, align 1
+  %378 = getelementptr { i1, ptr, ptr, i32 }, ptr %374, i32 0, i32 1
+  store ptr %373, ptr %378, align 8
+  store ptr %375, ptr %376, align 8
+  %379 = getelementptr { i1, ptr, ptr, i32 }, ptr %374, i32 0, i32 3
+  store i32 1, ptr %379, align 4
+  %380 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %365, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %380, i32 1, ptr @79, ptr @76, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont63:                                         ; preds = %ifcont61
-  %381 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 3
+  %381 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 3
   br i1 false, label %then64, label %ifcont65
 
 then64:                                           ; preds = %ifcont63
-  %382 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %383 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %384 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %383, i32 0, i32 0
-  %385 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %384, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @81, i32 0, i32 0), i8** %385, align 8
-  %386 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %384, i32 0, i32 1
-  store i32 27, i32* %386, align 4
-  %387 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %384, i32 0, i32 2
-  store i32 8, i32* %387, align 4
-  %388 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %384, i32 0, i32 3
-  store i32 27, i32* %388, align 4
-  %389 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %384, i32 0, i32 4
-  store i32 11, i32* %389, align 4
-  %390 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @82, i32 0, i32 0))
-  %391 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %382, i32 0, i32 0
-  %392 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %383, i32 0, i32 0
-  %393 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %391, i32 0, i32 2
-  %394 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %391, i32 0, i32 0
-  store i1 true, i1* %394, align 1
-  %395 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %391, i32 0, i32 1
-  store i8* %390, i8** %395, align 8
-  store { i8*, i32, i32, i32, i32 }* %392, { i8*, i32, i32, i32, i32 }** %393, align 8
-  %396 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %391, i32 0, i32 3
-  store i32 1, i32* %396, align 4
-  %397 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %382, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %397, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %382 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %383 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %384 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %383, i32 0, i32 0
+  %385 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %384, i32 0, i32 0
+  store ptr @81, ptr %385, align 8
+  %386 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %384, i32 0, i32 1
+  store i32 27, ptr %386, align 4
+  %387 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %384, i32 0, i32 2
+  store i32 8, ptr %387, align 4
+  %388 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %384, i32 0, i32 3
+  store i32 27, ptr %388, align 4
+  %389 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %384, i32 0, i32 4
+  store i32 11, ptr %389, align 4
+  %390 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @82)
+  %391 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %382, i32 0, i32 0
+  %392 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %383, i32 0, i32 0
+  %393 = getelementptr { i1, ptr, ptr, i32 }, ptr %391, i32 0, i32 2
+  %394 = getelementptr { i1, ptr, ptr, i32 }, ptr %391, i32 0, i32 0
+  store i1 true, ptr %394, align 1
+  %395 = getelementptr { i1, ptr, ptr, i32 }, ptr %391, i32 0, i32 1
+  store ptr %390, ptr %395, align 8
+  store ptr %392, ptr %393, align 8
+  %396 = getelementptr { i1, ptr, ptr, i32 }, ptr %391, i32 0, i32 3
+  store i32 1, ptr %396, align 4
+  %397 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %382, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %397, i32 1, ptr @83, ptr @80, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont65:                                         ; preds = %ifcont63
-  %398 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 0
-  %399 = load %complex_4, %complex_4* %398, align 1
+  %398 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 0
+  %399 = load %complex_4, ptr %398, align 1
   br i1 false, label %then66, label %ifcont67
 
 then66:                                           ; preds = %ifcont65
-  %400 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %401 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %402 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %401, i32 0, i32 0
-  %403 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %402, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @85, i32 0, i32 0), i8** %403, align 8
-  %404 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %402, i32 0, i32 1
-  store i32 27, i32* %404, align 4
-  %405 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %402, i32 0, i32 2
-  store i32 13, i32* %405, align 4
-  %406 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %402, i32 0, i32 3
-  store i32 27, i32* %406, align 4
-  %407 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %402, i32 0, i32 4
-  store i32 16, i32* %407, align 4
-  %408 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @86, i32 0, i32 0))
-  %409 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %400, i32 0, i32 0
-  %410 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %401, i32 0, i32 0
-  %411 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %409, i32 0, i32 2
-  %412 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %409, i32 0, i32 0
-  store i1 true, i1* %412, align 1
-  %413 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %409, i32 0, i32 1
-  store i8* %408, i8** %413, align 8
-  store { i8*, i32, i32, i32, i32 }* %410, { i8*, i32, i32, i32, i32 }** %411, align 8
-  %414 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %409, i32 0, i32 3
-  store i32 1, i32* %414, align 4
-  %415 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %400, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %400 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %401 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %402 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %401, i32 0, i32 0
+  %403 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %402, i32 0, i32 0
+  store ptr @85, ptr %403, align 8
+  %404 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %402, i32 0, i32 1
+  store i32 27, ptr %404, align 4
+  %405 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %402, i32 0, i32 2
+  store i32 13, ptr %405, align 4
+  %406 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %402, i32 0, i32 3
+  store i32 27, ptr %406, align 4
+  %407 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %402, i32 0, i32 4
+  store i32 16, ptr %407, align 4
+  %408 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @86)
+  %409 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %400, i32 0, i32 0
+  %410 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %401, i32 0, i32 0
+  %411 = getelementptr { i1, ptr, ptr, i32 }, ptr %409, i32 0, i32 2
+  %412 = getelementptr { i1, ptr, ptr, i32 }, ptr %409, i32 0, i32 0
+  store i1 true, ptr %412, align 1
+  %413 = getelementptr { i1, ptr, ptr, i32 }, ptr %409, i32 0, i32 1
+  store ptr %408, ptr %413, align 8
+  store ptr %410, ptr %411, align 8
+  %414 = getelementptr { i1, ptr, ptr, i32 }, ptr %409, i32 0, i32 3
+  store i32 1, ptr %414, align 4
+  %415 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %400, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %415, i32 1, ptr @87, ptr @84, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont67:                                         ; preds = %ifcont65
-  %416 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 1
-  %417 = load %complex_4, %complex_4* %416, align 1
+  %416 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 1
+  %417 = load %complex_4, ptr %416, align 1
   %418 = extractvalue %complex_4 %399, 0
   %419 = extractvalue %complex_4 %399, 1
   %420 = extractvalue %complex_4 %417, 0
@@ -1050,38 +1051,38 @@ ifcont67:                                         ; preds = %ifcont65
   br i1 false, label %then68, label %ifcont69
 
 then68:                                           ; preds = %ifcont67
-  %426 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %427 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %428 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %427, i32 0, i32 0
-  %429 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %428, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @89, i32 0, i32 0), i8** %429, align 8
-  %430 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %428, i32 0, i32 1
-  store i32 27, i32* %430, align 4
-  %431 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %428, i32 0, i32 2
-  store i32 18, i32* %431, align 4
-  %432 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %428, i32 0, i32 3
-  store i32 27, i32* %432, align 4
-  %433 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %428, i32 0, i32 4
-  store i32 21, i32* %433, align 4
-  %434 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @90, i32 0, i32 0))
-  %435 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %426, i32 0, i32 0
-  %436 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %427, i32 0, i32 0
-  %437 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %435, i32 0, i32 2
-  %438 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %435, i32 0, i32 0
-  store i1 true, i1* %438, align 1
-  %439 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %435, i32 0, i32 1
-  store i8* %434, i8** %439, align 8
-  store { i8*, i32, i32, i32, i32 }* %436, { i8*, i32, i32, i32, i32 }** %437, align 8
-  %440 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %435, i32 0, i32 3
-  store i32 1, i32* %440, align 4
-  %441 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %426, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %441, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %426 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %427 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %428 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %427, i32 0, i32 0
+  %429 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %428, i32 0, i32 0
+  store ptr @89, ptr %429, align 8
+  %430 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %428, i32 0, i32 1
+  store i32 27, ptr %430, align 4
+  %431 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %428, i32 0, i32 2
+  store i32 18, ptr %431, align 4
+  %432 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %428, i32 0, i32 3
+  store i32 27, ptr %432, align 4
+  %433 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %428, i32 0, i32 4
+  store i32 21, ptr %433, align 4
+  %434 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @90)
+  %435 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %426, i32 0, i32 0
+  %436 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %427, i32 0, i32 0
+  %437 = getelementptr { i1, ptr, ptr, i32 }, ptr %435, i32 0, i32 2
+  %438 = getelementptr { i1, ptr, ptr, i32 }, ptr %435, i32 0, i32 0
+  store i1 true, ptr %438, align 1
+  %439 = getelementptr { i1, ptr, ptr, i32 }, ptr %435, i32 0, i32 1
+  store ptr %434, ptr %439, align 8
+  store ptr %436, ptr %437, align 8
+  %440 = getelementptr { i1, ptr, ptr, i32 }, ptr %435, i32 0, i32 3
+  store i32 1, ptr %440, align 4
+  %441 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %426, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %441, i32 1, ptr @91, ptr @88, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont69:                                         ; preds = %ifcont67
-  %442 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 2
-  %443 = load %complex_4, %complex_4* %442, align 1
+  %442 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 2
+  %443 = load %complex_4, ptr %442, align 1
   %444 = extractvalue %complex_4 %425, 0
   %445 = extractvalue %complex_4 %425, 1
   %446 = extractvalue %complex_4 %443, 0
@@ -1093,38 +1094,38 @@ ifcont69:                                         ; preds = %ifcont67
   br i1 false, label %then70, label %ifcont71
 
 then70:                                           ; preds = %ifcont69
-  %452 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %453 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %454 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %453, i32 0, i32 0
-  %455 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %454, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @93, i32 0, i32 0), i8** %455, align 8
-  %456 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %454, i32 0, i32 1
-  store i32 27, i32* %456, align 4
-  %457 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %454, i32 0, i32 2
-  store i32 23, i32* %457, align 4
-  %458 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %454, i32 0, i32 3
-  store i32 27, i32* %458, align 4
-  %459 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %454, i32 0, i32 4
-  store i32 26, i32* %459, align 4
-  %460 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %461 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %452, i32 0, i32 0
-  %462 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %453, i32 0, i32 0
-  %463 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %461, i32 0, i32 2
-  %464 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %461, i32 0, i32 0
-  store i1 true, i1* %464, align 1
-  %465 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %461, i32 0, i32 1
-  store i8* %460, i8** %465, align 8
-  store { i8*, i32, i32, i32, i32 }* %462, { i8*, i32, i32, i32, i32 }** %463, align 8
-  %466 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %461, i32 0, i32 3
-  store i32 1, i32* %466, align 4
-  %467 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %452, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %467, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %452 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %453 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %454 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %453, i32 0, i32 0
+  %455 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %454, i32 0, i32 0
+  store ptr @93, ptr %455, align 8
+  %456 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %454, i32 0, i32 1
+  store i32 27, ptr %456, align 4
+  %457 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %454, i32 0, i32 2
+  store i32 23, ptr %457, align 4
+  %458 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %454, i32 0, i32 3
+  store i32 27, ptr %458, align 4
+  %459 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %454, i32 0, i32 4
+  store i32 26, ptr %459, align 4
+  %460 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @94)
+  %461 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %452, i32 0, i32 0
+  %462 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %453, i32 0, i32 0
+  %463 = getelementptr { i1, ptr, ptr, i32 }, ptr %461, i32 0, i32 2
+  %464 = getelementptr { i1, ptr, ptr, i32 }, ptr %461, i32 0, i32 0
+  store i1 true, ptr %464, align 1
+  %465 = getelementptr { i1, ptr, ptr, i32 }, ptr %461, i32 0, i32 1
+  store ptr %460, ptr %465, align 8
+  store ptr %462, ptr %463, align 8
+  %466 = getelementptr { i1, ptr, ptr, i32 }, ptr %461, i32 0, i32 3
+  store i32 1, ptr %466, align 4
+  %467 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %452, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %467, i32 1, ptr @95, ptr @92, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont71:                                         ; preds = %ifcont69
-  %468 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 0
-  %469 = load %complex_4, %complex_4* %468, align 1
+  %468 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 0
+  %469 = load %complex_4, ptr %468, align 1
   %470 = extractvalue %complex_4 %451, 0
   %471 = extractvalue %complex_4 %451, 1
   %472 = extractvalue %complex_4 %469, 0
@@ -1133,42 +1134,42 @@ ifcont71:                                         ; preds = %ifcont69
   %475 = fadd float %471, %473
   %476 = insertvalue %complex_4 undef, float %474, 0
   %477 = insertvalue %complex_4 %476, float %475, 1
-  store %complex_4 %477, %complex_4* %381, align 1
+  store %complex_4 %477, ptr %381, align 1
   br i1 false, label %then72, label %ifcont73
 
 then72:                                           ; preds = %ifcont71
-  %478 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %479 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %480 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %479, i32 0, i32 0
-  %481 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %480, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @97, i32 0, i32 0), i8** %481, align 8
-  %482 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %480, i32 0, i32 1
-  store i32 28, i32* %482, align 4
-  %483 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %480, i32 0, i32 2
-  store i32 5, i32* %483, align 4
-  %484 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %480, i32 0, i32 3
-  store i32 28, i32* %484, align 4
-  %485 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %480, i32 0, i32 4
-  store i32 8, i32* %485, align 4
-  %486 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %487 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %478, i32 0, i32 0
-  %488 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %479, i32 0, i32 0
-  %489 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %487, i32 0, i32 2
-  %490 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %487, i32 0, i32 0
-  store i1 true, i1* %490, align 1
-  %491 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %487, i32 0, i32 1
-  store i8* %486, i8** %491, align 8
-  store { i8*, i32, i32, i32, i32 }* %488, { i8*, i32, i32, i32, i32 }** %489, align 8
-  %492 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %487, i32 0, i32 3
-  store i32 1, i32* %492, align 4
-  %493 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %478, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %493, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %478 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %479 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %480 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %479, i32 0, i32 0
+  %481 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %480, i32 0, i32 0
+  store ptr @97, ptr %481, align 8
+  %482 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %480, i32 0, i32 1
+  store i32 28, ptr %482, align 4
+  %483 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %480, i32 0, i32 2
+  store i32 5, ptr %483, align 4
+  %484 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %480, i32 0, i32 3
+  store i32 28, ptr %484, align 4
+  %485 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %480, i32 0, i32 4
+  store i32 8, ptr %485, align 4
+  %486 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @98)
+  %487 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %478, i32 0, i32 0
+  %488 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %479, i32 0, i32 0
+  %489 = getelementptr { i1, ptr, ptr, i32 }, ptr %487, i32 0, i32 2
+  %490 = getelementptr { i1, ptr, ptr, i32 }, ptr %487, i32 0, i32 0
+  store i1 true, ptr %490, align 1
+  %491 = getelementptr { i1, ptr, ptr, i32 }, ptr %487, i32 0, i32 1
+  store ptr %486, ptr %491, align 8
+  store ptr %488, ptr %489, align 8
+  %492 = getelementptr { i1, ptr, ptr, i32 }, ptr %487, i32 0, i32 3
+  store i32 1, ptr %492, align 4
+  %493 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %478, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %493, i32 1, ptr @99, ptr @96, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont73:                                         ; preds = %ifcont71
-  %494 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 3
-  %495 = load %complex_4, %complex_4* %494, align 1
+  %494 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 3
+  %495 = load %complex_4, ptr %494, align 1
   %496 = extractvalue %complex_4 %495, 0
   %497 = extractvalue %complex_4 %495, 1
   %498 = fcmp one float %496, 1.700000e+01
@@ -1177,7 +1178,7 @@ ifcont73:                                         ; preds = %ifcont71
   br i1 %500, label %then74, label %else75
 
 then74:                                           ; preds = %ifcont73
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @101, ptr @"ERROR STOP", ptr @100)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1189,108 +1190,108 @@ ifcont76:                                         ; preds = %else75, %then74
   br i1 false, label %then77, label %ifcont78
 
 then77:                                           ; preds = %ifcont76
-  %501 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %502 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %503 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %502, i32 0, i32 0
-  %504 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %503, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @103, i32 0, i32 0), i8** %504, align 8
-  %505 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %503, i32 0, i32 1
-  store i32 30, i32* %505, align 4
-  %506 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %503, i32 0, i32 2
-  store i32 1, i32* %506, align 4
-  %507 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %503, i32 0, i32 3
-  store i32 30, i32* %507, align 4
-  %508 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %503, i32 0, i32 4
-  store i32 4, i32* %508, align 4
-  %509 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @104, i32 0, i32 0))
-  %510 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %501, i32 0, i32 0
-  %511 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %502, i32 0, i32 0
-  %512 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %510, i32 0, i32 2
-  %513 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %510, i32 0, i32 0
-  store i1 true, i1* %513, align 1
-  %514 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %510, i32 0, i32 1
-  store i8* %509, i8** %514, align 8
-  store { i8*, i32, i32, i32, i32 }* %511, { i8*, i32, i32, i32, i32 }** %512, align 8
-  %515 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %510, i32 0, i32 3
-  store i32 1, i32* %515, align 4
-  %516 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %501, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %516, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %501 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %502 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %503 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %502, i32 0, i32 0
+  %504 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %503, i32 0, i32 0
+  store ptr @103, ptr %504, align 8
+  %505 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %503, i32 0, i32 1
+  store i32 30, ptr %505, align 4
+  %506 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %503, i32 0, i32 2
+  store i32 1, ptr %506, align 4
+  %507 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %503, i32 0, i32 3
+  store i32 30, ptr %507, align 4
+  %508 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %503, i32 0, i32 4
+  store i32 4, ptr %508, align 4
+  %509 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @104)
+  %510 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %501, i32 0, i32 0
+  %511 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %502, i32 0, i32 0
+  %512 = getelementptr { i1, ptr, ptr, i32 }, ptr %510, i32 0, i32 2
+  %513 = getelementptr { i1, ptr, ptr, i32 }, ptr %510, i32 0, i32 0
+  store i1 true, ptr %513, align 1
+  %514 = getelementptr { i1, ptr, ptr, i32 }, ptr %510, i32 0, i32 1
+  store ptr %509, ptr %514, align 8
+  store ptr %511, ptr %512, align 8
+  %515 = getelementptr { i1, ptr, ptr, i32 }, ptr %510, i32 0, i32 3
+  store i32 1, ptr %515, align 4
+  %516 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %501, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %516, i32 1, ptr @105, ptr @102, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont78:                                         ; preds = %ifcont76
-  %517 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 3
+  %517 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 3
   br i1 false, label %then79, label %ifcont80
 
 then79:                                           ; preds = %ifcont78
-  %518 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %519 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %520 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %519, i32 0, i32 0
-  %521 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @107, i32 0, i32 0), i8** %521, align 8
-  %522 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 1
-  store i32 30, i32* %522, align 4
-  %523 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 2
-  store i32 8, i32* %523, align 4
-  %524 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 3
-  store i32 30, i32* %524, align 4
-  %525 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 4
-  store i32 11, i32* %525, align 4
-  %526 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @108, i32 0, i32 0))
-  %527 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %518, i32 0, i32 0
-  %528 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %519, i32 0, i32 0
-  %529 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 2
-  %530 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 0
-  store i1 true, i1* %530, align 1
-  %531 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 1
-  store i8* %526, i8** %531, align 8
-  store { i8*, i32, i32, i32, i32 }* %528, { i8*, i32, i32, i32, i32 }** %529, align 8
-  %532 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 3
-  store i32 1, i32* %532, align 4
-  %533 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %518, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %533, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %518 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %519 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %520 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %519, i32 0, i32 0
+  %521 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 0
+  store ptr @107, ptr %521, align 8
+  %522 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 1
+  store i32 30, ptr %522, align 4
+  %523 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 2
+  store i32 8, ptr %523, align 4
+  %524 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 3
+  store i32 30, ptr %524, align 4
+  %525 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 4
+  store i32 11, ptr %525, align 4
+  %526 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @108)
+  %527 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %518, i32 0, i32 0
+  %528 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %519, i32 0, i32 0
+  %529 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 2
+  %530 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 0
+  store i1 true, ptr %530, align 1
+  %531 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 1
+  store ptr %526, ptr %531, align 8
+  store ptr %528, ptr %529, align 8
+  %532 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 3
+  store i32 1, ptr %532, align 4
+  %533 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %518, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %533, i32 1, ptr @109, ptr @106, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont80:                                         ; preds = %ifcont78
-  %534 = getelementptr [3 x %complex_4], [3 x %complex_4]* %a, i32 0, i64 0
-  %535 = load %complex_4, %complex_4* %534, align 1
-  store %complex_4 %535, %complex_4* %517, align 1
+  %534 = getelementptr [3 x %complex_4], ptr %a, i32 0, i64 0
+  %535 = load %complex_4, ptr %534, align 1
+  store %complex_4 %535, ptr %517, align 1
   br i1 false, label %then81, label %ifcont82
 
 then81:                                           ; preds = %ifcont80
-  %536 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %537 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %538 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %537, i32 0, i32 0
-  %539 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %538, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @111, i32 0, i32 0), i8** %539, align 8
-  %540 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %538, i32 0, i32 1
-  store i32 31, i32* %540, align 4
-  %541 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %538, i32 0, i32 2
-  store i32 5, i32* %541, align 4
-  %542 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %538, i32 0, i32 3
-  store i32 31, i32* %542, align 4
-  %543 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %538, i32 0, i32 4
-  store i32 8, i32* %543, align 4
-  %544 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @112, i32 0, i32 0))
-  %545 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %536, i32 0, i32 0
-  %546 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %537, i32 0, i32 0
-  %547 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %545, i32 0, i32 2
-  %548 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %545, i32 0, i32 0
-  store i1 true, i1* %548, align 1
-  %549 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %545, i32 0, i32 1
-  store i8* %544, i8** %549, align 8
-  store { i8*, i32, i32, i32, i32 }* %546, { i8*, i32, i32, i32, i32 }** %547, align 8
-  %550 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %545, i32 0, i32 3
-  store i32 1, i32* %550, align 4
-  %551 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %536, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %551, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @113, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %536 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %537 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %538 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %537, i32 0, i32 0
+  %539 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %538, i32 0, i32 0
+  store ptr @111, ptr %539, align 8
+  %540 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %538, i32 0, i32 1
+  store i32 31, ptr %540, align 4
+  %541 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %538, i32 0, i32 2
+  store i32 5, ptr %541, align 4
+  %542 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %538, i32 0, i32 3
+  store i32 31, ptr %542, align 4
+  %543 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %538, i32 0, i32 4
+  store i32 8, ptr %543, align 4
+  %544 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @112)
+  %545 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %536, i32 0, i32 0
+  %546 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %537, i32 0, i32 0
+  %547 = getelementptr { i1, ptr, ptr, i32 }, ptr %545, i32 0, i32 2
+  %548 = getelementptr { i1, ptr, ptr, i32 }, ptr %545, i32 0, i32 0
+  store i1 true, ptr %548, align 1
+  %549 = getelementptr { i1, ptr, ptr, i32 }, ptr %545, i32 0, i32 1
+  store ptr %544, ptr %549, align 8
+  store ptr %546, ptr %547, align 8
+  %550 = getelementptr { i1, ptr, ptr, i32 }, ptr %545, i32 0, i32 3
+  store i32 1, ptr %550, align 4
+  %551 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %536, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %551, i32 1, ptr @113, ptr @110, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont82:                                         ; preds = %ifcont80
-  %552 = getelementptr [4 x %complex_4], [4 x %complex_4]* %b, i32 0, i64 3
-  %553 = load %complex_4, %complex_4* %552, align 1
+  %552 = getelementptr [4 x %complex_4], ptr %b, i32 0, i64 3
+  %553 = load %complex_4, ptr %552, align 1
   %554 = extractvalue %complex_4 %553, 0
   %555 = extractvalue %complex_4 %553, 1
   %556 = fcmp one float %554, 1.100000e+01
@@ -1299,7 +1300,7 @@ ifcont82:                                         ; preds = %ifcont80
   br i1 %558, label %then83, label %else84
 
 then83:                                           ; preds = %ifcont82
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @115, ptr @"ERROR STOP", ptr @114)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1308,34 +1309,34 @@ else84:                                           ; preds = %ifcont82
   br label %ifcont85
 
 ifcont85:                                         ; preds = %else84, %then83
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head86
 
 loop.head86:                                      ; preds = %loop.end94, %ifcont85
-  %559 = load i32, i32* %i, align 4
+  %559 = load i32, ptr %i, align 4
   %560 = add i32 %559, 1
   %561 = icmp sle i32 %560, 2
   br i1 %561, label %loop.body87, label %loop.end95
 
 loop.body87:                                      ; preds = %loop.head86
-  %562 = load i32, i32* %i, align 4
+  %562 = load i32, ptr %i, align 4
   %563 = add i32 %562, 1
-  store i32 %563, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %563, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head88
 
 loop.head88:                                      ; preds = %ifcont93, %loop.body87
-  %564 = load i32, i32* %j, align 4
+  %564 = load i32, ptr %j, align 4
   %565 = add i32 %564, 1
   %566 = icmp sle i32 %565, 2
   br i1 %566, label %loop.body89, label %loop.end94
 
 loop.body89:                                      ; preds = %loop.head88
-  %567 = load i32, i32* %j, align 4
+  %567 = load i32, ptr %j, align 4
   %568 = add i32 %567, 1
-  store i32 %568, i32* %j, align 4
-  %569 = load i32, i32* %i, align 4
-  %570 = load i32, i32* %j, align 4
+  store i32 %568, ptr %j, align 4
+  %569 = load i32, ptr %i, align 4
+  %570 = load i32, ptr %j, align 4
   %571 = sext i32 %569 to i64
   %572 = sub i64 %571, 1
   %573 = mul i64 1, %572
@@ -1346,32 +1347,32 @@ loop.body89:                                      ; preds = %loop.head88
   br i1 %577, label %then90, label %ifcont91
 
 then90:                                           ; preds = %loop.body89
-  %578 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %579 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %580 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %579, i32 0, i32 0
-  %581 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %580, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @117, i32 0, i32 0), i8** %581, align 8
-  %582 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %580, i32 0, i32 1
-  store i32 35, i32* %582, align 4
-  %583 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %580, i32 0, i32 2
-  store i32 9, i32* %583, align 4
-  %584 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %580, i32 0, i32 3
-  store i32 35, i32* %584, align 4
-  %585 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %580, i32 0, i32 4
-  store i32 15, i32* %585, align 4
-  %586 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @118, i32 0, i32 0))
-  %587 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %578, i32 0, i32 0
-  %588 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %579, i32 0, i32 0
-  %589 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %587, i32 0, i32 2
-  %590 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %587, i32 0, i32 0
-  store i1 true, i1* %590, align 1
-  %591 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %587, i32 0, i32 1
-  store i8* %586, i8** %591, align 8
-  store { i8*, i32, i32, i32, i32 }* %588, { i8*, i32, i32, i32, i32 }** %589, align 8
-  %592 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %587, i32 0, i32 3
-  store i32 1, i32* %592, align 4
-  %593 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %578, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %593, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @119, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @116, i32 0, i32 0), i64 %571, i32 1, i64 1, i64 2)
+  %578 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %579 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %580 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %579, i32 0, i32 0
+  %581 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %580, i32 0, i32 0
+  store ptr @117, ptr %581, align 8
+  %582 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %580, i32 0, i32 1
+  store i32 35, ptr %582, align 4
+  %583 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %580, i32 0, i32 2
+  store i32 9, ptr %583, align 4
+  %584 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %580, i32 0, i32 3
+  store i32 35, ptr %584, align 4
+  %585 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %580, i32 0, i32 4
+  store i32 15, ptr %585, align 4
+  %586 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @118)
+  %587 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %578, i32 0, i32 0
+  %588 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %579, i32 0, i32 0
+  %589 = getelementptr { i1, ptr, ptr, i32 }, ptr %587, i32 0, i32 2
+  %590 = getelementptr { i1, ptr, ptr, i32 }, ptr %587, i32 0, i32 0
+  store i1 true, ptr %590, align 1
+  %591 = getelementptr { i1, ptr, ptr, i32 }, ptr %587, i32 0, i32 1
+  store ptr %586, ptr %591, align 8
+  store ptr %588, ptr %589, align 8
+  %592 = getelementptr { i1, ptr, ptr, i32 }, ptr %587, i32 0, i32 3
+  store i32 1, ptr %592, align 4
+  %593 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %578, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %593, i32 1, ptr @119, ptr @116, i64 %571, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1386,45 +1387,45 @@ ifcont91:                                         ; preds = %loop.body89
   br i1 %600, label %then92, label %ifcont93
 
 then92:                                           ; preds = %ifcont91
-  %601 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %602 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %603 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %602, i32 0, i32 0
-  %604 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %603, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @121, i32 0, i32 0), i8** %604, align 8
-  %605 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %603, i32 0, i32 1
-  store i32 35, i32* %605, align 4
-  %606 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %603, i32 0, i32 2
-  store i32 9, i32* %606, align 4
-  %607 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %603, i32 0, i32 3
-  store i32 35, i32* %607, align 4
-  %608 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %603, i32 0, i32 4
-  store i32 15, i32* %608, align 4
-  %609 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @122, i32 0, i32 0))
-  %610 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %601, i32 0, i32 0
-  %611 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %602, i32 0, i32 0
-  %612 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %610, i32 0, i32 2
-  %613 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %610, i32 0, i32 0
-  store i1 true, i1* %613, align 1
-  %614 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %610, i32 0, i32 1
-  store i8* %609, i8** %614, align 8
-  store { i8*, i32, i32, i32, i32 }* %611, { i8*, i32, i32, i32, i32 }** %612, align 8
-  %615 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %610, i32 0, i32 3
-  store i32 1, i32* %615, align 4
-  %616 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %601, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %616, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @123, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @120, i32 0, i32 0), i64 %594, i32 2, i64 1, i64 2)
+  %601 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %602 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %603 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %602, i32 0, i32 0
+  %604 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %603, i32 0, i32 0
+  store ptr @121, ptr %604, align 8
+  %605 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %603, i32 0, i32 1
+  store i32 35, ptr %605, align 4
+  %606 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %603, i32 0, i32 2
+  store i32 9, ptr %606, align 4
+  %607 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %603, i32 0, i32 3
+  store i32 35, ptr %607, align 4
+  %608 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %603, i32 0, i32 4
+  store i32 15, ptr %608, align 4
+  %609 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @122)
+  %610 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %601, i32 0, i32 0
+  %611 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %602, i32 0, i32 0
+  %612 = getelementptr { i1, ptr, ptr, i32 }, ptr %610, i32 0, i32 2
+  %613 = getelementptr { i1, ptr, ptr, i32 }, ptr %610, i32 0, i32 0
+  store i1 true, ptr %613, align 1
+  %614 = getelementptr { i1, ptr, ptr, i32 }, ptr %610, i32 0, i32 1
+  store ptr %609, ptr %614, align 8
+  store ptr %611, ptr %612, align 8
+  %615 = getelementptr { i1, ptr, ptr, i32 }, ptr %610, i32 0, i32 3
+  store i32 1, ptr %615, align 4
+  %616 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %601, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %616, i32 1, ptr @123, ptr @120, i64 %594, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont93:                                         ; preds = %ifcont91
-  %617 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i64 %597
-  %618 = load i32, i32* %i, align 4
-  %619 = load i32, i32* %j, align 4
+  %617 = getelementptr [4 x %complex_4], ptr %c, i32 0, i64 %597
+  %618 = load i32, ptr %i, align 4
+  %619 = load i32, ptr %j, align 4
   %620 = add i32 %618, %619
   %621 = add i32 %620, 10
   %622 = sitofp i32 %621 to float
   %623 = insertvalue %complex_4 undef, float %622, 0
   %624 = insertvalue %complex_4 %623, float 0.000000e+00, 1
-  store %complex_4 %624, %complex_4* %617, align 1
+  store %complex_4 %624, ptr %617, align 1
   br label %loop.head88
 
 loop.end94:                                       ; preds = %loop.head88
@@ -1434,32 +1435,32 @@ loop.end95:                                       ; preds = %loop.head86
   br i1 false, label %then96, label %ifcont97
 
 then96:                                           ; preds = %loop.end95
-  %625 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %626 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %627 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %626, i32 0, i32 0
-  %628 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @125, i32 0, i32 0), i8** %628, align 8
-  %629 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 1
-  store i32 38, i32* %629, align 4
-  %630 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 2
-  store i32 5, i32* %630, align 4
-  %631 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 3
-  store i32 38, i32* %631, align 4
-  %632 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 4
-  store i32 11, i32* %632, align 4
-  %633 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @126, i32 0, i32 0))
-  %634 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %625, i32 0, i32 0
-  %635 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %626, i32 0, i32 0
-  %636 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 2
-  %637 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 0
-  store i1 true, i1* %637, align 1
-  %638 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 1
-  store i8* %633, i8** %638, align 8
-  store { i8*, i32, i32, i32, i32 }* %635, { i8*, i32, i32, i32, i32 }** %636, align 8
-  %639 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 3
-  store i32 1, i32* %639, align 4
-  %640 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %625, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @127, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @124, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %625 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %626 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %627 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %626, i32 0, i32 0
+  %628 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 0
+  store ptr @125, ptr %628, align 8
+  %629 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 1
+  store i32 38, ptr %629, align 4
+  %630 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 2
+  store i32 5, ptr %630, align 4
+  %631 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 3
+  store i32 38, ptr %631, align 4
+  %632 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 4
+  store i32 11, ptr %632, align 4
+  %633 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @126)
+  %634 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %625, i32 0, i32 0
+  %635 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %626, i32 0, i32 0
+  %636 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 2
+  %637 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 0
+  store i1 true, ptr %637, align 1
+  %638 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 1
+  store ptr %633, ptr %638, align 8
+  store ptr %635, ptr %636, align 8
+  %639 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 3
+  store i32 1, ptr %639, align 4
+  %640 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %625, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %640, i32 1, ptr @127, ptr @124, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1467,38 +1468,38 @@ ifcont97:                                         ; preds = %loop.end95
   br i1 false, label %then98, label %ifcont99
 
 then98:                                           ; preds = %ifcont97
-  %641 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %642 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %643 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %642, i32 0, i32 0
-  %644 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %643, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @129, i32 0, i32 0), i8** %644, align 8
-  %645 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %643, i32 0, i32 1
-  store i32 38, i32* %645, align 4
-  %646 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %643, i32 0, i32 2
-  store i32 5, i32* %646, align 4
-  %647 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %643, i32 0, i32 3
-  store i32 38, i32* %647, align 4
-  %648 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %643, i32 0, i32 4
-  store i32 11, i32* %648, align 4
-  %649 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @130, i32 0, i32 0))
-  %650 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %641, i32 0, i32 0
-  %651 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %642, i32 0, i32 0
-  %652 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %650, i32 0, i32 2
-  %653 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %650, i32 0, i32 0
-  store i1 true, i1* %653, align 1
-  %654 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %650, i32 0, i32 1
-  store i8* %649, i8** %654, align 8
-  store { i8*, i32, i32, i32, i32 }* %651, { i8*, i32, i32, i32, i32 }** %652, align 8
-  %655 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %650, i32 0, i32 3
-  store i32 1, i32* %655, align 4
-  %656 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %641, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %656, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @131, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @128, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %641 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %642 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %643 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %642, i32 0, i32 0
+  %644 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %643, i32 0, i32 0
+  store ptr @129, ptr %644, align 8
+  %645 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %643, i32 0, i32 1
+  store i32 38, ptr %645, align 4
+  %646 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %643, i32 0, i32 2
+  store i32 5, ptr %646, align 4
+  %647 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %643, i32 0, i32 3
+  store i32 38, ptr %647, align 4
+  %648 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %643, i32 0, i32 4
+  store i32 11, ptr %648, align 4
+  %649 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @130)
+  %650 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %641, i32 0, i32 0
+  %651 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %642, i32 0, i32 0
+  %652 = getelementptr { i1, ptr, ptr, i32 }, ptr %650, i32 0, i32 2
+  %653 = getelementptr { i1, ptr, ptr, i32 }, ptr %650, i32 0, i32 0
+  store i1 true, ptr %653, align 1
+  %654 = getelementptr { i1, ptr, ptr, i32 }, ptr %650, i32 0, i32 1
+  store ptr %649, ptr %654, align 8
+  store ptr %651, ptr %652, align 8
+  %655 = getelementptr { i1, ptr, ptr, i32 }, ptr %650, i32 0, i32 3
+  store i32 1, ptr %655, align 4
+  %656 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %641, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %656, i32 1, ptr @131, ptr @128, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont99:                                         ; preds = %ifcont97
-  %657 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i64 0
-  %658 = load %complex_4, %complex_4* %657, align 1
+  %657 = getelementptr [4 x %complex_4], ptr %c, i32 0, i64 0
+  %658 = load %complex_4, ptr %657, align 1
   %659 = extractvalue %complex_4 %658, 0
   %660 = extractvalue %complex_4 %658, 1
   %661 = fcmp one float %659, 1.200000e+01
@@ -1507,7 +1508,7 @@ ifcont99:                                         ; preds = %ifcont97
   br i1 %663, label %then100, label %else101
 
 then100:                                          ; preds = %ifcont99
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @133, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @133, ptr @"ERROR STOP", ptr @132)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont102
@@ -1519,32 +1520,32 @@ ifcont102:                                        ; preds = %else101, %then100
   br i1 false, label %then103, label %ifcont104
 
 then103:                                          ; preds = %ifcont102
-  %664 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %665 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %666 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %665, i32 0, i32 0
-  %667 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %666, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @135, i32 0, i32 0), i8** %667, align 8
-  %668 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %666, i32 0, i32 1
-  store i32 39, i32* %668, align 4
-  %669 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %666, i32 0, i32 2
-  store i32 5, i32* %669, align 4
-  %670 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %666, i32 0, i32 3
-  store i32 39, i32* %670, align 4
-  %671 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %666, i32 0, i32 4
-  store i32 11, i32* %671, align 4
-  %672 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @136, i32 0, i32 0))
-  %673 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %664, i32 0, i32 0
-  %674 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %665, i32 0, i32 0
-  %675 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %673, i32 0, i32 2
-  %676 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %673, i32 0, i32 0
-  store i1 true, i1* %676, align 1
-  %677 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %673, i32 0, i32 1
-  store i8* %672, i8** %677, align 8
-  store { i8*, i32, i32, i32, i32 }* %674, { i8*, i32, i32, i32, i32 }** %675, align 8
-  %678 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %673, i32 0, i32 3
-  store i32 1, i32* %678, align 4
-  %679 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %664, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %679, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @137, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @134, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %664 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %665 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %666 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %665, i32 0, i32 0
+  %667 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %666, i32 0, i32 0
+  store ptr @135, ptr %667, align 8
+  %668 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %666, i32 0, i32 1
+  store i32 39, ptr %668, align 4
+  %669 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %666, i32 0, i32 2
+  store i32 5, ptr %669, align 4
+  %670 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %666, i32 0, i32 3
+  store i32 39, ptr %670, align 4
+  %671 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %666, i32 0, i32 4
+  store i32 11, ptr %671, align 4
+  %672 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @136)
+  %673 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %664, i32 0, i32 0
+  %674 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %665, i32 0, i32 0
+  %675 = getelementptr { i1, ptr, ptr, i32 }, ptr %673, i32 0, i32 2
+  %676 = getelementptr { i1, ptr, ptr, i32 }, ptr %673, i32 0, i32 0
+  store i1 true, ptr %676, align 1
+  %677 = getelementptr { i1, ptr, ptr, i32 }, ptr %673, i32 0, i32 1
+  store ptr %672, ptr %677, align 8
+  store ptr %674, ptr %675, align 8
+  %678 = getelementptr { i1, ptr, ptr, i32 }, ptr %673, i32 0, i32 3
+  store i32 1, ptr %678, align 4
+  %679 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %664, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %679, i32 1, ptr @137, ptr @134, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1552,38 +1553,38 @@ ifcont104:                                        ; preds = %ifcont102
   br i1 false, label %then105, label %ifcont106
 
 then105:                                          ; preds = %ifcont104
-  %680 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %681 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %682 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %681, i32 0, i32 0
-  %683 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %682, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @139, i32 0, i32 0), i8** %683, align 8
-  %684 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %682, i32 0, i32 1
-  store i32 39, i32* %684, align 4
-  %685 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %682, i32 0, i32 2
-  store i32 5, i32* %685, align 4
-  %686 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %682, i32 0, i32 3
-  store i32 39, i32* %686, align 4
-  %687 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %682, i32 0, i32 4
-  store i32 11, i32* %687, align 4
-  %688 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @140, i32 0, i32 0))
-  %689 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %680, i32 0, i32 0
-  %690 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %681, i32 0, i32 0
-  %691 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %689, i32 0, i32 2
-  %692 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %689, i32 0, i32 0
-  store i1 true, i1* %692, align 1
-  %693 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %689, i32 0, i32 1
-  store i8* %688, i8** %693, align 8
-  store { i8*, i32, i32, i32, i32 }* %690, { i8*, i32, i32, i32, i32 }** %691, align 8
-  %694 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %689, i32 0, i32 3
-  store i32 1, i32* %694, align 4
-  %695 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %680, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %695, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @141, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @138, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %680 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %681 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %682 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %681, i32 0, i32 0
+  %683 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %682, i32 0, i32 0
+  store ptr @139, ptr %683, align 8
+  %684 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %682, i32 0, i32 1
+  store i32 39, ptr %684, align 4
+  %685 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %682, i32 0, i32 2
+  store i32 5, ptr %685, align 4
+  %686 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %682, i32 0, i32 3
+  store i32 39, ptr %686, align 4
+  %687 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %682, i32 0, i32 4
+  store i32 11, ptr %687, align 4
+  %688 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @140)
+  %689 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %680, i32 0, i32 0
+  %690 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %681, i32 0, i32 0
+  %691 = getelementptr { i1, ptr, ptr, i32 }, ptr %689, i32 0, i32 2
+  %692 = getelementptr { i1, ptr, ptr, i32 }, ptr %689, i32 0, i32 0
+  store i1 true, ptr %692, align 1
+  %693 = getelementptr { i1, ptr, ptr, i32 }, ptr %689, i32 0, i32 1
+  store ptr %688, ptr %693, align 8
+  store ptr %690, ptr %691, align 8
+  %694 = getelementptr { i1, ptr, ptr, i32 }, ptr %689, i32 0, i32 3
+  store i32 1, ptr %694, align 4
+  %695 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %680, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %695, i32 1, ptr @141, ptr @138, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont106:                                        ; preds = %ifcont104
-  %696 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i64 2
-  %697 = load %complex_4, %complex_4* %696, align 1
+  %696 = getelementptr [4 x %complex_4], ptr %c, i32 0, i64 2
+  %697 = load %complex_4, ptr %696, align 1
   %698 = extractvalue %complex_4 %697, 0
   %699 = extractvalue %complex_4 %697, 1
   %700 = fcmp one float %698, 1.300000e+01
@@ -1592,7 +1593,7 @@ ifcont106:                                        ; preds = %ifcont104
   br i1 %702, label %then107, label %else108
 
 then107:                                          ; preds = %ifcont106
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @142, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @143, ptr @"ERROR STOP", ptr @142)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont109
@@ -1604,32 +1605,32 @@ ifcont109:                                        ; preds = %else108, %then107
   br i1 false, label %then110, label %ifcont111
 
 then110:                                          ; preds = %ifcont109
-  %703 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %704 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %705 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %704, i32 0, i32 0
-  %706 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %705, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @145, i32 0, i32 0), i8** %706, align 8
-  %707 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %705, i32 0, i32 1
-  store i32 40, i32* %707, align 4
-  %708 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %705, i32 0, i32 2
-  store i32 5, i32* %708, align 4
-  %709 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %705, i32 0, i32 3
-  store i32 40, i32* %709, align 4
-  %710 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %705, i32 0, i32 4
-  store i32 11, i32* %710, align 4
-  %711 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @146, i32 0, i32 0))
-  %712 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %703, i32 0, i32 0
-  %713 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %704, i32 0, i32 0
-  %714 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %712, i32 0, i32 2
-  %715 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %712, i32 0, i32 0
-  store i1 true, i1* %715, align 1
-  %716 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %712, i32 0, i32 1
-  store i8* %711, i8** %716, align 8
-  store { i8*, i32, i32, i32, i32 }* %713, { i8*, i32, i32, i32, i32 }** %714, align 8
-  %717 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %712, i32 0, i32 3
-  store i32 1, i32* %717, align 4
-  %718 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %703, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %718, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @147, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @144, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %703 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %704 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %705 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %704, i32 0, i32 0
+  %706 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %705, i32 0, i32 0
+  store ptr @145, ptr %706, align 8
+  %707 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %705, i32 0, i32 1
+  store i32 40, ptr %707, align 4
+  %708 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %705, i32 0, i32 2
+  store i32 5, ptr %708, align 4
+  %709 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %705, i32 0, i32 3
+  store i32 40, ptr %709, align 4
+  %710 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %705, i32 0, i32 4
+  store i32 11, ptr %710, align 4
+  %711 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @146)
+  %712 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %703, i32 0, i32 0
+  %713 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %704, i32 0, i32 0
+  %714 = getelementptr { i1, ptr, ptr, i32 }, ptr %712, i32 0, i32 2
+  %715 = getelementptr { i1, ptr, ptr, i32 }, ptr %712, i32 0, i32 0
+  store i1 true, ptr %715, align 1
+  %716 = getelementptr { i1, ptr, ptr, i32 }, ptr %712, i32 0, i32 1
+  store ptr %711, ptr %716, align 8
+  store ptr %713, ptr %714, align 8
+  %717 = getelementptr { i1, ptr, ptr, i32 }, ptr %712, i32 0, i32 3
+  store i32 1, ptr %717, align 4
+  %718 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %703, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %718, i32 1, ptr @147, ptr @144, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1637,38 +1638,38 @@ ifcont111:                                        ; preds = %ifcont109
   br i1 false, label %then112, label %ifcont113
 
 then112:                                          ; preds = %ifcont111
-  %719 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %720 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %721 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %720, i32 0, i32 0
-  %722 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %721, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @149, i32 0, i32 0), i8** %722, align 8
-  %723 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %721, i32 0, i32 1
-  store i32 40, i32* %723, align 4
-  %724 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %721, i32 0, i32 2
-  store i32 5, i32* %724, align 4
-  %725 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %721, i32 0, i32 3
-  store i32 40, i32* %725, align 4
-  %726 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %721, i32 0, i32 4
-  store i32 11, i32* %726, align 4
-  %727 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @150, i32 0, i32 0))
-  %728 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %719, i32 0, i32 0
-  %729 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %720, i32 0, i32 0
-  %730 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %728, i32 0, i32 2
-  %731 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %728, i32 0, i32 0
-  store i1 true, i1* %731, align 1
-  %732 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %728, i32 0, i32 1
-  store i8* %727, i8** %732, align 8
-  store { i8*, i32, i32, i32, i32 }* %729, { i8*, i32, i32, i32, i32 }** %730, align 8
-  %733 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %728, i32 0, i32 3
-  store i32 1, i32* %733, align 4
-  %734 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %719, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %734, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @151, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @148, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %719 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %720 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %721 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %720, i32 0, i32 0
+  %722 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %721, i32 0, i32 0
+  store ptr @149, ptr %722, align 8
+  %723 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %721, i32 0, i32 1
+  store i32 40, ptr %723, align 4
+  %724 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %721, i32 0, i32 2
+  store i32 5, ptr %724, align 4
+  %725 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %721, i32 0, i32 3
+  store i32 40, ptr %725, align 4
+  %726 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %721, i32 0, i32 4
+  store i32 11, ptr %726, align 4
+  %727 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @150)
+  %728 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %719, i32 0, i32 0
+  %729 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %720, i32 0, i32 0
+  %730 = getelementptr { i1, ptr, ptr, i32 }, ptr %728, i32 0, i32 2
+  %731 = getelementptr { i1, ptr, ptr, i32 }, ptr %728, i32 0, i32 0
+  store i1 true, ptr %731, align 1
+  %732 = getelementptr { i1, ptr, ptr, i32 }, ptr %728, i32 0, i32 1
+  store ptr %727, ptr %732, align 8
+  store ptr %729, ptr %730, align 8
+  %733 = getelementptr { i1, ptr, ptr, i32 }, ptr %728, i32 0, i32 3
+  store i32 1, ptr %733, align 4
+  %734 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %719, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %734, i32 1, ptr @151, ptr @148, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont113:                                        ; preds = %ifcont111
-  %735 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i64 1
-  %736 = load %complex_4, %complex_4* %735, align 1
+  %735 = getelementptr [4 x %complex_4], ptr %c, i32 0, i64 1
+  %736 = load %complex_4, ptr %735, align 1
   %737 = extractvalue %complex_4 %736, 0
   %738 = extractvalue %complex_4 %736, 1
   %739 = fcmp one float %737, 1.300000e+01
@@ -1677,7 +1678,7 @@ ifcont113:                                        ; preds = %ifcont111
   br i1 %741, label %then114, label %else115
 
 then114:                                          ; preds = %ifcont113
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @153, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @152, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @153, ptr @"ERROR STOP", ptr @152)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont116
@@ -1689,32 +1690,32 @@ ifcont116:                                        ; preds = %else115, %then114
   br i1 false, label %then117, label %ifcont118
 
 then117:                                          ; preds = %ifcont116
-  %742 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %743 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %744 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %743, i32 0, i32 0
-  %745 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @155, i32 0, i32 0), i8** %745, align 8
-  %746 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 1
-  store i32 41, i32* %746, align 4
-  %747 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 2
-  store i32 5, i32* %747, align 4
-  %748 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 3
-  store i32 41, i32* %748, align 4
-  %749 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 4
-  store i32 11, i32* %749, align 4
-  %750 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @156, i32 0, i32 0))
-  %751 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %742, i32 0, i32 0
-  %752 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %743, i32 0, i32 0
-  %753 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 2
-  %754 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 0
-  store i1 true, i1* %754, align 1
-  %755 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 1
-  store i8* %750, i8** %755, align 8
-  store { i8*, i32, i32, i32, i32 }* %752, { i8*, i32, i32, i32, i32 }** %753, align 8
-  %756 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 3
-  store i32 1, i32* %756, align 4
-  %757 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %742, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %757, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @157, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @154, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %742 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %743 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %744 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %743, i32 0, i32 0
+  %745 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 0
+  store ptr @155, ptr %745, align 8
+  %746 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 1
+  store i32 41, ptr %746, align 4
+  %747 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 2
+  store i32 5, ptr %747, align 4
+  %748 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 3
+  store i32 41, ptr %748, align 4
+  %749 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 4
+  store i32 11, ptr %749, align 4
+  %750 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @156)
+  %751 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %742, i32 0, i32 0
+  %752 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %743, i32 0, i32 0
+  %753 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 2
+  %754 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 0
+  store i1 true, ptr %754, align 1
+  %755 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 1
+  store ptr %750, ptr %755, align 8
+  store ptr %752, ptr %753, align 8
+  %756 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 3
+  store i32 1, ptr %756, align 4
+  %757 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %742, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %757, i32 1, ptr @157, ptr @154, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1722,38 +1723,38 @@ ifcont118:                                        ; preds = %ifcont116
   br i1 false, label %then119, label %ifcont120
 
 then119:                                          ; preds = %ifcont118
-  %758 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %759 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %760 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %759, i32 0, i32 0
-  %761 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %760, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @159, i32 0, i32 0), i8** %761, align 8
-  %762 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %760, i32 0, i32 1
-  store i32 41, i32* %762, align 4
-  %763 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %760, i32 0, i32 2
-  store i32 5, i32* %763, align 4
-  %764 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %760, i32 0, i32 3
-  store i32 41, i32* %764, align 4
-  %765 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %760, i32 0, i32 4
-  store i32 11, i32* %765, align 4
-  %766 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @160, i32 0, i32 0))
-  %767 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %758, i32 0, i32 0
-  %768 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %759, i32 0, i32 0
-  %769 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %767, i32 0, i32 2
-  %770 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %767, i32 0, i32 0
-  store i1 true, i1* %770, align 1
-  %771 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %767, i32 0, i32 1
-  store i8* %766, i8** %771, align 8
-  store { i8*, i32, i32, i32, i32 }* %768, { i8*, i32, i32, i32, i32 }** %769, align 8
-  %772 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %767, i32 0, i32 3
-  store i32 1, i32* %772, align 4
-  %773 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %758, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %773, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @161, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @158, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %758 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %759 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %760 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %759, i32 0, i32 0
+  %761 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %760, i32 0, i32 0
+  store ptr @159, ptr %761, align 8
+  %762 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %760, i32 0, i32 1
+  store i32 41, ptr %762, align 4
+  %763 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %760, i32 0, i32 2
+  store i32 5, ptr %763, align 4
+  %764 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %760, i32 0, i32 3
+  store i32 41, ptr %764, align 4
+  %765 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %760, i32 0, i32 4
+  store i32 11, ptr %765, align 4
+  %766 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @160)
+  %767 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %758, i32 0, i32 0
+  %768 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %759, i32 0, i32 0
+  %769 = getelementptr { i1, ptr, ptr, i32 }, ptr %767, i32 0, i32 2
+  %770 = getelementptr { i1, ptr, ptr, i32 }, ptr %767, i32 0, i32 0
+  store i1 true, ptr %770, align 1
+  %771 = getelementptr { i1, ptr, ptr, i32 }, ptr %767, i32 0, i32 1
+  store ptr %766, ptr %771, align 8
+  store ptr %768, ptr %769, align 8
+  %772 = getelementptr { i1, ptr, ptr, i32 }, ptr %767, i32 0, i32 3
+  store i32 1, ptr %772, align 4
+  %773 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %758, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %773, i32 1, ptr @161, ptr @158, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont120:                                        ; preds = %ifcont118
-  %774 = getelementptr [4 x %complex_4], [4 x %complex_4]* %c, i32 0, i64 3
-  %775 = load %complex_4, %complex_4* %774, align 1
+  %774 = getelementptr [4 x %complex_4], ptr %c, i32 0, i64 3
+  %775 = load %complex_4, ptr %774, align 1
   %776 = extractvalue %complex_4 %775, 0
   %777 = extractvalue %complex_4 %775, 1
   %778 = fcmp one float %776, 1.400000e+01
@@ -1762,7 +1763,7 @@ ifcont120:                                        ; preds = %ifcont118
   br i1 %780, label %then121, label %else122
 
 then121:                                          ; preds = %ifcont120
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @163, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @163, ptr @"ERROR STOP", ptr @162)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont123
@@ -1781,16 +1782,16 @@ FINALIZE_SYMTABLE_arrays_01_complex:              ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.json
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_logical-f19a63d.stdout",
-    "stdout_hash": "634c7c7cbfdcf0da8a22126a8a8d3cc204e97b8bb56e51368d4c36fa",
+    "stdout_hash": "b9d54ce462b88fae159b29edc13c9b7b3acd4e5517dd01c9d6df2633",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
+++ b/tests/reference/llvm-arrays_01_logical-f19a63d.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @0 = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @1 = private unnamed_addr constant [49 x i8] c"tests/../integration_tests/arrays_01_logical.f90\00", align 1
@@ -192,10 +193,10 @@ target datalayout = "..."
 @186 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @187 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [3 x i32], align 4
   %b = alloca [4 x i32], align 4
   %c = alloca [4 x i32], align 4
@@ -204,52 +205,52 @@ define i32 @main(i32 %0, i8** %1) {
   br i1 false, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
-  %3 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %4 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %5 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %4, i32 0, i32 0
-  %6 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %5, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @1, i32 0, i32 0), i8** %6, align 8
-  %7 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %5, i32 0, i32 1
-  store i32 6, i32* %7, align 4
-  %8 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %5, i32 0, i32 2
-  store i32 1, i32* %8, align 4
-  %9 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %5, i32 0, i32 3
-  store i32 6, i32* %9, align 4
-  %10 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %5, i32 0, i32 4
-  store i32 4, i32* %10, align 4
-  %11 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
-  %12 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %3, i32 0, i32 0
-  %13 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %4, i32 0, i32 0
-  %14 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %12, i32 0, i32 2
-  %15 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %12, i32 0, i32 0
-  store i1 true, i1* %15, align 1
-  %16 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %12, i32 0, i32 1
-  store i8* %11, i8** %16, align 8
-  store { i8*, i32, i32, i32, i32 }* %13, { i8*, i32, i32, i32, i32 }** %14, align 8
-  %17 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %12, i32 0, i32 3
-  store i32 1, i32* %17, align 4
-  %18 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %3, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %18, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %3 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %4 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %5 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %4, i32 0, i32 0
+  %6 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %5, i32 0, i32 0
+  store ptr @1, ptr %6, align 8
+  %7 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %5, i32 0, i32 1
+  store i32 6, ptr %7, align 4
+  %8 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %5, i32 0, i32 2
+  store i32 1, ptr %8, align 4
+  %9 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %5, i32 0, i32 3
+  store i32 6, ptr %9, align 4
+  %10 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %5, i32 0, i32 4
+  store i32 4, ptr %10, align 4
+  %11 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %12 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %3, i32 0, i32 0
+  %13 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %4, i32 0, i32 0
+  %14 = getelementptr { i1, ptr, ptr, i32 }, ptr %12, i32 0, i32 2
+  %15 = getelementptr { i1, ptr, ptr, i32 }, ptr %12, i32 0, i32 0
+  store i1 true, ptr %15, align 1
+  %16 = getelementptr { i1, ptr, ptr, i32 }, ptr %12, i32 0, i32 1
+  store ptr %11, ptr %16, align 8
+  store ptr %13, ptr %14, align 8
+  %17 = getelementptr { i1, ptr, ptr, i32 }, ptr %12, i32 0, i32 3
+  store i32 1, ptr %17, align 4
+  %18 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %3, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %18, i32 1, ptr @3, ptr @0, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %.entry
-  %19 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  store i32 1, i32* %19, align 4
-  store i32 1, i32* %i, align 4
+  %19 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  store i32 1, ptr %19, align 4
+  store i32 1, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont4, %ifcont
-  %20 = load i32, i32* %i, align 4
+  %20 = load i32, ptr %i, align 4
   %21 = add i32 %20, 1
   %22 = icmp sle i32 %21, 3
   br i1 %22, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %23 = load i32, i32* %i, align 4
+  %23 = load i32, ptr %i, align 4
   %24 = add i32 %23, 1
-  store i32 %24, i32* %i, align 4
-  %25 = load i32, i32* %i, align 4
+  store i32 %24, ptr %i, align 4
+  %25 = load i32, ptr %i, align 4
   %26 = sext i32 %25 to i64
   %27 = sub i64 %26, 1
   %28 = mul i64 1, %27
@@ -260,38 +261,38 @@ loop.body:                                        ; preds = %loop.head
   br i1 %32, label %then1, label %ifcont2
 
 then1:                                            ; preds = %loop.body
-  %33 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %34 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %35 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %34, i32 0, i32 0
-  %36 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @5, i32 0, i32 0), i8** %36, align 8
-  %37 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 1
-  store i32 8, i32* %37, align 4
-  %38 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 2
-  store i32 5, i32* %38, align 4
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 3
-  store i32 8, i32* %39, align 4
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 4
-  store i32 8, i32* %40, align 4
-  %41 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %42 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %33, i32 0, i32 0
-  %43 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %34, i32 0, i32 0
-  %44 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 2
-  %45 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 0
-  store i1 true, i1* %45, align 1
-  %46 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 1
-  store i8* %41, i8** %46, align 8
-  store { i8*, i32, i32, i32, i32 }* %43, { i8*, i32, i32, i32, i32 }** %44, align 8
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 3
-  store i32 1, i32* %47, align 4
-  %48 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %33, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i64 %26, i32 1, i64 1, i64 3)
+  %33 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %34 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %35 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %34, i32 0, i32 0
+  %36 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %35, i32 0, i32 0
+  store ptr @5, ptr %36, align 8
+  %37 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %35, i32 0, i32 1
+  store i32 8, ptr %37, align 4
+  %38 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %35, i32 0, i32 2
+  store i32 5, ptr %38, align 4
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %35, i32 0, i32 3
+  store i32 8, ptr %39, align 4
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %35, i32 0, i32 4
+  store i32 8, ptr %40, align 4
+  %41 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %42 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %33, i32 0, i32 0
+  %43 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %34, i32 0, i32 0
+  %44 = getelementptr { i1, ptr, ptr, i32 }, ptr %42, i32 0, i32 2
+  %45 = getelementptr { i1, ptr, ptr, i32 }, ptr %42, i32 0, i32 0
+  store i1 true, ptr %45, align 1
+  %46 = getelementptr { i1, ptr, ptr, i32 }, ptr %42, i32 0, i32 1
+  store ptr %41, ptr %46, align 8
+  store ptr %43, ptr %44, align 8
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %42, i32 0, i32 3
+  store i32 1, ptr %47, align 4
+  %48 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %33, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %48, i32 1, ptr @7, ptr @4, i64 %26, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %loop.body
-  %49 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %29
-  %50 = load i32, i32* %i, align 4
+  %49 = getelementptr [3 x i32], ptr %a, i32 0, i64 %29
+  %50 = load i32, ptr %i, align 4
   %51 = sub i32 %50, 1
   %52 = sext i32 %51 to i64
   %53 = sub i64 %52, 1
@@ -303,84 +304,84 @@ ifcont2:                                          ; preds = %loop.body
   br i1 %58, label %then3, label %ifcont4
 
 then3:                                            ; preds = %ifcont2
-  %59 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %60 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %61 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %60, i32 0, i32 0
-  %62 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %61, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @9, i32 0, i32 0), i8** %62, align 8
-  %63 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %61, i32 0, i32 1
-  store i32 8, i32* %63, align 4
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %61, i32 0, i32 2
-  store i32 18, i32* %64, align 4
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %61, i32 0, i32 3
-  store i32 8, i32* %65, align 4
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %61, i32 0, i32 4
-  store i32 25, i32* %66, align 4
-  %67 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %68 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %59, i32 0, i32 0
-  %69 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %60, i32 0, i32 0
-  %70 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %68, i32 0, i32 2
-  %71 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %68, i32 0, i32 0
-  store i1 true, i1* %71, align 1
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %68, i32 0, i32 1
-  store i8* %67, i8** %72, align 8
-  store { i8*, i32, i32, i32, i32 }* %69, { i8*, i32, i32, i32, i32 }** %70, align 8
-  %73 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %68, i32 0, i32 3
-  store i32 1, i32* %73, align 4
-  %74 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %59, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %74, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i64 %52, i32 1, i64 1, i64 3)
+  %59 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %60 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %61 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %60, i32 0, i32 0
+  %62 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %61, i32 0, i32 0
+  store ptr @9, ptr %62, align 8
+  %63 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %61, i32 0, i32 1
+  store i32 8, ptr %63, align 4
+  %64 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %61, i32 0, i32 2
+  store i32 18, ptr %64, align 4
+  %65 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %61, i32 0, i32 3
+  store i32 8, ptr %65, align 4
+  %66 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %61, i32 0, i32 4
+  store i32 25, ptr %66, align 4
+  %67 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10)
+  %68 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %59, i32 0, i32 0
+  %69 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %60, i32 0, i32 0
+  %70 = getelementptr { i1, ptr, ptr, i32 }, ptr %68, i32 0, i32 2
+  %71 = getelementptr { i1, ptr, ptr, i32 }, ptr %68, i32 0, i32 0
+  store i1 true, ptr %71, align 1
+  %72 = getelementptr { i1, ptr, ptr, i32 }, ptr %68, i32 0, i32 1
+  store ptr %67, ptr %72, align 8
+  store ptr %69, ptr %70, align 8
+  %73 = getelementptr { i1, ptr, ptr, i32 }, ptr %68, i32 0, i32 3
+  store i32 1, ptr %73, align 4
+  %74 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %59, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %74, i32 1, ptr @11, ptr @8, i64 %52, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont4:                                          ; preds = %ifcont2
-  %75 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %55
-  %76 = load i32, i32* %75, align 4
+  %75 = getelementptr [3 x i32], ptr %a, i32 0, i64 %55
+  %76 = load i32, ptr %75, align 4
   %77 = xor i32 %76, 1
-  store i32 %77, i32* %49, align 4
+  store i32 %77, ptr %49, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then5, label %ifcont6
 
 then5:                                            ; preds = %loop.end
-  %78 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %79 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %80 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %79, i32 0, i32 0
-  %81 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %80, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @13, i32 0, i32 0), i8** %81, align 8
-  %82 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %80, i32 0, i32 1
-  store i32 10, i32* %82, align 4
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %80, i32 0, i32 2
-  store i32 11, i32* %83, align 4
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %80, i32 0, i32 3
-  store i32 10, i32* %84, align 4
-  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %80, i32 0, i32 4
-  store i32 14, i32* %85, align 4
-  %86 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
-  %87 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %78, i32 0, i32 0
-  %88 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %79, i32 0, i32 0
-  %89 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 0, i32 2
-  %90 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 0, i32 0
-  store i1 true, i1* %90, align 1
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 0, i32 1
-  store i8* %86, i8** %91, align 8
-  store { i8*, i32, i32, i32, i32 }* %88, { i8*, i32, i32, i32, i32 }** %89, align 8
-  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %87, i32 0, i32 3
-  store i32 1, i32* %92, align 4
-  %93 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %78, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %93, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %78 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %79 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %80 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %79, i32 0, i32 0
+  %81 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %80, i32 0, i32 0
+  store ptr @13, ptr %81, align 8
+  %82 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %80, i32 0, i32 1
+  store i32 10, ptr %82, align 4
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %80, i32 0, i32 2
+  store i32 11, ptr %83, align 4
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %80, i32 0, i32 3
+  store i32 10, ptr %84, align 4
+  %85 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %80, i32 0, i32 4
+  store i32 14, ptr %85, align 4
+  %86 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @14)
+  %87 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %78, i32 0, i32 0
+  %88 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %79, i32 0, i32 0
+  %89 = getelementptr { i1, ptr, ptr, i32 }, ptr %87, i32 0, i32 2
+  %90 = getelementptr { i1, ptr, ptr, i32 }, ptr %87, i32 0, i32 0
+  store i1 true, ptr %90, align 1
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %87, i32 0, i32 1
+  store ptr %86, ptr %91, align 8
+  store ptr %88, ptr %89, align 8
+  %92 = getelementptr { i1, ptr, ptr, i32 }, ptr %87, i32 0, i32 3
+  store i32 1, ptr %92, align 4
+  %93 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %78, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %93, i32 1, ptr @15, ptr @12, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %loop.end
-  %94 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %95 = load i32, i32* %94, align 4
+  %94 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %95 = load i32, ptr %94, align 4
   %96 = xor i32 %95, 1
   %97 = icmp ne i32 %96, 0
   br i1 %97, label %then7, label %else
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -392,43 +393,43 @@ ifcont8:                                          ; preds = %else, %then7
   br i1 false, label %then9, label %ifcont10
 
 then9:                                            ; preds = %ifcont8
-  %98 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %99 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %100 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %99, i32 0, i32 0
-  %101 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @19, i32 0, i32 0), i8** %101, align 8
-  %102 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 1
-  store i32 11, i32* %102, align 4
-  %103 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 2
-  store i32 5, i32* %103, align 4
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 3
-  store i32 11, i32* %104, align 4
-  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 4
-  store i32 8, i32* %105, align 4
-  %106 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @20, i32 0, i32 0))
-  %107 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %98, i32 0, i32 0
-  %108 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %99, i32 0, i32 0
-  %109 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 2
-  %110 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 0
-  store i1 true, i1* %110, align 1
-  %111 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 1
-  store i8* %106, i8** %111, align 8
-  store { i8*, i32, i32, i32, i32 }* %108, { i8*, i32, i32, i32, i32 }** %109, align 8
-  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 3
-  store i32 1, i32* %112, align 4
-  %113 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %98, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %113, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i64 2, i32 1, i64 1, i64 3)
+  %98 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %99 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %100 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %99, i32 0, i32 0
+  %101 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 0
+  store ptr @19, ptr %101, align 8
+  %102 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 1
+  store i32 11, ptr %102, align 4
+  %103 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 2
+  store i32 5, ptr %103, align 4
+  %104 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 3
+  store i32 11, ptr %104, align 4
+  %105 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 4
+  store i32 8, ptr %105, align 4
+  %106 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @20)
+  %107 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %98, i32 0, i32 0
+  %108 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %99, i32 0, i32 0
+  %109 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 2
+  %110 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 0
+  store i1 true, ptr %110, align 1
+  %111 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 1
+  store ptr %106, ptr %111, align 8
+  store ptr %108, ptr %109, align 8
+  %112 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 3
+  store i32 1, ptr %112, align 4
+  %113 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %98, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %113, i32 1, ptr @21, ptr @18, i64 2, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
-  %114 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 1
-  %115 = load i32, i32* %114, align 4
+  %114 = getelementptr [3 x i32], ptr %a, i32 0, i64 1
+  %115 = load i32, ptr %114, align 4
   %116 = icmp ne i32 %115, 0
   br i1 %116, label %then11, label %else12
 
 then11:                                           ; preds = %ifcont10
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @23, ptr @"ERROR STOP", ptr @22)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -440,44 +441,44 @@ ifcont13:                                         ; preds = %else12, %then11
   br i1 false, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  %117 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %118 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %119 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %118, i32 0, i32 0
-  %120 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %119, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @25, i32 0, i32 0), i8** %120, align 8
-  %121 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %119, i32 0, i32 1
-  store i32 12, i32* %121, align 4
-  %122 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %119, i32 0, i32 2
-  store i32 11, i32* %122, align 4
-  %123 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %119, i32 0, i32 3
-  store i32 12, i32* %123, align 4
-  %124 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %119, i32 0, i32 4
-  store i32 14, i32* %124, align 4
-  %125 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @26, i32 0, i32 0))
-  %126 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %117, i32 0, i32 0
-  %127 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %118, i32 0, i32 0
-  %128 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %126, i32 0, i32 2
-  %129 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %126, i32 0, i32 0
-  store i1 true, i1* %129, align 1
-  %130 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %126, i32 0, i32 1
-  store i8* %125, i8** %130, align 8
-  store { i8*, i32, i32, i32, i32 }* %127, { i8*, i32, i32, i32, i32 }** %128, align 8
-  %131 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %126, i32 0, i32 3
-  store i32 1, i32* %131, align 4
-  %132 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %117, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %132, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i64 3, i32 1, i64 1, i64 3)
+  %117 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %118 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %119 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %118, i32 0, i32 0
+  %120 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 0
+  store ptr @25, ptr %120, align 8
+  %121 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 1
+  store i32 12, ptr %121, align 4
+  %122 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 2
+  store i32 11, ptr %122, align 4
+  %123 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 3
+  store i32 12, ptr %123, align 4
+  %124 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %119, i32 0, i32 4
+  store i32 14, ptr %124, align 4
+  %125 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @26)
+  %126 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %117, i32 0, i32 0
+  %127 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %118, i32 0, i32 0
+  %128 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 2
+  %129 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 0
+  store i1 true, ptr %129, align 1
+  %130 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 1
+  store ptr %125, ptr %130, align 8
+  store ptr %127, ptr %128, align 8
+  %131 = getelementptr { i1, ptr, ptr, i32 }, ptr %126, i32 0, i32 3
+  store i32 1, ptr %131, align 4
+  %132 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %117, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %132, i32 1, ptr @27, ptr @24, i64 3, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %133 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 2
-  %134 = load i32, i32* %133, align 4
+  %133 = getelementptr [3 x i32], ptr %a, i32 0, i64 2
+  %134 = load i32, ptr %133, align 4
   %135 = xor i32 %134, 1
   %136 = icmp ne i32 %135, 0
   br i1 %136, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @29, ptr @"ERROR STOP", ptr @28)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -489,52 +490,52 @@ ifcont18:                                         ; preds = %else17, %then16
   br i1 false, label %then19, label %ifcont20
 
 then19:                                           ; preds = %ifcont18
-  %137 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %138 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %139 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %138, i32 0, i32 0
-  %140 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %139, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @31, i32 0, i32 0), i8** %140, align 8
-  %141 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %139, i32 0, i32 1
-  store i32 14, i32* %141, align 4
-  %142 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %139, i32 0, i32 2
-  store i32 1, i32* %142, align 4
-  %143 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %139, i32 0, i32 3
-  store i32 14, i32* %143, align 4
-  %144 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %139, i32 0, i32 4
-  store i32 4, i32* %144, align 4
-  %145 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @32, i32 0, i32 0))
-  %146 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %137, i32 0, i32 0
-  %147 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %138, i32 0, i32 0
-  %148 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %146, i32 0, i32 2
-  %149 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %146, i32 0, i32 0
-  store i1 true, i1* %149, align 1
-  %150 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %146, i32 0, i32 1
-  store i8* %145, i8** %150, align 8
-  store { i8*, i32, i32, i32, i32 }* %147, { i8*, i32, i32, i32, i32 }** %148, align 8
-  %151 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %146, i32 0, i32 3
-  store i32 1, i32* %151, align 4
-  %152 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %137, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %152, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %137 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %138 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %139 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %138, i32 0, i32 0
+  %140 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 0
+  store ptr @31, ptr %140, align 8
+  %141 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 1
+  store i32 14, ptr %141, align 4
+  %142 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 2
+  store i32 1, ptr %142, align 4
+  %143 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 3
+  store i32 14, ptr %143, align 4
+  %144 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %139, i32 0, i32 4
+  store i32 4, ptr %144, align 4
+  %145 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @32)
+  %146 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %137, i32 0, i32 0
+  %147 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %138, i32 0, i32 0
+  %148 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 2
+  %149 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 0
+  store i1 true, ptr %149, align 1
+  %150 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 1
+  store ptr %145, ptr %150, align 8
+  store ptr %147, ptr %148, align 8
+  %151 = getelementptr { i1, ptr, ptr, i32 }, ptr %146, i32 0, i32 3
+  store i32 1, ptr %151, align 4
+  %152 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %137, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %152, i32 1, ptr @33, ptr @30, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont20:                                         ; preds = %ifcont18
-  %153 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  store i32 0, i32* %153, align 4
-  store i32 11, i32* %i, align 4
+  %153 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  store i32 0, ptr %153, align 4
+  store i32 11, ptr %i, align 4
   br label %loop.head21
 
 loop.head21:                                      ; preds = %ifcont26, %ifcont20
-  %154 = load i32, i32* %i, align 4
+  %154 = load i32, ptr %i, align 4
   %155 = add i32 %154, 1
   %156 = icmp sle i32 %155, 14
   br i1 %156, label %loop.body22, label %loop.end27
 
 loop.body22:                                      ; preds = %loop.head21
-  %157 = load i32, i32* %i, align 4
+  %157 = load i32, ptr %i, align 4
   %158 = add i32 %157, 1
-  store i32 %158, i32* %i, align 4
-  %159 = load i32, i32* %i, align 4
+  store i32 %158, ptr %i, align 4
+  %159 = load i32, ptr %i, align 4
   %160 = sub i32 %159, 10
   %161 = sext i32 %160 to i64
   %162 = sub i64 %161, 1
@@ -546,38 +547,38 @@ loop.body22:                                      ; preds = %loop.head21
   br i1 %167, label %then23, label %ifcont24
 
 then23:                                           ; preds = %loop.body22
-  %168 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %169 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %170 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %169, i32 0, i32 0
-  %171 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %170, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @35, i32 0, i32 0), i8** %171, align 8
-  %172 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %170, i32 0, i32 1
-  store i32 16, i32* %172, align 4
-  %173 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %170, i32 0, i32 2
-  store i32 5, i32* %173, align 4
-  %174 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %170, i32 0, i32 3
-  store i32 16, i32* %174, align 4
-  %175 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %170, i32 0, i32 4
-  store i32 11, i32* %175, align 4
-  %176 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @36, i32 0, i32 0))
-  %177 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %168, i32 0, i32 0
-  %178 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %169, i32 0, i32 0
-  %179 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %177, i32 0, i32 2
-  %180 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %177, i32 0, i32 0
-  store i1 true, i1* %180, align 1
-  %181 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %177, i32 0, i32 1
-  store i8* %176, i8** %181, align 8
-  store { i8*, i32, i32, i32, i32 }* %178, { i8*, i32, i32, i32, i32 }** %179, align 8
-  %182 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %177, i32 0, i32 3
-  store i32 1, i32* %182, align 4
-  %183 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %168, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %183, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i64 %161, i32 1, i64 1, i64 4)
+  %168 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %169 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %170 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %169, i32 0, i32 0
+  %171 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 0
+  store ptr @35, ptr %171, align 8
+  %172 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 1
+  store i32 16, ptr %172, align 4
+  %173 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 2
+  store i32 5, ptr %173, align 4
+  %174 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 3
+  store i32 16, ptr %174, align 4
+  %175 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %170, i32 0, i32 4
+  store i32 11, ptr %175, align 4
+  %176 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @36)
+  %177 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %168, i32 0, i32 0
+  %178 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %169, i32 0, i32 0
+  %179 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 2
+  %180 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 0
+  store i1 true, ptr %180, align 1
+  %181 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 1
+  store ptr %176, ptr %181, align 8
+  store ptr %178, ptr %179, align 8
+  %182 = getelementptr { i1, ptr, ptr, i32 }, ptr %177, i32 0, i32 3
+  store i32 1, ptr %182, align 4
+  %183 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %168, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %183, i32 1, ptr @37, ptr @34, i64 %161, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %loop.body22
-  %184 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %164
-  %185 = load i32, i32* %i, align 4
+  %184 = getelementptr [4 x i32], ptr %b, i32 0, i64 %164
+  %185 = load i32, ptr %i, align 4
   %186 = sub i32 %185, 10
   %187 = sub i32 %186, 1
   %188 = sext i32 %187 to i64
@@ -590,83 +591,83 @@ ifcont24:                                         ; preds = %loop.body22
   br i1 %194, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %195 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %196 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %197 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %196, i32 0, i32 0
-  %198 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %197, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @39, i32 0, i32 0), i8** %198, align 8
-  %199 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %197, i32 0, i32 1
-  store i32 16, i32* %199, align 4
-  %200 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %197, i32 0, i32 2
-  store i32 21, i32* %200, align 4
-  %201 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %197, i32 0, i32 3
-  store i32 16, i32* %201, align 4
-  %202 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %197, i32 0, i32 4
-  store i32 33, i32* %202, align 4
-  %203 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %204 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %195, i32 0, i32 0
-  %205 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %196, i32 0, i32 0
-  %206 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %204, i32 0, i32 2
-  %207 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %204, i32 0, i32 0
-  store i1 true, i1* %207, align 1
-  %208 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %204, i32 0, i32 1
-  store i8* %203, i8** %208, align 8
-  store { i8*, i32, i32, i32, i32 }* %205, { i8*, i32, i32, i32, i32 }** %206, align 8
-  %209 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %204, i32 0, i32 3
-  store i32 1, i32* %209, align 4
-  %210 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %195, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %210, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i64 %188, i32 1, i64 1, i64 4)
+  %195 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %196 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %197 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %196, i32 0, i32 0
+  %198 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %197, i32 0, i32 0
+  store ptr @39, ptr %198, align 8
+  %199 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %197, i32 0, i32 1
+  store i32 16, ptr %199, align 4
+  %200 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %197, i32 0, i32 2
+  store i32 21, ptr %200, align 4
+  %201 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %197, i32 0, i32 3
+  store i32 16, ptr %201, align 4
+  %202 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %197, i32 0, i32 4
+  store i32 33, ptr %202, align 4
+  %203 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @40)
+  %204 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %195, i32 0, i32 0
+  %205 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %196, i32 0, i32 0
+  %206 = getelementptr { i1, ptr, ptr, i32 }, ptr %204, i32 0, i32 2
+  %207 = getelementptr { i1, ptr, ptr, i32 }, ptr %204, i32 0, i32 0
+  store i1 true, ptr %207, align 1
+  %208 = getelementptr { i1, ptr, ptr, i32 }, ptr %204, i32 0, i32 1
+  store ptr %203, ptr %208, align 8
+  store ptr %205, ptr %206, align 8
+  %209 = getelementptr { i1, ptr, ptr, i32 }, ptr %204, i32 0, i32 3
+  store i32 1, ptr %209, align 4
+  %210 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %195, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %210, i32 1, ptr @41, ptr @38, i64 %188, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %211 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %191
-  %212 = load i32, i32* %211, align 4
+  %211 = getelementptr [4 x i32], ptr %b, i32 0, i64 %191
+  %212 = load i32, ptr %211, align 4
   %213 = xor i32 %212, 1
-  store i32 %213, i32* %184, align 4
+  store i32 %213, ptr %184, align 4
   br label %loop.head21
 
 loop.end27:                                       ; preds = %loop.head21
   br i1 false, label %then28, label %ifcont29
 
 then28:                                           ; preds = %loop.end27
-  %214 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %215 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %216 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %215, i32 0, i32 0
-  %217 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %216, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @43, i32 0, i32 0), i8** %217, align 8
-  %218 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %216, i32 0, i32 1
-  store i32 18, i32* %218, align 4
-  %219 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %216, i32 0, i32 2
-  store i32 5, i32* %219, align 4
-  %220 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %216, i32 0, i32 3
-  store i32 18, i32* %220, align 4
-  %221 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %216, i32 0, i32 4
-  store i32 8, i32* %221, align 4
-  %222 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @44, i32 0, i32 0))
-  %223 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %214, i32 0, i32 0
-  %224 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %215, i32 0, i32 0
-  %225 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %223, i32 0, i32 2
-  %226 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %223, i32 0, i32 0
-  store i1 true, i1* %226, align 1
-  %227 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %223, i32 0, i32 1
-  store i8* %222, i8** %227, align 8
-  store { i8*, i32, i32, i32, i32 }* %224, { i8*, i32, i32, i32, i32 }** %225, align 8
-  %228 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %223, i32 0, i32 3
-  store i32 1, i32* %228, align 4
-  %229 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %214, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %229, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %214 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %215 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %216 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %215, i32 0, i32 0
+  %217 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %216, i32 0, i32 0
+  store ptr @43, ptr %217, align 8
+  %218 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %216, i32 0, i32 1
+  store i32 18, ptr %218, align 4
+  %219 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %216, i32 0, i32 2
+  store i32 5, ptr %219, align 4
+  %220 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %216, i32 0, i32 3
+  store i32 18, ptr %220, align 4
+  %221 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %216, i32 0, i32 4
+  store i32 8, ptr %221, align 4
+  %222 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @44)
+  %223 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %214, i32 0, i32 0
+  %224 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %215, i32 0, i32 0
+  %225 = getelementptr { i1, ptr, ptr, i32 }, ptr %223, i32 0, i32 2
+  %226 = getelementptr { i1, ptr, ptr, i32 }, ptr %223, i32 0, i32 0
+  store i1 true, ptr %226, align 1
+  %227 = getelementptr { i1, ptr, ptr, i32 }, ptr %223, i32 0, i32 1
+  store ptr %222, ptr %227, align 8
+  store ptr %224, ptr %225, align 8
+  %228 = getelementptr { i1, ptr, ptr, i32 }, ptr %223, i32 0, i32 3
+  store i32 1, ptr %228, align 4
+  %229 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %214, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %229, i32 1, ptr @45, ptr @42, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont29:                                         ; preds = %loop.end27
-  %230 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %231 = load i32, i32* %230, align 4
+  %230 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %231 = load i32, ptr %230, align 4
   %232 = icmp ne i32 %231, 0
   br i1 %232, label %then30, label %else31
 
 then30:                                           ; preds = %ifcont29
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @47, ptr @"ERROR STOP", ptr @46)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont32
@@ -678,44 +679,44 @@ ifcont32:                                         ; preds = %else31, %then30
   br i1 false, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  %233 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %234 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %235 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %234, i32 0, i32 0
-  %236 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %235, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @49, i32 0, i32 0), i8** %236, align 8
-  %237 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %235, i32 0, i32 1
-  store i32 19, i32* %237, align 4
-  %238 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %235, i32 0, i32 2
-  store i32 11, i32* %238, align 4
-  %239 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %235, i32 0, i32 3
-  store i32 19, i32* %239, align 4
-  %240 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %235, i32 0, i32 4
-  store i32 14, i32* %240, align 4
-  %241 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @50, i32 0, i32 0))
-  %242 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %233, i32 0, i32 0
-  %243 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %234, i32 0, i32 0
-  %244 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %242, i32 0, i32 2
-  %245 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %242, i32 0, i32 0
-  store i1 true, i1* %245, align 1
-  %246 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %242, i32 0, i32 1
-  store i8* %241, i8** %246, align 8
-  store { i8*, i32, i32, i32, i32 }* %243, { i8*, i32, i32, i32, i32 }** %244, align 8
-  %247 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %242, i32 0, i32 3
-  store i32 1, i32* %247, align 4
-  %248 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %233, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %248, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %233 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %234 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %235 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %234, i32 0, i32 0
+  %236 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 0
+  store ptr @49, ptr %236, align 8
+  %237 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 1
+  store i32 19, ptr %237, align 4
+  %238 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 2
+  store i32 11, ptr %238, align 4
+  %239 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 3
+  store i32 19, ptr %239, align 4
+  %240 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %235, i32 0, i32 4
+  store i32 14, ptr %240, align 4
+  %241 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @50)
+  %242 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %233, i32 0, i32 0
+  %243 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %234, i32 0, i32 0
+  %244 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 2
+  %245 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 0
+  store i1 true, ptr %245, align 1
+  %246 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 1
+  store ptr %241, ptr %246, align 8
+  store ptr %243, ptr %244, align 8
+  %247 = getelementptr { i1, ptr, ptr, i32 }, ptr %242, i32 0, i32 3
+  store i32 1, ptr %247, align 4
+  %248 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %233, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %248, i32 1, ptr @51, ptr @48, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %249 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %250 = load i32, i32* %249, align 4
+  %249 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %250 = load i32, ptr %249, align 4
   %251 = xor i32 %250, 1
   %252 = icmp ne i32 %251, 0
   br i1 %252, label %then35, label %else36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @53, ptr @"ERROR STOP", ptr @52)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -727,43 +728,43 @@ ifcont37:                                         ; preds = %else36, %then35
   br i1 false, label %then38, label %ifcont39
 
 then38:                                           ; preds = %ifcont37
-  %253 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %254 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %255 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %254, i32 0, i32 0
-  %256 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %255, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @55, i32 0, i32 0), i8** %256, align 8
-  %257 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %255, i32 0, i32 1
-  store i32 20, i32* %257, align 4
-  %258 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %255, i32 0, i32 2
-  store i32 5, i32* %258, align 4
-  %259 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %255, i32 0, i32 3
-  store i32 20, i32* %259, align 4
-  %260 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %255, i32 0, i32 4
-  store i32 8, i32* %260, align 4
-  %261 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @56, i32 0, i32 0))
-  %262 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %253, i32 0, i32 0
-  %263 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %254, i32 0, i32 0
-  %264 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %262, i32 0, i32 2
-  %265 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %262, i32 0, i32 0
-  store i1 true, i1* %265, align 1
-  %266 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %262, i32 0, i32 1
-  store i8* %261, i8** %266, align 8
-  store { i8*, i32, i32, i32, i32 }* %263, { i8*, i32, i32, i32, i32 }** %264, align 8
-  %267 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %262, i32 0, i32 3
-  store i32 1, i32* %267, align 4
-  %268 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %253, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %253 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %254 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %255 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %254, i32 0, i32 0
+  %256 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %255, i32 0, i32 0
+  store ptr @55, ptr %256, align 8
+  %257 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %255, i32 0, i32 1
+  store i32 20, ptr %257, align 4
+  %258 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %255, i32 0, i32 2
+  store i32 5, ptr %258, align 4
+  %259 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %255, i32 0, i32 3
+  store i32 20, ptr %259, align 4
+  %260 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %255, i32 0, i32 4
+  store i32 8, ptr %260, align 4
+  %261 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @56)
+  %262 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %253, i32 0, i32 0
+  %263 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %254, i32 0, i32 0
+  %264 = getelementptr { i1, ptr, ptr, i32 }, ptr %262, i32 0, i32 2
+  %265 = getelementptr { i1, ptr, ptr, i32 }, ptr %262, i32 0, i32 0
+  store i1 true, ptr %265, align 1
+  %266 = getelementptr { i1, ptr, ptr, i32 }, ptr %262, i32 0, i32 1
+  store ptr %261, ptr %266, align 8
+  store ptr %263, ptr %264, align 8
+  %267 = getelementptr { i1, ptr, ptr, i32 }, ptr %262, i32 0, i32 3
+  store i32 1, ptr %267, align 4
+  %268 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %253, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %268, i32 1, ptr @57, ptr @54, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont39:                                         ; preds = %ifcont37
-  %269 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %270 = load i32, i32* %269, align 4
+  %269 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %270 = load i32, ptr %269, align 4
   %271 = icmp ne i32 %270, 0
   br i1 %271, label %then40, label %else41
 
 then40:                                           ; preds = %ifcont39
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @59, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @59, ptr @"ERROR STOP", ptr @58)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -775,44 +776,44 @@ ifcont42:                                         ; preds = %else41, %then40
   br i1 false, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  %272 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %273 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %274 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %273, i32 0, i32 0
-  %275 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @61, i32 0, i32 0), i8** %275, align 8
-  %276 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 1
-  store i32 21, i32* %276, align 4
-  %277 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 2
-  store i32 11, i32* %277, align 4
-  %278 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 3
-  store i32 21, i32* %278, align 4
-  %279 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %274, i32 0, i32 4
-  store i32 14, i32* %279, align 4
-  %280 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @62, i32 0, i32 0))
-  %281 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %272, i32 0, i32 0
-  %282 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %273, i32 0, i32 0
-  %283 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 2
-  %284 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 0
-  store i1 true, i1* %284, align 1
-  %285 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 1
-  store i8* %280, i8** %285, align 8
-  store { i8*, i32, i32, i32, i32 }* %282, { i8*, i32, i32, i32, i32 }** %283, align 8
-  %286 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %281, i32 0, i32 3
-  store i32 1, i32* %286, align 4
-  %287 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %272, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @60, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %272 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %273 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %274 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %273, i32 0, i32 0
+  %275 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 0
+  store ptr @61, ptr %275, align 8
+  %276 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 1
+  store i32 21, ptr %276, align 4
+  %277 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 2
+  store i32 11, ptr %277, align 4
+  %278 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 3
+  store i32 21, ptr %278, align 4
+  %279 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %274, i32 0, i32 4
+  store i32 14, ptr %279, align 4
+  %280 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @62)
+  %281 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %272, i32 0, i32 0
+  %282 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %273, i32 0, i32 0
+  %283 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 2
+  %284 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 0
+  store i1 true, ptr %284, align 1
+  %285 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 1
+  store ptr %280, ptr %285, align 8
+  store ptr %282, ptr %283, align 8
+  %286 = getelementptr { i1, ptr, ptr, i32 }, ptr %281, i32 0, i32 3
+  store i32 1, ptr %286, align 4
+  %287 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %272, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %287, i32 1, ptr @63, ptr @60, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %288 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %289 = load i32, i32* %288, align 4
+  %288 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %289 = load i32, ptr %288, align 4
   %290 = xor i32 %289, 1
   %291 = icmp ne i32 %290, 0
   br i1 %291, label %then45, label %else46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @65, ptr @"ERROR STOP", ptr @64)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -821,20 +822,20 @@ else46:                                           ; preds = %ifcont44
   br label %ifcont47
 
 ifcont47:                                         ; preds = %else46, %then45
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head48
 
 loop.head48:                                      ; preds = %ifcont53, %ifcont47
-  %292 = load i32, i32* %i, align 4
+  %292 = load i32, ptr %i, align 4
   %293 = add i32 %292, 1
   %294 = icmp sle i32 %293, 3
   br i1 %294, label %loop.body49, label %loop.end54
 
 loop.body49:                                      ; preds = %loop.head48
-  %295 = load i32, i32* %i, align 4
+  %295 = load i32, ptr %i, align 4
   %296 = add i32 %295, 1
-  store i32 %296, i32* %i, align 4
-  %297 = load i32, i32* %i, align 4
+  store i32 %296, ptr %i, align 4
+  %297 = load i32, ptr %i, align 4
   %298 = sext i32 %297 to i64
   %299 = sub i64 %298, 1
   %300 = mul i64 1, %299
@@ -845,38 +846,38 @@ loop.body49:                                      ; preds = %loop.head48
   br i1 %304, label %then50, label %ifcont51
 
 then50:                                           ; preds = %loop.body49
-  %305 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %306 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %307 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %306, i32 0, i32 0
-  %308 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %307, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @67, i32 0, i32 0), i8** %308, align 8
-  %309 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %307, i32 0, i32 1
-  store i32 24, i32* %309, align 4
-  %310 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %307, i32 0, i32 2
-  store i32 5, i32* %310, align 4
-  %311 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %307, i32 0, i32 3
-  store i32 24, i32* %311, align 4
-  %312 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %307, i32 0, i32 4
-  store i32 8, i32* %312, align 4
-  %313 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @68, i32 0, i32 0))
-  %314 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %305, i32 0, i32 0
-  %315 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %306, i32 0, i32 0
-  %316 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %314, i32 0, i32 2
-  %317 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %314, i32 0, i32 0
-  store i1 true, i1* %317, align 1
-  %318 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %314, i32 0, i32 1
-  store i8* %313, i8** %318, align 8
-  store { i8*, i32, i32, i32, i32 }* %315, { i8*, i32, i32, i32, i32 }** %316, align 8
-  %319 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %314, i32 0, i32 3
-  store i32 1, i32* %319, align 4
-  %320 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %305, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %320, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0), i64 %298, i32 1, i64 1, i64 4)
+  %305 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %306 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %307 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %306, i32 0, i32 0
+  %308 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %307, i32 0, i32 0
+  store ptr @67, ptr %308, align 8
+  %309 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %307, i32 0, i32 1
+  store i32 24, ptr %309, align 4
+  %310 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %307, i32 0, i32 2
+  store i32 5, ptr %310, align 4
+  %311 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %307, i32 0, i32 3
+  store i32 24, ptr %311, align 4
+  %312 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %307, i32 0, i32 4
+  store i32 8, ptr %312, align 4
+  %313 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @68)
+  %314 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %305, i32 0, i32 0
+  %315 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %306, i32 0, i32 0
+  %316 = getelementptr { i1, ptr, ptr, i32 }, ptr %314, i32 0, i32 2
+  %317 = getelementptr { i1, ptr, ptr, i32 }, ptr %314, i32 0, i32 0
+  store i1 true, ptr %317, align 1
+  %318 = getelementptr { i1, ptr, ptr, i32 }, ptr %314, i32 0, i32 1
+  store ptr %313, ptr %318, align 8
+  store ptr %315, ptr %316, align 8
+  %319 = getelementptr { i1, ptr, ptr, i32 }, ptr %314, i32 0, i32 3
+  store i32 1, ptr %319, align 4
+  %320 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %305, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %320, i32 1, ptr @69, ptr @66, i64 %298, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont51:                                         ; preds = %loop.body49
-  %321 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %301
-  %322 = load i32, i32* %i, align 4
+  %321 = getelementptr [4 x i32], ptr %b, i32 0, i64 %301
+  %322 = load i32, ptr %i, align 4
   %323 = sext i32 %322 to i64
   %324 = sub i64 %323, 1
   %325 = mul i64 1, %324
@@ -887,83 +888,83 @@ ifcont51:                                         ; preds = %loop.body49
   br i1 %329, label %then52, label %ifcont53
 
 then52:                                           ; preds = %ifcont51
-  %330 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %331 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %332 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %331, i32 0, i32 0
-  %333 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @71, i32 0, i32 0), i8** %333, align 8
-  %334 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 1
-  store i32 24, i32* %334, align 4
-  %335 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 2
-  store i32 12, i32* %335, align 4
-  %336 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 3
-  store i32 24, i32* %336, align 4
-  %337 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %332, i32 0, i32 4
-  store i32 15, i32* %337, align 4
-  %338 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @72, i32 0, i32 0))
-  %339 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %330, i32 0, i32 0
-  %340 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %331, i32 0, i32 0
-  %341 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 2
-  %342 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 0
-  store i1 true, i1* %342, align 1
-  %343 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 1
-  store i8* %338, i8** %343, align 8
-  store { i8*, i32, i32, i32, i32 }* %340, { i8*, i32, i32, i32, i32 }** %341, align 8
-  %344 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %339, i32 0, i32 3
-  store i32 1, i32* %344, align 4
-  %345 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %330, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %345, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i64 %323, i32 1, i64 1, i64 3)
+  %330 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %331 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %332 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %331, i32 0, i32 0
+  %333 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %332, i32 0, i32 0
+  store ptr @71, ptr %333, align 8
+  %334 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %332, i32 0, i32 1
+  store i32 24, ptr %334, align 4
+  %335 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %332, i32 0, i32 2
+  store i32 12, ptr %335, align 4
+  %336 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %332, i32 0, i32 3
+  store i32 24, ptr %336, align 4
+  %337 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %332, i32 0, i32 4
+  store i32 15, ptr %337, align 4
+  %338 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @72)
+  %339 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %330, i32 0, i32 0
+  %340 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %331, i32 0, i32 0
+  %341 = getelementptr { i1, ptr, ptr, i32 }, ptr %339, i32 0, i32 2
+  %342 = getelementptr { i1, ptr, ptr, i32 }, ptr %339, i32 0, i32 0
+  store i1 true, ptr %342, align 1
+  %343 = getelementptr { i1, ptr, ptr, i32 }, ptr %339, i32 0, i32 1
+  store ptr %338, ptr %343, align 8
+  store ptr %340, ptr %341, align 8
+  %344 = getelementptr { i1, ptr, ptr, i32 }, ptr %339, i32 0, i32 3
+  store i32 1, ptr %344, align 4
+  %345 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %330, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %345, i32 1, ptr @73, ptr @70, i64 %323, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont53:                                         ; preds = %ifcont51
-  %346 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %326
-  %347 = load i32, i32* %346, align 4
+  %346 = getelementptr [3 x i32], ptr %a, i32 0, i64 %326
+  %347 = load i32, ptr %346, align 4
   %348 = and i32 %347, 0
-  store i32 %348, i32* %321, align 4
+  store i32 %348, ptr %321, align 4
   br label %loop.head48
 
 loop.end54:                                       ; preds = %loop.head48
   br i1 false, label %then55, label %ifcont56
 
 then55:                                           ; preds = %loop.end54
-  %349 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %350 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %351 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
-  %352 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @75, i32 0, i32 0), i8** %352, align 8
-  %353 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 1
-  store i32 26, i32* %353, align 4
-  %354 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 2
-  store i32 5, i32* %354, align 4
-  %355 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 3
-  store i32 26, i32* %355, align 4
-  %356 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %351, i32 0, i32 4
-  store i32 8, i32* %356, align 4
-  %357 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @76, i32 0, i32 0))
-  %358 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
-  %359 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %350, i32 0, i32 0
-  %360 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 2
-  %361 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 0
-  store i1 true, i1* %361, align 1
-  %362 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 1
-  store i8* %357, i8** %362, align 8
-  store { i8*, i32, i32, i32, i32 }* %359, { i8*, i32, i32, i32, i32 }** %360, align 8
-  %363 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %358, i32 0, i32 3
-  store i32 1, i32* %363, align 4
-  %364 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %349, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %364, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %349 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %350 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %351 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %350, i32 0, i32 0
+  %352 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 0
+  store ptr @75, ptr %352, align 8
+  %353 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 1
+  store i32 26, ptr %353, align 4
+  %354 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 2
+  store i32 5, ptr %354, align 4
+  %355 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 3
+  store i32 26, ptr %355, align 4
+  %356 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %351, i32 0, i32 4
+  store i32 8, ptr %356, align 4
+  %357 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @76)
+  %358 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %349, i32 0, i32 0
+  %359 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %350, i32 0, i32 0
+  %360 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 2
+  %361 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 0
+  store i1 true, ptr %361, align 1
+  %362 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 1
+  store ptr %357, ptr %362, align 8
+  store ptr %359, ptr %360, align 8
+  %363 = getelementptr { i1, ptr, ptr, i32 }, ptr %358, i32 0, i32 3
+  store i32 1, ptr %363, align 4
+  %364 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %349, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %364, i32 1, ptr @77, ptr @74, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont56:                                         ; preds = %loop.end54
-  %365 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %366 = load i32, i32* %365, align 4
+  %365 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %366 = load i32, ptr %365, align 4
   %367 = icmp ne i32 %366, 0
   br i1 %367, label %then57, label %else58
 
 then57:                                           ; preds = %ifcont56
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @79, ptr @"ERROR STOP", ptr @78)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont59
@@ -975,43 +976,43 @@ ifcont59:                                         ; preds = %else58, %then57
   br i1 false, label %then60, label %ifcont61
 
 then60:                                           ; preds = %ifcont59
-  %368 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %369 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %370 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %369, i32 0, i32 0
-  %371 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @81, i32 0, i32 0), i8** %371, align 8
-  %372 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 1
-  store i32 27, i32* %372, align 4
-  %373 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 2
-  store i32 5, i32* %373, align 4
-  %374 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 3
-  store i32 27, i32* %374, align 4
-  %375 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %370, i32 0, i32 4
-  store i32 8, i32* %375, align 4
-  %376 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @82, i32 0, i32 0))
-  %377 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %368, i32 0, i32 0
-  %378 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %369, i32 0, i32 0
-  %379 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 2
-  %380 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 0
-  store i1 true, i1* %380, align 1
-  %381 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 1
-  store i8* %376, i8** %381, align 8
-  store { i8*, i32, i32, i32, i32 }* %378, { i8*, i32, i32, i32, i32 }** %379, align 8
-  %382 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %377, i32 0, i32 3
-  store i32 1, i32* %382, align 4
-  %383 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %368, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %368 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %369 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %370 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %369, i32 0, i32 0
+  %371 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 0
+  store ptr @81, ptr %371, align 8
+  %372 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 1
+  store i32 27, ptr %372, align 4
+  %373 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 2
+  store i32 5, ptr %373, align 4
+  %374 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 3
+  store i32 27, ptr %374, align 4
+  %375 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %370, i32 0, i32 4
+  store i32 8, ptr %375, align 4
+  %376 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @82)
+  %377 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %368, i32 0, i32 0
+  %378 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %369, i32 0, i32 0
+  %379 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 2
+  %380 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 0
+  store i1 true, ptr %380, align 1
+  %381 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 1
+  store ptr %376, ptr %381, align 8
+  store ptr %378, ptr %379, align 8
+  %382 = getelementptr { i1, ptr, ptr, i32 }, ptr %377, i32 0, i32 3
+  store i32 1, ptr %382, align 4
+  %383 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %368, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %383, i32 1, ptr @83, ptr @80, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont61:                                         ; preds = %ifcont59
-  %384 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %385 = load i32, i32* %384, align 4
+  %384 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %385 = load i32, ptr %384, align 4
   %386 = icmp ne i32 %385, 0
   br i1 %386, label %then62, label %else63
 
 then62:                                           ; preds = %ifcont61
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @85, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @85, ptr @"ERROR STOP", ptr @84)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont64
@@ -1023,43 +1024,43 @@ ifcont64:                                         ; preds = %else63, %then62
   br i1 false, label %then65, label %ifcont66
 
 then65:                                           ; preds = %ifcont64
-  %387 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %388 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %389 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
-  %390 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @87, i32 0, i32 0), i8** %390, align 8
-  %391 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 1
-  store i32 28, i32* %391, align 4
-  %392 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 2
-  store i32 5, i32* %392, align 4
-  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 3
-  store i32 28, i32* %393, align 4
-  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %389, i32 0, i32 4
-  store i32 8, i32* %394, align 4
-  %395 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @88, i32 0, i32 0))
-  %396 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
-  %397 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %388, i32 0, i32 0
-  %398 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 2
-  %399 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 0
-  store i1 true, i1* %399, align 1
-  %400 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 1
-  store i8* %395, i8** %400, align 8
-  store { i8*, i32, i32, i32, i32 }* %397, { i8*, i32, i32, i32, i32 }** %398, align 8
-  %401 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %396, i32 0, i32 3
-  store i32 1, i32* %401, align 4
-  %402 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %387, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %402, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @89, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @86, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %387 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %388 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %389 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %388, i32 0, i32 0
+  %390 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 0
+  store ptr @87, ptr %390, align 8
+  %391 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 1
+  store i32 28, ptr %391, align 4
+  %392 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 2
+  store i32 5, ptr %392, align 4
+  %393 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 3
+  store i32 28, ptr %393, align 4
+  %394 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %389, i32 0, i32 4
+  store i32 8, ptr %394, align 4
+  %395 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @88)
+  %396 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %387, i32 0, i32 0
+  %397 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %388, i32 0, i32 0
+  %398 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 2
+  %399 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 0
+  store i1 true, ptr %399, align 1
+  %400 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 1
+  store ptr %395, ptr %400, align 8
+  store ptr %397, ptr %398, align 8
+  %401 = getelementptr { i1, ptr, ptr, i32 }, ptr %396, i32 0, i32 3
+  store i32 1, ptr %401, align 4
+  %402 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %387, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %402, i32 1, ptr @89, ptr @86, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont66:                                         ; preds = %ifcont64
-  %403 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %404 = load i32, i32* %403, align 4
+  %403 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %404 = load i32, ptr %403, align 4
   %405 = icmp ne i32 %404, 0
   br i1 %405, label %then67, label %else68
 
 then67:                                           ; preds = %ifcont66
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @90, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @91, ptr @"ERROR STOP", ptr @90)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -1071,222 +1072,222 @@ ifcont69:                                         ; preds = %else68, %then67
   br i1 false, label %then70, label %ifcont71
 
 then70:                                           ; preds = %ifcont69
-  %406 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %407 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %408 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %407, i32 0, i32 0
-  %409 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @93, i32 0, i32 0), i8** %409, align 8
-  %410 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 1
-  store i32 30, i32* %410, align 4
-  %411 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 2
-  store i32 1, i32* %411, align 4
-  %412 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 3
-  store i32 30, i32* %412, align 4
-  %413 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %408, i32 0, i32 4
-  store i32 4, i32* %413, align 4
-  %414 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %415 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %406, i32 0, i32 0
-  %416 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %407, i32 0, i32 0
-  %417 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 2
-  %418 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 0
-  store i1 true, i1* %418, align 1
-  %419 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 1
-  store i8* %414, i8** %419, align 8
-  store { i8*, i32, i32, i32, i32 }* %416, { i8*, i32, i32, i32, i32 }** %417, align 8
-  %420 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %415, i32 0, i32 3
-  store i32 1, i32* %420, align 4
-  %421 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %406, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %421, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %406 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %407 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %408 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %407, i32 0, i32 0
+  %409 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 0
+  store ptr @93, ptr %409, align 8
+  %410 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 1
+  store i32 30, ptr %410, align 4
+  %411 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 2
+  store i32 1, ptr %411, align 4
+  %412 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 3
+  store i32 30, ptr %412, align 4
+  %413 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %408, i32 0, i32 4
+  store i32 4, ptr %413, align 4
+  %414 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @94)
+  %415 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %406, i32 0, i32 0
+  %416 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %407, i32 0, i32 0
+  %417 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 2
+  %418 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 0
+  store i1 true, ptr %418, align 1
+  %419 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 1
+  store ptr %414, ptr %419, align 8
+  store ptr %416, ptr %417, align 8
+  %420 = getelementptr { i1, ptr, ptr, i32 }, ptr %415, i32 0, i32 3
+  store i32 1, ptr %420, align 4
+  %421 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %406, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %421, i32 1, ptr @95, ptr @92, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont71:                                         ; preds = %ifcont69
-  %422 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %422 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then72, label %ifcont73
 
 then72:                                           ; preds = %ifcont71
-  %423 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %424 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %425 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %424, i32 0, i32 0
-  %426 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %425, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @97, i32 0, i32 0), i8** %426, align 8
-  %427 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %425, i32 0, i32 1
-  store i32 30, i32* %427, align 4
-  %428 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %425, i32 0, i32 2
-  store i32 8, i32* %428, align 4
-  %429 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %425, i32 0, i32 3
-  store i32 30, i32* %429, align 4
-  %430 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %425, i32 0, i32 4
-  store i32 11, i32* %430, align 4
-  %431 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %432 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %423, i32 0, i32 0
-  %433 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %424, i32 0, i32 0
-  %434 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 0, i32 2
-  %435 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 0, i32 0
-  store i1 true, i1* %435, align 1
-  %436 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 0, i32 1
-  store i8* %431, i8** %436, align 8
-  store { i8*, i32, i32, i32, i32 }* %433, { i8*, i32, i32, i32, i32 }** %434, align 8
-  %437 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 0, i32 3
-  store i32 1, i32* %437, align 4
-  %438 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %423, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %438, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %423 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %424 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %425 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %424, i32 0, i32 0
+  %426 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %425, i32 0, i32 0
+  store ptr @97, ptr %426, align 8
+  %427 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %425, i32 0, i32 1
+  store i32 30, ptr %427, align 4
+  %428 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %425, i32 0, i32 2
+  store i32 8, ptr %428, align 4
+  %429 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %425, i32 0, i32 3
+  store i32 30, ptr %429, align 4
+  %430 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %425, i32 0, i32 4
+  store i32 11, ptr %430, align 4
+  %431 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @98)
+  %432 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %423, i32 0, i32 0
+  %433 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %424, i32 0, i32 0
+  %434 = getelementptr { i1, ptr, ptr, i32 }, ptr %432, i32 0, i32 2
+  %435 = getelementptr { i1, ptr, ptr, i32 }, ptr %432, i32 0, i32 0
+  store i1 true, ptr %435, align 1
+  %436 = getelementptr { i1, ptr, ptr, i32 }, ptr %432, i32 0, i32 1
+  store ptr %431, ptr %436, align 8
+  store ptr %433, ptr %434, align 8
+  %437 = getelementptr { i1, ptr, ptr, i32 }, ptr %432, i32 0, i32 3
+  store i32 1, ptr %437, align 4
+  %438 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %423, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %438, i32 1, ptr @99, ptr @96, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont73:                                         ; preds = %ifcont71
-  %439 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %440 = load i32, i32* %439, align 4
+  %439 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %440 = load i32, ptr %439, align 4
   br i1 false, label %then74, label %ifcont75
 
 then74:                                           ; preds = %ifcont73
-  %441 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %442 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %443 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %442, i32 0, i32 0
-  %444 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @101, i32 0, i32 0), i8** %444, align 8
-  %445 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 1
-  store i32 30, i32* %445, align 4
-  %446 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 2
-  store i32 18, i32* %446, align 4
-  %447 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 3
-  store i32 30, i32* %447, align 4
-  %448 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %443, i32 0, i32 4
-  store i32 21, i32* %448, align 4
-  %449 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @102, i32 0, i32 0))
-  %450 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %441, i32 0, i32 0
-  %451 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %442, i32 0, i32 0
-  %452 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 2
-  %453 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 0
-  store i1 true, i1* %453, align 1
-  %454 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 1
-  store i8* %449, i8** %454, align 8
-  store { i8*, i32, i32, i32, i32 }* %451, { i8*, i32, i32, i32, i32 }** %452, align 8
-  %455 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %450, i32 0, i32 3
-  store i32 1, i32* %455, align 4
-  %456 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %441, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %456, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %441 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %442 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %443 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %442, i32 0, i32 0
+  %444 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 0
+  store ptr @101, ptr %444, align 8
+  %445 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 1
+  store i32 30, ptr %445, align 4
+  %446 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 2
+  store i32 18, ptr %446, align 4
+  %447 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 3
+  store i32 30, ptr %447, align 4
+  %448 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %443, i32 0, i32 4
+  store i32 21, ptr %448, align 4
+  %449 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @102)
+  %450 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %441, i32 0, i32 0
+  %451 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %442, i32 0, i32 0
+  %452 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 2
+  %453 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 0
+  store i1 true, ptr %453, align 1
+  %454 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 1
+  store ptr %449, ptr %454, align 8
+  store ptr %451, ptr %452, align 8
+  %455 = getelementptr { i1, ptr, ptr, i32 }, ptr %450, i32 0, i32 3
+  store i32 1, ptr %455, align 4
+  %456 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %441, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %456, i32 1, ptr @103, ptr @100, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont75:                                         ; preds = %ifcont73
-  %457 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %458 = load i32, i32* %457, align 4
+  %457 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %458 = load i32, ptr %457, align 4
   %459 = or i32 %440, %458
   br i1 false, label %then76, label %ifcont77
 
 then76:                                           ; preds = %ifcont75
-  %460 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %461 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %462 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %461, i32 0, i32 0
-  %463 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @105, i32 0, i32 0), i8** %463, align 8
-  %464 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 1
-  store i32 30, i32* %464, align 4
-  %465 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 2
-  store i32 28, i32* %465, align 4
-  %466 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 3
-  store i32 30, i32* %466, align 4
-  %467 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %462, i32 0, i32 4
-  store i32 31, i32* %467, align 4
-  %468 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @106, i32 0, i32 0))
-  %469 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %460, i32 0, i32 0
-  %470 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %461, i32 0, i32 0
-  %471 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 2
-  %472 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 0
-  store i1 true, i1* %472, align 1
-  %473 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 1
-  store i8* %468, i8** %473, align 8
-  store { i8*, i32, i32, i32, i32 }* %470, { i8*, i32, i32, i32, i32 }** %471, align 8
-  %474 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %469, i32 0, i32 3
-  store i32 1, i32* %474, align 4
-  %475 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %460, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %475, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @107, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %460 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %461 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %462 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %461, i32 0, i32 0
+  %463 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 0
+  store ptr @105, ptr %463, align 8
+  %464 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 1
+  store i32 30, ptr %464, align 4
+  %465 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 2
+  store i32 28, ptr %465, align 4
+  %466 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 3
+  store i32 30, ptr %466, align 4
+  %467 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %462, i32 0, i32 4
+  store i32 31, ptr %467, align 4
+  %468 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @106)
+  %469 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %460, i32 0, i32 0
+  %470 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %461, i32 0, i32 0
+  %471 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 2
+  %472 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 0
+  store i1 true, ptr %472, align 1
+  %473 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 1
+  store ptr %468, ptr %473, align 8
+  store ptr %470, ptr %471, align 8
+  %474 = getelementptr { i1, ptr, ptr, i32 }, ptr %469, i32 0, i32 3
+  store i32 1, ptr %474, align 4
+  %475 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %460, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %475, i32 1, ptr @107, ptr @104, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont77:                                         ; preds = %ifcont75
-  %476 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %477 = load i32, i32* %476, align 4
+  %476 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %477 = load i32, ptr %476, align 4
   %478 = or i32 %459, %477
   br i1 false, label %then78, label %ifcont79
 
 then78:                                           ; preds = %ifcont77
-  %479 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %480 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %481 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %480, i32 0, i32 0
-  %482 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %481, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @109, i32 0, i32 0), i8** %482, align 8
-  %483 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %481, i32 0, i32 1
-  store i32 30, i32* %483, align 4
-  %484 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %481, i32 0, i32 2
-  store i32 38, i32* %484, align 4
-  %485 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %481, i32 0, i32 3
-  store i32 30, i32* %485, align 4
-  %486 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %481, i32 0, i32 4
-  store i32 41, i32* %486, align 4
-  %487 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @110, i32 0, i32 0))
-  %488 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %479, i32 0, i32 0
-  %489 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %480, i32 0, i32 0
-  %490 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %488, i32 0, i32 2
-  %491 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %488, i32 0, i32 0
-  store i1 true, i1* %491, align 1
-  %492 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %488, i32 0, i32 1
-  store i8* %487, i8** %492, align 8
-  store { i8*, i32, i32, i32, i32 }* %489, { i8*, i32, i32, i32, i32 }** %490, align 8
-  %493 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %488, i32 0, i32 3
-  store i32 1, i32* %493, align 4
-  %494 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %479, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %494, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @111, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @108, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %479 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %480 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %481 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %480, i32 0, i32 0
+  %482 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %481, i32 0, i32 0
+  store ptr @109, ptr %482, align 8
+  %483 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %481, i32 0, i32 1
+  store i32 30, ptr %483, align 4
+  %484 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %481, i32 0, i32 2
+  store i32 38, ptr %484, align 4
+  %485 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %481, i32 0, i32 3
+  store i32 30, ptr %485, align 4
+  %486 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %481, i32 0, i32 4
+  store i32 41, ptr %486, align 4
+  %487 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @110)
+  %488 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %479, i32 0, i32 0
+  %489 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %480, i32 0, i32 0
+  %490 = getelementptr { i1, ptr, ptr, i32 }, ptr %488, i32 0, i32 2
+  %491 = getelementptr { i1, ptr, ptr, i32 }, ptr %488, i32 0, i32 0
+  store i1 true, ptr %491, align 1
+  %492 = getelementptr { i1, ptr, ptr, i32 }, ptr %488, i32 0, i32 1
+  store ptr %487, ptr %492, align 8
+  store ptr %489, ptr %490, align 8
+  %493 = getelementptr { i1, ptr, ptr, i32 }, ptr %488, i32 0, i32 3
+  store i32 1, ptr %493, align 4
+  %494 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %479, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %494, i32 1, ptr @111, ptr @108, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont79:                                         ; preds = %ifcont77
-  %495 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %496 = load i32, i32* %495, align 4
+  %495 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %496 = load i32, ptr %495, align 4
   %497 = or i32 %478, %496
-  store i32 %497, i32* %422, align 4
+  store i32 %497, ptr %422, align 4
   br i1 false, label %then80, label %ifcont81
 
 then80:                                           ; preds = %ifcont79
-  %498 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %499 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %500 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %499, i32 0, i32 0
-  %501 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %500, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @113, i32 0, i32 0), i8** %501, align 8
-  %502 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %500, i32 0, i32 1
-  store i32 31, i32* %502, align 4
-  %503 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %500, i32 0, i32 2
-  store i32 11, i32* %503, align 4
-  %504 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %500, i32 0, i32 3
-  store i32 31, i32* %504, align 4
-  %505 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %500, i32 0, i32 4
-  store i32 14, i32* %505, align 4
-  %506 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @114, i32 0, i32 0))
-  %507 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %498, i32 0, i32 0
-  %508 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %499, i32 0, i32 0
-  %509 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %507, i32 0, i32 2
-  %510 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %507, i32 0, i32 0
-  store i1 true, i1* %510, align 1
-  %511 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %507, i32 0, i32 1
-  store i8* %506, i8** %511, align 8
-  store { i8*, i32, i32, i32, i32 }* %508, { i8*, i32, i32, i32, i32 }** %509, align 8
-  %512 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %507, i32 0, i32 3
-  store i32 1, i32* %512, align 4
-  %513 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %498, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %513, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @112, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %498 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %499 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %500 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %499, i32 0, i32 0
+  %501 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %500, i32 0, i32 0
+  store ptr @113, ptr %501, align 8
+  %502 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %500, i32 0, i32 1
+  store i32 31, ptr %502, align 4
+  %503 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %500, i32 0, i32 2
+  store i32 11, ptr %503, align 4
+  %504 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %500, i32 0, i32 3
+  store i32 31, ptr %504, align 4
+  %505 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %500, i32 0, i32 4
+  store i32 14, ptr %505, align 4
+  %506 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @114)
+  %507 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %498, i32 0, i32 0
+  %508 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %499, i32 0, i32 0
+  %509 = getelementptr { i1, ptr, ptr, i32 }, ptr %507, i32 0, i32 2
+  %510 = getelementptr { i1, ptr, ptr, i32 }, ptr %507, i32 0, i32 0
+  store i1 true, ptr %510, align 1
+  %511 = getelementptr { i1, ptr, ptr, i32 }, ptr %507, i32 0, i32 1
+  store ptr %506, ptr %511, align 8
+  store ptr %508, ptr %509, align 8
+  %512 = getelementptr { i1, ptr, ptr, i32 }, ptr %507, i32 0, i32 3
+  store i32 1, ptr %512, align 4
+  %513 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %498, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %513, i32 1, ptr @115, ptr @112, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont81:                                         ; preds = %ifcont79
-  %514 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %515 = load i32, i32* %514, align 4
+  %514 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %515 = load i32, ptr %514, align 4
   %516 = xor i32 %515, 1
   %517 = icmp ne i32 %516, 0
   br i1 %517, label %then82, label %else83
 
 then82:                                           ; preds = %ifcont81
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @117, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @116, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @117, ptr @"ERROR STOP", ptr @116)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont84
@@ -1298,114 +1299,114 @@ ifcont84:                                         ; preds = %else83, %then82
   br i1 false, label %then85, label %ifcont86
 
 then85:                                           ; preds = %ifcont84
-  %518 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %519 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %520 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %519, i32 0, i32 0
-  %521 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @119, i32 0, i32 0), i8** %521, align 8
-  %522 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 1
-  store i32 33, i32* %522, align 4
-  %523 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 2
-  store i32 1, i32* %523, align 4
-  %524 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 3
-  store i32 33, i32* %524, align 4
-  %525 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %520, i32 0, i32 4
-  store i32 4, i32* %525, align 4
-  %526 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @120, i32 0, i32 0))
-  %527 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %518, i32 0, i32 0
-  %528 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %519, i32 0, i32 0
-  %529 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 2
-  %530 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 0
-  store i1 true, i1* %530, align 1
-  %531 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 1
-  store i8* %526, i8** %531, align 8
-  store { i8*, i32, i32, i32, i32 }* %528, { i8*, i32, i32, i32, i32 }** %529, align 8
-  %532 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %527, i32 0, i32 3
-  store i32 1, i32* %532, align 4
-  %533 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %518, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %533, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @121, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @118, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %518 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %519 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %520 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %519, i32 0, i32 0
+  %521 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 0
+  store ptr @119, ptr %521, align 8
+  %522 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 1
+  store i32 33, ptr %522, align 4
+  %523 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 2
+  store i32 1, ptr %523, align 4
+  %524 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 3
+  store i32 33, ptr %524, align 4
+  %525 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %520, i32 0, i32 4
+  store i32 4, ptr %525, align 4
+  %526 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @120)
+  %527 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %518, i32 0, i32 0
+  %528 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %519, i32 0, i32 0
+  %529 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 2
+  %530 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 0
+  store i1 true, ptr %530, align 1
+  %531 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 1
+  store ptr %526, ptr %531, align 8
+  store ptr %528, ptr %529, align 8
+  %532 = getelementptr { i1, ptr, ptr, i32 }, ptr %527, i32 0, i32 3
+  store i32 1, ptr %532, align 4
+  %533 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %518, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %533, i32 1, ptr @121, ptr @118, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont86:                                         ; preds = %ifcont84
-  %534 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %534 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then87, label %ifcont88
 
 then87:                                           ; preds = %ifcont86
-  %535 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %536 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %537 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %536, i32 0, i32 0
-  %538 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %537, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @123, i32 0, i32 0), i8** %538, align 8
-  %539 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %537, i32 0, i32 1
-  store i32 33, i32* %539, align 4
-  %540 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %537, i32 0, i32 2
-  store i32 8, i32* %540, align 4
-  %541 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %537, i32 0, i32 3
-  store i32 33, i32* %541, align 4
-  %542 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %537, i32 0, i32 4
-  store i32 11, i32* %542, align 4
-  %543 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @124, i32 0, i32 0))
-  %544 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %535, i32 0, i32 0
-  %545 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %536, i32 0, i32 0
-  %546 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %544, i32 0, i32 2
-  %547 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %544, i32 0, i32 0
-  store i1 true, i1* %547, align 1
-  %548 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %544, i32 0, i32 1
-  store i8* %543, i8** %548, align 8
-  store { i8*, i32, i32, i32, i32 }* %545, { i8*, i32, i32, i32, i32 }** %546, align 8
-  %549 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %544, i32 0, i32 3
-  store i32 1, i32* %549, align 4
-  %550 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %535, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %550, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @125, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @122, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %535 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %536 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %537 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %536, i32 0, i32 0
+  %538 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %537, i32 0, i32 0
+  store ptr @123, ptr %538, align 8
+  %539 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %537, i32 0, i32 1
+  store i32 33, ptr %539, align 4
+  %540 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %537, i32 0, i32 2
+  store i32 8, ptr %540, align 4
+  %541 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %537, i32 0, i32 3
+  store i32 33, ptr %541, align 4
+  %542 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %537, i32 0, i32 4
+  store i32 11, ptr %542, align 4
+  %543 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @124)
+  %544 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %535, i32 0, i32 0
+  %545 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %536, i32 0, i32 0
+  %546 = getelementptr { i1, ptr, ptr, i32 }, ptr %544, i32 0, i32 2
+  %547 = getelementptr { i1, ptr, ptr, i32 }, ptr %544, i32 0, i32 0
+  store i1 true, ptr %547, align 1
+  %548 = getelementptr { i1, ptr, ptr, i32 }, ptr %544, i32 0, i32 1
+  store ptr %543, ptr %548, align 8
+  store ptr %545, ptr %546, align 8
+  %549 = getelementptr { i1, ptr, ptr, i32 }, ptr %544, i32 0, i32 3
+  store i32 1, ptr %549, align 4
+  %550 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %535, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %550, i32 1, ptr @125, ptr @122, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont88:                                         ; preds = %ifcont86
-  %551 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %552 = load i32, i32* %551, align 4
-  store i32 %552, i32* %534, align 4
+  %551 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %552 = load i32, ptr %551, align 4
+  store i32 %552, ptr %534, align 4
   br i1 false, label %then89, label %ifcont90
 
 then89:                                           ; preds = %ifcont88
-  %553 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %554 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %555 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %554, i32 0, i32 0
-  %556 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %555, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @127, i32 0, i32 0), i8** %556, align 8
-  %557 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %555, i32 0, i32 1
-  store i32 34, i32* %557, align 4
-  %558 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %555, i32 0, i32 2
-  store i32 11, i32* %558, align 4
-  %559 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %555, i32 0, i32 3
-  store i32 34, i32* %559, align 4
-  %560 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %555, i32 0, i32 4
-  store i32 14, i32* %560, align 4
-  %561 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @128, i32 0, i32 0))
-  %562 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %553, i32 0, i32 0
-  %563 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %554, i32 0, i32 0
-  %564 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %562, i32 0, i32 2
-  %565 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %562, i32 0, i32 0
-  store i1 true, i1* %565, align 1
-  %566 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %562, i32 0, i32 1
-  store i8* %561, i8** %566, align 8
-  store { i8*, i32, i32, i32, i32 }* %563, { i8*, i32, i32, i32, i32 }** %564, align 8
-  %567 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %562, i32 0, i32 3
-  store i32 1, i32* %567, align 4
-  %568 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %553, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %568, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @129, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @126, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %553 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %554 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %555 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %554, i32 0, i32 0
+  %556 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %555, i32 0, i32 0
+  store ptr @127, ptr %556, align 8
+  %557 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %555, i32 0, i32 1
+  store i32 34, ptr %557, align 4
+  %558 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %555, i32 0, i32 2
+  store i32 11, ptr %558, align 4
+  %559 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %555, i32 0, i32 3
+  store i32 34, ptr %559, align 4
+  %560 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %555, i32 0, i32 4
+  store i32 14, ptr %560, align 4
+  %561 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @128)
+  %562 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %553, i32 0, i32 0
+  %563 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %554, i32 0, i32 0
+  %564 = getelementptr { i1, ptr, ptr, i32 }, ptr %562, i32 0, i32 2
+  %565 = getelementptr { i1, ptr, ptr, i32 }, ptr %562, i32 0, i32 0
+  store i1 true, ptr %565, align 1
+  %566 = getelementptr { i1, ptr, ptr, i32 }, ptr %562, i32 0, i32 1
+  store ptr %561, ptr %566, align 8
+  store ptr %563, ptr %564, align 8
+  %567 = getelementptr { i1, ptr, ptr, i32 }, ptr %562, i32 0, i32 3
+  store i32 1, ptr %567, align 4
+  %568 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %553, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %568, i32 1, ptr @129, ptr @126, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont90:                                         ; preds = %ifcont88
-  %569 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %570 = load i32, i32* %569, align 4
+  %569 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %570 = load i32, ptr %569, align 4
   %571 = xor i32 %570, 1
   %572 = icmp ne i32 %571, 0
   br i1 %572, label %then91, label %else92
 
 then91:                                           ; preds = %ifcont90
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @131, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @130, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @131, ptr @"ERROR STOP", ptr @130)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont93
@@ -1414,37 +1415,37 @@ else92:                                           ; preds = %ifcont90
   br label %ifcont93
 
 ifcont93:                                         ; preds = %else92, %then91
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head94
 
 loop.head94:                                      ; preds = %loop.end109, %ifcont93
-  %573 = load i32, i32* %i, align 4
+  %573 = load i32, ptr %i, align 4
   %574 = add i32 %573, 1
   %575 = icmp sle i32 %574, 2
   br i1 %575, label %loop.body95, label %loop.end110
 
 loop.body95:                                      ; preds = %loop.head94
-  %576 = load i32, i32* %i, align 4
+  %576 = load i32, ptr %i, align 4
   %577 = add i32 %576, 1
-  store i32 %577, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %577, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head96
 
 loop.head96:                                      ; preds = %ifcont108, %loop.body95
-  %578 = load i32, i32* %j, align 4
+  %578 = load i32, ptr %j, align 4
   %579 = add i32 %578, 1
   %580 = icmp sle i32 %579, 2
   br i1 %580, label %loop.body97, label %loop.end109
 
 loop.body97:                                      ; preds = %loop.head96
-  %581 = load i32, i32* %j, align 4
+  %581 = load i32, ptr %j, align 4
   %582 = add i32 %581, 1
-  store i32 %582, i32* %j, align 4
-  %583 = load i32, i32* %i, align 4
-  %584 = load i32, i32* %j, align 4
+  store i32 %582, ptr %j, align 4
+  %583 = load i32, ptr %i, align 4
+  %584 = load i32, ptr %j, align 4
   %585 = add i32 %583, %584
-  %586 = load i32, i32* %i, align 4
-  %587 = load i32, i32* %j, align 4
+  %586 = load i32, ptr %i, align 4
+  %587 = load i32, ptr %j, align 4
   %588 = add i32 %586, %587
   %589 = sdiv i32 %588, 2
   %590 = mul i32 2, %589
@@ -1453,8 +1454,8 @@ loop.body97:                                      ; preds = %loop.head96
   br i1 %592, label %then98, label %else103
 
 then98:                                           ; preds = %loop.body97
-  %593 = load i32, i32* %i, align 4
-  %594 = load i32, i32* %j, align 4
+  %593 = load i32, ptr %i, align 4
+  %594 = load i32, ptr %j, align 4
   %595 = sext i32 %593 to i64
   %596 = sub i64 %595, 1
   %597 = mul i64 1, %596
@@ -1465,32 +1466,32 @@ then98:                                           ; preds = %loop.body97
   br i1 %601, label %then99, label %ifcont100
 
 then99:                                           ; preds = %then98
-  %602 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %603 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %604 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %603, i32 0, i32 0
-  %605 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %604, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @133, i32 0, i32 0), i8** %605, align 8
-  %606 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %604, i32 0, i32 1
-  store i32 39, i32* %606, align 4
-  %607 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %604, i32 0, i32 2
-  store i32 13, i32* %607, align 4
-  %608 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %604, i32 0, i32 3
-  store i32 39, i32* %608, align 4
-  %609 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %604, i32 0, i32 4
-  store i32 19, i32* %609, align 4
-  %610 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @134, i32 0, i32 0))
-  %611 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %602, i32 0, i32 0
-  %612 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %603, i32 0, i32 0
-  %613 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %611, i32 0, i32 2
-  %614 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %611, i32 0, i32 0
-  store i1 true, i1* %614, align 1
-  %615 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %611, i32 0, i32 1
-  store i8* %610, i8** %615, align 8
-  store { i8*, i32, i32, i32, i32 }* %612, { i8*, i32, i32, i32, i32 }** %613, align 8
-  %616 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %611, i32 0, i32 3
-  store i32 1, i32* %616, align 4
-  %617 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %602, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %617, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @135, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0), i64 %595, i32 1, i64 1, i64 2)
+  %602 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %603 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %604 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %603, i32 0, i32 0
+  %605 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %604, i32 0, i32 0
+  store ptr @133, ptr %605, align 8
+  %606 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %604, i32 0, i32 1
+  store i32 39, ptr %606, align 4
+  %607 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %604, i32 0, i32 2
+  store i32 13, ptr %607, align 4
+  %608 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %604, i32 0, i32 3
+  store i32 39, ptr %608, align 4
+  %609 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %604, i32 0, i32 4
+  store i32 19, ptr %609, align 4
+  %610 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @134)
+  %611 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %602, i32 0, i32 0
+  %612 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %603, i32 0, i32 0
+  %613 = getelementptr { i1, ptr, ptr, i32 }, ptr %611, i32 0, i32 2
+  %614 = getelementptr { i1, ptr, ptr, i32 }, ptr %611, i32 0, i32 0
+  store i1 true, ptr %614, align 1
+  %615 = getelementptr { i1, ptr, ptr, i32 }, ptr %611, i32 0, i32 1
+  store ptr %610, ptr %615, align 8
+  store ptr %612, ptr %613, align 8
+  %616 = getelementptr { i1, ptr, ptr, i32 }, ptr %611, i32 0, i32 3
+  store i32 1, ptr %616, align 4
+  %617 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %602, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %617, i32 1, ptr @135, ptr @132, i64 %595, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1505,43 +1506,43 @@ ifcont100:                                        ; preds = %then98
   br i1 %624, label %then101, label %ifcont102
 
 then101:                                          ; preds = %ifcont100
-  %625 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %626 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %627 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %626, i32 0, i32 0
-  %628 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @137, i32 0, i32 0), i8** %628, align 8
-  %629 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 1
-  store i32 39, i32* %629, align 4
-  %630 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 2
-  store i32 13, i32* %630, align 4
-  %631 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 3
-  store i32 39, i32* %631, align 4
-  %632 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %627, i32 0, i32 4
-  store i32 19, i32* %632, align 4
-  %633 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @138, i32 0, i32 0))
-  %634 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %625, i32 0, i32 0
-  %635 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %626, i32 0, i32 0
-  %636 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 2
-  %637 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 0
-  store i1 true, i1* %637, align 1
-  %638 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 1
-  store i8* %633, i8** %638, align 8
-  store { i8*, i32, i32, i32, i32 }* %635, { i8*, i32, i32, i32, i32 }** %636, align 8
-  %639 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %634, i32 0, i32 3
-  store i32 1, i32* %639, align 4
-  %640 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %625, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @139, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @136, i32 0, i32 0), i64 %618, i32 2, i64 1, i64 2)
+  %625 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %626 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %627 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %626, i32 0, i32 0
+  %628 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 0
+  store ptr @137, ptr %628, align 8
+  %629 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 1
+  store i32 39, ptr %629, align 4
+  %630 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 2
+  store i32 13, ptr %630, align 4
+  %631 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 3
+  store i32 39, ptr %631, align 4
+  %632 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %627, i32 0, i32 4
+  store i32 19, ptr %632, align 4
+  %633 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @138)
+  %634 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %625, i32 0, i32 0
+  %635 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %626, i32 0, i32 0
+  %636 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 2
+  %637 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 0
+  store i1 true, ptr %637, align 1
+  %638 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 1
+  store ptr %633, ptr %638, align 8
+  store ptr %635, ptr %636, align 8
+  %639 = getelementptr { i1, ptr, ptr, i32 }, ptr %634, i32 0, i32 3
+  store i32 1, ptr %639, align 4
+  %640 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %625, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %640, i32 1, ptr @139, ptr @136, i64 %618, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont102:                                        ; preds = %ifcont100
-  %641 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 %621
-  store i32 1, i32* %641, align 4
+  %641 = getelementptr [4 x i32], ptr %c, i32 0, i64 %621
+  store i32 1, ptr %641, align 4
   br label %ifcont108
 
 else103:                                          ; preds = %loop.body97
-  %642 = load i32, i32* %i, align 4
-  %643 = load i32, i32* %j, align 4
+  %642 = load i32, ptr %i, align 4
+  %643 = load i32, ptr %j, align 4
   %644 = sext i32 %642 to i64
   %645 = sub i64 %644, 1
   %646 = mul i64 1, %645
@@ -1552,32 +1553,32 @@ else103:                                          ; preds = %loop.body97
   br i1 %650, label %then104, label %ifcont105
 
 then104:                                          ; preds = %else103
-  %651 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %652 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %653 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %652, i32 0, i32 0
-  %654 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %653, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @141, i32 0, i32 0), i8** %654, align 8
-  %655 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %653, i32 0, i32 1
-  store i32 41, i32* %655, align 4
-  %656 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %653, i32 0, i32 2
-  store i32 13, i32* %656, align 4
-  %657 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %653, i32 0, i32 3
-  store i32 41, i32* %657, align 4
-  %658 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %653, i32 0, i32 4
-  store i32 19, i32* %658, align 4
-  %659 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @142, i32 0, i32 0))
-  %660 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %651, i32 0, i32 0
-  %661 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %652, i32 0, i32 0
-  %662 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %660, i32 0, i32 2
-  %663 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %660, i32 0, i32 0
-  store i1 true, i1* %663, align 1
-  %664 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %660, i32 0, i32 1
-  store i8* %659, i8** %664, align 8
-  store { i8*, i32, i32, i32, i32 }* %661, { i8*, i32, i32, i32, i32 }** %662, align 8
-  %665 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %660, i32 0, i32 3
-  store i32 1, i32* %665, align 4
-  %666 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %651, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %666, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @140, i32 0, i32 0), i64 %644, i32 1, i64 1, i64 2)
+  %651 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %652 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %653 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %652, i32 0, i32 0
+  %654 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %653, i32 0, i32 0
+  store ptr @141, ptr %654, align 8
+  %655 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %653, i32 0, i32 1
+  store i32 41, ptr %655, align 4
+  %656 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %653, i32 0, i32 2
+  store i32 13, ptr %656, align 4
+  %657 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %653, i32 0, i32 3
+  store i32 41, ptr %657, align 4
+  %658 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %653, i32 0, i32 4
+  store i32 19, ptr %658, align 4
+  %659 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @142)
+  %660 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %651, i32 0, i32 0
+  %661 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %652, i32 0, i32 0
+  %662 = getelementptr { i1, ptr, ptr, i32 }, ptr %660, i32 0, i32 2
+  %663 = getelementptr { i1, ptr, ptr, i32 }, ptr %660, i32 0, i32 0
+  store i1 true, ptr %663, align 1
+  %664 = getelementptr { i1, ptr, ptr, i32 }, ptr %660, i32 0, i32 1
+  store ptr %659, ptr %664, align 8
+  store ptr %661, ptr %662, align 8
+  %665 = getelementptr { i1, ptr, ptr, i32 }, ptr %660, i32 0, i32 3
+  store i32 1, ptr %665, align 4
+  %666 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %651, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %666, i32 1, ptr @143, ptr @140, i64 %644, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1592,38 +1593,38 @@ ifcont105:                                        ; preds = %else103
   br i1 %673, label %then106, label %ifcont107
 
 then106:                                          ; preds = %ifcont105
-  %674 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %675 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %676 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %675, i32 0, i32 0
-  %677 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %676, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @145, i32 0, i32 0), i8** %677, align 8
-  %678 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %676, i32 0, i32 1
-  store i32 41, i32* %678, align 4
-  %679 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %676, i32 0, i32 2
-  store i32 13, i32* %679, align 4
-  %680 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %676, i32 0, i32 3
-  store i32 41, i32* %680, align 4
-  %681 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %676, i32 0, i32 4
-  store i32 19, i32* %681, align 4
-  %682 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @146, i32 0, i32 0))
-  %683 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %674, i32 0, i32 0
-  %684 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %675, i32 0, i32 0
-  %685 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %683, i32 0, i32 2
-  %686 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %683, i32 0, i32 0
-  store i1 true, i1* %686, align 1
-  %687 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %683, i32 0, i32 1
-  store i8* %682, i8** %687, align 8
-  store { i8*, i32, i32, i32, i32 }* %684, { i8*, i32, i32, i32, i32 }** %685, align 8
-  %688 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %683, i32 0, i32 3
-  store i32 1, i32* %688, align 4
-  %689 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %674, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %689, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @147, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @144, i32 0, i32 0), i64 %667, i32 2, i64 1, i64 2)
+  %674 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %675 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %676 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %675, i32 0, i32 0
+  %677 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %676, i32 0, i32 0
+  store ptr @145, ptr %677, align 8
+  %678 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %676, i32 0, i32 1
+  store i32 41, ptr %678, align 4
+  %679 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %676, i32 0, i32 2
+  store i32 13, ptr %679, align 4
+  %680 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %676, i32 0, i32 3
+  store i32 41, ptr %680, align 4
+  %681 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %676, i32 0, i32 4
+  store i32 19, ptr %681, align 4
+  %682 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @146)
+  %683 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %674, i32 0, i32 0
+  %684 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %675, i32 0, i32 0
+  %685 = getelementptr { i1, ptr, ptr, i32 }, ptr %683, i32 0, i32 2
+  %686 = getelementptr { i1, ptr, ptr, i32 }, ptr %683, i32 0, i32 0
+  store i1 true, ptr %686, align 1
+  %687 = getelementptr { i1, ptr, ptr, i32 }, ptr %683, i32 0, i32 1
+  store ptr %682, ptr %687, align 8
+  store ptr %684, ptr %685, align 8
+  %688 = getelementptr { i1, ptr, ptr, i32 }, ptr %683, i32 0, i32 3
+  store i32 1, ptr %688, align 4
+  %689 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %674, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %689, i32 1, ptr @147, ptr @144, i64 %667, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont107:                                        ; preds = %ifcont105
-  %690 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 %670
-  store i32 0, i32* %690, align 4
+  %690 = getelementptr [4 x i32], ptr %c, i32 0, i64 %670
+  store i32 0, ptr %690, align 4
   br label %ifcont108
 
 ifcont108:                                        ; preds = %ifcont107, %ifcont102
@@ -1636,32 +1637,32 @@ loop.end110:                                      ; preds = %loop.head94
   br i1 false, label %then111, label %ifcont112
 
 then111:                                          ; preds = %loop.end110
-  %691 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %692 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %693 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %692, i32 0, i32 0
-  %694 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %693, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @149, i32 0, i32 0), i8** %694, align 8
-  %695 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %693, i32 0, i32 1
-  store i32 45, i32* %695, align 4
-  %696 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %693, i32 0, i32 2
-  store i32 5, i32* %696, align 4
-  %697 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %693, i32 0, i32 3
-  store i32 45, i32* %697, align 4
-  %698 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %693, i32 0, i32 4
-  store i32 11, i32* %698, align 4
-  %699 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @150, i32 0, i32 0))
-  %700 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %691, i32 0, i32 0
-  %701 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %692, i32 0, i32 0
-  %702 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %700, i32 0, i32 2
-  %703 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %700, i32 0, i32 0
-  store i1 true, i1* %703, align 1
-  %704 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %700, i32 0, i32 1
-  store i8* %699, i8** %704, align 8
-  store { i8*, i32, i32, i32, i32 }* %701, { i8*, i32, i32, i32, i32 }** %702, align 8
-  %705 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %700, i32 0, i32 3
-  store i32 1, i32* %705, align 4
-  %706 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %691, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %706, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @151, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @148, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %691 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %692 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %693 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %692, i32 0, i32 0
+  %694 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %693, i32 0, i32 0
+  store ptr @149, ptr %694, align 8
+  %695 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %693, i32 0, i32 1
+  store i32 45, ptr %695, align 4
+  %696 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %693, i32 0, i32 2
+  store i32 5, ptr %696, align 4
+  %697 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %693, i32 0, i32 3
+  store i32 45, ptr %697, align 4
+  %698 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %693, i32 0, i32 4
+  store i32 11, ptr %698, align 4
+  %699 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @150)
+  %700 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %691, i32 0, i32 0
+  %701 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %692, i32 0, i32 0
+  %702 = getelementptr { i1, ptr, ptr, i32 }, ptr %700, i32 0, i32 2
+  %703 = getelementptr { i1, ptr, ptr, i32 }, ptr %700, i32 0, i32 0
+  store i1 true, ptr %703, align 1
+  %704 = getelementptr { i1, ptr, ptr, i32 }, ptr %700, i32 0, i32 1
+  store ptr %699, ptr %704, align 8
+  store ptr %701, ptr %702, align 8
+  %705 = getelementptr { i1, ptr, ptr, i32 }, ptr %700, i32 0, i32 3
+  store i32 1, ptr %705, align 4
+  %706 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %691, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %706, i32 1, ptr @151, ptr @148, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1669,43 +1670,43 @@ ifcont112:                                        ; preds = %loop.end110
   br i1 false, label %then113, label %ifcont114
 
 then113:                                          ; preds = %ifcont112
-  %707 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %708 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %709 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %708, i32 0, i32 0
-  %710 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %709, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @153, i32 0, i32 0), i8** %710, align 8
-  %711 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %709, i32 0, i32 1
-  store i32 45, i32* %711, align 4
-  %712 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %709, i32 0, i32 2
-  store i32 5, i32* %712, align 4
-  %713 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %709, i32 0, i32 3
-  store i32 45, i32* %713, align 4
-  %714 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %709, i32 0, i32 4
-  store i32 11, i32* %714, align 4
-  %715 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @154, i32 0, i32 0))
-  %716 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %707, i32 0, i32 0
-  %717 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %708, i32 0, i32 0
-  %718 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %716, i32 0, i32 2
-  %719 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %716, i32 0, i32 0
-  store i1 true, i1* %719, align 1
-  %720 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %716, i32 0, i32 1
-  store i8* %715, i8** %720, align 8
-  store { i8*, i32, i32, i32, i32 }* %717, { i8*, i32, i32, i32, i32 }** %718, align 8
-  %721 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %716, i32 0, i32 3
-  store i32 1, i32* %721, align 4
-  %722 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %707, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %722, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @155, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @152, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %707 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %708 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %709 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %708, i32 0, i32 0
+  %710 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %709, i32 0, i32 0
+  store ptr @153, ptr %710, align 8
+  %711 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %709, i32 0, i32 1
+  store i32 45, ptr %711, align 4
+  %712 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %709, i32 0, i32 2
+  store i32 5, ptr %712, align 4
+  %713 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %709, i32 0, i32 3
+  store i32 45, ptr %713, align 4
+  %714 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %709, i32 0, i32 4
+  store i32 11, ptr %714, align 4
+  %715 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @154)
+  %716 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %707, i32 0, i32 0
+  %717 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %708, i32 0, i32 0
+  %718 = getelementptr { i1, ptr, ptr, i32 }, ptr %716, i32 0, i32 2
+  %719 = getelementptr { i1, ptr, ptr, i32 }, ptr %716, i32 0, i32 0
+  store i1 true, ptr %719, align 1
+  %720 = getelementptr { i1, ptr, ptr, i32 }, ptr %716, i32 0, i32 1
+  store ptr %715, ptr %720, align 8
+  store ptr %717, ptr %718, align 8
+  %721 = getelementptr { i1, ptr, ptr, i32 }, ptr %716, i32 0, i32 3
+  store i32 1, ptr %721, align 4
+  %722 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %707, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %722, i32 1, ptr @155, ptr @152, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont114:                                        ; preds = %ifcont112
-  %723 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 0
-  %724 = load i32, i32* %723, align 4
+  %723 = getelementptr [4 x i32], ptr %c, i32 0, i64 0
+  %724 = load i32, ptr %723, align 4
   %725 = icmp ne i32 %724, 0
   br i1 %725, label %then115, label %else116
 
 then115:                                          ; preds = %ifcont114
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @157, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @156, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @157, ptr @"ERROR STOP", ptr @156)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont117
@@ -1717,32 +1718,32 @@ ifcont117:                                        ; preds = %else116, %then115
   br i1 false, label %then118, label %ifcont119
 
 then118:                                          ; preds = %ifcont117
-  %726 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %727 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %728 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %727, i32 0, i32 0
-  %729 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %728, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @159, i32 0, i32 0), i8** %729, align 8
-  %730 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %728, i32 0, i32 1
-  store i32 46, i32* %730, align 4
-  %731 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %728, i32 0, i32 2
-  store i32 11, i32* %731, align 4
-  %732 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %728, i32 0, i32 3
-  store i32 46, i32* %732, align 4
-  %733 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %728, i32 0, i32 4
-  store i32 17, i32* %733, align 4
-  %734 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @160, i32 0, i32 0))
-  %735 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %726, i32 0, i32 0
-  %736 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %727, i32 0, i32 0
-  %737 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %735, i32 0, i32 2
-  %738 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %735, i32 0, i32 0
-  store i1 true, i1* %738, align 1
-  %739 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %735, i32 0, i32 1
-  store i8* %734, i8** %739, align 8
-  store { i8*, i32, i32, i32, i32 }* %736, { i8*, i32, i32, i32, i32 }** %737, align 8
-  %740 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %735, i32 0, i32 3
-  store i32 1, i32* %740, align 4
-  %741 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %726, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %741, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @161, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @158, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %726 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %727 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %728 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %727, i32 0, i32 0
+  %729 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %728, i32 0, i32 0
+  store ptr @159, ptr %729, align 8
+  %730 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %728, i32 0, i32 1
+  store i32 46, ptr %730, align 4
+  %731 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %728, i32 0, i32 2
+  store i32 11, ptr %731, align 4
+  %732 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %728, i32 0, i32 3
+  store i32 46, ptr %732, align 4
+  %733 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %728, i32 0, i32 4
+  store i32 17, ptr %733, align 4
+  %734 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @160)
+  %735 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %726, i32 0, i32 0
+  %736 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %727, i32 0, i32 0
+  %737 = getelementptr { i1, ptr, ptr, i32 }, ptr %735, i32 0, i32 2
+  %738 = getelementptr { i1, ptr, ptr, i32 }, ptr %735, i32 0, i32 0
+  store i1 true, ptr %738, align 1
+  %739 = getelementptr { i1, ptr, ptr, i32 }, ptr %735, i32 0, i32 1
+  store ptr %734, ptr %739, align 8
+  store ptr %736, ptr %737, align 8
+  %740 = getelementptr { i1, ptr, ptr, i32 }, ptr %735, i32 0, i32 3
+  store i32 1, ptr %740, align 4
+  %741 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %726, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %741, i32 1, ptr @161, ptr @158, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1750,44 +1751,44 @@ ifcont119:                                        ; preds = %ifcont117
   br i1 false, label %then120, label %ifcont121
 
 then120:                                          ; preds = %ifcont119
-  %742 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %743 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %744 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %743, i32 0, i32 0
-  %745 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @163, i32 0, i32 0), i8** %745, align 8
-  %746 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 1
-  store i32 46, i32* %746, align 4
-  %747 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 2
-  store i32 11, i32* %747, align 4
-  %748 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 3
-  store i32 46, i32* %748, align 4
-  %749 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %744, i32 0, i32 4
-  store i32 17, i32* %749, align 4
-  %750 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @164, i32 0, i32 0))
-  %751 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %742, i32 0, i32 0
-  %752 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %743, i32 0, i32 0
-  %753 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 2
-  %754 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 0
-  store i1 true, i1* %754, align 1
-  %755 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 1
-  store i8* %750, i8** %755, align 8
-  store { i8*, i32, i32, i32, i32 }* %752, { i8*, i32, i32, i32, i32 }** %753, align 8
-  %756 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %751, i32 0, i32 3
-  store i32 1, i32* %756, align 4
-  %757 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %742, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %757, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @165, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %742 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %743 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %744 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %743, i32 0, i32 0
+  %745 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 0
+  store ptr @163, ptr %745, align 8
+  %746 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 1
+  store i32 46, ptr %746, align 4
+  %747 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 2
+  store i32 11, ptr %747, align 4
+  %748 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 3
+  store i32 46, ptr %748, align 4
+  %749 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %744, i32 0, i32 4
+  store i32 17, ptr %749, align 4
+  %750 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @164)
+  %751 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %742, i32 0, i32 0
+  %752 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %743, i32 0, i32 0
+  %753 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 2
+  %754 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 0
+  store i1 true, ptr %754, align 1
+  %755 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 1
+  store ptr %750, ptr %755, align 8
+  store ptr %752, ptr %753, align 8
+  %756 = getelementptr { i1, ptr, ptr, i32 }, ptr %751, i32 0, i32 3
+  store i32 1, ptr %756, align 4
+  %757 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %742, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %757, i32 1, ptr @165, ptr @162, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont121:                                        ; preds = %ifcont119
-  %758 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 2
-  %759 = load i32, i32* %758, align 4
+  %758 = getelementptr [4 x i32], ptr %c, i32 0, i64 2
+  %759 = load i32, ptr %758, align 4
   %760 = xor i32 %759, 1
   %761 = icmp ne i32 %760, 0
   br i1 %761, label %then122, label %else123
 
 then122:                                          ; preds = %ifcont121
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @167, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @166, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @167, ptr @"ERROR STOP", ptr @166)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont124
@@ -1799,32 +1800,32 @@ ifcont124:                                        ; preds = %else123, %then122
   br i1 false, label %then125, label %ifcont126
 
 then125:                                          ; preds = %ifcont124
-  %762 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %763 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %764 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %763, i32 0, i32 0
-  %765 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %764, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @169, i32 0, i32 0), i8** %765, align 8
-  %766 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %764, i32 0, i32 1
-  store i32 47, i32* %766, align 4
-  %767 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %764, i32 0, i32 2
-  store i32 11, i32* %767, align 4
-  %768 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %764, i32 0, i32 3
-  store i32 47, i32* %768, align 4
-  %769 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %764, i32 0, i32 4
-  store i32 17, i32* %769, align 4
-  %770 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @170, i32 0, i32 0))
-  %771 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %762, i32 0, i32 0
-  %772 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %763, i32 0, i32 0
-  %773 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %771, i32 0, i32 2
-  %774 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %771, i32 0, i32 0
-  store i1 true, i1* %774, align 1
-  %775 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %771, i32 0, i32 1
-  store i8* %770, i8** %775, align 8
-  store { i8*, i32, i32, i32, i32 }* %772, { i8*, i32, i32, i32, i32 }** %773, align 8
-  %776 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %771, i32 0, i32 3
-  store i32 1, i32* %776, align 4
-  %777 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %762, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %777, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @171, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @168, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %762 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %763 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %764 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %763, i32 0, i32 0
+  %765 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %764, i32 0, i32 0
+  store ptr @169, ptr %765, align 8
+  %766 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %764, i32 0, i32 1
+  store i32 47, ptr %766, align 4
+  %767 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %764, i32 0, i32 2
+  store i32 11, ptr %767, align 4
+  %768 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %764, i32 0, i32 3
+  store i32 47, ptr %768, align 4
+  %769 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %764, i32 0, i32 4
+  store i32 17, ptr %769, align 4
+  %770 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @170)
+  %771 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %762, i32 0, i32 0
+  %772 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %763, i32 0, i32 0
+  %773 = getelementptr { i1, ptr, ptr, i32 }, ptr %771, i32 0, i32 2
+  %774 = getelementptr { i1, ptr, ptr, i32 }, ptr %771, i32 0, i32 0
+  store i1 true, ptr %774, align 1
+  %775 = getelementptr { i1, ptr, ptr, i32 }, ptr %771, i32 0, i32 1
+  store ptr %770, ptr %775, align 8
+  store ptr %772, ptr %773, align 8
+  %776 = getelementptr { i1, ptr, ptr, i32 }, ptr %771, i32 0, i32 3
+  store i32 1, ptr %776, align 4
+  %777 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %762, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %777, i32 1, ptr @171, ptr @168, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1832,44 +1833,44 @@ ifcont126:                                        ; preds = %ifcont124
   br i1 false, label %then127, label %ifcont128
 
 then127:                                          ; preds = %ifcont126
-  %778 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %779 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %780 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %779, i32 0, i32 0
-  %781 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %780, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @173, i32 0, i32 0), i8** %781, align 8
-  %782 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %780, i32 0, i32 1
-  store i32 47, i32* %782, align 4
-  %783 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %780, i32 0, i32 2
-  store i32 11, i32* %783, align 4
-  %784 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %780, i32 0, i32 3
-  store i32 47, i32* %784, align 4
-  %785 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %780, i32 0, i32 4
-  store i32 17, i32* %785, align 4
-  %786 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @174, i32 0, i32 0))
-  %787 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %778, i32 0, i32 0
-  %788 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %779, i32 0, i32 0
-  %789 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %787, i32 0, i32 2
-  %790 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %787, i32 0, i32 0
-  store i1 true, i1* %790, align 1
-  %791 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %787, i32 0, i32 1
-  store i8* %786, i8** %791, align 8
-  store { i8*, i32, i32, i32, i32 }* %788, { i8*, i32, i32, i32, i32 }** %789, align 8
-  %792 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %787, i32 0, i32 3
-  store i32 1, i32* %792, align 4
-  %793 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %778, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %793, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @175, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @172, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %778 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %779 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %780 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %779, i32 0, i32 0
+  %781 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %780, i32 0, i32 0
+  store ptr @173, ptr %781, align 8
+  %782 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %780, i32 0, i32 1
+  store i32 47, ptr %782, align 4
+  %783 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %780, i32 0, i32 2
+  store i32 11, ptr %783, align 4
+  %784 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %780, i32 0, i32 3
+  store i32 47, ptr %784, align 4
+  %785 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %780, i32 0, i32 4
+  store i32 17, ptr %785, align 4
+  %786 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @174)
+  %787 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %778, i32 0, i32 0
+  %788 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %779, i32 0, i32 0
+  %789 = getelementptr { i1, ptr, ptr, i32 }, ptr %787, i32 0, i32 2
+  %790 = getelementptr { i1, ptr, ptr, i32 }, ptr %787, i32 0, i32 0
+  store i1 true, ptr %790, align 1
+  %791 = getelementptr { i1, ptr, ptr, i32 }, ptr %787, i32 0, i32 1
+  store ptr %786, ptr %791, align 8
+  store ptr %788, ptr %789, align 8
+  %792 = getelementptr { i1, ptr, ptr, i32 }, ptr %787, i32 0, i32 3
+  store i32 1, ptr %792, align 4
+  %793 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %778, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %793, i32 1, ptr @175, ptr @172, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont128:                                        ; preds = %ifcont126
-  %794 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 1
-  %795 = load i32, i32* %794, align 4
+  %794 = getelementptr [4 x i32], ptr %c, i32 0, i64 1
+  %795 = load i32, ptr %794, align 4
   %796 = xor i32 %795, 1
   %797 = icmp ne i32 %796, 0
   br i1 %797, label %then129, label %else130
 
 then129:                                          ; preds = %ifcont128
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @177, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @176, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @177, ptr @"ERROR STOP", ptr @176)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont131
@@ -1881,32 +1882,32 @@ ifcont131:                                        ; preds = %else130, %then129
   br i1 false, label %then132, label %ifcont133
 
 then132:                                          ; preds = %ifcont131
-  %798 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %799 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %800 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %799, i32 0, i32 0
-  %801 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %800, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @179, i32 0, i32 0), i8** %801, align 8
-  %802 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %800, i32 0, i32 1
-  store i32 48, i32* %802, align 4
-  %803 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %800, i32 0, i32 2
-  store i32 5, i32* %803, align 4
-  %804 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %800, i32 0, i32 3
-  store i32 48, i32* %804, align 4
-  %805 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %800, i32 0, i32 4
-  store i32 11, i32* %805, align 4
-  %806 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @180, i32 0, i32 0))
-  %807 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %798, i32 0, i32 0
-  %808 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %799, i32 0, i32 0
-  %809 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %807, i32 0, i32 2
-  %810 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %807, i32 0, i32 0
-  store i1 true, i1* %810, align 1
-  %811 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %807, i32 0, i32 1
-  store i8* %806, i8** %811, align 8
-  store { i8*, i32, i32, i32, i32 }* %808, { i8*, i32, i32, i32, i32 }** %809, align 8
-  %812 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %807, i32 0, i32 3
-  store i32 1, i32* %812, align 4
-  %813 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %798, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %813, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @181, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @178, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %798 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %799 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %800 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %799, i32 0, i32 0
+  %801 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %800, i32 0, i32 0
+  store ptr @179, ptr %801, align 8
+  %802 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %800, i32 0, i32 1
+  store i32 48, ptr %802, align 4
+  %803 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %800, i32 0, i32 2
+  store i32 5, ptr %803, align 4
+  %804 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %800, i32 0, i32 3
+  store i32 48, ptr %804, align 4
+  %805 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %800, i32 0, i32 4
+  store i32 11, ptr %805, align 4
+  %806 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @180)
+  %807 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %798, i32 0, i32 0
+  %808 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %799, i32 0, i32 0
+  %809 = getelementptr { i1, ptr, ptr, i32 }, ptr %807, i32 0, i32 2
+  %810 = getelementptr { i1, ptr, ptr, i32 }, ptr %807, i32 0, i32 0
+  store i1 true, ptr %810, align 1
+  %811 = getelementptr { i1, ptr, ptr, i32 }, ptr %807, i32 0, i32 1
+  store ptr %806, ptr %811, align 8
+  store ptr %808, ptr %809, align 8
+  %812 = getelementptr { i1, ptr, ptr, i32 }, ptr %807, i32 0, i32 3
+  store i32 1, ptr %812, align 4
+  %813 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %798, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %813, i32 1, ptr @181, ptr @178, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1914,43 +1915,43 @@ ifcont133:                                        ; preds = %ifcont131
   br i1 false, label %then134, label %ifcont135
 
 then134:                                          ; preds = %ifcont133
-  %814 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %815 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %816 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %815, i32 0, i32 0
-  %817 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %816, i32 0, i32 0
-  store i8* getelementptr inbounds ([49 x i8], [49 x i8]* @183, i32 0, i32 0), i8** %817, align 8
-  %818 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %816, i32 0, i32 1
-  store i32 48, i32* %818, align 4
-  %819 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %816, i32 0, i32 2
-  store i32 5, i32* %819, align 4
-  %820 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %816, i32 0, i32 3
-  store i32 48, i32* %820, align 4
-  %821 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %816, i32 0, i32 4
-  store i32 11, i32* %821, align 4
-  %822 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @184, i32 0, i32 0))
-  %823 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %814, i32 0, i32 0
-  %824 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %815, i32 0, i32 0
-  %825 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %823, i32 0, i32 2
-  %826 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %823, i32 0, i32 0
-  store i1 true, i1* %826, align 1
-  %827 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %823, i32 0, i32 1
-  store i8* %822, i8** %827, align 8
-  store { i8*, i32, i32, i32, i32 }* %824, { i8*, i32, i32, i32, i32 }** %825, align 8
-  %828 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %823, i32 0, i32 3
-  store i32 1, i32* %828, align 4
-  %829 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %814, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %829, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @185, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @182, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %814 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %815 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %816 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %815, i32 0, i32 0
+  %817 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %816, i32 0, i32 0
+  store ptr @183, ptr %817, align 8
+  %818 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %816, i32 0, i32 1
+  store i32 48, ptr %818, align 4
+  %819 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %816, i32 0, i32 2
+  store i32 5, ptr %819, align 4
+  %820 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %816, i32 0, i32 3
+  store i32 48, ptr %820, align 4
+  %821 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %816, i32 0, i32 4
+  store i32 11, ptr %821, align 4
+  %822 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @184)
+  %823 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %814, i32 0, i32 0
+  %824 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %815, i32 0, i32 0
+  %825 = getelementptr { i1, ptr, ptr, i32 }, ptr %823, i32 0, i32 2
+  %826 = getelementptr { i1, ptr, ptr, i32 }, ptr %823, i32 0, i32 0
+  store i1 true, ptr %826, align 1
+  %827 = getelementptr { i1, ptr, ptr, i32 }, ptr %823, i32 0, i32 1
+  store ptr %822, ptr %827, align 8
+  store ptr %824, ptr %825, align 8
+  %828 = getelementptr { i1, ptr, ptr, i32 }, ptr %823, i32 0, i32 3
+  store i32 1, ptr %828, align 4
+  %829 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %814, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %829, i32 1, ptr @185, ptr @182, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont135:                                        ; preds = %ifcont133
-  %830 = getelementptr [4 x i32], [4 x i32]* %c, i32 0, i64 3
-  %831 = load i32, i32* %830, align 4
+  %830 = getelementptr [4 x i32], ptr %c, i32 0, i64 3
+  %831 = load i32, ptr %830, align 4
   %832 = icmp ne i32 %831, 0
   br i1 %832, label %then136, label %else137
 
 then136:                                          ; preds = %ifcont135
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @187, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @186, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @187, ptr @"ERROR STOP", ptr @186)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont138
@@ -1969,16 +1970,16 @@ FINALIZE_SYMTABLE_arrays_01_logical:              ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_real-6c5e850.json
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_real-6c5e850.stdout",
-    "stdout_hash": "678fb87712f28eea2eb2b5c0b36dbc7a8d590462d7f3faaa1faeaec4",
+    "stdout_hash": "fc2feb20f446a8ce596c6428d4608c6c3df8cc81cee7bd02bedf805d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_real-6c5e850.stdout
+++ b/tests/reference/llvm-arrays_01_real-6c5e850.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @0 = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @1 = private unnamed_addr constant [46 x i8] c"tests/../integration_tests/arrays_01_real.f90\00", align 1
@@ -168,29 +169,29 @@ target datalayout = "..."
 @162 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @163 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca [3 x double], align 8
   %b = alloca [4 x double], align 8
   %c = alloca [4 x double], align 8
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 3
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %i, align 4
+  store i32 %7, ptr %i, align 4
+  %8 = load i32, ptr %i, align 4
   %9 = sext i32 %8 to i64
   %10 = sub i64 %9, 1
   %11 = mul i64 1, %10
@@ -201,84 +202,84 @@ loop.body:                                        ; preds = %loop.head
   br i1 %15, label %then, label %ifcont
 
 then:                                             ; preds = %loop.body
-  %16 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %17 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %18 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %19 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @1, i32 0, i32 0), i8** %19, align 8
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 1
-  store i32 6, i32* %20, align 4
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 2
-  store i32 5, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 3
-  store i32 6, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 4
-  store i32 8, i32* %23, align 4
-  %24 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
-  %25 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  %26 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 2
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 0
-  store i1 true, i1* %28, align 1
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 1
-  store i8* %24, i8** %29, align 8
-  store { i8*, i32, i32, i32, i32 }* %26, { i8*, i32, i32, i32, i32 }** %27, align 8
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 3
-  store i32 1, i32* %30, align 4
-  %31 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i64 %9, i32 1, i64 1, i64 3)
+  %16 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %17 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %18 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %19 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 0
+  store ptr @1, ptr %19, align 8
+  %20 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 1
+  store i32 6, ptr %20, align 4
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 2
+  store i32 5, ptr %21, align 4
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 3
+  store i32 6, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 4
+  store i32 8, ptr %23, align 4
+  %24 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %25 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  %26 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %27 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 2
+  %28 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 0
+  store i1 true, ptr %28, align 1
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 1
+  store ptr %24, ptr %29, align 8
+  store ptr %26, ptr %27, align 8
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 3
+  store i32 1, ptr %30, align 4
+  %31 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %31, i32 1, ptr @3, ptr @0, i64 %9, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %loop.body
-  %32 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 %12
-  %33 = load i32, i32* %i, align 4
+  %32 = getelementptr [3 x double], ptr %a, i32 0, i64 %12
+  %33 = load i32, ptr %i, align 4
   %34 = add i32 %33, 10
   %35 = sitofp i32 %34 to double
-  store double %35, double* %32, align 8
+  store double %35, ptr %32, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then1, label %ifcont2
 
 then1:                                            ; preds = %loop.end
-  %36 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %37 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %38 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @5, i32 0, i32 0), i8** %39, align 8
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 1
-  store i32 8, i32* %40, align 4
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 2
-  store i32 5, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 3
-  store i32 8, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 4
-  store i32 8, i32* %43, align 4
-  %44 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %45 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
-  %46 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 2
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 0
-  store i1 true, i1* %48, align 1
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 1
-  store i8* %44, i8** %49, align 8
-  store { i8*, i32, i32, i32, i32 }* %46, { i8*, i32, i32, i32, i32 }** %47, align 8
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 3
-  store i32 1, i32* %50, align 4
-  %51 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %51, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %36 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %37 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %38 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 0
+  store ptr @5, ptr %39, align 8
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 1
+  store i32 8, ptr %40, align 4
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 2
+  store i32 5, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 3
+  store i32 8, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 4
+  store i32 8, ptr %43, align 4
+  %44 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %45 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  %46 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 2
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 0
+  store i1 true, ptr %48, align 1
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 1
+  store ptr %44, ptr %49, align 8
+  store ptr %46, ptr %47, align 8
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 3
+  store i32 1, ptr %50, align 4
+  %51 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %51, i32 1, ptr @7, ptr @4, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %loop.end
-  %52 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 0
-  %53 = load double, double* %52, align 8
+  %52 = getelementptr [3 x double], ptr %a, i32 0, i64 0
+  %53 = load double, ptr %52, align 8
   %54 = fcmp une double %53, 1.100000e+01
   br i1 %54, label %then3, label %else
 
 then3:                                            ; preds = %ifcont2
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont4
@@ -290,43 +291,43 @@ ifcont4:                                          ; preds = %else, %then3
   br i1 false, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %55 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %56 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %57 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %56, i32 0, i32 0
-  %58 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %57, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @11, i32 0, i32 0), i8** %58, align 8
-  %59 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %57, i32 0, i32 1
-  store i32 9, i32* %59, align 4
-  %60 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %57, i32 0, i32 2
-  store i32 5, i32* %60, align 4
-  %61 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %57, i32 0, i32 3
-  store i32 9, i32* %61, align 4
-  %62 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %57, i32 0, i32 4
-  store i32 8, i32* %62, align 4
-  %63 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @12, i32 0, i32 0))
-  %64 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %55, i32 0, i32 0
-  %65 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %56, i32 0, i32 0
-  %66 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %64, i32 0, i32 2
-  %67 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %64, i32 0, i32 0
-  store i1 true, i1* %67, align 1
-  %68 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %64, i32 0, i32 1
-  store i8* %63, i8** %68, align 8
-  store { i8*, i32, i32, i32, i32 }* %65, { i8*, i32, i32, i32, i32 }** %66, align 8
-  %69 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %64, i32 0, i32 3
-  store i32 1, i32* %69, align 4
-  %70 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %55, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i64 2, i32 1, i64 1, i64 3)
+  %55 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %56 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %57 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %56, i32 0, i32 0
+  %58 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %57, i32 0, i32 0
+  store ptr @11, ptr %58, align 8
+  %59 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %57, i32 0, i32 1
+  store i32 9, ptr %59, align 4
+  %60 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %57, i32 0, i32 2
+  store i32 5, ptr %60, align 4
+  %61 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %57, i32 0, i32 3
+  store i32 9, ptr %61, align 4
+  %62 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %57, i32 0, i32 4
+  store i32 8, ptr %62, align 4
+  %63 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @12)
+  %64 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %55, i32 0, i32 0
+  %65 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %56, i32 0, i32 0
+  %66 = getelementptr { i1, ptr, ptr, i32 }, ptr %64, i32 0, i32 2
+  %67 = getelementptr { i1, ptr, ptr, i32 }, ptr %64, i32 0, i32 0
+  store i1 true, ptr %67, align 1
+  %68 = getelementptr { i1, ptr, ptr, i32 }, ptr %64, i32 0, i32 1
+  store ptr %63, ptr %68, align 8
+  store ptr %65, ptr %66, align 8
+  %69 = getelementptr { i1, ptr, ptr, i32 }, ptr %64, i32 0, i32 3
+  store i32 1, ptr %69, align 4
+  %70 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %55, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %70, i32 1, ptr @13, ptr @10, i64 2, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  %71 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 1
-  %72 = load double, double* %71, align 8
+  %71 = getelementptr [3 x double], ptr %a, i32 0, i64 1
+  %72 = load double, ptr %71, align 8
   %73 = fcmp une double %72, 1.200000e+01
   br i1 %73, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -338,43 +339,43 @@ ifcont9:                                          ; preds = %else8, %then7
   br i1 false, label %then10, label %ifcont11
 
 then10:                                           ; preds = %ifcont9
-  %74 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %75 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %76 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @17, i32 0, i32 0), i8** %77, align 8
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 1
-  store i32 10, i32* %78, align 4
-  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 2
-  store i32 5, i32* %79, align 4
-  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 3
-  store i32 10, i32* %80, align 4
-  %81 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 4
-  store i32 8, i32* %81, align 4
-  %82 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %83 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  %84 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 2
-  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 0
-  store i1 true, i1* %86, align 1
-  %87 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 1
-  store i8* %82, i8** %87, align 8
-  store { i8*, i32, i32, i32, i32 }* %84, { i8*, i32, i32, i32, i32 }** %85, align 8
-  %88 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 3
-  store i32 1, i32* %88, align 4
-  %89 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i64 3, i32 1, i64 1, i64 3)
+  %74 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %75 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %76 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %75, i32 0, i32 0
+  %77 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %76, i32 0, i32 0
+  store ptr @17, ptr %77, align 8
+  %78 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %76, i32 0, i32 1
+  store i32 10, ptr %78, align 4
+  %79 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %76, i32 0, i32 2
+  store i32 5, ptr %79, align 4
+  %80 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %76, i32 0, i32 3
+  store i32 10, ptr %80, align 4
+  %81 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %76, i32 0, i32 4
+  store i32 8, ptr %81, align 4
+  %82 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @18)
+  %83 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %74, i32 0, i32 0
+  %84 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %75, i32 0, i32 0
+  %85 = getelementptr { i1, ptr, ptr, i32 }, ptr %83, i32 0, i32 2
+  %86 = getelementptr { i1, ptr, ptr, i32 }, ptr %83, i32 0, i32 0
+  store i1 true, ptr %86, align 1
+  %87 = getelementptr { i1, ptr, ptr, i32 }, ptr %83, i32 0, i32 1
+  store ptr %82, ptr %87, align 8
+  store ptr %84, ptr %85, align 8
+  %88 = getelementptr { i1, ptr, ptr, i32 }, ptr %83, i32 0, i32 3
+  store i32 1, ptr %88, align 4
+  %89 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %74, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %89, i32 1, ptr @19, ptr @16, i64 3, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont11:                                         ; preds = %ifcont9
-  %90 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 2
-  %91 = load double, double* %90, align 8
+  %90 = getelementptr [3 x double], ptr %a, i32 0, i64 2
+  %91 = load double, ptr %90, align 8
   %92 = fcmp une double %91, 1.300000e+01
   br i1 %92, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont11
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont14
@@ -383,20 +384,20 @@ else13:                                           ; preds = %ifcont11
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  store i32 10, i32* %i, align 4
+  store i32 10, ptr %i, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %ifcont18, %ifcont14
-  %93 = load i32, i32* %i, align 4
+  %93 = load i32, ptr %i, align 4
   %94 = add i32 %93, 1
   %95 = icmp sle i32 %94, 14
   br i1 %95, label %loop.body16, label %loop.end19
 
 loop.body16:                                      ; preds = %loop.head15
-  %96 = load i32, i32* %i, align 4
+  %96 = load i32, ptr %i, align 4
   %97 = add i32 %96, 1
-  store i32 %97, i32* %i, align 4
-  %98 = load i32, i32* %i, align 4
+  store i32 %97, ptr %i, align 4
+  %98 = load i32, ptr %i, align 4
   %99 = sub i32 %98, 10
   %100 = sext i32 %99 to i64
   %101 = sub i64 %100, 1
@@ -408,83 +409,83 @@ loop.body16:                                      ; preds = %loop.head15
   br i1 %106, label %then17, label %ifcont18
 
 then17:                                           ; preds = %loop.body16
-  %107 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %108 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %109 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %108, i32 0, i32 0
-  %110 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %109, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @23, i32 0, i32 0), i8** %110, align 8
-  %111 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %109, i32 0, i32 1
-  store i32 13, i32* %111, align 4
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %109, i32 0, i32 2
-  store i32 5, i32* %112, align 4
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %109, i32 0, i32 3
-  store i32 13, i32* %113, align 4
-  %114 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %109, i32 0, i32 4
-  store i32 11, i32* %114, align 4
-  %115 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @24, i32 0, i32 0))
-  %116 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %107, i32 0, i32 0
-  %117 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %108, i32 0, i32 0
-  %118 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 0, i32 2
-  %119 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 0, i32 0
-  store i1 true, i1* %119, align 1
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 0, i32 1
-  store i8* %115, i8** %120, align 8
-  store { i8*, i32, i32, i32, i32 }* %117, { i8*, i32, i32, i32, i32 }** %118, align 8
-  %121 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %116, i32 0, i32 3
-  store i32 1, i32* %121, align 4
-  %122 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %107, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %122, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i64 %100, i32 1, i64 1, i64 4)
+  %107 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %108 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %109 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %108, i32 0, i32 0
+  %110 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %109, i32 0, i32 0
+  store ptr @23, ptr %110, align 8
+  %111 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %109, i32 0, i32 1
+  store i32 13, ptr %111, align 4
+  %112 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %109, i32 0, i32 2
+  store i32 5, ptr %112, align 4
+  %113 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %109, i32 0, i32 3
+  store i32 13, ptr %113, align 4
+  %114 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %109, i32 0, i32 4
+  store i32 11, ptr %114, align 4
+  %115 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @24)
+  %116 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %107, i32 0, i32 0
+  %117 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %108, i32 0, i32 0
+  %118 = getelementptr { i1, ptr, ptr, i32 }, ptr %116, i32 0, i32 2
+  %119 = getelementptr { i1, ptr, ptr, i32 }, ptr %116, i32 0, i32 0
+  store i1 true, ptr %119, align 1
+  %120 = getelementptr { i1, ptr, ptr, i32 }, ptr %116, i32 0, i32 1
+  store ptr %115, ptr %120, align 8
+  store ptr %117, ptr %118, align 8
+  %121 = getelementptr { i1, ptr, ptr, i32 }, ptr %116, i32 0, i32 3
+  store i32 1, ptr %121, align 4
+  %122 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %107, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %122, i32 1, ptr @25, ptr @22, i64 %100, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %loop.body16
-  %123 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 %103
-  %124 = load i32, i32* %i, align 4
+  %123 = getelementptr [4 x double], ptr %b, i32 0, i64 %103
+  %124 = load i32, ptr %i, align 4
   %125 = sitofp i32 %124 to double
-  store double %125, double* %123, align 8
+  store double %125, ptr %123, align 8
   br label %loop.head15
 
 loop.end19:                                       ; preds = %loop.head15
   br i1 false, label %then20, label %ifcont21
 
 then20:                                           ; preds = %loop.end19
-  %126 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %127 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %128 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %127, i32 0, i32 0
-  %129 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %128, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @27, i32 0, i32 0), i8** %129, align 8
-  %130 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %128, i32 0, i32 1
-  store i32 15, i32* %130, align 4
-  %131 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %128, i32 0, i32 2
-  store i32 5, i32* %131, align 4
-  %132 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %128, i32 0, i32 3
-  store i32 15, i32* %132, align 4
-  %133 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %128, i32 0, i32 4
-  store i32 8, i32* %133, align 4
-  %134 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @28, i32 0, i32 0))
-  %135 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %126, i32 0, i32 0
-  %136 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %127, i32 0, i32 0
-  %137 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %135, i32 0, i32 2
-  %138 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %135, i32 0, i32 0
-  store i1 true, i1* %138, align 1
-  %139 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %135, i32 0, i32 1
-  store i8* %134, i8** %139, align 8
-  store { i8*, i32, i32, i32, i32 }* %136, { i8*, i32, i32, i32, i32 }** %137, align 8
-  %140 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %135, i32 0, i32 3
-  store i32 1, i32* %140, align 4
-  %141 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %126, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %141, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %126 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %127 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %128 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %127, i32 0, i32 0
+  %129 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %128, i32 0, i32 0
+  store ptr @27, ptr %129, align 8
+  %130 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %128, i32 0, i32 1
+  store i32 15, ptr %130, align 4
+  %131 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %128, i32 0, i32 2
+  store i32 5, ptr %131, align 4
+  %132 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %128, i32 0, i32 3
+  store i32 15, ptr %132, align 4
+  %133 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %128, i32 0, i32 4
+  store i32 8, ptr %133, align 4
+  %134 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @28)
+  %135 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %126, i32 0, i32 0
+  %136 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %127, i32 0, i32 0
+  %137 = getelementptr { i1, ptr, ptr, i32 }, ptr %135, i32 0, i32 2
+  %138 = getelementptr { i1, ptr, ptr, i32 }, ptr %135, i32 0, i32 0
+  store i1 true, ptr %138, align 1
+  %139 = getelementptr { i1, ptr, ptr, i32 }, ptr %135, i32 0, i32 1
+  store ptr %134, ptr %139, align 8
+  store ptr %136, ptr %137, align 8
+  %140 = getelementptr { i1, ptr, ptr, i32 }, ptr %135, i32 0, i32 3
+  store i32 1, ptr %140, align 4
+  %141 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %126, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %141, i32 1, ptr @29, ptr @26, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %loop.end19
-  %142 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 0
-  %143 = load double, double* %142, align 8
+  %142 = getelementptr [4 x double], ptr %b, i32 0, i64 0
+  %143 = load double, ptr %142, align 8
   %144 = fcmp une double %143, 1.100000e+01
   br i1 %144, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @31, ptr @"ERROR STOP", ptr @30)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -496,43 +497,43 @@ ifcont24:                                         ; preds = %else23, %then22
   br i1 false, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %145 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %146 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %147 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %146, i32 0, i32 0
-  %148 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %147, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @33, i32 0, i32 0), i8** %148, align 8
-  %149 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %147, i32 0, i32 1
-  store i32 16, i32* %149, align 4
-  %150 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %147, i32 0, i32 2
-  store i32 5, i32* %150, align 4
-  %151 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %147, i32 0, i32 3
-  store i32 16, i32* %151, align 4
-  %152 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %147, i32 0, i32 4
-  store i32 8, i32* %152, align 4
-  %153 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @34, i32 0, i32 0))
-  %154 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %145, i32 0, i32 0
-  %155 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %146, i32 0, i32 0
-  %156 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %154, i32 0, i32 2
-  %157 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %154, i32 0, i32 0
-  store i1 true, i1* %157, align 1
-  %158 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %154, i32 0, i32 1
-  store i8* %153, i8** %158, align 8
-  store { i8*, i32, i32, i32, i32 }* %155, { i8*, i32, i32, i32, i32 }** %156, align 8
-  %159 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %154, i32 0, i32 3
-  store i32 1, i32* %159, align 4
-  %160 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %145, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %160, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %145 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %146 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %147 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %146, i32 0, i32 0
+  %148 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %147, i32 0, i32 0
+  store ptr @33, ptr %148, align 8
+  %149 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %147, i32 0, i32 1
+  store i32 16, ptr %149, align 4
+  %150 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %147, i32 0, i32 2
+  store i32 5, ptr %150, align 4
+  %151 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %147, i32 0, i32 3
+  store i32 16, ptr %151, align 4
+  %152 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %147, i32 0, i32 4
+  store i32 8, ptr %152, align 4
+  %153 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @34)
+  %154 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %145, i32 0, i32 0
+  %155 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %146, i32 0, i32 0
+  %156 = getelementptr { i1, ptr, ptr, i32 }, ptr %154, i32 0, i32 2
+  %157 = getelementptr { i1, ptr, ptr, i32 }, ptr %154, i32 0, i32 0
+  store i1 true, ptr %157, align 1
+  %158 = getelementptr { i1, ptr, ptr, i32 }, ptr %154, i32 0, i32 1
+  store ptr %153, ptr %158, align 8
+  store ptr %155, ptr %156, align 8
+  %159 = getelementptr { i1, ptr, ptr, i32 }, ptr %154, i32 0, i32 3
+  store i32 1, ptr %159, align 4
+  %160 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %145, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %160, i32 1, ptr @35, ptr @32, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %161 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 1
-  %162 = load double, double* %161, align 8
+  %161 = getelementptr [4 x double], ptr %b, i32 0, i64 1
+  %162 = load double, ptr %161, align 8
   %163 = fcmp une double %162, 1.200000e+01
   br i1 %163, label %then27, label %else28
 
 then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @37, ptr @"ERROR STOP", ptr @36)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -544,43 +545,43 @@ ifcont29:                                         ; preds = %else28, %then27
   br i1 false, label %then30, label %ifcont31
 
 then30:                                           ; preds = %ifcont29
-  %164 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %165 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %166 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %165, i32 0, i32 0
-  %167 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @39, i32 0, i32 0), i8** %167, align 8
-  %168 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 1
-  store i32 17, i32* %168, align 4
-  %169 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 2
-  store i32 5, i32* %169, align 4
-  %170 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 3
-  store i32 17, i32* %170, align 4
-  %171 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %166, i32 0, i32 4
-  store i32 8, i32* %171, align 4
-  %172 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @40, i32 0, i32 0))
-  %173 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %164, i32 0, i32 0
-  %174 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %165, i32 0, i32 0
-  %175 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 2
-  %176 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 0
-  store i1 true, i1* %176, align 1
-  %177 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 1
-  store i8* %172, i8** %177, align 8
-  store { i8*, i32, i32, i32, i32 }* %174, { i8*, i32, i32, i32, i32 }** %175, align 8
-  %178 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %173, i32 0, i32 3
-  store i32 1, i32* %178, align 4
-  %179 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %164, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %179, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %164 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %165 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %166 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %165, i32 0, i32 0
+  %167 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %166, i32 0, i32 0
+  store ptr @39, ptr %167, align 8
+  %168 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %166, i32 0, i32 1
+  store i32 17, ptr %168, align 4
+  %169 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %166, i32 0, i32 2
+  store i32 5, ptr %169, align 4
+  %170 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %166, i32 0, i32 3
+  store i32 17, ptr %170, align 4
+  %171 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %166, i32 0, i32 4
+  store i32 8, ptr %171, align 4
+  %172 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @40)
+  %173 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %164, i32 0, i32 0
+  %174 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %165, i32 0, i32 0
+  %175 = getelementptr { i1, ptr, ptr, i32 }, ptr %173, i32 0, i32 2
+  %176 = getelementptr { i1, ptr, ptr, i32 }, ptr %173, i32 0, i32 0
+  store i1 true, ptr %176, align 1
+  %177 = getelementptr { i1, ptr, ptr, i32 }, ptr %173, i32 0, i32 1
+  store ptr %172, ptr %177, align 8
+  store ptr %174, ptr %175, align 8
+  %178 = getelementptr { i1, ptr, ptr, i32 }, ptr %173, i32 0, i32 3
+  store i32 1, ptr %178, align 4
+  %179 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %164, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %179, i32 1, ptr @41, ptr @38, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont31:                                         ; preds = %ifcont29
-  %180 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 2
-  %181 = load double, double* %180, align 8
+  %180 = getelementptr [4 x double], ptr %b, i32 0, i64 2
+  %181 = load double, ptr %180, align 8
   %182 = fcmp une double %181, 1.300000e+01
   br i1 %182, label %then32, label %else33
 
 then32:                                           ; preds = %ifcont31
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @43, ptr @"ERROR STOP", ptr @42)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont34
@@ -592,43 +593,43 @@ ifcont34:                                         ; preds = %else33, %then32
   br i1 false, label %then35, label %ifcont36
 
 then35:                                           ; preds = %ifcont34
-  %183 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %184 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %185 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %184, i32 0, i32 0
-  %186 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %185, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @45, i32 0, i32 0), i8** %186, align 8
-  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %185, i32 0, i32 1
-  store i32 18, i32* %187, align 4
-  %188 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %185, i32 0, i32 2
-  store i32 5, i32* %188, align 4
-  %189 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %185, i32 0, i32 3
-  store i32 18, i32* %189, align 4
-  %190 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %185, i32 0, i32 4
-  store i32 8, i32* %190, align 4
-  %191 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @46, i32 0, i32 0))
-  %192 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %183, i32 0, i32 0
-  %193 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %184, i32 0, i32 0
-  %194 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %192, i32 0, i32 2
-  %195 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %192, i32 0, i32 0
-  store i1 true, i1* %195, align 1
-  %196 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %192, i32 0, i32 1
-  store i8* %191, i8** %196, align 8
-  store { i8*, i32, i32, i32, i32 }* %193, { i8*, i32, i32, i32, i32 }** %194, align 8
-  %197 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %192, i32 0, i32 3
-  store i32 1, i32* %197, align 4
-  %198 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %183, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %198, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %183 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %184 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %185 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %184, i32 0, i32 0
+  %186 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 0
+  store ptr @45, ptr %186, align 8
+  %187 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 1
+  store i32 18, ptr %187, align 4
+  %188 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 2
+  store i32 5, ptr %188, align 4
+  %189 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 3
+  store i32 18, ptr %189, align 4
+  %190 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %185, i32 0, i32 4
+  store i32 8, ptr %190, align 4
+  %191 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @46)
+  %192 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %183, i32 0, i32 0
+  %193 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %184, i32 0, i32 0
+  %194 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 2
+  %195 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 0
+  store i1 true, ptr %195, align 1
+  %196 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 1
+  store ptr %191, ptr %196, align 8
+  store ptr %193, ptr %194, align 8
+  %197 = getelementptr { i1, ptr, ptr, i32 }, ptr %192, i32 0, i32 3
+  store i32 1, ptr %197, align 4
+  %198 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %183, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %198, i32 1, ptr @47, ptr @44, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont36:                                         ; preds = %ifcont34
-  %199 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 3
-  %200 = load double, double* %199, align 8
+  %199 = getelementptr [4 x double], ptr %b, i32 0, i64 3
+  %200 = load double, ptr %199, align 8
   %201 = fcmp une double %200, 1.400000e+01
   br i1 %201, label %then37, label %else38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @49, ptr @"ERROR STOP", ptr @48)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -637,20 +638,20 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head40
 
 loop.head40:                                      ; preds = %ifcont45, %ifcont39
-  %202 = load i32, i32* %i, align 4
+  %202 = load i32, ptr %i, align 4
   %203 = add i32 %202, 1
   %204 = icmp sle i32 %203, 3
   br i1 %204, label %loop.body41, label %loop.end46
 
 loop.body41:                                      ; preds = %loop.head40
-  %205 = load i32, i32* %i, align 4
+  %205 = load i32, ptr %i, align 4
   %206 = add i32 %205, 1
-  store i32 %206, i32* %i, align 4
-  %207 = load i32, i32* %i, align 4
+  store i32 %206, ptr %i, align 4
+  %207 = load i32, ptr %i, align 4
   %208 = sext i32 %207 to i64
   %209 = sub i64 %208, 1
   %210 = mul i64 1, %209
@@ -661,38 +662,38 @@ loop.body41:                                      ; preds = %loop.head40
   br i1 %214, label %then42, label %ifcont43
 
 then42:                                           ; preds = %loop.body41
-  %215 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %216 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %217 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %216, i32 0, i32 0
-  %218 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %217, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @51, i32 0, i32 0), i8** %218, align 8
-  %219 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %217, i32 0, i32 1
-  store i32 21, i32* %219, align 4
-  %220 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %217, i32 0, i32 2
-  store i32 5, i32* %220, align 4
-  %221 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %217, i32 0, i32 3
-  store i32 21, i32* %221, align 4
-  %222 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %217, i32 0, i32 4
-  store i32 8, i32* %222, align 4
-  %223 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @52, i32 0, i32 0))
-  %224 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %215, i32 0, i32 0
-  %225 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %216, i32 0, i32 0
-  %226 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %224, i32 0, i32 2
-  %227 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %224, i32 0, i32 0
-  store i1 true, i1* %227, align 1
-  %228 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %224, i32 0, i32 1
-  store i8* %223, i8** %228, align 8
-  store { i8*, i32, i32, i32, i32 }* %225, { i8*, i32, i32, i32, i32 }** %226, align 8
-  %229 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %224, i32 0, i32 3
-  store i32 1, i32* %229, align 4
-  %230 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %215, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %230, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0), i64 %208, i32 1, i64 1, i64 4)
+  %215 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %216 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %217 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %216, i32 0, i32 0
+  %218 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %217, i32 0, i32 0
+  store ptr @51, ptr %218, align 8
+  %219 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %217, i32 0, i32 1
+  store i32 21, ptr %219, align 4
+  %220 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %217, i32 0, i32 2
+  store i32 5, ptr %220, align 4
+  %221 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %217, i32 0, i32 3
+  store i32 21, ptr %221, align 4
+  %222 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %217, i32 0, i32 4
+  store i32 8, ptr %222, align 4
+  %223 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @52)
+  %224 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %215, i32 0, i32 0
+  %225 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %216, i32 0, i32 0
+  %226 = getelementptr { i1, ptr, ptr, i32 }, ptr %224, i32 0, i32 2
+  %227 = getelementptr { i1, ptr, ptr, i32 }, ptr %224, i32 0, i32 0
+  store i1 true, ptr %227, align 1
+  %228 = getelementptr { i1, ptr, ptr, i32 }, ptr %224, i32 0, i32 1
+  store ptr %223, ptr %228, align 8
+  store ptr %225, ptr %226, align 8
+  %229 = getelementptr { i1, ptr, ptr, i32 }, ptr %224, i32 0, i32 3
+  store i32 1, ptr %229, align 4
+  %230 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %215, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %230, i32 1, ptr @53, ptr @50, i64 %208, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont43:                                         ; preds = %loop.body41
-  %231 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 %211
-  %232 = load i32, i32* %i, align 4
+  %231 = getelementptr [4 x double], ptr %b, i32 0, i64 %211
+  %232 = load i32, ptr %i, align 4
   %233 = sext i32 %232 to i64
   %234 = sub i64 %233, 1
   %235 = mul i64 1, %234
@@ -703,83 +704,83 @@ ifcont43:                                         ; preds = %loop.body41
   br i1 %239, label %then44, label %ifcont45
 
 then44:                                           ; preds = %ifcont43
-  %240 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %241 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %242 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %241, i32 0, i32 0
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %242, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @55, i32 0, i32 0), i8** %243, align 8
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %242, i32 0, i32 1
-  store i32 21, i32* %244, align 4
-  %245 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %242, i32 0, i32 2
-  store i32 12, i32* %245, align 4
-  %246 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %242, i32 0, i32 3
-  store i32 21, i32* %246, align 4
-  %247 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %242, i32 0, i32 4
-  store i32 15, i32* %247, align 4
-  %248 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @56, i32 0, i32 0))
-  %249 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %240, i32 0, i32 0
-  %250 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %241, i32 0, i32 0
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %249, i32 0, i32 2
-  %252 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %249, i32 0, i32 0
-  store i1 true, i1* %252, align 1
-  %253 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %249, i32 0, i32 1
-  store i8* %248, i8** %253, align 8
-  store { i8*, i32, i32, i32, i32 }* %250, { i8*, i32, i32, i32, i32 }** %251, align 8
-  %254 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %249, i32 0, i32 3
-  store i32 1, i32* %254, align 4
-  %255 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %240, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %255, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i64 %233, i32 1, i64 1, i64 3)
+  %240 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %241 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %242 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %241, i32 0, i32 0
+  %243 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %242, i32 0, i32 0
+  store ptr @55, ptr %243, align 8
+  %244 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %242, i32 0, i32 1
+  store i32 21, ptr %244, align 4
+  %245 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %242, i32 0, i32 2
+  store i32 12, ptr %245, align 4
+  %246 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %242, i32 0, i32 3
+  store i32 21, ptr %246, align 4
+  %247 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %242, i32 0, i32 4
+  store i32 15, ptr %247, align 4
+  %248 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @56)
+  %249 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %240, i32 0, i32 0
+  %250 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %241, i32 0, i32 0
+  %251 = getelementptr { i1, ptr, ptr, i32 }, ptr %249, i32 0, i32 2
+  %252 = getelementptr { i1, ptr, ptr, i32 }, ptr %249, i32 0, i32 0
+  store i1 true, ptr %252, align 1
+  %253 = getelementptr { i1, ptr, ptr, i32 }, ptr %249, i32 0, i32 1
+  store ptr %248, ptr %253, align 8
+  store ptr %250, ptr %251, align 8
+  %254 = getelementptr { i1, ptr, ptr, i32 }, ptr %249, i32 0, i32 3
+  store i32 1, ptr %254, align 4
+  %255 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %240, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %255, i32 1, ptr @57, ptr @54, i64 %233, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont45:                                         ; preds = %ifcont43
-  %256 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 %236
-  %257 = load double, double* %256, align 8
+  %256 = getelementptr [3 x double], ptr %a, i32 0, i64 %236
+  %257 = load double, ptr %256, align 8
   %258 = fsub double %257, 1.000000e+01
-  store double %258, double* %231, align 8
+  store double %258, ptr %231, align 8
   br label %loop.head40
 
 loop.end46:                                       ; preds = %loop.head40
   br i1 false, label %then47, label %ifcont48
 
 then47:                                           ; preds = %loop.end46
-  %259 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %260 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %261 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %260, i32 0, i32 0
-  %262 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @59, i32 0, i32 0), i8** %262, align 8
-  %263 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 1
-  store i32 23, i32* %263, align 4
-  %264 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 2
-  store i32 5, i32* %264, align 4
-  %265 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 3
-  store i32 23, i32* %265, align 4
-  %266 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %261, i32 0, i32 4
-  store i32 8, i32* %266, align 4
-  %267 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @60, i32 0, i32 0))
-  %268 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %259, i32 0, i32 0
-  %269 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %260, i32 0, i32 0
-  %270 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 2
-  %271 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 0
-  store i1 true, i1* %271, align 1
-  %272 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 1
-  store i8* %267, i8** %272, align 8
-  store { i8*, i32, i32, i32, i32 }* %269, { i8*, i32, i32, i32, i32 }** %270, align 8
-  %273 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %268, i32 0, i32 3
-  store i32 1, i32* %273, align 4
-  %274 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %259, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %259 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %260 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %261 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %260, i32 0, i32 0
+  %262 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %261, i32 0, i32 0
+  store ptr @59, ptr %262, align 8
+  %263 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %261, i32 0, i32 1
+  store i32 23, ptr %263, align 4
+  %264 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %261, i32 0, i32 2
+  store i32 5, ptr %264, align 4
+  %265 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %261, i32 0, i32 3
+  store i32 23, ptr %265, align 4
+  %266 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %261, i32 0, i32 4
+  store i32 8, ptr %266, align 4
+  %267 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @60)
+  %268 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %259, i32 0, i32 0
+  %269 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %260, i32 0, i32 0
+  %270 = getelementptr { i1, ptr, ptr, i32 }, ptr %268, i32 0, i32 2
+  %271 = getelementptr { i1, ptr, ptr, i32 }, ptr %268, i32 0, i32 0
+  store i1 true, ptr %271, align 1
+  %272 = getelementptr { i1, ptr, ptr, i32 }, ptr %268, i32 0, i32 1
+  store ptr %267, ptr %272, align 8
+  store ptr %269, ptr %270, align 8
+  %273 = getelementptr { i1, ptr, ptr, i32 }, ptr %268, i32 0, i32 3
+  store i32 1, ptr %273, align 4
+  %274 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %259, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %274, i32 1, ptr @61, ptr @58, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %loop.end46
-  %275 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 0
-  %276 = load double, double* %275, align 8
+  %275 = getelementptr [4 x double], ptr %b, i32 0, i64 0
+  %276 = load double, ptr %275, align 8
   %277 = fcmp une double %276, 1.000000e+00
   br i1 %277, label %then49, label %else50
 
 then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @63, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @63, ptr @"ERROR STOP", ptr @62)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -791,43 +792,43 @@ ifcont51:                                         ; preds = %else50, %then49
   br i1 false, label %then52, label %ifcont53
 
 then52:                                           ; preds = %ifcont51
-  %278 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %279 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %280 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %279, i32 0, i32 0
-  %281 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %280, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @65, i32 0, i32 0), i8** %281, align 8
-  %282 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %280, i32 0, i32 1
-  store i32 24, i32* %282, align 4
-  %283 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %280, i32 0, i32 2
-  store i32 5, i32* %283, align 4
-  %284 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %280, i32 0, i32 3
-  store i32 24, i32* %284, align 4
-  %285 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %280, i32 0, i32 4
-  store i32 8, i32* %285, align 4
-  %286 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @66, i32 0, i32 0))
-  %287 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %278, i32 0, i32 0
-  %288 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %279, i32 0, i32 0
-  %289 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 0, i32 2
-  %290 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 0, i32 0
-  store i1 true, i1* %290, align 1
-  %291 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 0, i32 1
-  store i8* %286, i8** %291, align 8
-  store { i8*, i32, i32, i32, i32 }* %288, { i8*, i32, i32, i32, i32 }** %289, align 8
-  %292 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %287, i32 0, i32 3
-  store i32 1, i32* %292, align 4
-  %293 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %278, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %293, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @64, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %278 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %279 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %280 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %279, i32 0, i32 0
+  %281 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %280, i32 0, i32 0
+  store ptr @65, ptr %281, align 8
+  %282 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %280, i32 0, i32 1
+  store i32 24, ptr %282, align 4
+  %283 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %280, i32 0, i32 2
+  store i32 5, ptr %283, align 4
+  %284 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %280, i32 0, i32 3
+  store i32 24, ptr %284, align 4
+  %285 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %280, i32 0, i32 4
+  store i32 8, ptr %285, align 4
+  %286 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @66)
+  %287 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %278, i32 0, i32 0
+  %288 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %279, i32 0, i32 0
+  %289 = getelementptr { i1, ptr, ptr, i32 }, ptr %287, i32 0, i32 2
+  %290 = getelementptr { i1, ptr, ptr, i32 }, ptr %287, i32 0, i32 0
+  store i1 true, ptr %290, align 1
+  %291 = getelementptr { i1, ptr, ptr, i32 }, ptr %287, i32 0, i32 1
+  store ptr %286, ptr %291, align 8
+  store ptr %288, ptr %289, align 8
+  %292 = getelementptr { i1, ptr, ptr, i32 }, ptr %287, i32 0, i32 3
+  store i32 1, ptr %292, align 4
+  %293 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %278, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %293, i32 1, ptr @67, ptr @64, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont53:                                         ; preds = %ifcont51
-  %294 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 1
-  %295 = load double, double* %294, align 8
+  %294 = getelementptr [4 x double], ptr %b, i32 0, i64 1
+  %295 = load double, ptr %294, align 8
   %296 = fcmp une double %295, 2.000000e+00
   br i1 %296, label %then54, label %else55
 
 then54:                                           ; preds = %ifcont53
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @69, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @69, ptr @"ERROR STOP", ptr @68)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont56
@@ -839,43 +840,43 @@ ifcont56:                                         ; preds = %else55, %then54
   br i1 false, label %then57, label %ifcont58
 
 then57:                                           ; preds = %ifcont56
-  %297 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %298 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %299 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %298, i32 0, i32 0
-  %300 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %299, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @71, i32 0, i32 0), i8** %300, align 8
-  %301 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %299, i32 0, i32 1
-  store i32 25, i32* %301, align 4
-  %302 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %299, i32 0, i32 2
-  store i32 5, i32* %302, align 4
-  %303 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %299, i32 0, i32 3
-  store i32 25, i32* %303, align 4
-  %304 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %299, i32 0, i32 4
-  store i32 8, i32* %304, align 4
-  %305 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @72, i32 0, i32 0))
-  %306 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %297, i32 0, i32 0
-  %307 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %298, i32 0, i32 0
-  %308 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %306, i32 0, i32 2
-  %309 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %306, i32 0, i32 0
-  store i1 true, i1* %309, align 1
-  %310 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %306, i32 0, i32 1
-  store i8* %305, i8** %310, align 8
-  store { i8*, i32, i32, i32, i32 }* %307, { i8*, i32, i32, i32, i32 }** %308, align 8
-  %311 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %306, i32 0, i32 3
-  store i32 1, i32* %311, align 4
-  %312 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %297, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %312, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @70, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %297 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %298 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %299 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %298, i32 0, i32 0
+  %300 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %299, i32 0, i32 0
+  store ptr @71, ptr %300, align 8
+  %301 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %299, i32 0, i32 1
+  store i32 25, ptr %301, align 4
+  %302 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %299, i32 0, i32 2
+  store i32 5, ptr %302, align 4
+  %303 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %299, i32 0, i32 3
+  store i32 25, ptr %303, align 4
+  %304 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %299, i32 0, i32 4
+  store i32 8, ptr %304, align 4
+  %305 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @72)
+  %306 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %297, i32 0, i32 0
+  %307 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %298, i32 0, i32 0
+  %308 = getelementptr { i1, ptr, ptr, i32 }, ptr %306, i32 0, i32 2
+  %309 = getelementptr { i1, ptr, ptr, i32 }, ptr %306, i32 0, i32 0
+  store i1 true, ptr %309, align 1
+  %310 = getelementptr { i1, ptr, ptr, i32 }, ptr %306, i32 0, i32 1
+  store ptr %305, ptr %310, align 8
+  store ptr %307, ptr %308, align 8
+  %311 = getelementptr { i1, ptr, ptr, i32 }, ptr %306, i32 0, i32 3
+  store i32 1, ptr %311, align 4
+  %312 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %297, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %312, i32 1, ptr @73, ptr @70, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont58:                                         ; preds = %ifcont56
-  %313 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 2
-  %314 = load double, double* %313, align 8
+  %313 = getelementptr [4 x double], ptr %b, i32 0, i64 2
+  %314 = load double, ptr %313, align 8
   %315 = fcmp une double %314, 3.000000e+00
   br i1 %315, label %then59, label %else60
 
 then59:                                           ; preds = %ifcont58
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @75, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @75, ptr @"ERROR STOP", ptr @74)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont61
@@ -887,221 +888,221 @@ ifcont61:                                         ; preds = %else60, %then59
   br i1 false, label %then62, label %ifcont63
 
 then62:                                           ; preds = %ifcont61
-  %316 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %317 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %318 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %317, i32 0, i32 0
-  %319 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %318, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @77, i32 0, i32 0), i8** %319, align 8
-  %320 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %318, i32 0, i32 1
-  store i32 27, i32* %320, align 4
-  %321 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %318, i32 0, i32 2
-  store i32 1, i32* %321, align 4
-  %322 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %318, i32 0, i32 3
-  store i32 27, i32* %322, align 4
-  %323 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %318, i32 0, i32 4
-  store i32 4, i32* %323, align 4
-  %324 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @78, i32 0, i32 0))
-  %325 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %316, i32 0, i32 0
-  %326 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %317, i32 0, i32 0
-  %327 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %325, i32 0, i32 2
-  %328 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %325, i32 0, i32 0
-  store i1 true, i1* %328, align 1
-  %329 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %325, i32 0, i32 1
-  store i8* %324, i8** %329, align 8
-  store { i8*, i32, i32, i32, i32 }* %326, { i8*, i32, i32, i32, i32 }** %327, align 8
-  %330 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %325, i32 0, i32 3
-  store i32 1, i32* %330, align 4
-  %331 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %316, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %331, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @76, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %316 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %317 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %318 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %317, i32 0, i32 0
+  %319 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %318, i32 0, i32 0
+  store ptr @77, ptr %319, align 8
+  %320 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %318, i32 0, i32 1
+  store i32 27, ptr %320, align 4
+  %321 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %318, i32 0, i32 2
+  store i32 1, ptr %321, align 4
+  %322 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %318, i32 0, i32 3
+  store i32 27, ptr %322, align 4
+  %323 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %318, i32 0, i32 4
+  store i32 4, ptr %323, align 4
+  %324 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @78)
+  %325 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %316, i32 0, i32 0
+  %326 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %317, i32 0, i32 0
+  %327 = getelementptr { i1, ptr, ptr, i32 }, ptr %325, i32 0, i32 2
+  %328 = getelementptr { i1, ptr, ptr, i32 }, ptr %325, i32 0, i32 0
+  store i1 true, ptr %328, align 1
+  %329 = getelementptr { i1, ptr, ptr, i32 }, ptr %325, i32 0, i32 1
+  store ptr %324, ptr %329, align 8
+  store ptr %326, ptr %327, align 8
+  %330 = getelementptr { i1, ptr, ptr, i32 }, ptr %325, i32 0, i32 3
+  store i32 1, ptr %330, align 4
+  %331 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %316, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %331, i32 1, ptr @79, ptr @76, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont63:                                         ; preds = %ifcont61
-  %332 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 3
+  %332 = getelementptr [4 x double], ptr %b, i32 0, i64 3
   br i1 false, label %then64, label %ifcont65
 
 then64:                                           ; preds = %ifcont63
-  %333 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %334 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %335 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %334, i32 0, i32 0
-  %336 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %335, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @81, i32 0, i32 0), i8** %336, align 8
-  %337 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %335, i32 0, i32 1
-  store i32 27, i32* %337, align 4
-  %338 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %335, i32 0, i32 2
-  store i32 8, i32* %338, align 4
-  %339 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %335, i32 0, i32 3
-  store i32 27, i32* %339, align 4
-  %340 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %335, i32 0, i32 4
-  store i32 11, i32* %340, align 4
-  %341 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @82, i32 0, i32 0))
-  %342 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %333, i32 0, i32 0
-  %343 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %334, i32 0, i32 0
-  %344 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %342, i32 0, i32 2
-  %345 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %342, i32 0, i32 0
-  store i1 true, i1* %345, align 1
-  %346 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %342, i32 0, i32 1
-  store i8* %341, i8** %346, align 8
-  store { i8*, i32, i32, i32, i32 }* %343, { i8*, i32, i32, i32, i32 }** %344, align 8
-  %347 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %342, i32 0, i32 3
-  store i32 1, i32* %347, align 4
-  %348 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %333, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %348, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %333 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %334 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %335 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %334, i32 0, i32 0
+  %336 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %335, i32 0, i32 0
+  store ptr @81, ptr %336, align 8
+  %337 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %335, i32 0, i32 1
+  store i32 27, ptr %337, align 4
+  %338 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %335, i32 0, i32 2
+  store i32 8, ptr %338, align 4
+  %339 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %335, i32 0, i32 3
+  store i32 27, ptr %339, align 4
+  %340 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %335, i32 0, i32 4
+  store i32 11, ptr %340, align 4
+  %341 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @82)
+  %342 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %333, i32 0, i32 0
+  %343 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %334, i32 0, i32 0
+  %344 = getelementptr { i1, ptr, ptr, i32 }, ptr %342, i32 0, i32 2
+  %345 = getelementptr { i1, ptr, ptr, i32 }, ptr %342, i32 0, i32 0
+  store i1 true, ptr %345, align 1
+  %346 = getelementptr { i1, ptr, ptr, i32 }, ptr %342, i32 0, i32 1
+  store ptr %341, ptr %346, align 8
+  store ptr %343, ptr %344, align 8
+  %347 = getelementptr { i1, ptr, ptr, i32 }, ptr %342, i32 0, i32 3
+  store i32 1, ptr %347, align 4
+  %348 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %333, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %348, i32 1, ptr @83, ptr @80, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont65:                                         ; preds = %ifcont63
-  %349 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 0
-  %350 = load double, double* %349, align 8
+  %349 = getelementptr [4 x double], ptr %b, i32 0, i64 0
+  %350 = load double, ptr %349, align 8
   br i1 false, label %then66, label %ifcont67
 
 then66:                                           ; preds = %ifcont65
-  %351 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %352 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %353 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %352, i32 0, i32 0
-  %354 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %353, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @85, i32 0, i32 0), i8** %354, align 8
-  %355 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %353, i32 0, i32 1
-  store i32 27, i32* %355, align 4
-  %356 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %353, i32 0, i32 2
-  store i32 13, i32* %356, align 4
-  %357 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %353, i32 0, i32 3
-  store i32 27, i32* %357, align 4
-  %358 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %353, i32 0, i32 4
-  store i32 16, i32* %358, align 4
-  %359 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @86, i32 0, i32 0))
-  %360 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %351, i32 0, i32 0
-  %361 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %352, i32 0, i32 0
-  %362 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %360, i32 0, i32 2
-  %363 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %360, i32 0, i32 0
-  store i1 true, i1* %363, align 1
-  %364 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %360, i32 0, i32 1
-  store i8* %359, i8** %364, align 8
-  store { i8*, i32, i32, i32, i32 }* %361, { i8*, i32, i32, i32, i32 }** %362, align 8
-  %365 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %360, i32 0, i32 3
-  store i32 1, i32* %365, align 4
-  %366 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %351, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %366, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %351 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %352 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %353 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %352, i32 0, i32 0
+  %354 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %353, i32 0, i32 0
+  store ptr @85, ptr %354, align 8
+  %355 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %353, i32 0, i32 1
+  store i32 27, ptr %355, align 4
+  %356 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %353, i32 0, i32 2
+  store i32 13, ptr %356, align 4
+  %357 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %353, i32 0, i32 3
+  store i32 27, ptr %357, align 4
+  %358 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %353, i32 0, i32 4
+  store i32 16, ptr %358, align 4
+  %359 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @86)
+  %360 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %351, i32 0, i32 0
+  %361 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %352, i32 0, i32 0
+  %362 = getelementptr { i1, ptr, ptr, i32 }, ptr %360, i32 0, i32 2
+  %363 = getelementptr { i1, ptr, ptr, i32 }, ptr %360, i32 0, i32 0
+  store i1 true, ptr %363, align 1
+  %364 = getelementptr { i1, ptr, ptr, i32 }, ptr %360, i32 0, i32 1
+  store ptr %359, ptr %364, align 8
+  store ptr %361, ptr %362, align 8
+  %365 = getelementptr { i1, ptr, ptr, i32 }, ptr %360, i32 0, i32 3
+  store i32 1, ptr %365, align 4
+  %366 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %351, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %366, i32 1, ptr @87, ptr @84, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont67:                                         ; preds = %ifcont65
-  %367 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 1
-  %368 = load double, double* %367, align 8
+  %367 = getelementptr [4 x double], ptr %b, i32 0, i64 1
+  %368 = load double, ptr %367, align 8
   %369 = fadd double %350, %368
   br i1 false, label %then68, label %ifcont69
 
 then68:                                           ; preds = %ifcont67
-  %370 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %371 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %372 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %371, i32 0, i32 0
-  %373 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %372, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @89, i32 0, i32 0), i8** %373, align 8
-  %374 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %372, i32 0, i32 1
-  store i32 27, i32* %374, align 4
-  %375 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %372, i32 0, i32 2
-  store i32 18, i32* %375, align 4
-  %376 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %372, i32 0, i32 3
-  store i32 27, i32* %376, align 4
-  %377 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %372, i32 0, i32 4
-  store i32 21, i32* %377, align 4
-  %378 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @90, i32 0, i32 0))
-  %379 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %370, i32 0, i32 0
-  %380 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %371, i32 0, i32 0
-  %381 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %379, i32 0, i32 2
-  %382 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %379, i32 0, i32 0
-  store i1 true, i1* %382, align 1
-  %383 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %379, i32 0, i32 1
-  store i8* %378, i8** %383, align 8
-  store { i8*, i32, i32, i32, i32 }* %380, { i8*, i32, i32, i32, i32 }** %381, align 8
-  %384 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %379, i32 0, i32 3
-  store i32 1, i32* %384, align 4
-  %385 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %370, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %385, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %370 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %371 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %372 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %371, i32 0, i32 0
+  %373 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %372, i32 0, i32 0
+  store ptr @89, ptr %373, align 8
+  %374 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %372, i32 0, i32 1
+  store i32 27, ptr %374, align 4
+  %375 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %372, i32 0, i32 2
+  store i32 18, ptr %375, align 4
+  %376 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %372, i32 0, i32 3
+  store i32 27, ptr %376, align 4
+  %377 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %372, i32 0, i32 4
+  store i32 21, ptr %377, align 4
+  %378 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @90)
+  %379 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %370, i32 0, i32 0
+  %380 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %371, i32 0, i32 0
+  %381 = getelementptr { i1, ptr, ptr, i32 }, ptr %379, i32 0, i32 2
+  %382 = getelementptr { i1, ptr, ptr, i32 }, ptr %379, i32 0, i32 0
+  store i1 true, ptr %382, align 1
+  %383 = getelementptr { i1, ptr, ptr, i32 }, ptr %379, i32 0, i32 1
+  store ptr %378, ptr %383, align 8
+  store ptr %380, ptr %381, align 8
+  %384 = getelementptr { i1, ptr, ptr, i32 }, ptr %379, i32 0, i32 3
+  store i32 1, ptr %384, align 4
+  %385 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %370, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %385, i32 1, ptr @91, ptr @88, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont69:                                         ; preds = %ifcont67
-  %386 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 2
-  %387 = load double, double* %386, align 8
+  %386 = getelementptr [4 x double], ptr %b, i32 0, i64 2
+  %387 = load double, ptr %386, align 8
   %388 = fadd double %369, %387
   br i1 false, label %then70, label %ifcont71
 
 then70:                                           ; preds = %ifcont69
-  %389 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %390 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %391 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %390, i32 0, i32 0
-  %392 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %391, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @93, i32 0, i32 0), i8** %392, align 8
-  %393 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %391, i32 0, i32 1
-  store i32 27, i32* %393, align 4
-  %394 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %391, i32 0, i32 2
-  store i32 23, i32* %394, align 4
-  %395 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %391, i32 0, i32 3
-  store i32 27, i32* %395, align 4
-  %396 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %391, i32 0, i32 4
-  store i32 26, i32* %396, align 4
-  %397 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %398 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %389, i32 0, i32 0
-  %399 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %390, i32 0, i32 0
-  %400 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %398, i32 0, i32 2
-  %401 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %398, i32 0, i32 0
-  store i1 true, i1* %401, align 1
-  %402 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %398, i32 0, i32 1
-  store i8* %397, i8** %402, align 8
-  store { i8*, i32, i32, i32, i32 }* %399, { i8*, i32, i32, i32, i32 }** %400, align 8
-  %403 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %398, i32 0, i32 3
-  store i32 1, i32* %403, align 4
-  %404 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %389, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %404, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %389 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %390 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %391 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %390, i32 0, i32 0
+  %392 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %391, i32 0, i32 0
+  store ptr @93, ptr %392, align 8
+  %393 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %391, i32 0, i32 1
+  store i32 27, ptr %393, align 4
+  %394 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %391, i32 0, i32 2
+  store i32 23, ptr %394, align 4
+  %395 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %391, i32 0, i32 3
+  store i32 27, ptr %395, align 4
+  %396 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %391, i32 0, i32 4
+  store i32 26, ptr %396, align 4
+  %397 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @94)
+  %398 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %389, i32 0, i32 0
+  %399 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %390, i32 0, i32 0
+  %400 = getelementptr { i1, ptr, ptr, i32 }, ptr %398, i32 0, i32 2
+  %401 = getelementptr { i1, ptr, ptr, i32 }, ptr %398, i32 0, i32 0
+  store i1 true, ptr %401, align 1
+  %402 = getelementptr { i1, ptr, ptr, i32 }, ptr %398, i32 0, i32 1
+  store ptr %397, ptr %402, align 8
+  store ptr %399, ptr %400, align 8
+  %403 = getelementptr { i1, ptr, ptr, i32 }, ptr %398, i32 0, i32 3
+  store i32 1, ptr %403, align 4
+  %404 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %389, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %404, i32 1, ptr @95, ptr @92, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont71:                                         ; preds = %ifcont69
-  %405 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 0
-  %406 = load double, double* %405, align 8
+  %405 = getelementptr [3 x double], ptr %a, i32 0, i64 0
+  %406 = load double, ptr %405, align 8
   %407 = fadd double %388, %406
-  store double %407, double* %332, align 8
+  store double %407, ptr %332, align 8
   br i1 false, label %then72, label %ifcont73
 
 then72:                                           ; preds = %ifcont71
-  %408 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %409 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %410 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %409, i32 0, i32 0
-  %411 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %410, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @97, i32 0, i32 0), i8** %411, align 8
-  %412 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %410, i32 0, i32 1
-  store i32 28, i32* %412, align 4
-  %413 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %410, i32 0, i32 2
-  store i32 5, i32* %413, align 4
-  %414 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %410, i32 0, i32 3
-  store i32 28, i32* %414, align 4
-  %415 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %410, i32 0, i32 4
-  store i32 8, i32* %415, align 4
-  %416 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %417 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %408, i32 0, i32 0
-  %418 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %409, i32 0, i32 0
-  %419 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %417, i32 0, i32 2
-  %420 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %417, i32 0, i32 0
-  store i1 true, i1* %420, align 1
-  %421 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %417, i32 0, i32 1
-  store i8* %416, i8** %421, align 8
-  store { i8*, i32, i32, i32, i32 }* %418, { i8*, i32, i32, i32, i32 }** %419, align 8
-  %422 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %417, i32 0, i32 3
-  store i32 1, i32* %422, align 4
-  %423 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %408, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %423, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %408 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %409 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %410 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %409, i32 0, i32 0
+  %411 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %410, i32 0, i32 0
+  store ptr @97, ptr %411, align 8
+  %412 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %410, i32 0, i32 1
+  store i32 28, ptr %412, align 4
+  %413 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %410, i32 0, i32 2
+  store i32 5, ptr %413, align 4
+  %414 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %410, i32 0, i32 3
+  store i32 28, ptr %414, align 4
+  %415 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %410, i32 0, i32 4
+  store i32 8, ptr %415, align 4
+  %416 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @98)
+  %417 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %408, i32 0, i32 0
+  %418 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %409, i32 0, i32 0
+  %419 = getelementptr { i1, ptr, ptr, i32 }, ptr %417, i32 0, i32 2
+  %420 = getelementptr { i1, ptr, ptr, i32 }, ptr %417, i32 0, i32 0
+  store i1 true, ptr %420, align 1
+  %421 = getelementptr { i1, ptr, ptr, i32 }, ptr %417, i32 0, i32 1
+  store ptr %416, ptr %421, align 8
+  store ptr %418, ptr %419, align 8
+  %422 = getelementptr { i1, ptr, ptr, i32 }, ptr %417, i32 0, i32 3
+  store i32 1, ptr %422, align 4
+  %423 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %408, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %423, i32 1, ptr @99, ptr @96, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont73:                                         ; preds = %ifcont71
-  %424 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 3
-  %425 = load double, double* %424, align 8
+  %424 = getelementptr [4 x double], ptr %b, i32 0, i64 3
+  %425 = load double, ptr %424, align 8
   %426 = fcmp une double %425, 1.700000e+01
   br i1 %426, label %then74, label %else75
 
 then74:                                           ; preds = %ifcont73
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @101, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @101, ptr @"ERROR STOP", ptr @100)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont76
@@ -1113,113 +1114,113 @@ ifcont76:                                         ; preds = %else75, %then74
   br i1 false, label %then77, label %ifcont78
 
 then77:                                           ; preds = %ifcont76
-  %427 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %428 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %429 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %428, i32 0, i32 0
-  %430 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %429, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @103, i32 0, i32 0), i8** %430, align 8
-  %431 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %429, i32 0, i32 1
-  store i32 30, i32* %431, align 4
-  %432 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %429, i32 0, i32 2
-  store i32 1, i32* %432, align 4
-  %433 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %429, i32 0, i32 3
-  store i32 30, i32* %433, align 4
-  %434 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %429, i32 0, i32 4
-  store i32 4, i32* %434, align 4
-  %435 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @104, i32 0, i32 0))
-  %436 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %427, i32 0, i32 0
-  %437 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %428, i32 0, i32 0
-  %438 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %436, i32 0, i32 2
-  %439 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %436, i32 0, i32 0
-  store i1 true, i1* %439, align 1
-  %440 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %436, i32 0, i32 1
-  store i8* %435, i8** %440, align 8
-  store { i8*, i32, i32, i32, i32 }* %437, { i8*, i32, i32, i32, i32 }** %438, align 8
-  %441 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %436, i32 0, i32 3
-  store i32 1, i32* %441, align 4
-  %442 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %427, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %442, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @102, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %427 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %428 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %429 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %428, i32 0, i32 0
+  %430 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %429, i32 0, i32 0
+  store ptr @103, ptr %430, align 8
+  %431 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %429, i32 0, i32 1
+  store i32 30, ptr %431, align 4
+  %432 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %429, i32 0, i32 2
+  store i32 1, ptr %432, align 4
+  %433 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %429, i32 0, i32 3
+  store i32 30, ptr %433, align 4
+  %434 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %429, i32 0, i32 4
+  store i32 4, ptr %434, align 4
+  %435 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @104)
+  %436 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %427, i32 0, i32 0
+  %437 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %428, i32 0, i32 0
+  %438 = getelementptr { i1, ptr, ptr, i32 }, ptr %436, i32 0, i32 2
+  %439 = getelementptr { i1, ptr, ptr, i32 }, ptr %436, i32 0, i32 0
+  store i1 true, ptr %439, align 1
+  %440 = getelementptr { i1, ptr, ptr, i32 }, ptr %436, i32 0, i32 1
+  store ptr %435, ptr %440, align 8
+  store ptr %437, ptr %438, align 8
+  %441 = getelementptr { i1, ptr, ptr, i32 }, ptr %436, i32 0, i32 3
+  store i32 1, ptr %441, align 4
+  %442 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %427, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %442, i32 1, ptr @105, ptr @102, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont78:                                         ; preds = %ifcont76
-  %443 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 3
+  %443 = getelementptr [4 x double], ptr %b, i32 0, i64 3
   br i1 false, label %then79, label %ifcont80
 
 then79:                                           ; preds = %ifcont78
-  %444 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %445 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %446 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %445, i32 0, i32 0
-  %447 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %446, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @107, i32 0, i32 0), i8** %447, align 8
-  %448 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %446, i32 0, i32 1
-  store i32 30, i32* %448, align 4
-  %449 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %446, i32 0, i32 2
-  store i32 8, i32* %449, align 4
-  %450 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %446, i32 0, i32 3
-  store i32 30, i32* %450, align 4
-  %451 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %446, i32 0, i32 4
-  store i32 11, i32* %451, align 4
-  %452 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @108, i32 0, i32 0))
-  %453 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %444, i32 0, i32 0
-  %454 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %445, i32 0, i32 0
-  %455 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %453, i32 0, i32 2
-  %456 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %453, i32 0, i32 0
-  store i1 true, i1* %456, align 1
-  %457 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %453, i32 0, i32 1
-  store i8* %452, i8** %457, align 8
-  store { i8*, i32, i32, i32, i32 }* %454, { i8*, i32, i32, i32, i32 }** %455, align 8
-  %458 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %453, i32 0, i32 3
-  store i32 1, i32* %458, align 4
-  %459 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %444, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %459, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %444 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %445 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %446 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %445, i32 0, i32 0
+  %447 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %446, i32 0, i32 0
+  store ptr @107, ptr %447, align 8
+  %448 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %446, i32 0, i32 1
+  store i32 30, ptr %448, align 4
+  %449 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %446, i32 0, i32 2
+  store i32 8, ptr %449, align 4
+  %450 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %446, i32 0, i32 3
+  store i32 30, ptr %450, align 4
+  %451 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %446, i32 0, i32 4
+  store i32 11, ptr %451, align 4
+  %452 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @108)
+  %453 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %444, i32 0, i32 0
+  %454 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %445, i32 0, i32 0
+  %455 = getelementptr { i1, ptr, ptr, i32 }, ptr %453, i32 0, i32 2
+  %456 = getelementptr { i1, ptr, ptr, i32 }, ptr %453, i32 0, i32 0
+  store i1 true, ptr %456, align 1
+  %457 = getelementptr { i1, ptr, ptr, i32 }, ptr %453, i32 0, i32 1
+  store ptr %452, ptr %457, align 8
+  store ptr %454, ptr %455, align 8
+  %458 = getelementptr { i1, ptr, ptr, i32 }, ptr %453, i32 0, i32 3
+  store i32 1, ptr %458, align 4
+  %459 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %444, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %459, i32 1, ptr @109, ptr @106, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont80:                                         ; preds = %ifcont78
-  %460 = getelementptr [3 x double], [3 x double]* %a, i32 0, i64 0
-  %461 = load double, double* %460, align 8
-  store double %461, double* %443, align 8
+  %460 = getelementptr [3 x double], ptr %a, i32 0, i64 0
+  %461 = load double, ptr %460, align 8
+  store double %461, ptr %443, align 8
   br i1 false, label %then81, label %ifcont82
 
 then81:                                           ; preds = %ifcont80
-  %462 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %463 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %464 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %463, i32 0, i32 0
-  %465 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %464, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @111, i32 0, i32 0), i8** %465, align 8
-  %466 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %464, i32 0, i32 1
-  store i32 31, i32* %466, align 4
-  %467 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %464, i32 0, i32 2
-  store i32 5, i32* %467, align 4
-  %468 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %464, i32 0, i32 3
-  store i32 31, i32* %468, align 4
-  %469 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %464, i32 0, i32 4
-  store i32 8, i32* %469, align 4
-  %470 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @112, i32 0, i32 0))
-  %471 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %462, i32 0, i32 0
-  %472 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %463, i32 0, i32 0
-  %473 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %471, i32 0, i32 2
-  %474 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %471, i32 0, i32 0
-  store i1 true, i1* %474, align 1
-  %475 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %471, i32 0, i32 1
-  store i8* %470, i8** %475, align 8
-  store { i8*, i32, i32, i32, i32 }* %472, { i8*, i32, i32, i32, i32 }** %473, align 8
-  %476 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %471, i32 0, i32 3
-  store i32 1, i32* %476, align 4
-  %477 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %462, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %477, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @113, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %462 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %463 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %464 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %463, i32 0, i32 0
+  %465 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %464, i32 0, i32 0
+  store ptr @111, ptr %465, align 8
+  %466 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %464, i32 0, i32 1
+  store i32 31, ptr %466, align 4
+  %467 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %464, i32 0, i32 2
+  store i32 5, ptr %467, align 4
+  %468 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %464, i32 0, i32 3
+  store i32 31, ptr %468, align 4
+  %469 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %464, i32 0, i32 4
+  store i32 8, ptr %469, align 4
+  %470 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @112)
+  %471 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %462, i32 0, i32 0
+  %472 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %463, i32 0, i32 0
+  %473 = getelementptr { i1, ptr, ptr, i32 }, ptr %471, i32 0, i32 2
+  %474 = getelementptr { i1, ptr, ptr, i32 }, ptr %471, i32 0, i32 0
+  store i1 true, ptr %474, align 1
+  %475 = getelementptr { i1, ptr, ptr, i32 }, ptr %471, i32 0, i32 1
+  store ptr %470, ptr %475, align 8
+  store ptr %472, ptr %473, align 8
+  %476 = getelementptr { i1, ptr, ptr, i32 }, ptr %471, i32 0, i32 3
+  store i32 1, ptr %476, align 4
+  %477 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %462, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %477, i32 1, ptr @113, ptr @110, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont82:                                         ; preds = %ifcont80
-  %478 = getelementptr [4 x double], [4 x double]* %b, i32 0, i64 3
-  %479 = load double, double* %478, align 8
+  %478 = getelementptr [4 x double], ptr %b, i32 0, i64 3
+  %479 = load double, ptr %478, align 8
   %480 = fcmp une double %479, 1.100000e+01
   br i1 %480, label %then83, label %else84
 
 then83:                                           ; preds = %ifcont82
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @115, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @115, ptr @"ERROR STOP", ptr @114)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont85
@@ -1228,34 +1229,34 @@ else84:                                           ; preds = %ifcont82
   br label %ifcont85
 
 ifcont85:                                         ; preds = %else84, %then83
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head86
 
 loop.head86:                                      ; preds = %loop.end94, %ifcont85
-  %481 = load i32, i32* %i, align 4
+  %481 = load i32, ptr %i, align 4
   %482 = add i32 %481, 1
   %483 = icmp sle i32 %482, 2
   br i1 %483, label %loop.body87, label %loop.end95
 
 loop.body87:                                      ; preds = %loop.head86
-  %484 = load i32, i32* %i, align 4
+  %484 = load i32, ptr %i, align 4
   %485 = add i32 %484, 1
-  store i32 %485, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %485, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head88
 
 loop.head88:                                      ; preds = %ifcont93, %loop.body87
-  %486 = load i32, i32* %j, align 4
+  %486 = load i32, ptr %j, align 4
   %487 = add i32 %486, 1
   %488 = icmp sle i32 %487, 2
   br i1 %488, label %loop.body89, label %loop.end94
 
 loop.body89:                                      ; preds = %loop.head88
-  %489 = load i32, i32* %j, align 4
+  %489 = load i32, ptr %j, align 4
   %490 = add i32 %489, 1
-  store i32 %490, i32* %j, align 4
-  %491 = load i32, i32* %i, align 4
-  %492 = load i32, i32* %j, align 4
+  store i32 %490, ptr %j, align 4
+  %491 = load i32, ptr %i, align 4
+  %492 = load i32, ptr %j, align 4
   %493 = sext i32 %491 to i64
   %494 = sub i64 %493, 1
   %495 = mul i64 1, %494
@@ -1266,32 +1267,32 @@ loop.body89:                                      ; preds = %loop.head88
   br i1 %499, label %then90, label %ifcont91
 
 then90:                                           ; preds = %loop.body89
-  %500 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %501 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %502 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %501, i32 0, i32 0
-  %503 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %502, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @117, i32 0, i32 0), i8** %503, align 8
-  %504 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %502, i32 0, i32 1
-  store i32 35, i32* %504, align 4
-  %505 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %502, i32 0, i32 2
-  store i32 9, i32* %505, align 4
-  %506 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %502, i32 0, i32 3
-  store i32 35, i32* %506, align 4
-  %507 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %502, i32 0, i32 4
-  store i32 15, i32* %507, align 4
-  %508 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @118, i32 0, i32 0))
-  %509 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %500, i32 0, i32 0
-  %510 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %501, i32 0, i32 0
-  %511 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %509, i32 0, i32 2
-  %512 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %509, i32 0, i32 0
-  store i1 true, i1* %512, align 1
-  %513 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %509, i32 0, i32 1
-  store i8* %508, i8** %513, align 8
-  store { i8*, i32, i32, i32, i32 }* %510, { i8*, i32, i32, i32, i32 }** %511, align 8
-  %514 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %509, i32 0, i32 3
-  store i32 1, i32* %514, align 4
-  %515 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %500, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %515, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @119, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @116, i32 0, i32 0), i64 %493, i32 1, i64 1, i64 2)
+  %500 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %501 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %502 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %501, i32 0, i32 0
+  %503 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %502, i32 0, i32 0
+  store ptr @117, ptr %503, align 8
+  %504 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %502, i32 0, i32 1
+  store i32 35, ptr %504, align 4
+  %505 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %502, i32 0, i32 2
+  store i32 9, ptr %505, align 4
+  %506 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %502, i32 0, i32 3
+  store i32 35, ptr %506, align 4
+  %507 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %502, i32 0, i32 4
+  store i32 15, ptr %507, align 4
+  %508 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @118)
+  %509 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %500, i32 0, i32 0
+  %510 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %501, i32 0, i32 0
+  %511 = getelementptr { i1, ptr, ptr, i32 }, ptr %509, i32 0, i32 2
+  %512 = getelementptr { i1, ptr, ptr, i32 }, ptr %509, i32 0, i32 0
+  store i1 true, ptr %512, align 1
+  %513 = getelementptr { i1, ptr, ptr, i32 }, ptr %509, i32 0, i32 1
+  store ptr %508, ptr %513, align 8
+  store ptr %510, ptr %511, align 8
+  %514 = getelementptr { i1, ptr, ptr, i32 }, ptr %509, i32 0, i32 3
+  store i32 1, ptr %514, align 4
+  %515 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %500, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %515, i32 1, ptr @119, ptr @116, i64 %493, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1306,43 +1307,43 @@ ifcont91:                                         ; preds = %loop.body89
   br i1 %522, label %then92, label %ifcont93
 
 then92:                                           ; preds = %ifcont91
-  %523 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %524 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %525 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %524, i32 0, i32 0
-  %526 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %525, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @121, i32 0, i32 0), i8** %526, align 8
-  %527 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %525, i32 0, i32 1
-  store i32 35, i32* %527, align 4
-  %528 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %525, i32 0, i32 2
-  store i32 9, i32* %528, align 4
-  %529 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %525, i32 0, i32 3
-  store i32 35, i32* %529, align 4
-  %530 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %525, i32 0, i32 4
-  store i32 15, i32* %530, align 4
-  %531 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @122, i32 0, i32 0))
-  %532 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %523, i32 0, i32 0
-  %533 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %524, i32 0, i32 0
-  %534 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %532, i32 0, i32 2
-  %535 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %532, i32 0, i32 0
-  store i1 true, i1* %535, align 1
-  %536 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %532, i32 0, i32 1
-  store i8* %531, i8** %536, align 8
-  store { i8*, i32, i32, i32, i32 }* %533, { i8*, i32, i32, i32, i32 }** %534, align 8
-  %537 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %532, i32 0, i32 3
-  store i32 1, i32* %537, align 4
-  %538 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %523, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %538, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @123, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @120, i32 0, i32 0), i64 %516, i32 2, i64 1, i64 2)
+  %523 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %524 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %525 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %524, i32 0, i32 0
+  %526 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %525, i32 0, i32 0
+  store ptr @121, ptr %526, align 8
+  %527 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %525, i32 0, i32 1
+  store i32 35, ptr %527, align 4
+  %528 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %525, i32 0, i32 2
+  store i32 9, ptr %528, align 4
+  %529 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %525, i32 0, i32 3
+  store i32 35, ptr %529, align 4
+  %530 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %525, i32 0, i32 4
+  store i32 15, ptr %530, align 4
+  %531 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @122)
+  %532 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %523, i32 0, i32 0
+  %533 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %524, i32 0, i32 0
+  %534 = getelementptr { i1, ptr, ptr, i32 }, ptr %532, i32 0, i32 2
+  %535 = getelementptr { i1, ptr, ptr, i32 }, ptr %532, i32 0, i32 0
+  store i1 true, ptr %535, align 1
+  %536 = getelementptr { i1, ptr, ptr, i32 }, ptr %532, i32 0, i32 1
+  store ptr %531, ptr %536, align 8
+  store ptr %533, ptr %534, align 8
+  %537 = getelementptr { i1, ptr, ptr, i32 }, ptr %532, i32 0, i32 3
+  store i32 1, ptr %537, align 4
+  %538 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %523, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %538, i32 1, ptr @123, ptr @120, i64 %516, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont93:                                         ; preds = %ifcont91
-  %539 = getelementptr [4 x double], [4 x double]* %c, i32 0, i64 %519
-  %540 = load i32, i32* %i, align 4
-  %541 = load i32, i32* %j, align 4
+  %539 = getelementptr [4 x double], ptr %c, i32 0, i64 %519
+  %540 = load i32, ptr %i, align 4
+  %541 = load i32, ptr %j, align 4
   %542 = add i32 %540, %541
   %543 = add i32 %542, 10
   %544 = sitofp i32 %543 to double
-  store double %544, double* %539, align 8
+  store double %544, ptr %539, align 8
   br label %loop.head88
 
 loop.end94:                                       ; preds = %loop.head88
@@ -1352,32 +1353,32 @@ loop.end95:                                       ; preds = %loop.head86
   br i1 false, label %then96, label %ifcont97
 
 then96:                                           ; preds = %loop.end95
-  %545 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %546 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %547 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %546, i32 0, i32 0
-  %548 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %547, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @125, i32 0, i32 0), i8** %548, align 8
-  %549 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %547, i32 0, i32 1
-  store i32 38, i32* %549, align 4
-  %550 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %547, i32 0, i32 2
-  store i32 5, i32* %550, align 4
-  %551 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %547, i32 0, i32 3
-  store i32 38, i32* %551, align 4
-  %552 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %547, i32 0, i32 4
-  store i32 11, i32* %552, align 4
-  %553 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @126, i32 0, i32 0))
-  %554 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %545, i32 0, i32 0
-  %555 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %546, i32 0, i32 0
-  %556 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %554, i32 0, i32 2
-  %557 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %554, i32 0, i32 0
-  store i1 true, i1* %557, align 1
-  %558 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %554, i32 0, i32 1
-  store i8* %553, i8** %558, align 8
-  store { i8*, i32, i32, i32, i32 }* %555, { i8*, i32, i32, i32, i32 }** %556, align 8
-  %559 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %554, i32 0, i32 3
-  store i32 1, i32* %559, align 4
-  %560 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %545, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %560, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @127, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @124, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %545 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %546 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %547 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %546, i32 0, i32 0
+  %548 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %547, i32 0, i32 0
+  store ptr @125, ptr %548, align 8
+  %549 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %547, i32 0, i32 1
+  store i32 38, ptr %549, align 4
+  %550 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %547, i32 0, i32 2
+  store i32 5, ptr %550, align 4
+  %551 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %547, i32 0, i32 3
+  store i32 38, ptr %551, align 4
+  %552 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %547, i32 0, i32 4
+  store i32 11, ptr %552, align 4
+  %553 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @126)
+  %554 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %545, i32 0, i32 0
+  %555 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %546, i32 0, i32 0
+  %556 = getelementptr { i1, ptr, ptr, i32 }, ptr %554, i32 0, i32 2
+  %557 = getelementptr { i1, ptr, ptr, i32 }, ptr %554, i32 0, i32 0
+  store i1 true, ptr %557, align 1
+  %558 = getelementptr { i1, ptr, ptr, i32 }, ptr %554, i32 0, i32 1
+  store ptr %553, ptr %558, align 8
+  store ptr %555, ptr %556, align 8
+  %559 = getelementptr { i1, ptr, ptr, i32 }, ptr %554, i32 0, i32 3
+  store i32 1, ptr %559, align 4
+  %560 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %545, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %560, i32 1, ptr @127, ptr @124, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1385,43 +1386,43 @@ ifcont97:                                         ; preds = %loop.end95
   br i1 false, label %then98, label %ifcont99
 
 then98:                                           ; preds = %ifcont97
-  %561 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %562 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %563 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %562, i32 0, i32 0
-  %564 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %563, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @129, i32 0, i32 0), i8** %564, align 8
-  %565 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %563, i32 0, i32 1
-  store i32 38, i32* %565, align 4
-  %566 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %563, i32 0, i32 2
-  store i32 5, i32* %566, align 4
-  %567 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %563, i32 0, i32 3
-  store i32 38, i32* %567, align 4
-  %568 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %563, i32 0, i32 4
-  store i32 11, i32* %568, align 4
-  %569 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @130, i32 0, i32 0))
-  %570 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %561, i32 0, i32 0
-  %571 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %562, i32 0, i32 0
-  %572 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %570, i32 0, i32 2
-  %573 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %570, i32 0, i32 0
-  store i1 true, i1* %573, align 1
-  %574 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %570, i32 0, i32 1
-  store i8* %569, i8** %574, align 8
-  store { i8*, i32, i32, i32, i32 }* %571, { i8*, i32, i32, i32, i32 }** %572, align 8
-  %575 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %570, i32 0, i32 3
-  store i32 1, i32* %575, align 4
-  %576 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %561, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %576, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @131, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @128, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %561 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %562 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %563 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %562, i32 0, i32 0
+  %564 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %563, i32 0, i32 0
+  store ptr @129, ptr %564, align 8
+  %565 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %563, i32 0, i32 1
+  store i32 38, ptr %565, align 4
+  %566 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %563, i32 0, i32 2
+  store i32 5, ptr %566, align 4
+  %567 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %563, i32 0, i32 3
+  store i32 38, ptr %567, align 4
+  %568 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %563, i32 0, i32 4
+  store i32 11, ptr %568, align 4
+  %569 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @130)
+  %570 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %561, i32 0, i32 0
+  %571 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %562, i32 0, i32 0
+  %572 = getelementptr { i1, ptr, ptr, i32 }, ptr %570, i32 0, i32 2
+  %573 = getelementptr { i1, ptr, ptr, i32 }, ptr %570, i32 0, i32 0
+  store i1 true, ptr %573, align 1
+  %574 = getelementptr { i1, ptr, ptr, i32 }, ptr %570, i32 0, i32 1
+  store ptr %569, ptr %574, align 8
+  store ptr %571, ptr %572, align 8
+  %575 = getelementptr { i1, ptr, ptr, i32 }, ptr %570, i32 0, i32 3
+  store i32 1, ptr %575, align 4
+  %576 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %561, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %576, i32 1, ptr @131, ptr @128, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont99:                                         ; preds = %ifcont97
-  %577 = getelementptr [4 x double], [4 x double]* %c, i32 0, i64 0
-  %578 = load double, double* %577, align 8
+  %577 = getelementptr [4 x double], ptr %c, i32 0, i64 0
+  %578 = load double, ptr %577, align 8
   %579 = fcmp une double %578, 1.200000e+01
   br i1 %579, label %then100, label %else101
 
 then100:                                          ; preds = %ifcont99
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @133, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @132, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @133, ptr @"ERROR STOP", ptr @132)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont102
@@ -1433,32 +1434,32 @@ ifcont102:                                        ; preds = %else101, %then100
   br i1 false, label %then103, label %ifcont104
 
 then103:                                          ; preds = %ifcont102
-  %580 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %581 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %582 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %581, i32 0, i32 0
-  %583 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %582, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @135, i32 0, i32 0), i8** %583, align 8
-  %584 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %582, i32 0, i32 1
-  store i32 39, i32* %584, align 4
-  %585 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %582, i32 0, i32 2
-  store i32 5, i32* %585, align 4
-  %586 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %582, i32 0, i32 3
-  store i32 39, i32* %586, align 4
-  %587 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %582, i32 0, i32 4
-  store i32 11, i32* %587, align 4
-  %588 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @136, i32 0, i32 0))
-  %589 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %580, i32 0, i32 0
-  %590 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %581, i32 0, i32 0
-  %591 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %589, i32 0, i32 2
-  %592 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %589, i32 0, i32 0
-  store i1 true, i1* %592, align 1
-  %593 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %589, i32 0, i32 1
-  store i8* %588, i8** %593, align 8
-  store { i8*, i32, i32, i32, i32 }* %590, { i8*, i32, i32, i32, i32 }** %591, align 8
-  %594 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %589, i32 0, i32 3
-  store i32 1, i32* %594, align 4
-  %595 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %580, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %595, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @137, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @134, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2)
+  %580 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %581 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %582 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %581, i32 0, i32 0
+  %583 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %582, i32 0, i32 0
+  store ptr @135, ptr %583, align 8
+  %584 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %582, i32 0, i32 1
+  store i32 39, ptr %584, align 4
+  %585 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %582, i32 0, i32 2
+  store i32 5, ptr %585, align 4
+  %586 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %582, i32 0, i32 3
+  store i32 39, ptr %586, align 4
+  %587 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %582, i32 0, i32 4
+  store i32 11, ptr %587, align 4
+  %588 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @136)
+  %589 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %580, i32 0, i32 0
+  %590 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %581, i32 0, i32 0
+  %591 = getelementptr { i1, ptr, ptr, i32 }, ptr %589, i32 0, i32 2
+  %592 = getelementptr { i1, ptr, ptr, i32 }, ptr %589, i32 0, i32 0
+  store i1 true, ptr %592, align 1
+  %593 = getelementptr { i1, ptr, ptr, i32 }, ptr %589, i32 0, i32 1
+  store ptr %588, ptr %593, align 8
+  store ptr %590, ptr %591, align 8
+  %594 = getelementptr { i1, ptr, ptr, i32 }, ptr %589, i32 0, i32 3
+  store i32 1, ptr %594, align 4
+  %595 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %580, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %595, i32 1, ptr @137, ptr @134, i64 1, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1466,43 +1467,43 @@ ifcont104:                                        ; preds = %ifcont102
   br i1 false, label %then105, label %ifcont106
 
 then105:                                          ; preds = %ifcont104
-  %596 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %597 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %598 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %597, i32 0, i32 0
-  %599 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %598, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @139, i32 0, i32 0), i8** %599, align 8
-  %600 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %598, i32 0, i32 1
-  store i32 39, i32* %600, align 4
-  %601 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %598, i32 0, i32 2
-  store i32 5, i32* %601, align 4
-  %602 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %598, i32 0, i32 3
-  store i32 39, i32* %602, align 4
-  %603 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %598, i32 0, i32 4
-  store i32 11, i32* %603, align 4
-  %604 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @140, i32 0, i32 0))
-  %605 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %596, i32 0, i32 0
-  %606 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %597, i32 0, i32 0
-  %607 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %605, i32 0, i32 2
-  %608 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %605, i32 0, i32 0
-  store i1 true, i1* %608, align 1
-  %609 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %605, i32 0, i32 1
-  store i8* %604, i8** %609, align 8
-  store { i8*, i32, i32, i32, i32 }* %606, { i8*, i32, i32, i32, i32 }** %607, align 8
-  %610 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %605, i32 0, i32 3
-  store i32 1, i32* %610, align 4
-  %611 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %596, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %611, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @141, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @138, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %596 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %597 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %598 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %597, i32 0, i32 0
+  %599 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %598, i32 0, i32 0
+  store ptr @139, ptr %599, align 8
+  %600 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %598, i32 0, i32 1
+  store i32 39, ptr %600, align 4
+  %601 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %598, i32 0, i32 2
+  store i32 5, ptr %601, align 4
+  %602 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %598, i32 0, i32 3
+  store i32 39, ptr %602, align 4
+  %603 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %598, i32 0, i32 4
+  store i32 11, ptr %603, align 4
+  %604 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @140)
+  %605 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %596, i32 0, i32 0
+  %606 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %597, i32 0, i32 0
+  %607 = getelementptr { i1, ptr, ptr, i32 }, ptr %605, i32 0, i32 2
+  %608 = getelementptr { i1, ptr, ptr, i32 }, ptr %605, i32 0, i32 0
+  store i1 true, ptr %608, align 1
+  %609 = getelementptr { i1, ptr, ptr, i32 }, ptr %605, i32 0, i32 1
+  store ptr %604, ptr %609, align 8
+  store ptr %606, ptr %607, align 8
+  %610 = getelementptr { i1, ptr, ptr, i32 }, ptr %605, i32 0, i32 3
+  store i32 1, ptr %610, align 4
+  %611 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %596, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %611, i32 1, ptr @141, ptr @138, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont106:                                        ; preds = %ifcont104
-  %612 = getelementptr [4 x double], [4 x double]* %c, i32 0, i64 2
-  %613 = load double, double* %612, align 8
+  %612 = getelementptr [4 x double], ptr %c, i32 0, i64 2
+  %613 = load double, ptr %612, align 8
   %614 = fcmp une double %613, 1.300000e+01
   br i1 %614, label %then107, label %else108
 
 then107:                                          ; preds = %ifcont106
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @143, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @142, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @143, ptr @"ERROR STOP", ptr @142)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont109
@@ -1514,32 +1515,32 @@ ifcont109:                                        ; preds = %else108, %then107
   br i1 false, label %then110, label %ifcont111
 
 then110:                                          ; preds = %ifcont109
-  %615 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %616 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %617 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %616, i32 0, i32 0
-  %618 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %617, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @145, i32 0, i32 0), i8** %618, align 8
-  %619 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %617, i32 0, i32 1
-  store i32 40, i32* %619, align 4
-  %620 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %617, i32 0, i32 2
-  store i32 5, i32* %620, align 4
-  %621 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %617, i32 0, i32 3
-  store i32 40, i32* %621, align 4
-  %622 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %617, i32 0, i32 4
-  store i32 11, i32* %622, align 4
-  %623 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @146, i32 0, i32 0))
-  %624 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %615, i32 0, i32 0
-  %625 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %616, i32 0, i32 0
-  %626 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %624, i32 0, i32 2
-  %627 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %624, i32 0, i32 0
-  store i1 true, i1* %627, align 1
-  %628 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %624, i32 0, i32 1
-  store i8* %623, i8** %628, align 8
-  store { i8*, i32, i32, i32, i32 }* %625, { i8*, i32, i32, i32, i32 }** %626, align 8
-  %629 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %624, i32 0, i32 3
-  store i32 1, i32* %629, align 4
-  %630 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %615, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %630, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @147, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @144, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %615 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %616 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %617 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %616, i32 0, i32 0
+  %618 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %617, i32 0, i32 0
+  store ptr @145, ptr %618, align 8
+  %619 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %617, i32 0, i32 1
+  store i32 40, ptr %619, align 4
+  %620 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %617, i32 0, i32 2
+  store i32 5, ptr %620, align 4
+  %621 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %617, i32 0, i32 3
+  store i32 40, ptr %621, align 4
+  %622 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %617, i32 0, i32 4
+  store i32 11, ptr %622, align 4
+  %623 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @146)
+  %624 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %615, i32 0, i32 0
+  %625 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %616, i32 0, i32 0
+  %626 = getelementptr { i1, ptr, ptr, i32 }, ptr %624, i32 0, i32 2
+  %627 = getelementptr { i1, ptr, ptr, i32 }, ptr %624, i32 0, i32 0
+  store i1 true, ptr %627, align 1
+  %628 = getelementptr { i1, ptr, ptr, i32 }, ptr %624, i32 0, i32 1
+  store ptr %623, ptr %628, align 8
+  store ptr %625, ptr %626, align 8
+  %629 = getelementptr { i1, ptr, ptr, i32 }, ptr %624, i32 0, i32 3
+  store i32 1, ptr %629, align 4
+  %630 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %615, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %630, i32 1, ptr @147, ptr @144, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1547,43 +1548,43 @@ ifcont111:                                        ; preds = %ifcont109
   br i1 false, label %then112, label %ifcont113
 
 then112:                                          ; preds = %ifcont111
-  %631 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %632 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %633 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %632, i32 0, i32 0
-  %634 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %633, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @149, i32 0, i32 0), i8** %634, align 8
-  %635 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %633, i32 0, i32 1
-  store i32 40, i32* %635, align 4
-  %636 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %633, i32 0, i32 2
-  store i32 5, i32* %636, align 4
-  %637 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %633, i32 0, i32 3
-  store i32 40, i32* %637, align 4
-  %638 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %633, i32 0, i32 4
-  store i32 11, i32* %638, align 4
-  %639 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @150, i32 0, i32 0))
-  %640 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %631, i32 0, i32 0
-  %641 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %632, i32 0, i32 0
-  %642 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 0, i32 2
-  %643 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 0, i32 0
-  store i1 true, i1* %643, align 1
-  %644 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 0, i32 1
-  store i8* %639, i8** %644, align 8
-  store { i8*, i32, i32, i32, i32 }* %641, { i8*, i32, i32, i32, i32 }** %642, align 8
-  %645 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %640, i32 0, i32 3
-  store i32 1, i32* %645, align 4
-  %646 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %631, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %646, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @151, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @148, i32 0, i32 0), i64 1, i32 2, i64 1, i64 2)
+  %631 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %632 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %633 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %632, i32 0, i32 0
+  %634 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %633, i32 0, i32 0
+  store ptr @149, ptr %634, align 8
+  %635 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %633, i32 0, i32 1
+  store i32 40, ptr %635, align 4
+  %636 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %633, i32 0, i32 2
+  store i32 5, ptr %636, align 4
+  %637 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %633, i32 0, i32 3
+  store i32 40, ptr %637, align 4
+  %638 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %633, i32 0, i32 4
+  store i32 11, ptr %638, align 4
+  %639 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @150)
+  %640 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %631, i32 0, i32 0
+  %641 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %632, i32 0, i32 0
+  %642 = getelementptr { i1, ptr, ptr, i32 }, ptr %640, i32 0, i32 2
+  %643 = getelementptr { i1, ptr, ptr, i32 }, ptr %640, i32 0, i32 0
+  store i1 true, ptr %643, align 1
+  %644 = getelementptr { i1, ptr, ptr, i32 }, ptr %640, i32 0, i32 1
+  store ptr %639, ptr %644, align 8
+  store ptr %641, ptr %642, align 8
+  %645 = getelementptr { i1, ptr, ptr, i32 }, ptr %640, i32 0, i32 3
+  store i32 1, ptr %645, align 4
+  %646 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %631, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %646, i32 1, ptr @151, ptr @148, i64 1, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont113:                                        ; preds = %ifcont111
-  %647 = getelementptr [4 x double], [4 x double]* %c, i32 0, i64 1
-  %648 = load double, double* %647, align 8
+  %647 = getelementptr [4 x double], ptr %c, i32 0, i64 1
+  %648 = load double, ptr %647, align 8
   %649 = fcmp une double %648, 1.300000e+01
   br i1 %649, label %then114, label %else115
 
 then114:                                          ; preds = %ifcont113
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @153, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @152, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @153, ptr @"ERROR STOP", ptr @152)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont116
@@ -1595,32 +1596,32 @@ ifcont116:                                        ; preds = %else115, %then114
   br i1 false, label %then117, label %ifcont118
 
 then117:                                          ; preds = %ifcont116
-  %650 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %651 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %652 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %651, i32 0, i32 0
-  %653 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %652, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @155, i32 0, i32 0), i8** %653, align 8
-  %654 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %652, i32 0, i32 1
-  store i32 41, i32* %654, align 4
-  %655 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %652, i32 0, i32 2
-  store i32 5, i32* %655, align 4
-  %656 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %652, i32 0, i32 3
-  store i32 41, i32* %656, align 4
-  %657 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %652, i32 0, i32 4
-  store i32 11, i32* %657, align 4
-  %658 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @156, i32 0, i32 0))
-  %659 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %650, i32 0, i32 0
-  %660 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %651, i32 0, i32 0
-  %661 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %659, i32 0, i32 2
-  %662 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %659, i32 0, i32 0
-  store i1 true, i1* %662, align 1
-  %663 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %659, i32 0, i32 1
-  store i8* %658, i8** %663, align 8
-  store { i8*, i32, i32, i32, i32 }* %660, { i8*, i32, i32, i32, i32 }** %661, align 8
-  %664 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %659, i32 0, i32 3
-  store i32 1, i32* %664, align 4
-  %665 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %650, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %665, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @157, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @154, i32 0, i32 0), i64 2, i32 1, i64 1, i64 2)
+  %650 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %651 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %652 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %651, i32 0, i32 0
+  %653 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %652, i32 0, i32 0
+  store ptr @155, ptr %653, align 8
+  %654 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %652, i32 0, i32 1
+  store i32 41, ptr %654, align 4
+  %655 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %652, i32 0, i32 2
+  store i32 5, ptr %655, align 4
+  %656 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %652, i32 0, i32 3
+  store i32 41, ptr %656, align 4
+  %657 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %652, i32 0, i32 4
+  store i32 11, ptr %657, align 4
+  %658 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @156)
+  %659 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %650, i32 0, i32 0
+  %660 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %651, i32 0, i32 0
+  %661 = getelementptr { i1, ptr, ptr, i32 }, ptr %659, i32 0, i32 2
+  %662 = getelementptr { i1, ptr, ptr, i32 }, ptr %659, i32 0, i32 0
+  store i1 true, ptr %662, align 1
+  %663 = getelementptr { i1, ptr, ptr, i32 }, ptr %659, i32 0, i32 1
+  store ptr %658, ptr %663, align 8
+  store ptr %660, ptr %661, align 8
+  %664 = getelementptr { i1, ptr, ptr, i32 }, ptr %659, i32 0, i32 3
+  store i32 1, ptr %664, align 4
+  %665 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %650, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %665, i32 1, ptr @157, ptr @154, i64 2, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
@@ -1628,43 +1629,43 @@ ifcont118:                                        ; preds = %ifcont116
   br i1 false, label %then119, label %ifcont120
 
 then119:                                          ; preds = %ifcont118
-  %666 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %667 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %668 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %667, i32 0, i32 0
-  %669 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %668, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @159, i32 0, i32 0), i8** %669, align 8
-  %670 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %668, i32 0, i32 1
-  store i32 41, i32* %670, align 4
-  %671 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %668, i32 0, i32 2
-  store i32 5, i32* %671, align 4
-  %672 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %668, i32 0, i32 3
-  store i32 41, i32* %672, align 4
-  %673 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %668, i32 0, i32 4
-  store i32 11, i32* %673, align 4
-  %674 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @160, i32 0, i32 0))
-  %675 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %666, i32 0, i32 0
-  %676 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %667, i32 0, i32 0
-  %677 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %675, i32 0, i32 2
-  %678 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %675, i32 0, i32 0
-  store i1 true, i1* %678, align 1
-  %679 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %675, i32 0, i32 1
-  store i8* %674, i8** %679, align 8
-  store { i8*, i32, i32, i32, i32 }* %676, { i8*, i32, i32, i32, i32 }** %677, align 8
-  %680 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %675, i32 0, i32 3
-  store i32 1, i32* %680, align 4
-  %681 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %666, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %681, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @161, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @158, i32 0, i32 0), i64 2, i32 2, i64 1, i64 2)
+  %666 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %667 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %668 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %667, i32 0, i32 0
+  %669 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %668, i32 0, i32 0
+  store ptr @159, ptr %669, align 8
+  %670 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %668, i32 0, i32 1
+  store i32 41, ptr %670, align 4
+  %671 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %668, i32 0, i32 2
+  store i32 5, ptr %671, align 4
+  %672 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %668, i32 0, i32 3
+  store i32 41, ptr %672, align 4
+  %673 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %668, i32 0, i32 4
+  store i32 11, ptr %673, align 4
+  %674 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @160)
+  %675 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %666, i32 0, i32 0
+  %676 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %667, i32 0, i32 0
+  %677 = getelementptr { i1, ptr, ptr, i32 }, ptr %675, i32 0, i32 2
+  %678 = getelementptr { i1, ptr, ptr, i32 }, ptr %675, i32 0, i32 0
+  store i1 true, ptr %678, align 1
+  %679 = getelementptr { i1, ptr, ptr, i32 }, ptr %675, i32 0, i32 1
+  store ptr %674, ptr %679, align 8
+  store ptr %676, ptr %677, align 8
+  %680 = getelementptr { i1, ptr, ptr, i32 }, ptr %675, i32 0, i32 3
+  store i32 1, ptr %680, align 4
+  %681 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %666, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %681, i32 1, ptr @161, ptr @158, i64 2, i32 2, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont120:                                        ; preds = %ifcont118
-  %682 = getelementptr [4 x double], [4 x double]* %c, i32 0, i64 3
-  %683 = load double, double* %682, align 8
+  %682 = getelementptr [4 x double], ptr %c, i32 0, i64 3
+  %683 = load double, ptr %682, align 8
   %684 = fcmp une double %683, 1.400000e+01
   br i1 %684, label %then121, label %else122
 
 then121:                                          ; preds = %ifcont120
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @163, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @162, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @163, ptr @"ERROR STOP", ptr @162)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont123
@@ -1683,16 +1684,16 @@ FINALIZE_SYMTABLE_arrays_01_real:                 ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-arrays_01_size-aaed99f.json
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_01_size-aaed99f.stdout",
-    "stdout_hash": "30c6e44be82350ae08109151db8952d910017f0d86f701a130bf6eee",
+    "stdout_hash": "704d8102096599927590367ee1b064985b5d3aa7ace04ecf49565342",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_01_size-aaed99f.stdout
+++ b/tests/reference/llvm-arrays_01_size-aaed99f.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -124,10 +125,10 @@ target datalayout = "..."
 @118 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @119 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
   %__do_loop_end2 = alloca i32, align 4
@@ -136,14 +137,14 @@ define i32 @main(i32 %0, i8** %1) {
   %i = alloca i32, align 4
   %size_a = alloca i32, align 4
   %size_b = alloca i32, align 4
-  store i32 3, i32* %size_a, align 4
-  store i32 4, i32* %size_b, align 4
-  %3 = load i32, i32* %size_a, align 4
+  store i32 3, ptr %size_a, align 4
+  store i32 4, ptr %size_b, align 4
+  %3 = load i32, ptr %size_a, align 4
   %4 = icmp ne i32 %3, 3
   br i1 %4, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -152,12 +153,12 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load i32, i32* %size_b, align 4
+  %5 = load i32, ptr %size_b, align 4
   %6 = icmp ne i32 %5, 4
   br i1 %6, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -166,23 +167,23 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %7 = load i32, i32* %size_a, align 4
-  store i32 %7, i32* %__do_loop_end, align 4
-  store i32 0, i32* %i, align 4
+  %7 = load i32, ptr %size_a, align 4
+  store i32 %7, ptr %__do_loop_end, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont5, %ifcont3
-  %8 = load i32, i32* %i, align 4
+  %8 = load i32, ptr %i, align 4
   %9 = add i32 %8, 1
-  %10 = load i32, i32* %__do_loop_end, align 4
+  %10 = load i32, ptr %__do_loop_end, align 4
   %11 = icmp sle i32 %9, %10
   br i1 %11, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, ptr %i, align 4
   %13 = add i32 %12, 1
-  store i32 %13, i32* %i, align 4
-  %14 = load i32, i32* %i, align 4
+  store i32 %13, ptr %i, align 4
+  %14 = load i32, ptr %i, align 4
   %15 = sext i32 %14 to i64
   %16 = sub i64 %15, 1
   %17 = mul i64 1, %16
@@ -193,83 +194,83 @@ loop.body:                                        ; preds = %loop.head
   br i1 %21, label %then4, label %ifcont5
 
 then4:                                            ; preds = %loop.body
-  %22 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %23 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %24 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %23, i32 0, i32 0
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %24, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @5, i32 0, i32 0), i8** %25, align 8
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %24, i32 0, i32 1
-  store i32 13, i32* %26, align 4
-  %27 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %24, i32 0, i32 2
-  store i32 5, i32* %27, align 4
-  %28 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %24, i32 0, i32 3
-  store i32 13, i32* %28, align 4
-  %29 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %24, i32 0, i32 4
-  store i32 8, i32* %29, align 4
-  %30 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %31 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %22, i32 0, i32 0
-  %32 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %23, i32 0, i32 0
-  %33 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 0, i32 2
-  %34 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 0, i32 0
-  store i1 true, i1* %34, align 1
-  %35 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 0, i32 1
-  store i8* %30, i8** %35, align 8
-  store { i8*, i32, i32, i32, i32 }* %32, { i8*, i32, i32, i32, i32 }** %33, align 8
-  %36 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 0, i32 3
-  store i32 1, i32* %36, align 4
-  %37 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %22, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %37, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i64 %15, i32 1, i64 1, i64 3)
+  %22 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %23 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %24 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %23, i32 0, i32 0
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 0
+  store ptr @5, ptr %25, align 8
+  %26 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 1
+  store i32 13, ptr %26, align 4
+  %27 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 2
+  store i32 5, ptr %27, align 4
+  %28 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 3
+  store i32 13, ptr %28, align 4
+  %29 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 4
+  store i32 8, ptr %29, align 4
+  %30 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %31 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %22, i32 0, i32 0
+  %32 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %23, i32 0, i32 0
+  %33 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 2
+  %34 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 0
+  store i1 true, ptr %34, align 1
+  %35 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 1
+  store ptr %30, ptr %35, align 8
+  store ptr %32, ptr %33, align 8
+  %36 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 3
+  store i32 1, ptr %36, align 4
+  %37 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %22, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %37, i32 1, ptr @7, ptr @4, i64 %15, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %loop.body
-  %38 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %18
-  %39 = load i32, i32* %i, align 4
+  %38 = getelementptr [3 x i32], ptr %a, i32 0, i64 %18
+  %39 = load i32, ptr %i, align 4
   %40 = add i32 %39, 10
-  store i32 %40, i32* %38, align 4
+  store i32 %40, ptr %38, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then6, label %ifcont7
 
 then6:                                            ; preds = %loop.end
-  %41 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %42 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %43 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %42, i32 0, i32 0
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %43, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @9, i32 0, i32 0), i8** %44, align 8
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %43, i32 0, i32 1
-  store i32 15, i32* %45, align 4
-  %46 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %43, i32 0, i32 2
-  store i32 5, i32* %46, align 4
-  %47 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %43, i32 0, i32 3
-  store i32 15, i32* %47, align 4
-  %48 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %43, i32 0, i32 4
-  store i32 8, i32* %48, align 4
-  %49 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %50 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %41, i32 0, i32 0
-  %51 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %42, i32 0, i32 0
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 0, i32 2
-  %53 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 0, i32 0
-  store i1 true, i1* %53, align 1
-  %54 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 0, i32 1
-  store i8* %49, i8** %54, align 8
-  store { i8*, i32, i32, i32, i32 }* %51, { i8*, i32, i32, i32, i32 }** %52, align 8
-  %55 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %50, i32 0, i32 3
-  store i32 1, i32* %55, align 4
-  %56 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %41, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %56, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %41 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %42 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %43 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %42, i32 0, i32 0
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %43, i32 0, i32 0
+  store ptr @9, ptr %44, align 8
+  %45 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %43, i32 0, i32 1
+  store i32 15, ptr %45, align 4
+  %46 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %43, i32 0, i32 2
+  store i32 5, ptr %46, align 4
+  %47 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %43, i32 0, i32 3
+  store i32 15, ptr %47, align 4
+  %48 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %43, i32 0, i32 4
+  store i32 8, ptr %48, align 4
+  %49 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10)
+  %50 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %41, i32 0, i32 0
+  %51 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %42, i32 0, i32 0
+  %52 = getelementptr { i1, ptr, ptr, i32 }, ptr %50, i32 0, i32 2
+  %53 = getelementptr { i1, ptr, ptr, i32 }, ptr %50, i32 0, i32 0
+  store i1 true, ptr %53, align 1
+  %54 = getelementptr { i1, ptr, ptr, i32 }, ptr %50, i32 0, i32 1
+  store ptr %49, ptr %54, align 8
+  store ptr %51, ptr %52, align 8
+  %55 = getelementptr { i1, ptr, ptr, i32 }, ptr %50, i32 0, i32 3
+  store i32 1, ptr %55, align 4
+  %56 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %41, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %56, i32 1, ptr @11, ptr @8, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont7:                                          ; preds = %loop.end
-  %57 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %58 = load i32, i32* %57, align 4
+  %57 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %58 = load i32, ptr %57, align 4
   %59 = icmp ne i32 %58, 11
   br i1 %59, label %then8, label %else9
 
 then8:                                            ; preds = %ifcont7
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont10
@@ -281,43 +282,43 @@ ifcont10:                                         ; preds = %else9, %then8
   br i1 false, label %then11, label %ifcont12
 
 then11:                                           ; preds = %ifcont10
-  %60 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %61 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %62 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %61, i32 0, i32 0
-  %63 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %62, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @15, i32 0, i32 0), i8** %63, align 8
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %62, i32 0, i32 1
-  store i32 16, i32* %64, align 4
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %62, i32 0, i32 2
-  store i32 5, i32* %65, align 4
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %62, i32 0, i32 3
-  store i32 16, i32* %66, align 4
-  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %62, i32 0, i32 4
-  store i32 8, i32* %67, align 4
-  %68 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @16, i32 0, i32 0))
-  %69 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %60, i32 0, i32 0
-  %70 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %61, i32 0, i32 0
-  %71 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %69, i32 0, i32 2
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %69, i32 0, i32 0
-  store i1 true, i1* %72, align 1
-  %73 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %69, i32 0, i32 1
-  store i8* %68, i8** %73, align 8
-  store { i8*, i32, i32, i32, i32 }* %70, { i8*, i32, i32, i32, i32 }** %71, align 8
-  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %69, i32 0, i32 3
-  store i32 1, i32* %74, align 4
-  %75 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %60, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i64 2, i32 1, i64 1, i64 3)
+  %60 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %61 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %62 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %61, i32 0, i32 0
+  %63 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %62, i32 0, i32 0
+  store ptr @15, ptr %63, align 8
+  %64 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %62, i32 0, i32 1
+  store i32 16, ptr %64, align 4
+  %65 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %62, i32 0, i32 2
+  store i32 5, ptr %65, align 4
+  %66 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %62, i32 0, i32 3
+  store i32 16, ptr %66, align 4
+  %67 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %62, i32 0, i32 4
+  store i32 8, ptr %67, align 4
+  %68 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @16)
+  %69 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %60, i32 0, i32 0
+  %70 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %61, i32 0, i32 0
+  %71 = getelementptr { i1, ptr, ptr, i32 }, ptr %69, i32 0, i32 2
+  %72 = getelementptr { i1, ptr, ptr, i32 }, ptr %69, i32 0, i32 0
+  store i1 true, ptr %72, align 1
+  %73 = getelementptr { i1, ptr, ptr, i32 }, ptr %69, i32 0, i32 1
+  store ptr %68, ptr %73, align 8
+  store ptr %70, ptr %71, align 8
+  %74 = getelementptr { i1, ptr, ptr, i32 }, ptr %69, i32 0, i32 3
+  store i32 1, ptr %74, align 4
+  %75 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %60, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %75, i32 1, ptr @17, ptr @14, i64 2, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %ifcont10
-  %76 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 1
-  %77 = load i32, i32* %76, align 4
+  %76 = getelementptr [3 x i32], ptr %a, i32 0, i64 1
+  %77 = load i32, ptr %76, align 4
   %78 = icmp ne i32 %77, 12
   br i1 %78, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @19, ptr @"ERROR STOP", ptr @18)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -329,43 +330,43 @@ ifcont15:                                         ; preds = %else14, %then13
   br i1 false, label %then16, label %ifcont17
 
 then16:                                           ; preds = %ifcont15
-  %79 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %80 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %81 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %80, i32 0, i32 0
-  %82 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @21, i32 0, i32 0), i8** %82, align 8
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 1
-  store i32 17, i32* %83, align 4
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 2
-  store i32 5, i32* %84, align 4
-  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 3
-  store i32 17, i32* %85, align 4
-  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %81, i32 0, i32 4
-  store i32 8, i32* %86, align 4
-  %87 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @22, i32 0, i32 0))
-  %88 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %79, i32 0, i32 0
-  %89 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %80, i32 0, i32 0
-  %90 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 2
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 0
-  store i1 true, i1* %91, align 1
-  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 1
-  store i8* %87, i8** %92, align 8
-  store { i8*, i32, i32, i32, i32 }* %89, { i8*, i32, i32, i32, i32 }** %90, align 8
-  %93 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %88, i32 0, i32 3
-  store i32 1, i32* %93, align 4
-  %94 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %79, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %94, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i64 3, i32 1, i64 1, i64 3)
+  %79 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %80 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %81 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %80, i32 0, i32 0
+  %82 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %81, i32 0, i32 0
+  store ptr @21, ptr %82, align 8
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %81, i32 0, i32 1
+  store i32 17, ptr %83, align 4
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %81, i32 0, i32 2
+  store i32 5, ptr %84, align 4
+  %85 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %81, i32 0, i32 3
+  store i32 17, ptr %85, align 4
+  %86 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %81, i32 0, i32 4
+  store i32 8, ptr %86, align 4
+  %87 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @22)
+  %88 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %79, i32 0, i32 0
+  %89 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %80, i32 0, i32 0
+  %90 = getelementptr { i1, ptr, ptr, i32 }, ptr %88, i32 0, i32 2
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %88, i32 0, i32 0
+  store i1 true, ptr %91, align 1
+  %92 = getelementptr { i1, ptr, ptr, i32 }, ptr %88, i32 0, i32 1
+  store ptr %87, ptr %92, align 8
+  store ptr %89, ptr %90, align 8
+  %93 = getelementptr { i1, ptr, ptr, i32 }, ptr %88, i32 0, i32 3
+  store i32 1, ptr %93, align 4
+  %94 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %79, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %94, i32 1, ptr @23, ptr @20, i64 3, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont17:                                         ; preds = %ifcont15
-  %95 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 2
-  %96 = load i32, i32* %95, align 4
+  %95 = getelementptr [3 x i32], ptr %a, i32 0, i64 2
+  %96 = load i32, ptr %95, align 4
   %97 = icmp ne i32 %96, 13
   br i1 %97, label %then18, label %else19
 
 then18:                                           ; preds = %ifcont17
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @25, ptr @"ERROR STOP", ptr @24)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont20
@@ -374,24 +375,24 @@ else19:                                           ; preds = %ifcont17
   br label %ifcont20
 
 ifcont20:                                         ; preds = %else19, %then18
-  %98 = load i32, i32* %size_b, align 4
+  %98 = load i32, ptr %size_b, align 4
   %99 = add i32 10, %98
-  store i32 %99, i32* %__do_loop_end1, align 4
-  store i32 10, i32* %i, align 4
+  store i32 %99, ptr %__do_loop_end1, align 4
+  store i32 10, ptr %i, align 4
   br label %loop.head21
 
 loop.head21:                                      ; preds = %ifcont24, %ifcont20
-  %100 = load i32, i32* %i, align 4
+  %100 = load i32, ptr %i, align 4
   %101 = add i32 %100, 1
-  %102 = load i32, i32* %__do_loop_end1, align 4
+  %102 = load i32, ptr %__do_loop_end1, align 4
   %103 = icmp sle i32 %101, %102
   br i1 %103, label %loop.body22, label %loop.end25
 
 loop.body22:                                      ; preds = %loop.head21
-  %104 = load i32, i32* %i, align 4
+  %104 = load i32, ptr %i, align 4
   %105 = add i32 %104, 1
-  store i32 %105, i32* %i, align 4
-  %106 = load i32, i32* %i, align 4
+  store i32 %105, ptr %i, align 4
+  %106 = load i32, ptr %i, align 4
   %107 = sub i32 %106, 10
   %108 = sext i32 %107 to i64
   %109 = sub i64 %108, 1
@@ -403,82 +404,82 @@ loop.body22:                                      ; preds = %loop.head21
   br i1 %114, label %then23, label %ifcont24
 
 then23:                                           ; preds = %loop.body22
-  %115 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %116 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %117 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %116, i32 0, i32 0
-  %118 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %117, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @27, i32 0, i32 0), i8** %118, align 8
-  %119 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %117, i32 0, i32 1
-  store i32 20, i32* %119, align 4
-  %120 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %117, i32 0, i32 2
-  store i32 5, i32* %120, align 4
-  %121 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %117, i32 0, i32 3
-  store i32 20, i32* %121, align 4
-  %122 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %117, i32 0, i32 4
-  store i32 11, i32* %122, align 4
-  %123 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @28, i32 0, i32 0))
-  %124 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %115, i32 0, i32 0
-  %125 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %116, i32 0, i32 0
-  %126 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 0, i32 2
-  %127 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 0, i32 0
-  store i1 true, i1* %127, align 1
-  %128 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 0, i32 1
-  store i8* %123, i8** %128, align 8
-  store { i8*, i32, i32, i32, i32 }* %125, { i8*, i32, i32, i32, i32 }** %126, align 8
-  %129 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %124, i32 0, i32 3
-  store i32 1, i32* %129, align 4
-  %130 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %115, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %130, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i64 %108, i32 1, i64 1, i64 4)
+  %115 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %116 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %117 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %116, i32 0, i32 0
+  %118 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %117, i32 0, i32 0
+  store ptr @27, ptr %118, align 8
+  %119 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %117, i32 0, i32 1
+  store i32 20, ptr %119, align 4
+  %120 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %117, i32 0, i32 2
+  store i32 5, ptr %120, align 4
+  %121 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %117, i32 0, i32 3
+  store i32 20, ptr %121, align 4
+  %122 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %117, i32 0, i32 4
+  store i32 11, ptr %122, align 4
+  %123 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @28)
+  %124 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %115, i32 0, i32 0
+  %125 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %116, i32 0, i32 0
+  %126 = getelementptr { i1, ptr, ptr, i32 }, ptr %124, i32 0, i32 2
+  %127 = getelementptr { i1, ptr, ptr, i32 }, ptr %124, i32 0, i32 0
+  store i1 true, ptr %127, align 1
+  %128 = getelementptr { i1, ptr, ptr, i32 }, ptr %124, i32 0, i32 1
+  store ptr %123, ptr %128, align 8
+  store ptr %125, ptr %126, align 8
+  %129 = getelementptr { i1, ptr, ptr, i32 }, ptr %124, i32 0, i32 3
+  store i32 1, ptr %129, align 4
+  %130 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %115, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %130, i32 1, ptr @29, ptr @26, i64 %108, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %loop.body22
-  %131 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %111
-  %132 = load i32, i32* %i, align 4
-  store i32 %132, i32* %131, align 4
+  %131 = getelementptr [4 x i32], ptr %b, i32 0, i64 %111
+  %132 = load i32, ptr %i, align 4
+  store i32 %132, ptr %131, align 4
   br label %loop.head21
 
 loop.end25:                                       ; preds = %loop.head21
   br i1 false, label %then26, label %ifcont27
 
 then26:                                           ; preds = %loop.end25
-  %133 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %134 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %135 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %134, i32 0, i32 0
-  %136 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @31, i32 0, i32 0), i8** %136, align 8
-  %137 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 1
-  store i32 22, i32* %137, align 4
-  %138 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 2
-  store i32 5, i32* %138, align 4
-  %139 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 3
-  store i32 22, i32* %139, align 4
-  %140 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %135, i32 0, i32 4
-  store i32 8, i32* %140, align 4
-  %141 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @32, i32 0, i32 0))
-  %142 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %133, i32 0, i32 0
-  %143 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %134, i32 0, i32 0
-  %144 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 2
-  %145 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 0
-  store i1 true, i1* %145, align 1
-  %146 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 1
-  store i8* %141, i8** %146, align 8
-  store { i8*, i32, i32, i32, i32 }* %143, { i8*, i32, i32, i32, i32 }** %144, align 8
-  %147 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %142, i32 0, i32 3
-  store i32 1, i32* %147, align 4
-  %148 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %133, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %148, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %133 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %134 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %135 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %134, i32 0, i32 0
+  %136 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %135, i32 0, i32 0
+  store ptr @31, ptr %136, align 8
+  %137 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %135, i32 0, i32 1
+  store i32 22, ptr %137, align 4
+  %138 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %135, i32 0, i32 2
+  store i32 5, ptr %138, align 4
+  %139 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %135, i32 0, i32 3
+  store i32 22, ptr %139, align 4
+  %140 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %135, i32 0, i32 4
+  store i32 8, ptr %140, align 4
+  %141 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @32)
+  %142 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %133, i32 0, i32 0
+  %143 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %134, i32 0, i32 0
+  %144 = getelementptr { i1, ptr, ptr, i32 }, ptr %142, i32 0, i32 2
+  %145 = getelementptr { i1, ptr, ptr, i32 }, ptr %142, i32 0, i32 0
+  store i1 true, ptr %145, align 1
+  %146 = getelementptr { i1, ptr, ptr, i32 }, ptr %142, i32 0, i32 1
+  store ptr %141, ptr %146, align 8
+  store ptr %143, ptr %144, align 8
+  %147 = getelementptr { i1, ptr, ptr, i32 }, ptr %142, i32 0, i32 3
+  store i32 1, ptr %147, align 4
+  %148 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %133, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %148, i32 1, ptr @33, ptr @30, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont27:                                         ; preds = %loop.end25
-  %149 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %150 = load i32, i32* %149, align 4
+  %149 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %150 = load i32, ptr %149, align 4
   %151 = icmp ne i32 %150, 11
   br i1 %151, label %then28, label %else29
 
 then28:                                           ; preds = %ifcont27
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @35, ptr @"ERROR STOP", ptr @34)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont30
@@ -490,43 +491,43 @@ ifcont30:                                         ; preds = %else29, %then28
   br i1 false, label %then31, label %ifcont32
 
 then31:                                           ; preds = %ifcont30
-  %152 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %153 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %154 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %153, i32 0, i32 0
-  %155 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %154, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @37, i32 0, i32 0), i8** %155, align 8
-  %156 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %154, i32 0, i32 1
-  store i32 23, i32* %156, align 4
-  %157 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %154, i32 0, i32 2
-  store i32 5, i32* %157, align 4
-  %158 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %154, i32 0, i32 3
-  store i32 23, i32* %158, align 4
-  %159 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %154, i32 0, i32 4
-  store i32 8, i32* %159, align 4
-  %160 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @38, i32 0, i32 0))
-  %161 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %152, i32 0, i32 0
-  %162 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %153, i32 0, i32 0
-  %163 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %161, i32 0, i32 2
-  %164 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %161, i32 0, i32 0
-  store i1 true, i1* %164, align 1
-  %165 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %161, i32 0, i32 1
-  store i8* %160, i8** %165, align 8
-  store { i8*, i32, i32, i32, i32 }* %162, { i8*, i32, i32, i32, i32 }** %163, align 8
-  %166 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %161, i32 0, i32 3
-  store i32 1, i32* %166, align 4
-  %167 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %152, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %167, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %152 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %153 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %154 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %153, i32 0, i32 0
+  %155 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %154, i32 0, i32 0
+  store ptr @37, ptr %155, align 8
+  %156 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %154, i32 0, i32 1
+  store i32 23, ptr %156, align 4
+  %157 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %154, i32 0, i32 2
+  store i32 5, ptr %157, align 4
+  %158 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %154, i32 0, i32 3
+  store i32 23, ptr %158, align 4
+  %159 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %154, i32 0, i32 4
+  store i32 8, ptr %159, align 4
+  %160 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @38)
+  %161 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %152, i32 0, i32 0
+  %162 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %153, i32 0, i32 0
+  %163 = getelementptr { i1, ptr, ptr, i32 }, ptr %161, i32 0, i32 2
+  %164 = getelementptr { i1, ptr, ptr, i32 }, ptr %161, i32 0, i32 0
+  store i1 true, ptr %164, align 1
+  %165 = getelementptr { i1, ptr, ptr, i32 }, ptr %161, i32 0, i32 1
+  store ptr %160, ptr %165, align 8
+  store ptr %162, ptr %163, align 8
+  %166 = getelementptr { i1, ptr, ptr, i32 }, ptr %161, i32 0, i32 3
+  store i32 1, ptr %166, align 4
+  %167 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %152, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %167, i32 1, ptr @39, ptr @36, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %168 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %169 = load i32, i32* %168, align 4
+  %168 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %169 = load i32, ptr %168, align 4
   %170 = icmp ne i32 %169, 12
   br i1 %170, label %then33, label %else34
 
 then33:                                           ; preds = %ifcont32
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @41, ptr @"ERROR STOP", ptr @40)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont35
@@ -538,43 +539,43 @@ ifcont35:                                         ; preds = %else34, %then33
   br i1 false, label %then36, label %ifcont37
 
 then36:                                           ; preds = %ifcont35
-  %171 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %172 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %173 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
-  %174 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @43, i32 0, i32 0), i8** %174, align 8
-  %175 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 1
-  store i32 24, i32* %175, align 4
-  %176 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 2
-  store i32 5, i32* %176, align 4
-  %177 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 3
-  store i32 24, i32* %177, align 4
-  %178 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %173, i32 0, i32 4
-  store i32 8, i32* %178, align 4
-  %179 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @44, i32 0, i32 0))
-  %180 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
-  %181 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %172, i32 0, i32 0
-  %182 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 2
-  %183 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 0
-  store i1 true, i1* %183, align 1
-  %184 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 1
-  store i8* %179, i8** %184, align 8
-  store { i8*, i32, i32, i32, i32 }* %181, { i8*, i32, i32, i32, i32 }** %182, align 8
-  %185 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %180, i32 0, i32 3
-  store i32 1, i32* %185, align 4
-  %186 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %171, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %186, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %171 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %172 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %173 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %172, i32 0, i32 0
+  %174 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %173, i32 0, i32 0
+  store ptr @43, ptr %174, align 8
+  %175 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %173, i32 0, i32 1
+  store i32 24, ptr %175, align 4
+  %176 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %173, i32 0, i32 2
+  store i32 5, ptr %176, align 4
+  %177 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %173, i32 0, i32 3
+  store i32 24, ptr %177, align 4
+  %178 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %173, i32 0, i32 4
+  store i32 8, ptr %178, align 4
+  %179 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @44)
+  %180 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %171, i32 0, i32 0
+  %181 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %172, i32 0, i32 0
+  %182 = getelementptr { i1, ptr, ptr, i32 }, ptr %180, i32 0, i32 2
+  %183 = getelementptr { i1, ptr, ptr, i32 }, ptr %180, i32 0, i32 0
+  store i1 true, ptr %183, align 1
+  %184 = getelementptr { i1, ptr, ptr, i32 }, ptr %180, i32 0, i32 1
+  store ptr %179, ptr %184, align 8
+  store ptr %181, ptr %182, align 8
+  %185 = getelementptr { i1, ptr, ptr, i32 }, ptr %180, i32 0, i32 3
+  store i32 1, ptr %185, align 4
+  %186 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %171, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %186, i32 1, ptr @45, ptr @42, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont37:                                         ; preds = %ifcont35
-  %187 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %188 = load i32, i32* %187, align 4
+  %187 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %188 = load i32, ptr %187, align 4
   %189 = icmp ne i32 %188, 13
   br i1 %189, label %then38, label %else39
 
 then38:                                           ; preds = %ifcont37
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @47, ptr @"ERROR STOP", ptr @46)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont40
@@ -586,43 +587,43 @@ ifcont40:                                         ; preds = %else39, %then38
   br i1 false, label %then41, label %ifcont42
 
 then41:                                           ; preds = %ifcont40
-  %190 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %191 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %192 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %191, i32 0, i32 0
-  %193 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %192, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @49, i32 0, i32 0), i8** %193, align 8
-  %194 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %192, i32 0, i32 1
-  store i32 25, i32* %194, align 4
-  %195 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %192, i32 0, i32 2
-  store i32 5, i32* %195, align 4
-  %196 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %192, i32 0, i32 3
-  store i32 25, i32* %196, align 4
-  %197 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %192, i32 0, i32 4
-  store i32 8, i32* %197, align 4
-  %198 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @50, i32 0, i32 0))
-  %199 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %190, i32 0, i32 0
-  %200 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %191, i32 0, i32 0
-  %201 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 0, i32 2
-  %202 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 0, i32 0
-  store i1 true, i1* %202, align 1
-  %203 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 0, i32 1
-  store i8* %198, i8** %203, align 8
-  store { i8*, i32, i32, i32, i32 }* %200, { i8*, i32, i32, i32, i32 }** %201, align 8
-  %204 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 0, i32 3
-  store i32 1, i32* %204, align 4
-  %205 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %190, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %205, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %190 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %191 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %192 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %191, i32 0, i32 0
+  %193 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 0
+  store ptr @49, ptr %193, align 8
+  %194 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 1
+  store i32 25, ptr %194, align 4
+  %195 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 2
+  store i32 5, ptr %195, align 4
+  %196 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 3
+  store i32 25, ptr %196, align 4
+  %197 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 4
+  store i32 8, ptr %197, align 4
+  %198 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @50)
+  %199 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %190, i32 0, i32 0
+  %200 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %191, i32 0, i32 0
+  %201 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 2
+  %202 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 0
+  store i1 true, ptr %202, align 1
+  %203 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 1
+  store ptr %198, ptr %203, align 8
+  store ptr %200, ptr %201, align 8
+  %204 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 3
+  store i32 1, ptr %204, align 4
+  %205 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %190, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %205, i32 1, ptr @51, ptr @48, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont42:                                         ; preds = %ifcont40
-  %206 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %207 = load i32, i32* %206, align 4
+  %206 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %207 = load i32, ptr %206, align 4
   %208 = icmp ne i32 %207, 14
   br i1 %208, label %then43, label %else44
 
 then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @53, ptr @"ERROR STOP", ptr @52)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont45
@@ -631,23 +632,23 @@ else44:                                           ; preds = %ifcont42
   br label %ifcont45
 
 ifcont45:                                         ; preds = %else44, %then43
-  %209 = load i32, i32* %size_a, align 4
-  store i32 %209, i32* %__do_loop_end2, align 4
-  store i32 0, i32* %i, align 4
+  %209 = load i32, ptr %size_a, align 4
+  store i32 %209, ptr %__do_loop_end2, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head46
 
 loop.head46:                                      ; preds = %ifcont51, %ifcont45
-  %210 = load i32, i32* %i, align 4
+  %210 = load i32, ptr %i, align 4
   %211 = add i32 %210, 1
-  %212 = load i32, i32* %__do_loop_end2, align 4
+  %212 = load i32, ptr %__do_loop_end2, align 4
   %213 = icmp sle i32 %211, %212
   br i1 %213, label %loop.body47, label %loop.end52
 
 loop.body47:                                      ; preds = %loop.head46
-  %214 = load i32, i32* %i, align 4
+  %214 = load i32, ptr %i, align 4
   %215 = add i32 %214, 1
-  store i32 %215, i32* %i, align 4
-  %216 = load i32, i32* %i, align 4
+  store i32 %215, ptr %i, align 4
+  %216 = load i32, ptr %i, align 4
   %217 = sext i32 %216 to i64
   %218 = sub i64 %217, 1
   %219 = mul i64 1, %218
@@ -658,38 +659,38 @@ loop.body47:                                      ; preds = %loop.head46
   br i1 %223, label %then48, label %ifcont49
 
 then48:                                           ; preds = %loop.body47
-  %224 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %225 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %226 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %225, i32 0, i32 0
-  %227 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %226, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @55, i32 0, i32 0), i8** %227, align 8
-  %228 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %226, i32 0, i32 1
-  store i32 28, i32* %228, align 4
-  %229 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %226, i32 0, i32 2
-  store i32 5, i32* %229, align 4
-  %230 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %226, i32 0, i32 3
-  store i32 28, i32* %230, align 4
-  %231 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %226, i32 0, i32 4
-  store i32 8, i32* %231, align 4
-  %232 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @56, i32 0, i32 0))
-  %233 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %224, i32 0, i32 0
-  %234 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %225, i32 0, i32 0
-  %235 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %233, i32 0, i32 2
-  %236 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %233, i32 0, i32 0
-  store i1 true, i1* %236, align 1
-  %237 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %233, i32 0, i32 1
-  store i8* %232, i8** %237, align 8
-  store { i8*, i32, i32, i32, i32 }* %234, { i8*, i32, i32, i32, i32 }** %235, align 8
-  %238 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %233, i32 0, i32 3
-  store i32 1, i32* %238, align 4
-  %239 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %224, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %239, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @57, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0), i64 %217, i32 1, i64 1, i64 4)
+  %224 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %225 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %226 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %225, i32 0, i32 0
+  %227 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %226, i32 0, i32 0
+  store ptr @55, ptr %227, align 8
+  %228 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %226, i32 0, i32 1
+  store i32 28, ptr %228, align 4
+  %229 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %226, i32 0, i32 2
+  store i32 5, ptr %229, align 4
+  %230 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %226, i32 0, i32 3
+  store i32 28, ptr %230, align 4
+  %231 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %226, i32 0, i32 4
+  store i32 8, ptr %231, align 4
+  %232 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @56)
+  %233 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %224, i32 0, i32 0
+  %234 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %225, i32 0, i32 0
+  %235 = getelementptr { i1, ptr, ptr, i32 }, ptr %233, i32 0, i32 2
+  %236 = getelementptr { i1, ptr, ptr, i32 }, ptr %233, i32 0, i32 0
+  store i1 true, ptr %236, align 1
+  %237 = getelementptr { i1, ptr, ptr, i32 }, ptr %233, i32 0, i32 1
+  store ptr %232, ptr %237, align 8
+  store ptr %234, ptr %235, align 8
+  %238 = getelementptr { i1, ptr, ptr, i32 }, ptr %233, i32 0, i32 3
+  store i32 1, ptr %238, align 4
+  %239 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %224, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %239, i32 1, ptr @57, ptr @54, i64 %217, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont49:                                         ; preds = %loop.body47
-  %240 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 %220
-  %241 = load i32, i32* %i, align 4
+  %240 = getelementptr [4 x i32], ptr %b, i32 0, i64 %220
+  %241 = load i32, ptr %i, align 4
   %242 = sext i32 %241 to i64
   %243 = sub i64 %242, 1
   %244 = mul i64 1, %243
@@ -700,83 +701,83 @@ ifcont49:                                         ; preds = %loop.body47
   br i1 %248, label %then50, label %ifcont51
 
 then50:                                           ; preds = %ifcont49
-  %249 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %250 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %251 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %250, i32 0, i32 0
-  %252 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @59, i32 0, i32 0), i8** %252, align 8
-  %253 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 1
-  store i32 28, i32* %253, align 4
-  %254 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 2
-  store i32 12, i32* %254, align 4
-  %255 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 3
-  store i32 28, i32* %255, align 4
-  %256 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %251, i32 0, i32 4
-  store i32 15, i32* %256, align 4
-  %257 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @60, i32 0, i32 0))
-  %258 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %249, i32 0, i32 0
-  %259 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %250, i32 0, i32 0
-  %260 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 2
-  %261 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 0
-  store i1 true, i1* %261, align 1
-  %262 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 1
-  store i8* %257, i8** %262, align 8
-  store { i8*, i32, i32, i32, i32 }* %259, { i8*, i32, i32, i32, i32 }** %260, align 8
-  %263 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %258, i32 0, i32 3
-  store i32 1, i32* %263, align 4
-  %264 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %249, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %264, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @61, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @58, i32 0, i32 0), i64 %242, i32 1, i64 1, i64 3)
+  %249 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %250 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %251 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %250, i32 0, i32 0
+  %252 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %251, i32 0, i32 0
+  store ptr @59, ptr %252, align 8
+  %253 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %251, i32 0, i32 1
+  store i32 28, ptr %253, align 4
+  %254 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %251, i32 0, i32 2
+  store i32 12, ptr %254, align 4
+  %255 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %251, i32 0, i32 3
+  store i32 28, ptr %255, align 4
+  %256 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %251, i32 0, i32 4
+  store i32 15, ptr %256, align 4
+  %257 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @60)
+  %258 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %249, i32 0, i32 0
+  %259 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %250, i32 0, i32 0
+  %260 = getelementptr { i1, ptr, ptr, i32 }, ptr %258, i32 0, i32 2
+  %261 = getelementptr { i1, ptr, ptr, i32 }, ptr %258, i32 0, i32 0
+  store i1 true, ptr %261, align 1
+  %262 = getelementptr { i1, ptr, ptr, i32 }, ptr %258, i32 0, i32 1
+  store ptr %257, ptr %262, align 8
+  store ptr %259, ptr %260, align 8
+  %263 = getelementptr { i1, ptr, ptr, i32 }, ptr %258, i32 0, i32 3
+  store i32 1, ptr %263, align 4
+  %264 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %249, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %264, i32 1, ptr @61, ptr @58, i64 %242, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont51:                                         ; preds = %ifcont49
-  %265 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 %245
-  %266 = load i32, i32* %265, align 4
+  %265 = getelementptr [3 x i32], ptr %a, i32 0, i64 %245
+  %266 = load i32, ptr %265, align 4
   %267 = sub i32 %266, 10
-  store i32 %267, i32* %240, align 4
+  store i32 %267, ptr %240, align 4
   br label %loop.head46
 
 loop.end52:                                       ; preds = %loop.head46
   br i1 false, label %then53, label %ifcont54
 
 then53:                                           ; preds = %loop.end52
-  %268 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %269 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %270 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %269, i32 0, i32 0
-  %271 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %270, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @63, i32 0, i32 0), i8** %271, align 8
-  %272 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %270, i32 0, i32 1
-  store i32 30, i32* %272, align 4
-  %273 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %270, i32 0, i32 2
-  store i32 5, i32* %273, align 4
-  %274 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %270, i32 0, i32 3
-  store i32 30, i32* %274, align 4
-  %275 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %270, i32 0, i32 4
-  store i32 8, i32* %275, align 4
-  %276 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @64, i32 0, i32 0))
-  %277 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %268, i32 0, i32 0
-  %278 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %269, i32 0, i32 0
-  %279 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %277, i32 0, i32 2
-  %280 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %277, i32 0, i32 0
-  store i1 true, i1* %280, align 1
-  %281 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %277, i32 0, i32 1
-  store i8* %276, i8** %281, align 8
-  store { i8*, i32, i32, i32, i32 }* %278, { i8*, i32, i32, i32, i32 }** %279, align 8
-  %282 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %277, i32 0, i32 3
-  store i32 1, i32* %282, align 4
-  %283 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %268, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %283, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @65, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @62, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %268 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %269 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %270 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %269, i32 0, i32 0
+  %271 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %270, i32 0, i32 0
+  store ptr @63, ptr %271, align 8
+  %272 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %270, i32 0, i32 1
+  store i32 30, ptr %272, align 4
+  %273 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %270, i32 0, i32 2
+  store i32 5, ptr %273, align 4
+  %274 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %270, i32 0, i32 3
+  store i32 30, ptr %274, align 4
+  %275 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %270, i32 0, i32 4
+  store i32 8, ptr %275, align 4
+  %276 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @64)
+  %277 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %268, i32 0, i32 0
+  %278 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %269, i32 0, i32 0
+  %279 = getelementptr { i1, ptr, ptr, i32 }, ptr %277, i32 0, i32 2
+  %280 = getelementptr { i1, ptr, ptr, i32 }, ptr %277, i32 0, i32 0
+  store i1 true, ptr %280, align 1
+  %281 = getelementptr { i1, ptr, ptr, i32 }, ptr %277, i32 0, i32 1
+  store ptr %276, ptr %281, align 8
+  store ptr %278, ptr %279, align 8
+  %282 = getelementptr { i1, ptr, ptr, i32 }, ptr %277, i32 0, i32 3
+  store i32 1, ptr %282, align 4
+  %283 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %268, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %283, i32 1, ptr @65, ptr @62, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont54:                                         ; preds = %loop.end52
-  %284 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %285 = load i32, i32* %284, align 4
+  %284 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %285 = load i32, ptr %284, align 4
   %286 = icmp ne i32 %285, 1
   br i1 %286, label %then55, label %else56
 
 then55:                                           ; preds = %ifcont54
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @67, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @66, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @67, ptr @"ERROR STOP", ptr @66)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont57
@@ -788,43 +789,43 @@ ifcont57:                                         ; preds = %else56, %then55
   br i1 false, label %then58, label %ifcont59
 
 then58:                                           ; preds = %ifcont57
-  %287 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %288 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %289 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %288, i32 0, i32 0
-  %290 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %289, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @69, i32 0, i32 0), i8** %290, align 8
-  %291 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %289, i32 0, i32 1
-  store i32 31, i32* %291, align 4
-  %292 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %289, i32 0, i32 2
-  store i32 5, i32* %292, align 4
-  %293 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %289, i32 0, i32 3
-  store i32 31, i32* %293, align 4
-  %294 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %289, i32 0, i32 4
-  store i32 8, i32* %294, align 4
-  %295 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @70, i32 0, i32 0))
-  %296 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %287, i32 0, i32 0
-  %297 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %288, i32 0, i32 0
-  %298 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %296, i32 0, i32 2
-  %299 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %296, i32 0, i32 0
-  store i1 true, i1* %299, align 1
-  %300 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %296, i32 0, i32 1
-  store i8* %295, i8** %300, align 8
-  store { i8*, i32, i32, i32, i32 }* %297, { i8*, i32, i32, i32, i32 }** %298, align 8
-  %301 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %296, i32 0, i32 3
-  store i32 1, i32* %301, align 4
-  %302 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %287, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %302, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @71, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @68, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %287 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %288 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %289 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %288, i32 0, i32 0
+  %290 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %289, i32 0, i32 0
+  store ptr @69, ptr %290, align 8
+  %291 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %289, i32 0, i32 1
+  store i32 31, ptr %291, align 4
+  %292 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %289, i32 0, i32 2
+  store i32 5, ptr %292, align 4
+  %293 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %289, i32 0, i32 3
+  store i32 31, ptr %293, align 4
+  %294 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %289, i32 0, i32 4
+  store i32 8, ptr %294, align 4
+  %295 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @70)
+  %296 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %287, i32 0, i32 0
+  %297 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %288, i32 0, i32 0
+  %298 = getelementptr { i1, ptr, ptr, i32 }, ptr %296, i32 0, i32 2
+  %299 = getelementptr { i1, ptr, ptr, i32 }, ptr %296, i32 0, i32 0
+  store i1 true, ptr %299, align 1
+  %300 = getelementptr { i1, ptr, ptr, i32 }, ptr %296, i32 0, i32 1
+  store ptr %295, ptr %300, align 8
+  store ptr %297, ptr %298, align 8
+  %301 = getelementptr { i1, ptr, ptr, i32 }, ptr %296, i32 0, i32 3
+  store i32 1, ptr %301, align 4
+  %302 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %287, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %302, i32 1, ptr @71, ptr @68, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont59:                                         ; preds = %ifcont57
-  %303 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %304 = load i32, i32* %303, align 4
+  %303 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %304 = load i32, ptr %303, align 4
   %305 = icmp ne i32 %304, 2
   br i1 %305, label %then60, label %else61
 
 then60:                                           ; preds = %ifcont59
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @72, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @73, ptr @"ERROR STOP", ptr @72)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont62
@@ -836,43 +837,43 @@ ifcont62:                                         ; preds = %else61, %then60
   br i1 false, label %then63, label %ifcont64
 
 then63:                                           ; preds = %ifcont62
-  %306 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %307 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %308 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %307, i32 0, i32 0
-  %309 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %308, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @75, i32 0, i32 0), i8** %309, align 8
-  %310 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %308, i32 0, i32 1
-  store i32 32, i32* %310, align 4
-  %311 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %308, i32 0, i32 2
-  store i32 5, i32* %311, align 4
-  %312 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %308, i32 0, i32 3
-  store i32 32, i32* %312, align 4
-  %313 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %308, i32 0, i32 4
-  store i32 8, i32* %313, align 4
-  %314 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @76, i32 0, i32 0))
-  %315 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %306, i32 0, i32 0
-  %316 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %307, i32 0, i32 0
-  %317 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %315, i32 0, i32 2
-  %318 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %315, i32 0, i32 0
-  store i1 true, i1* %318, align 1
-  %319 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %315, i32 0, i32 1
-  store i8* %314, i8** %319, align 8
-  store { i8*, i32, i32, i32, i32 }* %316, { i8*, i32, i32, i32, i32 }** %317, align 8
-  %320 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %315, i32 0, i32 3
-  store i32 1, i32* %320, align 4
-  %321 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %306, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %321, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @77, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @74, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %306 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %307 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %308 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %307, i32 0, i32 0
+  %309 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %308, i32 0, i32 0
+  store ptr @75, ptr %309, align 8
+  %310 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %308, i32 0, i32 1
+  store i32 32, ptr %310, align 4
+  %311 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %308, i32 0, i32 2
+  store i32 5, ptr %311, align 4
+  %312 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %308, i32 0, i32 3
+  store i32 32, ptr %312, align 4
+  %313 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %308, i32 0, i32 4
+  store i32 8, ptr %313, align 4
+  %314 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @76)
+  %315 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %306, i32 0, i32 0
+  %316 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %307, i32 0, i32 0
+  %317 = getelementptr { i1, ptr, ptr, i32 }, ptr %315, i32 0, i32 2
+  %318 = getelementptr { i1, ptr, ptr, i32 }, ptr %315, i32 0, i32 0
+  store i1 true, ptr %318, align 1
+  %319 = getelementptr { i1, ptr, ptr, i32 }, ptr %315, i32 0, i32 1
+  store ptr %314, ptr %319, align 8
+  store ptr %316, ptr %317, align 8
+  %320 = getelementptr { i1, ptr, ptr, i32 }, ptr %315, i32 0, i32 3
+  store i32 1, ptr %320, align 4
+  %321 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %306, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %321, i32 1, ptr @77, ptr @74, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont64:                                         ; preds = %ifcont62
-  %322 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %323 = load i32, i32* %322, align 4
+  %322 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %323 = load i32, ptr %322, align 4
   %324 = icmp ne i32 %323, 3
   br i1 %324, label %then65, label %else66
 
 then65:                                           ; preds = %ifcont64
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @79, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @78, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @79, ptr @"ERROR STOP", ptr @78)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont67
@@ -884,221 +885,221 @@ ifcont67:                                         ; preds = %else66, %then65
   br i1 false, label %then68, label %ifcont69
 
 then68:                                           ; preds = %ifcont67
-  %325 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %326 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %327 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %326, i32 0, i32 0
-  %328 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %327, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @81, i32 0, i32 0), i8** %328, align 8
-  %329 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %327, i32 0, i32 1
-  store i32 34, i32* %329, align 4
-  %330 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %327, i32 0, i32 2
-  store i32 1, i32* %330, align 4
-  %331 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %327, i32 0, i32 3
-  store i32 34, i32* %331, align 4
-  %332 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %327, i32 0, i32 4
-  store i32 4, i32* %332, align 4
-  %333 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @82, i32 0, i32 0))
-  %334 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %325, i32 0, i32 0
-  %335 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %326, i32 0, i32 0
-  %336 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %334, i32 0, i32 2
-  %337 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %334, i32 0, i32 0
-  store i1 true, i1* %337, align 1
-  %338 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %334, i32 0, i32 1
-  store i8* %333, i8** %338, align 8
-  store { i8*, i32, i32, i32, i32 }* %335, { i8*, i32, i32, i32, i32 }** %336, align 8
-  %339 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %334, i32 0, i32 3
-  store i32 1, i32* %339, align 4
-  %340 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %325, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @83, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @80, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %325 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %326 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %327 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %326, i32 0, i32 0
+  %328 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %327, i32 0, i32 0
+  store ptr @81, ptr %328, align 8
+  %329 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %327, i32 0, i32 1
+  store i32 34, ptr %329, align 4
+  %330 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %327, i32 0, i32 2
+  store i32 1, ptr %330, align 4
+  %331 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %327, i32 0, i32 3
+  store i32 34, ptr %331, align 4
+  %332 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %327, i32 0, i32 4
+  store i32 4, ptr %332, align 4
+  %333 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @82)
+  %334 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %325, i32 0, i32 0
+  %335 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %326, i32 0, i32 0
+  %336 = getelementptr { i1, ptr, ptr, i32 }, ptr %334, i32 0, i32 2
+  %337 = getelementptr { i1, ptr, ptr, i32 }, ptr %334, i32 0, i32 0
+  store i1 true, ptr %337, align 1
+  %338 = getelementptr { i1, ptr, ptr, i32 }, ptr %334, i32 0, i32 1
+  store ptr %333, ptr %338, align 8
+  store ptr %335, ptr %336, align 8
+  %339 = getelementptr { i1, ptr, ptr, i32 }, ptr %334, i32 0, i32 3
+  store i32 1, ptr %339, align 4
+  %340 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %325, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %340, i32 1, ptr @83, ptr @80, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont69:                                         ; preds = %ifcont67
-  %341 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %341 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then70, label %ifcont71
 
 then70:                                           ; preds = %ifcont69
-  %342 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %343 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %344 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %343, i32 0, i32 0
-  %345 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @85, i32 0, i32 0), i8** %345, align 8
-  %346 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 1
-  store i32 34, i32* %346, align 4
-  %347 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 2
-  store i32 8, i32* %347, align 4
-  %348 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 3
-  store i32 34, i32* %348, align 4
-  %349 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %344, i32 0, i32 4
-  store i32 11, i32* %349, align 4
-  %350 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @86, i32 0, i32 0))
-  %351 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %342, i32 0, i32 0
-  %352 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %343, i32 0, i32 0
-  %353 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 2
-  %354 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 0
-  store i1 true, i1* %354, align 1
-  %355 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 1
-  store i8* %350, i8** %355, align 8
-  store { i8*, i32, i32, i32, i32 }* %352, { i8*, i32, i32, i32, i32 }** %353, align 8
-  %356 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %351, i32 0, i32 3
-  store i32 1, i32* %356, align 4
-  %357 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %342, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %357, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @87, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @84, i32 0, i32 0), i64 1, i32 1, i64 1, i64 4)
+  %342 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %343 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %344 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %343, i32 0, i32 0
+  %345 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 0
+  store ptr @85, ptr %345, align 8
+  %346 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 1
+  store i32 34, ptr %346, align 4
+  %347 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 2
+  store i32 8, ptr %347, align 4
+  %348 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 3
+  store i32 34, ptr %348, align 4
+  %349 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %344, i32 0, i32 4
+  store i32 11, ptr %349, align 4
+  %350 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @86)
+  %351 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %342, i32 0, i32 0
+  %352 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %343, i32 0, i32 0
+  %353 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 2
+  %354 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 0
+  store i1 true, ptr %354, align 1
+  %355 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 1
+  store ptr %350, ptr %355, align 8
+  store ptr %352, ptr %353, align 8
+  %356 = getelementptr { i1, ptr, ptr, i32 }, ptr %351, i32 0, i32 3
+  store i32 1, ptr %356, align 4
+  %357 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %342, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %357, i32 1, ptr @87, ptr @84, i64 1, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont71:                                         ; preds = %ifcont69
-  %358 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 0
-  %359 = load i32, i32* %358, align 4
+  %358 = getelementptr [4 x i32], ptr %b, i32 0, i64 0
+  %359 = load i32, ptr %358, align 4
   br i1 false, label %then72, label %ifcont73
 
 then72:                                           ; preds = %ifcont71
-  %360 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %361 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %362 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %361, i32 0, i32 0
-  %363 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %362, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @89, i32 0, i32 0), i8** %363, align 8
-  %364 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %362, i32 0, i32 1
-  store i32 34, i32* %364, align 4
-  %365 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %362, i32 0, i32 2
-  store i32 13, i32* %365, align 4
-  %366 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %362, i32 0, i32 3
-  store i32 34, i32* %366, align 4
-  %367 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %362, i32 0, i32 4
-  store i32 16, i32* %367, align 4
-  %368 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @90, i32 0, i32 0))
-  %369 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %360, i32 0, i32 0
-  %370 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %361, i32 0, i32 0
-  %371 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %369, i32 0, i32 2
-  %372 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %369, i32 0, i32 0
-  store i1 true, i1* %372, align 1
-  %373 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %369, i32 0, i32 1
-  store i8* %368, i8** %373, align 8
-  store { i8*, i32, i32, i32, i32 }* %370, { i8*, i32, i32, i32, i32 }** %371, align 8
-  %374 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %369, i32 0, i32 3
-  store i32 1, i32* %374, align 4
-  %375 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %360, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %375, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @91, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @88, i32 0, i32 0), i64 2, i32 1, i64 1, i64 4)
+  %360 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %361 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %362 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %361, i32 0, i32 0
+  %363 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 0
+  store ptr @89, ptr %363, align 8
+  %364 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 1
+  store i32 34, ptr %364, align 4
+  %365 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 2
+  store i32 13, ptr %365, align 4
+  %366 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 3
+  store i32 34, ptr %366, align 4
+  %367 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %362, i32 0, i32 4
+  store i32 16, ptr %367, align 4
+  %368 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @90)
+  %369 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %360, i32 0, i32 0
+  %370 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %361, i32 0, i32 0
+  %371 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 2
+  %372 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 0
+  store i1 true, ptr %372, align 1
+  %373 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 1
+  store ptr %368, ptr %373, align 8
+  store ptr %370, ptr %371, align 8
+  %374 = getelementptr { i1, ptr, ptr, i32 }, ptr %369, i32 0, i32 3
+  store i32 1, ptr %374, align 4
+  %375 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %360, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %375, i32 1, ptr @91, ptr @88, i64 2, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont73:                                         ; preds = %ifcont71
-  %376 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 1
-  %377 = load i32, i32* %376, align 4
+  %376 = getelementptr [4 x i32], ptr %b, i32 0, i64 1
+  %377 = load i32, ptr %376, align 4
   %378 = add i32 %359, %377
   br i1 false, label %then74, label %ifcont75
 
 then74:                                           ; preds = %ifcont73
-  %379 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %380 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %381 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %380, i32 0, i32 0
-  %382 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %381, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @93, i32 0, i32 0), i8** %382, align 8
-  %383 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %381, i32 0, i32 1
-  store i32 34, i32* %383, align 4
-  %384 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %381, i32 0, i32 2
-  store i32 18, i32* %384, align 4
-  %385 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %381, i32 0, i32 3
-  store i32 34, i32* %385, align 4
-  %386 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %381, i32 0, i32 4
-  store i32 21, i32* %386, align 4
-  %387 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @94, i32 0, i32 0))
-  %388 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %379, i32 0, i32 0
-  %389 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %380, i32 0, i32 0
-  %390 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %388, i32 0, i32 2
-  %391 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %388, i32 0, i32 0
-  store i1 true, i1* %391, align 1
-  %392 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %388, i32 0, i32 1
-  store i8* %387, i8** %392, align 8
-  store { i8*, i32, i32, i32, i32 }* %389, { i8*, i32, i32, i32, i32 }** %390, align 8
-  %393 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %388, i32 0, i32 3
-  store i32 1, i32* %393, align 4
-  %394 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %379, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %394, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @95, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @92, i32 0, i32 0), i64 3, i32 1, i64 1, i64 4)
+  %379 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %380 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %381 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %380, i32 0, i32 0
+  %382 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %381, i32 0, i32 0
+  store ptr @93, ptr %382, align 8
+  %383 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %381, i32 0, i32 1
+  store i32 34, ptr %383, align 4
+  %384 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %381, i32 0, i32 2
+  store i32 18, ptr %384, align 4
+  %385 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %381, i32 0, i32 3
+  store i32 34, ptr %385, align 4
+  %386 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %381, i32 0, i32 4
+  store i32 21, ptr %386, align 4
+  %387 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @94)
+  %388 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %379, i32 0, i32 0
+  %389 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %380, i32 0, i32 0
+  %390 = getelementptr { i1, ptr, ptr, i32 }, ptr %388, i32 0, i32 2
+  %391 = getelementptr { i1, ptr, ptr, i32 }, ptr %388, i32 0, i32 0
+  store i1 true, ptr %391, align 1
+  %392 = getelementptr { i1, ptr, ptr, i32 }, ptr %388, i32 0, i32 1
+  store ptr %387, ptr %392, align 8
+  store ptr %389, ptr %390, align 8
+  %393 = getelementptr { i1, ptr, ptr, i32 }, ptr %388, i32 0, i32 3
+  store i32 1, ptr %393, align 4
+  %394 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %379, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %394, i32 1, ptr @95, ptr @92, i64 3, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont75:                                         ; preds = %ifcont73
-  %395 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 2
-  %396 = load i32, i32* %395, align 4
+  %395 = getelementptr [4 x i32], ptr %b, i32 0, i64 2
+  %396 = load i32, ptr %395, align 4
   %397 = add i32 %378, %396
   br i1 false, label %then76, label %ifcont77
 
 then76:                                           ; preds = %ifcont75
-  %398 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %399 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %400 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %399, i32 0, i32 0
-  %401 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %400, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @97, i32 0, i32 0), i8** %401, align 8
-  %402 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %400, i32 0, i32 1
-  store i32 34, i32* %402, align 4
-  %403 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %400, i32 0, i32 2
-  store i32 23, i32* %403, align 4
-  %404 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %400, i32 0, i32 3
-  store i32 34, i32* %404, align 4
-  %405 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %400, i32 0, i32 4
-  store i32 26, i32* %405, align 4
-  %406 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @98, i32 0, i32 0))
-  %407 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %398, i32 0, i32 0
-  %408 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %399, i32 0, i32 0
-  %409 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %407, i32 0, i32 2
-  %410 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %407, i32 0, i32 0
-  store i1 true, i1* %410, align 1
-  %411 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %407, i32 0, i32 1
-  store i8* %406, i8** %411, align 8
-  store { i8*, i32, i32, i32, i32 }* %408, { i8*, i32, i32, i32, i32 }** %409, align 8
-  %412 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %407, i32 0, i32 3
-  store i32 1, i32* %412, align 4
-  %413 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %398, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %413, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @99, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @96, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %398 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %399 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %400 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %399, i32 0, i32 0
+  %401 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %400, i32 0, i32 0
+  store ptr @97, ptr %401, align 8
+  %402 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %400, i32 0, i32 1
+  store i32 34, ptr %402, align 4
+  %403 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %400, i32 0, i32 2
+  store i32 23, ptr %403, align 4
+  %404 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %400, i32 0, i32 3
+  store i32 34, ptr %404, align 4
+  %405 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %400, i32 0, i32 4
+  store i32 26, ptr %405, align 4
+  %406 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @98)
+  %407 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %398, i32 0, i32 0
+  %408 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %399, i32 0, i32 0
+  %409 = getelementptr { i1, ptr, ptr, i32 }, ptr %407, i32 0, i32 2
+  %410 = getelementptr { i1, ptr, ptr, i32 }, ptr %407, i32 0, i32 0
+  store i1 true, ptr %410, align 1
+  %411 = getelementptr { i1, ptr, ptr, i32 }, ptr %407, i32 0, i32 1
+  store ptr %406, ptr %411, align 8
+  store ptr %408, ptr %409, align 8
+  %412 = getelementptr { i1, ptr, ptr, i32 }, ptr %407, i32 0, i32 3
+  store i32 1, ptr %412, align 4
+  %413 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %398, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %413, i32 1, ptr @99, ptr @96, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont77:                                         ; preds = %ifcont75
-  %414 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %415 = load i32, i32* %414, align 4
+  %414 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %415 = load i32, ptr %414, align 4
   %416 = add i32 %397, %415
-  store i32 %416, i32* %341, align 4
+  store i32 %416, ptr %341, align 4
   br i1 false, label %then78, label %ifcont79
 
 then78:                                           ; preds = %ifcont77
-  %417 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %418 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %419 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %418, i32 0, i32 0
-  %420 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @101, i32 0, i32 0), i8** %420, align 8
-  %421 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 1
-  store i32 35, i32* %421, align 4
-  %422 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 2
-  store i32 5, i32* %422, align 4
-  %423 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 3
-  store i32 35, i32* %423, align 4
-  %424 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %419, i32 0, i32 4
-  store i32 8, i32* %424, align 4
-  %425 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @102, i32 0, i32 0))
-  %426 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %417, i32 0, i32 0
-  %427 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %418, i32 0, i32 0
-  %428 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 2
-  %429 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 0
-  store i1 true, i1* %429, align 1
-  %430 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 1
-  store i8* %425, i8** %430, align 8
-  store { i8*, i32, i32, i32, i32 }* %427, { i8*, i32, i32, i32, i32 }** %428, align 8
-  %431 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %426, i32 0, i32 3
-  store i32 1, i32* %431, align 4
-  %432 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %417, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %432, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @103, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @100, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %417 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %418 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %419 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %418, i32 0, i32 0
+  %420 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %419, i32 0, i32 0
+  store ptr @101, ptr %420, align 8
+  %421 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %419, i32 0, i32 1
+  store i32 35, ptr %421, align 4
+  %422 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %419, i32 0, i32 2
+  store i32 5, ptr %422, align 4
+  %423 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %419, i32 0, i32 3
+  store i32 35, ptr %423, align 4
+  %424 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %419, i32 0, i32 4
+  store i32 8, ptr %424, align 4
+  %425 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @102)
+  %426 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %417, i32 0, i32 0
+  %427 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %418, i32 0, i32 0
+  %428 = getelementptr { i1, ptr, ptr, i32 }, ptr %426, i32 0, i32 2
+  %429 = getelementptr { i1, ptr, ptr, i32 }, ptr %426, i32 0, i32 0
+  store i1 true, ptr %429, align 1
+  %430 = getelementptr { i1, ptr, ptr, i32 }, ptr %426, i32 0, i32 1
+  store ptr %425, ptr %430, align 8
+  store ptr %427, ptr %428, align 8
+  %431 = getelementptr { i1, ptr, ptr, i32 }, ptr %426, i32 0, i32 3
+  store i32 1, ptr %431, align 4
+  %432 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %417, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %432, i32 1, ptr @103, ptr @100, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont79:                                         ; preds = %ifcont77
-  %433 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %434 = load i32, i32* %433, align 4
+  %433 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %434 = load i32, ptr %433, align 4
   %435 = icmp ne i32 %434, 17
   br i1 %435, label %then80, label %else81
 
 then80:                                           ; preds = %ifcont79
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @105, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @104, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @105, ptr @"ERROR STOP", ptr @104)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont82
@@ -1110,113 +1111,113 @@ ifcont82:                                         ; preds = %else81, %then80
   br i1 false, label %then83, label %ifcont84
 
 then83:                                           ; preds = %ifcont82
-  %436 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %437 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %438 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %437, i32 0, i32 0
-  %439 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %438, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @107, i32 0, i32 0), i8** %439, align 8
-  %440 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %438, i32 0, i32 1
-  store i32 37, i32* %440, align 4
-  %441 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %438, i32 0, i32 2
-  store i32 1, i32* %441, align 4
-  %442 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %438, i32 0, i32 3
-  store i32 37, i32* %442, align 4
-  %443 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %438, i32 0, i32 4
-  store i32 4, i32* %443, align 4
-  %444 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @108, i32 0, i32 0))
-  %445 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %436, i32 0, i32 0
-  %446 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %437, i32 0, i32 0
-  %447 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %445, i32 0, i32 2
-  %448 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %445, i32 0, i32 0
-  store i1 true, i1* %448, align 1
-  %449 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %445, i32 0, i32 1
-  store i8* %444, i8** %449, align 8
-  store { i8*, i32, i32, i32, i32 }* %446, { i8*, i32, i32, i32, i32 }** %447, align 8
-  %450 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %445, i32 0, i32 3
-  store i32 1, i32* %450, align 4
-  %451 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %436, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %451, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @109, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @106, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %436 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %437 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %438 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %437, i32 0, i32 0
+  %439 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %438, i32 0, i32 0
+  store ptr @107, ptr %439, align 8
+  %440 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %438, i32 0, i32 1
+  store i32 37, ptr %440, align 4
+  %441 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %438, i32 0, i32 2
+  store i32 1, ptr %441, align 4
+  %442 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %438, i32 0, i32 3
+  store i32 37, ptr %442, align 4
+  %443 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %438, i32 0, i32 4
+  store i32 4, ptr %443, align 4
+  %444 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @108)
+  %445 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %436, i32 0, i32 0
+  %446 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %437, i32 0, i32 0
+  %447 = getelementptr { i1, ptr, ptr, i32 }, ptr %445, i32 0, i32 2
+  %448 = getelementptr { i1, ptr, ptr, i32 }, ptr %445, i32 0, i32 0
+  store i1 true, ptr %448, align 1
+  %449 = getelementptr { i1, ptr, ptr, i32 }, ptr %445, i32 0, i32 1
+  store ptr %444, ptr %449, align 8
+  store ptr %446, ptr %447, align 8
+  %450 = getelementptr { i1, ptr, ptr, i32 }, ptr %445, i32 0, i32 3
+  store i32 1, ptr %450, align 4
+  %451 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %436, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %451, i32 1, ptr @109, ptr @106, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont84:                                         ; preds = %ifcont82
-  %452 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
+  %452 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
   br i1 false, label %then85, label %ifcont86
 
 then85:                                           ; preds = %ifcont84
-  %453 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %454 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %455 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %454, i32 0, i32 0
-  %456 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %455, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @111, i32 0, i32 0), i8** %456, align 8
-  %457 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %455, i32 0, i32 1
-  store i32 37, i32* %457, align 4
-  %458 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %455, i32 0, i32 2
-  store i32 8, i32* %458, align 4
-  %459 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %455, i32 0, i32 3
-  store i32 37, i32* %459, align 4
-  %460 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %455, i32 0, i32 4
-  store i32 11, i32* %460, align 4
-  %461 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @112, i32 0, i32 0))
-  %462 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %453, i32 0, i32 0
-  %463 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %454, i32 0, i32 0
-  %464 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %462, i32 0, i32 2
-  %465 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %462, i32 0, i32 0
-  store i1 true, i1* %465, align 1
-  %466 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %462, i32 0, i32 1
-  store i8* %461, i8** %466, align 8
-  store { i8*, i32, i32, i32, i32 }* %463, { i8*, i32, i32, i32, i32 }** %464, align 8
-  %467 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %462, i32 0, i32 3
-  store i32 1, i32* %467, align 4
-  %468 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %453, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %468, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @113, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i64 1, i32 1, i64 1, i64 3)
+  %453 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %454 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %455 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %454, i32 0, i32 0
+  %456 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %455, i32 0, i32 0
+  store ptr @111, ptr %456, align 8
+  %457 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %455, i32 0, i32 1
+  store i32 37, ptr %457, align 4
+  %458 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %455, i32 0, i32 2
+  store i32 8, ptr %458, align 4
+  %459 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %455, i32 0, i32 3
+  store i32 37, ptr %459, align 4
+  %460 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %455, i32 0, i32 4
+  store i32 11, ptr %460, align 4
+  %461 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @112)
+  %462 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %453, i32 0, i32 0
+  %463 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %454, i32 0, i32 0
+  %464 = getelementptr { i1, ptr, ptr, i32 }, ptr %462, i32 0, i32 2
+  %465 = getelementptr { i1, ptr, ptr, i32 }, ptr %462, i32 0, i32 0
+  store i1 true, ptr %465, align 1
+  %466 = getelementptr { i1, ptr, ptr, i32 }, ptr %462, i32 0, i32 1
+  store ptr %461, ptr %466, align 8
+  store ptr %463, ptr %464, align 8
+  %467 = getelementptr { i1, ptr, ptr, i32 }, ptr %462, i32 0, i32 3
+  store i32 1, ptr %467, align 4
+  %468 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %453, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %468, i32 1, ptr @113, ptr @110, i64 1, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont86:                                         ; preds = %ifcont84
-  %469 = getelementptr [3 x i32], [3 x i32]* %a, i32 0, i64 0
-  %470 = load i32, i32* %469, align 4
-  store i32 %470, i32* %452, align 4
+  %469 = getelementptr [3 x i32], ptr %a, i32 0, i64 0
+  %470 = load i32, ptr %469, align 4
+  store i32 %470, ptr %452, align 4
   br i1 false, label %then87, label %ifcont88
 
 then87:                                           ; preds = %ifcont86
-  %471 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %472 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %473 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %472, i32 0, i32 0
-  %474 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %473, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @115, i32 0, i32 0), i8** %474, align 8
-  %475 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %473, i32 0, i32 1
-  store i32 38, i32* %475, align 4
-  %476 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %473, i32 0, i32 2
-  store i32 5, i32* %476, align 4
-  %477 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %473, i32 0, i32 3
-  store i32 38, i32* %477, align 4
-  %478 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %473, i32 0, i32 4
-  store i32 8, i32* %478, align 4
-  %479 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @116, i32 0, i32 0))
-  %480 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %471, i32 0, i32 0
-  %481 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %472, i32 0, i32 0
-  %482 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %480, i32 0, i32 2
-  %483 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %480, i32 0, i32 0
-  store i1 true, i1* %483, align 1
-  %484 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %480, i32 0, i32 1
-  store i8* %479, i8** %484, align 8
-  store { i8*, i32, i32, i32, i32 }* %481, { i8*, i32, i32, i32, i32 }** %482, align 8
-  %485 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %480, i32 0, i32 3
-  store i32 1, i32* %485, align 4
-  %486 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %471, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %486, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @117, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @114, i32 0, i32 0), i64 4, i32 1, i64 1, i64 4)
+  %471 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %472 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %473 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %472, i32 0, i32 0
+  %474 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %473, i32 0, i32 0
+  store ptr @115, ptr %474, align 8
+  %475 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %473, i32 0, i32 1
+  store i32 38, ptr %475, align 4
+  %476 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %473, i32 0, i32 2
+  store i32 5, ptr %476, align 4
+  %477 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %473, i32 0, i32 3
+  store i32 38, ptr %477, align 4
+  %478 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %473, i32 0, i32 4
+  store i32 8, ptr %478, align 4
+  %479 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @116)
+  %480 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %471, i32 0, i32 0
+  %481 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %472, i32 0, i32 0
+  %482 = getelementptr { i1, ptr, ptr, i32 }, ptr %480, i32 0, i32 2
+  %483 = getelementptr { i1, ptr, ptr, i32 }, ptr %480, i32 0, i32 0
+  store i1 true, ptr %483, align 1
+  %484 = getelementptr { i1, ptr, ptr, i32 }, ptr %480, i32 0, i32 1
+  store ptr %479, ptr %484, align 8
+  store ptr %481, ptr %482, align 8
+  %485 = getelementptr { i1, ptr, ptr, i32 }, ptr %480, i32 0, i32 3
+  store i32 1, ptr %485, align 4
+  %486 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %471, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %486, i32 1, ptr @117, ptr @114, i64 4, i32 1, i64 1, i64 4)
   call void @exit(i32 1)
   unreachable
 
 ifcont88:                                         ; preds = %ifcont86
-  %487 = getelementptr [4 x i32], [4 x i32]* %b, i32 0, i64 3
-  %488 = load i32, i32* %487, align 4
+  %487 = getelementptr [4 x i32], ptr %b, i32 0, i64 3
+  %488 = load i32, ptr %487, align 4
   %489 = icmp ne i32 %488, 11
   br i1 %489, label %then89, label %else90
 
 then89:                                           ; preds = %ifcont88
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @119, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @118, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @119, ptr @"ERROR STOP", ptr @118)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont91
@@ -1235,16 +1236,16 @@ FINALIZE_SYMTABLE_arrays_01:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)

--- a/tests/reference/llvm-arrays_101-8ed52ae.json
+++ b/tests/reference/llvm-arrays_101-8ed52ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_101-8ed52ae.stdout",
-    "stdout_hash": "3d53bfb5fed0d2173e9785f585739f0dfa7fe8386a1dbfb4a227178f",
+    "stdout_hash": "396a2b60ac9e4e5f73a819ba5f75629c48f7c4833a6a2716a0362551",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_101-8ed52ae.stdout
+++ b/tests/reference/llvm-arrays_101-8ed52ae.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [10 x i8] c"small_arr\00", align 1
 @1 = private unnamed_addr constant [42 x i8] c"tests/../integration_tests/arrays_101.f90\00", align 1
@@ -37,253 +38,252 @@ target datalayout = "..."
 @29 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @30 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [2 x i8] c"OK"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data, i32 0, i32 0), i64 2 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 2 }>
 @31 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_real_i32(i32* %x) {
+define float @_lcompilers_real_i32(ptr %x) {
 .entry:
   %_lcompilers_real_i32 = alloca float, align 4
-  %0 = load i32, i32* %x, align 4
+  %0 = load i32, ptr %x, align 4
   %1 = sitofp i32 %0 to float
-  store float %1, float* %_lcompilers_real_i32, align 4
+  store float %1, ptr %_lcompilers_real_i32, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE__lcompilers_real_i32
 
 FINALIZE_SYMTABLE__lcompilers_real_i32:           ; preds = %return
-  %2 = load float, float* %_lcompilers_real_i32, align 4
+  %2 = load float, ptr %_lcompilers_real_i32, align 4
   ret float %2
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %array_bound38 = alloca i32, align 4
   %array_bound34 = alloca i32, align 4
   %array_bound11 = alloca i32, align 4
   %array_bound7 = alloca i32, align 4
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
   %__libasr_index_0_ = alloca i32, align 4
   %__libasr_index_0_1 = alloca i32, align 4
   %i = alloca i32, align 4
-  %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 8000)
-  %5 = bitcast i8* %4 to [2000 x float]*
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 8000)
   %small_arr = alloca [100 x float], align 4
   %sum = alloca float, align 4
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 100, i32* %array_bound, align 4
+  store i32 100, ptr %array_bound, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %6 = load i32, i32* %array_bound, align 4
-  store i32 %6, i32* %__do_loop_end, align 4
+  %5 = load i32, ptr %array_bound, align 4
+  store i32 %5, ptr %__do_loop_end, align 4
   br i1 true, label %then2, label %else3
 
 then2:                                            ; preds = %ifcont
-  store i32 1, i32* %array_bound1, align 4
+  store i32 1, ptr %array_bound1, align 4
   br label %ifcont4
 
 else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %then2
-  %7 = load i32, i32* %array_bound1, align 4
-  %8 = sub i32 %7, 1
-  store i32 %8, i32* %__libasr_index_0_, align 4
+  %6 = load i32, ptr %array_bound1, align 4
+  %7 = sub i32 %6, 1
+  store i32 %7, ptr %__libasr_index_0_, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont6, %ifcont4
-  %9 = load i32, i32* %__libasr_index_0_, align 4
-  %10 = add i32 %9, 1
-  %11 = load i32, i32* %__do_loop_end, align 4
-  %12 = icmp sle i32 %10, %11
-  br i1 %12, label %loop.body, label %loop.end
+  %8 = load i32, ptr %__libasr_index_0_, align 4
+  %9 = add i32 %8, 1
+  %10 = load i32, ptr %__do_loop_end, align 4
+  %11 = icmp sle i32 %9, %10
+  br i1 %11, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %13 = load i32, i32* %__libasr_index_0_, align 4
-  %14 = add i32 %13, 1
-  store i32 %14, i32* %__libasr_index_0_, align 4
-  %15 = load i32, i32* %__libasr_index_0_, align 4
-  %16 = sext i32 %15 to i64
-  %17 = sub i64 %16, 1
-  %18 = mul i64 1, %17
-  %19 = add i64 0, %18
-  %20 = icmp slt i64 %16, 1
-  %21 = icmp sgt i64 %16, 100
-  %22 = or i1 %20, %21
-  br i1 %22, label %then5, label %ifcont6
+  %12 = load i32, ptr %__libasr_index_0_, align 4
+  %13 = add i32 %12, 1
+  store i32 %13, ptr %__libasr_index_0_, align 4
+  %14 = load i32, ptr %__libasr_index_0_, align 4
+  %15 = sext i32 %14 to i64
+  %16 = sub i64 %15, 1
+  %17 = mul i64 1, %16
+  %18 = add i64 0, %17
+  %19 = icmp slt i64 %15, 1
+  %20 = icmp sgt i64 %15, 100
+  %21 = or i1 %19, %20
+  br i1 %21, label %then5, label %ifcont6
 
 then5:                                            ; preds = %loop.body
-  %23 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %24 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %25 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %24, i32 0, i32 0
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @1, i32 0, i32 0), i8** %26, align 8
-  %27 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 1
-  store i32 17, i32* %27, align 4
-  %28 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 2
-  store i32 5, i32* %28, align 4
-  %29 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 3
-  store i32 17, i32* %29, align 4
-  %30 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 4
-  store i32 13, i32* %30, align 4
-  %31 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
-  %32 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %23, i32 0, i32 0
-  %33 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %24, i32 0, i32 0
-  %34 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 2
-  %35 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 0
-  store i1 true, i1* %35, align 1
-  %36 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 1
-  store i8* %31, i8** %36, align 8
-  store { i8*, i32, i32, i32, i32 }* %33, { i8*, i32, i32, i32, i32 }** %34, align 8
-  %37 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 3
-  store i32 1, i32* %37, align 4
-  %38 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %23, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %38, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @0, i32 0, i32 0), i64 %16, i32 1, i64 1, i64 100)
+  %22 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %23 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %24 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %23, i32 0, i32 0
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 0
+  store ptr @1, ptr %25, align 8
+  %26 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 1
+  store i32 17, ptr %26, align 4
+  %27 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 2
+  store i32 5, ptr %27, align 4
+  %28 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 3
+  store i32 17, ptr %28, align 4
+  %29 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %24, i32 0, i32 4
+  store i32 13, ptr %29, align 4
+  %30 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %31 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %22, i32 0, i32 0
+  %32 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %23, i32 0, i32 0
+  %33 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 2
+  %34 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 0
+  store i1 true, ptr %34, align 1
+  %35 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 1
+  store ptr %30, ptr %35, align 8
+  store ptr %32, ptr %33, align 8
+  %36 = getelementptr { i1, ptr, ptr, i32 }, ptr %31, i32 0, i32 3
+  store i32 1, ptr %36, align 4
+  %37 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %22, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %37, i32 1, ptr @3, ptr @0, i64 %15, i32 1, i64 1, i64 100)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %loop.body
-  %39 = getelementptr [100 x float], [100 x float]* %small_arr, i32 0, i64 %19
-  store float 1.000000e+00, float* %39, align 4
+  %38 = getelementptr [100 x float], ptr %small_arr, i32 0, i64 %18
+  store float 1.000000e+00, ptr %38, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 true, label %then8, label %else9
 
 then8:                                            ; preds = %loop.end
-  store i32 2000, i32* %array_bound7, align 4
+  store i32 2000, ptr %array_bound7, align 4
   br label %ifcont10
 
 else9:                                            ; preds = %loop.end
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %40 = load i32, i32* %array_bound7, align 4
-  store i32 %40, i32* %__do_loop_end1, align 4
+  %39 = load i32, ptr %array_bound7, align 4
+  store i32 %39, ptr %__do_loop_end1, align 4
   br i1 true, label %then12, label %else13
 
 then12:                                           ; preds = %ifcont10
-  store i32 1, i32* %array_bound11, align 4
+  store i32 1, ptr %array_bound11, align 4
   br label %ifcont14
 
 else13:                                           ; preds = %ifcont10
   br label %ifcont14
 
 ifcont14:                                         ; preds = %else13, %then12
-  %41 = load i32, i32* %array_bound11, align 4
-  %42 = sub i32 %41, 1
-  store i32 %42, i32* %__libasr_index_0_1, align 4
+  %40 = load i32, ptr %array_bound11, align 4
+  %41 = sub i32 %40, 1
+  store i32 %41, ptr %__libasr_index_0_1, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %ifcont18, %ifcont14
-  %43 = load i32, i32* %__libasr_index_0_1, align 4
-  %44 = add i32 %43, 1
-  %45 = load i32, i32* %__do_loop_end1, align 4
-  %46 = icmp sle i32 %44, %45
-  br i1 %46, label %loop.body16, label %loop.end19
+  %42 = load i32, ptr %__libasr_index_0_1, align 4
+  %43 = add i32 %42, 1
+  %44 = load i32, ptr %__do_loop_end1, align 4
+  %45 = icmp sle i32 %43, %44
+  br i1 %45, label %loop.body16, label %loop.end19
 
 loop.body16:                                      ; preds = %loop.head15
-  %47 = load i32, i32* %__libasr_index_0_1, align 4
-  %48 = add i32 %47, 1
-  store i32 %48, i32* %__libasr_index_0_1, align 4
-  %49 = load i32, i32* %__libasr_index_0_1, align 4
-  %50 = sext i32 %49 to i64
-  %51 = sub i64 %50, 1
-  %52 = mul i64 1, %51
-  %53 = add i64 0, %52
-  %54 = icmp slt i64 %50, 1
-  %55 = icmp sgt i64 %50, 2000
-  %56 = or i1 %54, %55
-  br i1 %56, label %then17, label %ifcont18
+  %46 = load i32, ptr %__libasr_index_0_1, align 4
+  %47 = add i32 %46, 1
+  store i32 %47, ptr %__libasr_index_0_1, align 4
+  %48 = load i32, ptr %__libasr_index_0_1, align 4
+  %49 = sext i32 %48 to i64
+  %50 = sub i64 %49, 1
+  %51 = mul i64 1, %50
+  %52 = add i64 0, %51
+  %53 = icmp slt i64 %49, 1
+  %54 = icmp sgt i64 %49, 2000
+  %55 = or i1 %53, %54
+  br i1 %55, label %then17, label %ifcont18
 
 then17:                                           ; preds = %loop.body16
-  %57 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %58 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %59 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %58, i32 0, i32 0
-  %60 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %59, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @5, i32 0, i32 0), i8** %60, align 8
-  %61 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %59, i32 0, i32 1
-  store i32 18, i32* %61, align 4
-  %62 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %59, i32 0, i32 2
-  store i32 5, i32* %62, align 4
-  %63 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %59, i32 0, i32 3
-  store i32 18, i32* %63, align 4
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %59, i32 0, i32 4
-  store i32 13, i32* %64, align 4
-  %65 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %66 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %57, i32 0, i32 0
-  %67 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %58, i32 0, i32 0
-  %68 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %66, i32 0, i32 2
-  %69 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %66, i32 0, i32 0
-  store i1 true, i1* %69, align 1
-  %70 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %66, i32 0, i32 1
-  store i8* %65, i8** %70, align 8
-  store { i8*, i32, i32, i32, i32 }* %67, { i8*, i32, i32, i32, i32 }** %68, align 8
-  %71 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %66, i32 0, i32 3
-  store i32 1, i32* %71, align 4
-  %72 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %57, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @4, i32 0, i32 0), i64 %50, i32 1, i64 1, i64 2000)
+  %56 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %57 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %58 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %57, i32 0, i32 0
+  %59 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 0
+  store ptr @5, ptr %59, align 8
+  %60 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 1
+  store i32 18, ptr %60, align 4
+  %61 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 2
+  store i32 5, ptr %61, align 4
+  %62 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 3
+  store i32 18, ptr %62, align 4
+  %63 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 4
+  store i32 13, ptr %63, align 4
+  %64 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %65 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %56, i32 0, i32 0
+  %66 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %57, i32 0, i32 0
+  %67 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 2
+  %68 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 0
+  store i1 true, ptr %68, align 1
+  %69 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 1
+  store ptr %64, ptr %69, align 8
+  store ptr %66, ptr %67, align 8
+  %70 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 3
+  store i32 1, ptr %70, align 4
+  %71 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %56, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %71, i32 1, ptr @7, ptr @4, i64 %49, i32 1, i64 1, i64 2000)
   call void @exit(i32 1)
   unreachable
 
 ifcont18:                                         ; preds = %loop.body16
-  %73 = getelementptr [2000 x float], [2000 x float]* %5, i32 0, i64 %53
-  store float 2.000000e+00, float* %73, align 4
+  %72 = getelementptr [2000 x float], ptr %4, i32 0, i64 %52
+  store float 2.000000e+00, ptr %72, align 4
   br label %loop.head15
 
 loop.end19:                                       ; preds = %loop.head15
   br i1 false, label %then20, label %ifcont21
 
 then20:                                           ; preds = %loop.end19
-  %74 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %75 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %76 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @9, i32 0, i32 0), i8** %77, align 8
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 1
-  store i32 21, i32* %78, align 4
-  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 2
-  store i32 9, i32* %79, align 4
-  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 3
-  store i32 21, i32* %80, align 4
-  %81 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 4
-  store i32 20, i32* %81, align 4
-  %82 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %83 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  %84 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 2
-  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 0
-  store i1 true, i1* %86, align 1
-  %87 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 1
-  store i8* %82, i8** %87, align 8
-  store { i8*, i32, i32, i32, i32 }* %84, { i8*, i32, i32, i32, i32 }** %85, align 8
-  %88 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 3
-  store i32 1, i32* %88, align 4
-  %89 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @8, i32 0, i32 0), i64 1, i32 1, i64 1, i64 100)
+  %73 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %74 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %75 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %74, i32 0, i32 0
+  %76 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 0
+  store ptr @9, ptr %76, align 8
+  %77 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 1
+  store i32 21, ptr %77, align 4
+  %78 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 2
+  store i32 9, ptr %78, align 4
+  %79 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 3
+  store i32 21, ptr %79, align 4
+  %80 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %75, i32 0, i32 4
+  store i32 20, ptr %80, align 4
+  %81 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10)
+  %82 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %73, i32 0, i32 0
+  %83 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %74, i32 0, i32 0
+  %84 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 2
+  %85 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 0
+  store i1 true, ptr %85, align 1
+  %86 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 1
+  store ptr %81, ptr %86, align 8
+  store ptr %83, ptr %84, align 8
+  %87 = getelementptr { i1, ptr, ptr, i32 }, ptr %82, i32 0, i32 3
+  store i32 1, ptr %87, align 4
+  %88 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %73, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %88, i32 1, ptr @11, ptr @8, i64 1, i32 1, i64 1, i64 100)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %loop.end19
-  %90 = getelementptr [100 x float], [100 x float]* %small_arr, i32 0, i64 0
-  %91 = load float, float* %90, align 4
-  %92 = fcmp une float %91, 1.000000e+00
-  br i1 %92, label %then22, label %else23
+  %89 = getelementptr [100 x float], ptr %small_arr, i32 0, i64 0
+  %90 = load float, ptr %89, align 4
+  %91 = fcmp une float %90, 1.000000e+00
+  br i1 %91, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -295,43 +295,43 @@ ifcont24:                                         ; preds = %else23, %then22
   br i1 false, label %then25, label %ifcont26
 
 then25:                                           ; preds = %ifcont24
-  %93 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %94 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %95 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %94, i32 0, i32 0
-  %96 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %95, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @15, i32 0, i32 0), i8** %96, align 8
-  %97 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %95, i32 0, i32 1
-  store i32 22, i32* %97, align 4
-  %98 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %95, i32 0, i32 2
-  store i32 9, i32* %98, align 4
-  %99 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %95, i32 0, i32 3
-  store i32 22, i32* %99, align 4
-  %100 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %95, i32 0, i32 4
-  store i32 20, i32* %100, align 4
-  %101 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @16, i32 0, i32 0))
-  %102 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %93, i32 0, i32 0
-  %103 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %94, i32 0, i32 0
-  %104 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 0, i32 2
-  %105 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 0, i32 0
-  store i1 true, i1* %105, align 1
-  %106 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 0, i32 1
-  store i8* %101, i8** %106, align 8
-  store { i8*, i32, i32, i32, i32 }* %103, { i8*, i32, i32, i32, i32 }** %104, align 8
-  %107 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 0, i32 3
-  store i32 1, i32* %107, align 4
-  %108 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %93, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %108, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @14, i32 0, i32 0), i64 1, i32 1, i64 1, i64 2000)
+  %92 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %93 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %94 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %93, i32 0, i32 0
+  %95 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %94, i32 0, i32 0
+  store ptr @15, ptr %95, align 8
+  %96 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %94, i32 0, i32 1
+  store i32 22, ptr %96, align 4
+  %97 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %94, i32 0, i32 2
+  store i32 9, ptr %97, align 4
+  %98 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %94, i32 0, i32 3
+  store i32 22, ptr %98, align 4
+  %99 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %94, i32 0, i32 4
+  store i32 20, ptr %99, align 4
+  %100 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @16)
+  %101 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %92, i32 0, i32 0
+  %102 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %93, i32 0, i32 0
+  %103 = getelementptr { i1, ptr, ptr, i32 }, ptr %101, i32 0, i32 2
+  %104 = getelementptr { i1, ptr, ptr, i32 }, ptr %101, i32 0, i32 0
+  store i1 true, ptr %104, align 1
+  %105 = getelementptr { i1, ptr, ptr, i32 }, ptr %101, i32 0, i32 1
+  store ptr %100, ptr %105, align 8
+  store ptr %102, ptr %103, align 8
+  %106 = getelementptr { i1, ptr, ptr, i32 }, ptr %101, i32 0, i32 3
+  store i32 1, ptr %106, align 4
+  %107 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %92, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %107, i32 1, ptr @17, ptr @14, i64 1, i32 1, i64 1, i64 2000)
   call void @exit(i32 1)
   unreachable
 
 ifcont26:                                         ; preds = %ifcont24
-  %109 = getelementptr [2000 x float], [2000 x float]* %5, i32 0, i64 0
-  %110 = load float, float* %109, align 4
-  %111 = fcmp une float %110, 2.000000e+00
-  br i1 %111, label %then27, label %else28
+  %108 = getelementptr [2000 x float], ptr %4, i32 0, i64 0
+  %109 = load float, ptr %108, align 4
+  %110 = fcmp une float %109, 2.000000e+00
+  br i1 %110, label %then27, label %else28
 
 then27:                                           ; preds = %ifcont26
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @19, ptr @"ERROR STOP", ptr @18)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -340,178 +340,177 @@ else28:                                           ; preds = %ifcont26
   br label %ifcont29
 
 ifcont29:                                         ; preds = %else28, %then27
-  store float 0.000000e+00, float* %sum, align 4
-  store i32 0, i32* %i, align 4
+  store float 0.000000e+00, ptr %sum, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head30
 
 loop.head30:                                      ; preds = %free_done, %ifcont29
-  %112 = load i32, i32* %i, align 4
-  %113 = add i32 %112, 1
-  %114 = icmp sle i32 %113, 1000
-  br i1 %114, label %loop.body31, label %loop.end49
+  %111 = load i32, ptr %i, align 4
+  %112 = add i32 %111, 1
+  %113 = icmp sle i32 %112, 1000
+  br i1 %113, label %loop.body31, label %loop.end49
 
 loop.body31:                                      ; preds = %loop.head30
-  %115 = load i32, i32* %i, align 4
-  %116 = add i32 %115, 1
-  store i32 %116, i32* %i, align 4
+  %114 = load i32, ptr %i, align 4
+  %115 = add i32 %114, 1
+  store i32 %115, ptr %i, align 4
   br label %block.start
 
 block.start:                                      ; preds = %loop.body31
-  %117 = call i8* @llvm.stacksave()
+  %116 = call ptr @llvm.stacksave.p0()
   %__do_loop_end32 = alloca i32, align 4
   %__libasr_index_0_33 = alloca i32, align 4
-  %118 = call i8* @_lfortran_get_default_allocator()
-  %119 = call i8* @_lfortran_malloc_alloc(i8* %118, i64 2000)
-  %120 = bitcast i8* %119 to [500 x float]*
+  %117 = call ptr @_lfortran_get_default_allocator()
+  %118 = call ptr @_lfortran_malloc_alloc(ptr %117, i64 2000)
   br i1 true, label %then35, label %else36
 
 then35:                                           ; preds = %block.start
-  store i32 500, i32* %array_bound34, align 4
+  store i32 500, ptr %array_bound34, align 4
   br label %ifcont37
 
 else36:                                           ; preds = %block.start
   br label %ifcont37
 
 ifcont37:                                         ; preds = %else36, %then35
-  %121 = load i32, i32* %array_bound34, align 4
-  store i32 %121, i32* %__do_loop_end32, align 4
+  %119 = load i32, ptr %array_bound34, align 4
+  store i32 %119, ptr %__do_loop_end32, align 4
   br i1 true, label %then39, label %else40
 
 then39:                                           ; preds = %ifcont37
-  store i32 1, i32* %array_bound38, align 4
+  store i32 1, ptr %array_bound38, align 4
   br label %ifcont41
 
 else40:                                           ; preds = %ifcont37
   br label %ifcont41
 
 ifcont41:                                         ; preds = %else40, %then39
-  %122 = load i32, i32* %array_bound38, align 4
-  %123 = sub i32 %122, 1
-  store i32 %123, i32* %__libasr_index_0_33, align 4
+  %120 = load i32, ptr %array_bound38, align 4
+  %121 = sub i32 %120, 1
+  store i32 %121, ptr %__libasr_index_0_33, align 4
   br label %loop.head42
 
 loop.head42:                                      ; preds = %ifcont45, %ifcont41
-  %124 = load i32, i32* %__libasr_index_0_33, align 4
-  %125 = add i32 %124, 1
-  %126 = load i32, i32* %__do_loop_end32, align 4
-  %127 = icmp sle i32 %125, %126
-  br i1 %127, label %loop.body43, label %loop.end46
+  %122 = load i32, ptr %__libasr_index_0_33, align 4
+  %123 = add i32 %122, 1
+  %124 = load i32, ptr %__do_loop_end32, align 4
+  %125 = icmp sle i32 %123, %124
+  br i1 %125, label %loop.body43, label %loop.end46
 
 loop.body43:                                      ; preds = %loop.head42
-  %128 = load i32, i32* %__libasr_index_0_33, align 4
-  %129 = add i32 %128, 1
-  store i32 %129, i32* %__libasr_index_0_33, align 4
-  %130 = load i32, i32* %__libasr_index_0_33, align 4
-  %131 = sext i32 %130 to i64
-  %132 = sub i64 %131, 1
-  %133 = mul i64 1, %132
-  %134 = add i64 0, %133
-  %135 = icmp slt i64 %131, 1
-  %136 = icmp sgt i64 %131, 500
-  %137 = or i1 %135, %136
-  br i1 %137, label %then44, label %ifcont45
+  %126 = load i32, ptr %__libasr_index_0_33, align 4
+  %127 = add i32 %126, 1
+  store i32 %127, ptr %__libasr_index_0_33, align 4
+  %128 = load i32, ptr %__libasr_index_0_33, align 4
+  %129 = sext i32 %128 to i64
+  %130 = sub i64 %129, 1
+  %131 = mul i64 1, %130
+  %132 = add i64 0, %131
+  %133 = icmp slt i64 %129, 1
+  %134 = icmp sgt i64 %129, 500
+  %135 = or i1 %133, %134
+  br i1 %135, label %then44, label %ifcont45
 
 then44:                                           ; preds = %loop.body43
-  %138 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %139 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %140 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %139, i32 0, i32 0
-  %141 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %140, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @21, i32 0, i32 0), i8** %141, align 8
-  %142 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %140, i32 0, i32 1
-  store i32 30, i32* %142, align 4
-  %143 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %140, i32 0, i32 2
-  store i32 13, i32* %143, align 4
-  %144 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %140, i32 0, i32 3
-  store i32 30, i32* %144, align 4
-  %145 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %140, i32 0, i32 4
-  store i32 21, i32* %145, align 4
-  %146 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @22, i32 0, i32 0))
-  %147 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %138, i32 0, i32 0
-  %148 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %139, i32 0, i32 0
-  %149 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %147, i32 0, i32 2
-  %150 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %147, i32 0, i32 0
-  store i1 true, i1* %150, align 1
-  %151 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %147, i32 0, i32 1
-  store i8* %146, i8** %151, align 8
-  store { i8*, i32, i32, i32, i32 }* %148, { i8*, i32, i32, i32, i32 }** %149, align 8
-  %152 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %147, i32 0, i32 3
-  store i32 1, i32* %152, align 4
-  %153 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %138, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %153, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @20, i32 0, i32 0), i64 %131, i32 1, i64 1, i64 500)
+  %136 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %137 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %138 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %137, i32 0, i32 0
+  %139 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %138, i32 0, i32 0
+  store ptr @21, ptr %139, align 8
+  %140 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %138, i32 0, i32 1
+  store i32 30, ptr %140, align 4
+  %141 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %138, i32 0, i32 2
+  store i32 13, ptr %141, align 4
+  %142 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %138, i32 0, i32 3
+  store i32 30, ptr %142, align 4
+  %143 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %138, i32 0, i32 4
+  store i32 21, ptr %143, align 4
+  %144 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @22)
+  %145 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %136, i32 0, i32 0
+  %146 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %137, i32 0, i32 0
+  %147 = getelementptr { i1, ptr, ptr, i32 }, ptr %145, i32 0, i32 2
+  %148 = getelementptr { i1, ptr, ptr, i32 }, ptr %145, i32 0, i32 0
+  store i1 true, ptr %148, align 1
+  %149 = getelementptr { i1, ptr, ptr, i32 }, ptr %145, i32 0, i32 1
+  store ptr %144, ptr %149, align 8
+  store ptr %146, ptr %147, align 8
+  %150 = getelementptr { i1, ptr, ptr, i32 }, ptr %145, i32 0, i32 3
+  store i32 1, ptr %150, align 4
+  %151 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %136, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %151, i32 1, ptr @23, ptr @20, i64 %129, i32 1, i64 1, i64 500)
   call void @exit(i32 1)
   unreachable
 
 ifcont45:                                         ; preds = %loop.body43
-  %154 = getelementptr [500 x float], [500 x float]* %120, i32 0, i64 %134
-  %155 = call float @_lcompilers_real_i32(i32* %i)
-  store float %155, float* %154, align 4
+  %152 = getelementptr [500 x float], ptr %118, i32 0, i64 %132
+  %153 = call float @_lcompilers_real_i32(ptr %i)
+  store float %153, ptr %152, align 4
   br label %loop.head42
 
 loop.end46:                                       ; preds = %loop.head42
-  %156 = load float, float* %sum, align 4
+  %154 = load float, ptr %sum, align 4
   br i1 false, label %then47, label %ifcont48
 
 then47:                                           ; preds = %loop.end46
-  %157 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %158 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %159 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %158, i32 0, i32 0
-  %160 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %159, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @25, i32 0, i32 0), i8** %160, align 8
-  %161 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %159, i32 0, i32 1
-  store i32 31, i32* %161, align 4
-  %162 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %159, i32 0, i32 2
-  store i32 25, i32* %162, align 4
-  %163 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %159, i32 0, i32 3
-  store i32 31, i32* %163, align 4
-  %164 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %159, i32 0, i32 4
-  store i32 36, i32* %164, align 4
-  %165 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @26, i32 0, i32 0))
-  %166 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %157, i32 0, i32 0
-  %167 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %158, i32 0, i32 0
-  %168 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %166, i32 0, i32 2
-  %169 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %166, i32 0, i32 0
-  store i1 true, i1* %169, align 1
-  %170 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %166, i32 0, i32 1
-  store i8* %165, i8** %170, align 8
-  store { i8*, i32, i32, i32, i32 }* %167, { i8*, i32, i32, i32, i32 }** %168, align 8
-  %171 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %166, i32 0, i32 3
-  store i32 1, i32* %171, align 4
-  %172 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %157, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %172, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([10 x i8], [10 x i8]* @24, i32 0, i32 0), i64 1, i32 1, i64 1, i64 500)
+  %155 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %156 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %157 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %156, i32 0, i32 0
+  %158 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %157, i32 0, i32 0
+  store ptr @25, ptr %158, align 8
+  %159 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %157, i32 0, i32 1
+  store i32 31, ptr %159, align 4
+  %160 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %157, i32 0, i32 2
+  store i32 25, ptr %160, align 4
+  %161 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %157, i32 0, i32 3
+  store i32 31, ptr %161, align 4
+  %162 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %157, i32 0, i32 4
+  store i32 36, ptr %162, align 4
+  %163 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @26)
+  %164 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %155, i32 0, i32 0
+  %165 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %156, i32 0, i32 0
+  %166 = getelementptr { i1, ptr, ptr, i32 }, ptr %164, i32 0, i32 2
+  %167 = getelementptr { i1, ptr, ptr, i32 }, ptr %164, i32 0, i32 0
+  store i1 true, ptr %167, align 1
+  %168 = getelementptr { i1, ptr, ptr, i32 }, ptr %164, i32 0, i32 1
+  store ptr %163, ptr %168, align 8
+  store ptr %165, ptr %166, align 8
+  %169 = getelementptr { i1, ptr, ptr, i32 }, ptr %164, i32 0, i32 3
+  store i32 1, ptr %169, align 4
+  %170 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %155, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %170, i32 1, ptr @27, ptr @24, i64 1, i32 1, i64 1, i64 500)
   call void @exit(i32 1)
   unreachable
 
 ifcont48:                                         ; preds = %loop.end46
-  %173 = getelementptr [500 x float], [500 x float]* %120, i32 0, i64 0
-  %174 = load float, float* %173, align 4
-  %175 = fadd float %156, %174
-  store float %175, float* %sum, align 4
+  %171 = getelementptr [500 x float], ptr %118, i32 0, i64 0
+  %172 = load float, ptr %171, align 4
+  %173 = fadd float %154, %172
+  store float %173, ptr %sum, align 4
   br label %block.end
 
 block.end:                                        ; preds = %ifcont48
   br label %FINALIZE_SYMTABLE_block
 
 FINALIZE_SYMTABLE_block:                          ; preds = %block.end
-  %176 = icmp eq i8* %119, null
-  br i1 %176, label %free_done, label %free_nonnull
+  %174 = icmp eq ptr %118, null
+  br i1 %174, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %FINALIZE_SYMTABLE_block
-  call void @_lfortran_free_alloc(i8* %2, i8* %119)
+  call void @_lfortran_free_alloc(ptr %2, ptr %118)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %FINALIZE_SYMTABLE_block
-  call void @llvm.stackrestore(i8* %117)
+  call void @llvm.stackrestore.p0(ptr %116)
   br label %loop.head30
 
 loop.end49:                                       ; preds = %loop.head30
-  %177 = load float, float* %sum, align 4
-  %178 = fsub float %177, 5.005000e+05
-  %179 = call float @llvm.fabs.f32(float %178)
-  %180 = fcmp ogt float %179, 0x3FB99999A0000000
-  br i1 %180, label %then50, label %else51
+  %175 = load float, ptr %sum, align 4
+  %176 = fsub float %175, 5.005000e+05
+  %177 = call float @llvm.fabs.f32(float %176)
+  %178 = fcmp ogt float %177, 0x3FB99999A0000000
+  br i1 %178, label %then50, label %else51
 
 then50:                                           ; preds = %loop.end49
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @29, ptr @"ERROR STOP", ptr @28)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont52
@@ -520,19 +519,19 @@ else51:                                           ; preds = %loop.end49
   br label %ifcont52
 
 ifcont52:                                         ; preds = %else51, %then50
-  %181 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %181, i32 2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  %179 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @31, ptr %179, i32 2, ptr @30, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont52
   br label %FINALIZE_SYMTABLE_static_large_array
 
 FINALIZE_SYMTABLE_static_large_array:             ; preds = %return
-  %182 = icmp eq i8* %4, null
-  br i1 %182, label %free_done54, label %free_nonnull53
+  %180 = icmp eq ptr %4, null
+  br i1 %180, label %free_done54, label %free_nonnull53
 
 free_nonnull53:                                   ; preds = %FINALIZE_SYMTABLE_static_large_array
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done54
 
 free_done54:                                      ; preds = %free_nonnull53, %FINALIZE_SYMTABLE_static_large_array
@@ -540,34 +539,34 @@ free_done54:                                      ; preds = %free_nonnull53, %FI
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare ptr @llvm.stacksave.p0() #0
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare void @llvm.stackrestore.p0(ptr) #0
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare float @llvm.fabs.f32(float) #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-attributes #0 = { nounwind }
-attributes #1 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nofree nosync nounwind willreturn }
+attributes #1 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "d30aa37d429a25d27a0a4772161e32cd7d77f86dc4c1cc5f7c3d74ce",
+    "stdout_hash": "16c2ee32a7ddbcdb689682d4d107cdd8eb857e63b44eceb7bedef525",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -1,9 +1,10 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %complex_4 = type <{ float, float }>
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @associate_02.t1 = internal global i32 2
 @associate_02.t2 = internal global double 2.000000e+00
@@ -33,7 +34,7 @@ target datalayout = "..."
 @serialization_info.7 = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
@@ -43,163 +44,163 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %p1 = alloca i32*, align 8
-  store i32* null, i32** %p1, align 8
-  %p2 = alloca double*, align 8
-  store double* null, double** %p2, align 8
-  %p3 = alloca %complex_4*, align 8
-  store %complex_4* null, %complex_4** %p3, align 8
-  store %complex_4 <{ float 2.000000e+00, float 3.000000e+00 }>, %complex_4* @associate_02.t3, align 1
-  store i32* @associate_02.t1, i32** %p1, align 8
-  store double* @associate_02.t2, double** %p2, align 8
-  store %complex_4* @associate_02.t3, %complex_4** %p3, align 8
-  %3 = load i32*, i32** %p1, align 8
-  store i32 1, i32* %3, align 4
-  %4 = load double*, double** %p2, align 8
-  store double 4.000000e+00, double* %4, align 8
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %p1 = alloca ptr, align 8
+  store ptr null, ptr %p1, align 8
+  %p2 = alloca ptr, align 8
+  store ptr null, ptr %p2, align 8
+  %p3 = alloca ptr, align 8
+  store ptr null, ptr %p3, align 8
+  store %complex_4 <{ float 2.000000e+00, float 3.000000e+00 }>, ptr @associate_02.t3, align 1
+  store ptr @associate_02.t1, ptr %p1, align 8
+  store ptr @associate_02.t2, ptr %p2, align 8
+  store ptr @associate_02.t3, ptr %p3, align 8
+  %3 = load ptr, ptr %p1, align 8
+  store i32 1, ptr %3, align 4
+  %4 = load ptr, ptr %p2, align 8
+  store double 4.000000e+00, ptr %4, align 8
   %5 = alloca i64, align 8
-  %6 = load i32*, i32** %p1, align 8
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %6)
-  %8 = load i64, i64* %5, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %7, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %8, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %14 = load i64, i64* %13, align 8
+  %6 = load ptr, ptr %p1, align 8
+  %7 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %5, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %6)
+  %8 = load i64, ptr %5, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %16 = icmp eq i8* %7, null
+  call void @_lfortran_printf(ptr @1, ptr %12, i32 %15, ptr @0, i32 1)
+  %16 = icmp eq ptr %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %7)
+  call void @_lfortran_free_alloc(ptr %2, ptr %7)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @associate_02.t1)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @associate_02.t1)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %18)
+  call void @_lfortran_free_alloc(ptr %2, ptr %18)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %28 = load double*, double** %p2, align 8
-  %29 = load double, double* %28, align 8
-  %30 = load i32*, i32** %p1, align 8
-  %31 = load i32, i32* %30, align 4
+  %28 = load ptr, ptr %p2, align 8
+  %29 = load double, ptr %28, align 8
+  %30 = load ptr, ptr %p1, align 8
+  %31 = load i32, ptr %30, align 4
   %32 = sitofp i32 %31 to double
   %33 = fadd double %29, %32
   %34 = fptosi double %33 to i32
-  store i32 %34, i32* @associate_02.t1, align 4
+  store i32 %34, ptr @associate_02.t1, align 4
   %35 = alloca i64, align 8
-  %36 = load i32*, i32** %p1, align 8
-  %37 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %35, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %36)
-  %38 = load i64, i64* %35, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %38, i64* %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %44 = load i64, i64* %43, align 8
+  %36 = load ptr, ptr %p1, align 8
+  %37 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %35, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %36)
+  %38 = load i64, ptr %35, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %44 = load i64, ptr %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %46 = icmp eq i8* %37, null
+  call void @_lfortran_printf(ptr @5, ptr %42, i32 %45, ptr @4, i32 1)
+  %46 = icmp eq ptr %37, null
   br i1 %46, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %37)
+  call void @_lfortran_free_alloc(ptr %2, ptr %37)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   %47 = alloca i64, align 8
-  %48 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %47, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @associate_02.t1)
-  %49 = load i64, i64* %47, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %48, i8** %50, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %49, i64* %51, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %55 = load i64, i64* %54, align 8
+  %48 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %47, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @associate_02.t1)
+  %49 = load i64, ptr %47, align 8
+  %50 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %48, ptr %50, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %49, ptr %51, align 8
+  %52 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %55 = load i64, ptr %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %57 = icmp eq i8* %48, null
+  call void @_lfortran_printf(ptr @7, ptr %53, i32 %56, ptr @6, i32 1)
+  %57 = icmp eq ptr %48, null
   br i1 %57, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %48)
+  call void @_lfortran_free_alloc(ptr %2, ptr %48)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  store i32 8, i32* @associate_02.t1, align 4
+  store i32 8, ptr @associate_02.t1, align 4
   %58 = alloca i64, align 8
-  %59 = load i32*, i32** %p1, align 8
-  %60 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %58, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %59)
-  %61 = load i64, i64* %58, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %60, i8** %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %61, i64* %63, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %65 = load i8*, i8** %64, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %67 = load i64, i64* %66, align 8
+  %59 = load ptr, ptr %p1, align 8
+  %60 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %58, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %59)
+  %61 = load i64, ptr %58, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %60, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %61, ptr %63, align 8
+  %64 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %65 = load ptr, ptr %64, align 8
+  %66 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %67 = load i64, ptr %66, align 8
   %68 = trunc i64 %67 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %69 = icmp eq i8* %60, null
+  call void @_lfortran_printf(ptr @9, ptr %65, i32 %68, ptr @8, i32 1)
+  %69 = icmp eq ptr %60, null
   br i1 %69, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free_alloc(i8* %2, i8* %60)
+  call void @_lfortran_free_alloc(ptr %2, ptr %60)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
   %70 = alloca i64, align 8
-  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %70, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @associate_02.t1)
-  %72 = load i64, i64* %70, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %71, i8** %73, align 8
-  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %72, i64* %74, align 8
-  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %76 = load i8*, i8** %75, align 8
-  %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %78 = load i64, i64* %77, align 8
+  %71 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.5, ptr %70, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @associate_02.t1)
+  %72 = load i64, ptr %70, align 8
+  %73 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %71, ptr %73, align 8
+  %74 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %72, ptr %74, align 8
+  %75 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %76 = load ptr, ptr %75, align 8
+  %77 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %78 = load i64, ptr %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %80 = icmp eq i8* %71, null
+  call void @_lfortran_printf(ptr @11, ptr %76, i32 %79, ptr @10, i32 1)
+  %80 = icmp eq ptr %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free_alloc(i8* %2, i8* %71)
+  call void @_lfortran_free_alloc(ptr %2, ptr %71)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  %81 = load %complex_4*, %complex_4** %p3, align 8
-  %82 = load %complex_4*, %complex_4** %p3, align 8
-  %83 = load %complex_4, %complex_4* %82, align 1
+  %81 = load ptr, ptr %p3, align 8
+  %82 = load ptr, ptr %p3, align 8
+  %83 = load %complex_4, ptr %82, align 1
   %84 = extractvalue %complex_4 %83, 0
   %85 = extractvalue %complex_4 %83, 1
   %86 = fmul float 2.000000e+00, %84
@@ -210,47 +211,47 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %91 = fadd float %88, %89
   %92 = insertvalue %complex_4 undef, float %90, 0
   %93 = insertvalue %complex_4 %92, float %91, 1
-  store %complex_4 %93, %complex_4* %81, align 1
+  store %complex_4 %93, ptr %81, align 1
   %94 = alloca i64, align 8
-  %95 = load %complex_4*, %complex_4** %p3, align 8
-  %96 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.6, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %95)
-  %97 = load i64, i64* %94, align 8
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %96, i8** %98, align 8
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %97, i64* %99, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %101 = load i8*, i8** %100, align 8
-  %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %103 = load i64, i64* %102, align 8
+  %95 = load ptr, ptr %p3, align 8
+  %96 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.6, ptr %94, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %95)
+  %97 = load i64, ptr %94, align 8
+  %98 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %96, ptr %98, align 8
+  %99 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %97, ptr %99, align 8
+  %100 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %101 = load ptr, ptr %100, align 8
+  %102 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %103 = load i64, ptr %102, align 8
   %104 = trunc i64 %103 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %101, i32 %104, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %105 = icmp eq i8* %96, null
+  call void @_lfortran_printf(ptr @13, ptr %101, i32 %104, ptr @12, i32 1)
+  %105 = icmp eq ptr %96, null
   br i1 %105, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free_alloc(i8* %2, i8* %96)
+  call void @_lfortran_free_alloc(ptr %2, ptr %96)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
   %106 = alloca i64, align 8
-  %107 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.7, i32 0, i32 0), i64* %106, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* @associate_02.t3)
-  %108 = load i64, i64* %106, align 8
-  %109 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %107, i8** %109, align 8
-  %110 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %108, i64* %110, align 8
-  %111 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %112 = load i8*, i8** %111, align 8
-  %113 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %114 = load i64, i64* %113, align 8
+  %107 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.7, ptr %106, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @associate_02.t3)
+  %108 = load i64, ptr %106, align 8
+  %109 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  store ptr %107, ptr %109, align 8
+  %110 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  store i64 %108, ptr %110, align 8
+  %111 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  %112 = load ptr, ptr %111, align 8
+  %113 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  %114 = load i64, ptr %113, align 8
   %115 = trunc i64 %114 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %112, i32 %115, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %116 = icmp eq i8* %107, null
+  call void @_lfortran_printf(ptr @15, ptr %112, i32 %115, ptr @14, i32 1)
+  %116 = icmp eq ptr %107, null
   br i1 %116, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %free_done18
-  call void @_lfortran_free_alloc(i8* %2, i8* %107)
+  call void @_lfortran_free_alloc(ptr %2, ptr %107)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
@@ -264,14 +265,14 @@ FINALIZE_SYMTABLE_associate_02:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "380481401a2ff635fc6249287ed6082e86892b6feee99b7da4fe9c19",
+    "stdout_hash": "549b4308e5eff7a2a9fccf81dff7113a9903507875a98789746730f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @associate_03.t1 = internal global i32 2
 @associate_03.t2 = internal global i32 1
@@ -16,82 +17,82 @@ target datalayout = "..."
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
-  %p1 = alloca i32*, align 8
-  store i32* null, i32** %p1, align 8
+  %p1 = alloca ptr, align 8
+  store ptr null, ptr %p1, align 8
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @associate_03.t1, i32* @associate_03.t2)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @associate_03.t1, ptr @associate_03.t2)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load i32, i32* @associate_03.t1, align 4
-  %15 = load i32, i32* @associate_03.t2, align 4
+  %14 = load i32, ptr @associate_03.t1, align 4
+  %15 = load i32, ptr @associate_03.t2, align 4
   %16 = icmp sgt i32 %14, %15
   br i1 %16, label %then, label %else
 
 then:                                             ; preds = %free_done
-  store i32* @associate_03.t1, i32** %p1, align 8
+  store ptr @associate_03.t1, ptr %p1, align 8
   br label %ifcont
 
 else:                                             ; preds = %free_done
-  store i32* @associate_03.t2, i32** %p1, align 8
+  store ptr @associate_03.t2, ptr %p1, align 8
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
   %17 = alloca i64, align 8
-  %18 = load i32*, i32** %p1, align 8
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %18)
-  %20 = load i64, i64* %17, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %19, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %20, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %26 = load i64, i64* %25, align 8
+  %18 = load ptr, ptr %p1, align 8
+  %19 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %18)
+  %20 = load i64, ptr %17, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %20, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %26 = load i64, ptr %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %28 = icmp eq i8* %19, null
+  call void @_lfortran_printf(ptr @3, ptr %24, i32 %27, ptr @2, i32 1)
+  %28 = icmp eq ptr %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %19)
+  call void @_lfortran_free_alloc(ptr %2, ptr %19)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %ifcont
-  %29 = load i32*, i32** %p1, align 8
-  %30 = load i32, i32* %29, align 4
-  store i32 %30, i32* %i, align 4
-  %31 = load i32, i32* %i, align 4
-  %32 = load i32, i32* @associate_03.t2, align 4
+  %29 = load ptr, ptr %p1, align 8
+  %30 = load i32, ptr %29, align 4
+  store i32 %30, ptr %i, align 4
+  %31 = load i32, ptr %i, align 4
+  %32 = load i32, ptr @associate_03.t2, align 4
   %33 = icmp eq i32 %31, %32
   br i1 %33, label %then4, label %else5
 
 then4:                                            ; preds = %free_done3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -110,17 +111,17 @@ FINALIZE_SYMTABLE_associate_03:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "29e561c66bb1202d565380fe6249881fc42703c0dc90d7c6e147c74c",
+    "stdout_hash": "e433c312bcd181671d26228b6aa6f3cd779eebb6e7957d6b9cf983d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [9 x i8] c"R4,R4,R4\00", align 1
@@ -14,133 +15,133 @@ target datalayout = "..."
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_cos_f32(float* %x) {
+define float @_lcompilers_cos_f32(ptr %x) {
 .entry:
   %_lcompilers_cos_f32 = alloca float, align 4
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = call float @_lfortran_scos(float %0)
-  store float %1, float* %_lcompilers_cos_f32, align 4
+  store float %1, ptr %_lcompilers_cos_f32, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE__lcompilers_cos_f32
 
 FINALIZE_SYMTABLE__lcompilers_cos_f32:            ; preds = %return
-  %2 = load float, float* %_lcompilers_cos_f32, align 4
+  %2 = load float, ptr %_lcompilers_cos_f32, align 4
   ret float %2
 }
 
 declare float @_lfortran_scos(float)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca float, align 4
   %myreal = alloca float, align 4
   %theta = alloca float, align 4
   %x = alloca float, align 4
   %y = alloca float, align 4
-  store float 0x3FDAE147A0000000, float* %x, align 4
-  store float 0x3FD6666660000000, float* %y, align 4
-  store float 0x4022333340000000, float* %myreal, align 4
-  store float 1.500000e+00, float* %theta, align 4
-  store float 0x3FD99999A0000000, float* %a, align 4
+  store float 0x3FDAE147A0000000, ptr %x, align 4
+  store float 0x3FD6666660000000, ptr %y, align 4
+  store float 0x4022333340000000, ptr %myreal, align 4
+  store float 1.500000e+00, ptr %theta, align 4
+  store float 0x3FD99999A0000000, ptr %a, align 4
   br label %associate_block_start
 
 associate_block_start:                            ; preds = %.entry
-  %3 = call i8* @llvm.stacksave()
-  %v = alloca float*, align 8
-  store float* null, float** %v, align 8
+  %3 = call ptr @llvm.stacksave.p0()
+  %v = alloca ptr, align 8
+  store ptr null, ptr %v, align 8
   %z = alloca float, align 4
-  %4 = load float, float* %x, align 4
+  %4 = load float, ptr %x, align 4
   %5 = fmul float %4, 2.000000e+00
-  %6 = load float, float* %y, align 4
+  %6 = load float, ptr %y, align 4
   %7 = fmul float %6, 2.000000e+00
   %8 = fadd float %5, %7
   %9 = fneg float %8
-  %10 = call float @_lcompilers_cos_f32(float* %theta)
+  %10 = call float @_lcompilers_cos_f32(ptr %theta)
   %11 = fmul float %9, %10
-  store float %11, float* %z, align 4
-  store float* %myreal, float** %v, align 8
+  store float %11, ptr %z, align 4
+  store ptr %myreal, ptr %v, align 8
   %12 = alloca i64, align 8
-  %13 = load float, float* %a, align 4
-  %14 = load float, float* %z, align 4
+  %13 = load float, ptr %a, align 4
+  %14 = load float, ptr %z, align 4
   %15 = fadd float %13, %14
   %16 = alloca float, align 4
-  store float %15, float* %16, align 4
-  %17 = load float, float* %a, align 4
-  %18 = load float, float* %z, align 4
+  store float %15, ptr %16, align 4
+  %17 = load float, ptr %a, align 4
+  %18 = load float, ptr %z, align 4
   %19 = fsub float %17, %18
   %20 = alloca float, align 4
-  store float %19, float* %20, align 4
-  %21 = load float*, float** %v, align 8
-  %22 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* %16, float* %20, float* %21)
-  %23 = load i64, i64* %12, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %22, i8** %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %23, i64* %25, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %27 = load i8*, i8** %26, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %29 = load i64, i64* %28, align 8
+  store float %19, ptr %20, align 4
+  %21 = load ptr, ptr %v, align 8
+  %22 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %12, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %16, ptr %20, ptr %21)
+  %23 = load i64, ptr %12, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %22, ptr %24, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %23, ptr %25, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %27 = load ptr, ptr %26, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %29 = load i64, ptr %28, align 8
   %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %31 = icmp eq i8* %22, null
+  call void @_lfortran_printf(ptr @1, ptr %27, i32 %30, ptr @0, i32 1)
+  %31 = icmp eq ptr %22, null
   br i1 %31, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %associate_block_start
-  call void @_lfortran_free_alloc(i8* %2, i8* %22)
+  call void @_lfortran_free_alloc(ptr %2, ptr %22)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %associate_block_start
-  %32 = load float*, float** %v, align 8
-  %33 = load float*, float** %v, align 8
-  %34 = load float, float* %33, align 4
+  %32 = load ptr, ptr %v, align 8
+  %33 = load ptr, ptr %v, align 8
+  %34 = load float, ptr %33, align 4
   %35 = fmul float %34, 0x4012666660000000
-  store float %35, float* %32, align 4
+  store float %35, ptr %32, align 4
   br label %associate_block_end
 
 associate_block_end:                              ; preds = %free_done
   br label %FINALIZE_SYMTABLE_associate_block
 
 FINALIZE_SYMTABLE_associate_block:                ; preds = %associate_block_end
-  call void @llvm.stackrestore(i8* %3)
+  call void @llvm.stackrestore.p0(ptr %3)
   %36 = alloca i64, align 8
-  %37 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %36, i32 0, i32 0, i32 0, i32 0, i32 0, float* %myreal)
-  %38 = load i64, i64* %36, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %38, i64* %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %44 = load i64, i64* %43, align 8
+  %37 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %36, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %myreal)
+  %38 = load i64, ptr %36, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %44 = load i64, ptr %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %46 = icmp eq i8* %37, null
+  call void @_lfortran_printf(ptr @3, ptr %42, i32 %45, ptr @2, i32 1)
+  %46 = icmp eq ptr %37, null
   br i1 %46, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %FINALIZE_SYMTABLE_associate_block
-  call void @_lfortran_free_alloc(i8* %2, i8* %37)
+  call void @_lfortran_free_alloc(ptr %2, ptr %37)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %FINALIZE_SYMTABLE_associate_block
-  %47 = load float, float* %myreal, align 4
+  %47 = load float, ptr %myreal, align 4
   %48 = fsub float %47, 0x4044EE1480000000
   %49 = fcmp ogt float %48, 0x3EE4F8B580000000
-  %50 = load float, float* %myreal, align 4
+  %50 = load float, ptr %myreal, align 4
   %51 = fsub float %50, 0x4044EE1480000000
   %52 = fcmp olt float %51, 0xBEE4F8B580000000
   %53 = or i1 %49, %52
   br i1 %53, label %then, label %else
 
 then:                                             ; preds = %free_done3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -159,26 +160,26 @@ FINALIZE_SYMTABLE_associate_04:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare ptr @llvm.stacksave.p0() #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare void @llvm.stackrestore.p0(ptr) #0
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-attributes #0 = { nounwind }
+attributes #0 = { nocallback nofree nosync nounwind willreturn }

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-automatic_allocation_02-2a7afc4.stdout",
-    "stdout_hash": "78c9c7e9f76a7c846ac530be6052dd9e4ce290defe63d215909ff751",
+    "stdout_hash": "219c5a465820529e4c17f10ef07e4c9039c779043f98ffdaf493f844",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
+++ b/tests/reference/llvm-automatic_allocation_02-2a7afc4.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %complex_4 = type <{ float, float }>
 
@@ -46,277 +47,273 @@ target datalayout = "..."
 @38 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @39 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %c = alloca %complex_4*, align 8
-  store %complex_4* null, %complex_4** %c, align 8
-  %i = alloca i32*, align 8
-  store i32* null, i32** %i, align 8
-  %l = alloca i32*, align 8
-  store i32* null, i32** %l, align 8
-  %r = alloca float*, align 8
-  store float* null, float** %r, align 8
-  %3 = load i32*, i32** %i, align 8
-  %4 = icmp eq i32* %3, null
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %c = alloca ptr, align 8
+  store ptr null, ptr %c, align 8
+  %i = alloca ptr, align 8
+  store ptr null, ptr %i, align 8
+  %l = alloca ptr, align 8
+  store ptr null, ptr %l, align 8
+  %r = alloca ptr, align 8
+  store ptr null, ptr %r, align 8
+  %3 = load ptr, ptr %i, align 8
+  %4 = icmp eq ptr %3, null
   br i1 %4, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %5 = load i32*, i32** %i, align 8
-  %6 = ptrtoint i32* %5 to i64
+  %5 = load ptr, ptr %i, align 8
+  %6 = ptrtoint ptr %5 to i64
   %7 = icmp ne i64 %6, 0
   br i1 %7, label %then1, label %ifcont
 
 then1:                                            ; preds = %then
-  %8 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %9 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %10 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %9, i32 0, i32 0
-  %11 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %10, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @1, i32 0, i32 0), i8** %11, align 8
-  %12 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %10, i32 0, i32 1
-  store i32 9, i32* %12, align 4
-  %13 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %10, i32 0, i32 2
-  store i32 5, i32* %13, align 4
-  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %10, i32 0, i32 3
-  store i32 9, i32* %14, align 4
-  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %10, i32 0, i32 4
-  store i32 5, i32* %15, align 4
-  %16 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  %17 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %8, i32 0, i32 0
-  %18 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %9, i32 0, i32 0
-  %19 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %17, i32 0, i32 2
-  %20 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %17, i32 0, i32 0
-  store i1 true, i1* %20, align 1
-  %21 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %17, i32 0, i32 1
-  store i8* %16, i8** %21, align 8
-  store { i8*, i32, i32, i32, i32 }* %18, { i8*, i32, i32, i32, i32 }** %19, align 8
-  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %17, i32 0, i32 3
-  store i32 1, i32* %22, align 4
-  %23 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %8, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %23, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  %8 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %9 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %10 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %9, i32 0, i32 0
+  %11 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %10, i32 0, i32 0
+  store ptr @1, ptr %11, align 8
+  %12 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %10, i32 0, i32 1
+  store i32 9, ptr %12, align 4
+  %13 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %10, i32 0, i32 2
+  store i32 5, ptr %13, align 4
+  %14 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %10, i32 0, i32 3
+  store i32 9, ptr %14, align 4
+  %15 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %10, i32 0, i32 4
+  store i32 5, ptr %15, align 4
+  %16 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2, ptr @0)
+  %17 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %8, i32 0, i32 0
+  %18 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %9, i32 0, i32 0
+  %19 = getelementptr { i1, ptr, ptr, i32 }, ptr %17, i32 0, i32 2
+  %20 = getelementptr { i1, ptr, ptr, i32 }, ptr %17, i32 0, i32 0
+  store i1 true, ptr %20, align 1
+  %21 = getelementptr { i1, ptr, ptr, i32 }, ptr %17, i32 0, i32 1
+  store ptr %16, ptr %21, align 8
+  store ptr %18, ptr %19, align 8
+  %22 = getelementptr { i1, ptr, ptr, i32 }, ptr %17, i32 0, i32 3
+  store i32 1, ptr %22, align 4
+  %23 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %8, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %23, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %then
-  %24 = call i8* @_lfortran_get_default_allocator()
-  %25 = call i8* @_lfortran_malloc_alloc(i8* %24, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %25, i8 0, i32 4, i1 false)
-  %26 = bitcast i8* %25 to i32*
-  store i32* %26, i32** %i, align 8
+  %24 = call ptr @_lfortran_get_default_allocator()
+  %25 = call ptr @_lfortran_malloc_alloc(ptr %24, i64 4)
+  call void @llvm.memset.p0.i32(ptr %25, i8 0, i32 4, i1 false)
+  store ptr %25, ptr %i, align 8
   br label %ifcont2
 
 else:                                             ; preds = %.entry
   br label %ifcont2
 
 ifcont2:                                          ; preds = %else, %ifcont
-  %27 = load i32*, i32** %i, align 8
-  store i32 10, i32* %27, align 4
-  %28 = load float*, float** %r, align 8
-  %29 = icmp eq float* %28, null
-  br i1 %29, label %then3, label %else6
+  %26 = load ptr, ptr %i, align 8
+  store i32 10, ptr %26, align 4
+  %27 = load ptr, ptr %r, align 8
+  %28 = icmp eq ptr %27, null
+  br i1 %28, label %then3, label %else6
 
 then3:                                            ; preds = %ifcont2
-  %30 = load float*, float** %r, align 8
-  %31 = ptrtoint float* %30 to i64
-  %32 = icmp ne i64 %31, 0
-  br i1 %32, label %then4, label %ifcont5
+  %29 = load ptr, ptr %r, align 8
+  %30 = ptrtoint ptr %29 to i64
+  %31 = icmp ne i64 %30, 0
+  br i1 %31, label %then4, label %ifcont5
 
 then4:                                            ; preds = %then3
-  %33 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %34 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %35 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %34, i32 0, i32 0
-  %36 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @5, i32 0, i32 0), i8** %36, align 8
-  %37 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 1
-  store i32 10, i32* %37, align 4
-  %38 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 2
-  store i32 5, i32* %38, align 4
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 3
-  store i32 10, i32* %39, align 4
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %35, i32 0, i32 4
-  store i32 5, i32* %40, align 4
-  %41 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %42 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %33, i32 0, i32 0
-  %43 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %34, i32 0, i32 0
-  %44 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 2
-  %45 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 0
-  store i1 true, i1* %45, align 1
-  %46 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 1
-  store i8* %41, i8** %46, align 8
-  store { i8*, i32, i32, i32, i32 }* %43, { i8*, i32, i32, i32, i32 }** %44, align 8
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %42, i32 0, i32 3
-  store i32 1, i32* %47, align 4
-  %48 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %33, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  %32 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %33 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %34 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %33, i32 0, i32 0
+  %35 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %34, i32 0, i32 0
+  store ptr @5, ptr %35, align 8
+  %36 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %34, i32 0, i32 1
+  store i32 10, ptr %36, align 4
+  %37 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %34, i32 0, i32 2
+  store i32 5, ptr %37, align 4
+  %38 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %34, i32 0, i32 3
+  store i32 10, ptr %38, align 4
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %34, i32 0, i32 4
+  store i32 5, ptr %39, align 4
+  %40 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6, ptr @4)
+  %41 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %32, i32 0, i32 0
+  %42 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %33, i32 0, i32 0
+  %43 = getelementptr { i1, ptr, ptr, i32 }, ptr %41, i32 0, i32 2
+  %44 = getelementptr { i1, ptr, ptr, i32 }, ptr %41, i32 0, i32 0
+  store i1 true, ptr %44, align 1
+  %45 = getelementptr { i1, ptr, ptr, i32 }, ptr %41, i32 0, i32 1
+  store ptr %40, ptr %45, align 8
+  store ptr %42, ptr %43, align 8
+  %46 = getelementptr { i1, ptr, ptr, i32 }, ptr %41, i32 0, i32 3
+  store i32 1, ptr %46, align 4
+  %47 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %32, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %47, i32 1, ptr @7, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %then3
-  %49 = call i8* @_lfortran_get_default_allocator()
-  %50 = call i8* @_lfortran_malloc_alloc(i8* %49, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %50, i8 0, i32 4, i1 false)
-  %51 = bitcast i8* %50 to float*
-  store float* %51, float** %r, align 8
+  %48 = call ptr @_lfortran_get_default_allocator()
+  %49 = call ptr @_lfortran_malloc_alloc(ptr %48, i64 4)
+  call void @llvm.memset.p0.i32(ptr %49, i8 0, i32 4, i1 false)
+  store ptr %49, ptr %r, align 8
   br label %ifcont7
 
 else6:                                            ; preds = %ifcont2
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %ifcont5
-  %52 = load float*, float** %r, align 8
-  store float 0x40119999A0000000, float* %52, align 4
-  %53 = load %complex_4*, %complex_4** %c, align 8
-  %54 = icmp eq %complex_4* %53, null
-  br i1 %54, label %then8, label %else11
+  %50 = load ptr, ptr %r, align 8
+  store float 0x40119999A0000000, ptr %50, align 4
+  %51 = load ptr, ptr %c, align 8
+  %52 = icmp eq ptr %51, null
+  br i1 %52, label %then8, label %else11
 
 then8:                                            ; preds = %ifcont7
-  %55 = load %complex_4*, %complex_4** %c, align 8
-  %56 = ptrtoint %complex_4* %55 to i64
-  %57 = icmp ne i64 %56, 0
-  br i1 %57, label %then9, label %ifcont10
+  %53 = load ptr, ptr %c, align 8
+  %54 = ptrtoint ptr %53 to i64
+  %55 = icmp ne i64 %54, 0
+  br i1 %55, label %then9, label %ifcont10
 
 then9:                                            ; preds = %then8
-  %58 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %59 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %60 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %59, i32 0, i32 0
-  %61 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @9, i32 0, i32 0), i8** %61, align 8
-  %62 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 1
-  store i32 11, i32* %62, align 4
-  %63 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 2
-  store i32 5, i32* %63, align 4
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 3
-  store i32 11, i32* %64, align 4
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %60, i32 0, i32 4
-  store i32 5, i32* %65, align 4
-  %66 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @10, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
-  %67 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %58, i32 0, i32 0
-  %68 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %59, i32 0, i32 0
-  %69 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 2
-  %70 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 0
-  store i1 true, i1* %70, align 1
-  %71 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 1
-  store i8* %66, i8** %71, align 8
-  store { i8*, i32, i32, i32, i32 }* %68, { i8*, i32, i32, i32, i32 }** %69, align 8
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 0, i32 3
-  store i32 1, i32* %72, align 4
-  %73 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %58, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %73, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  %56 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %57 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %58 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %57, i32 0, i32 0
+  %59 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 0
+  store ptr @9, ptr %59, align 8
+  %60 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 1
+  store i32 11, ptr %60, align 4
+  %61 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 2
+  store i32 5, ptr %61, align 4
+  %62 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 3
+  store i32 11, ptr %62, align 4
+  %63 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %58, i32 0, i32 4
+  store i32 5, ptr %63, align 4
+  %64 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10, ptr @8)
+  %65 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %56, i32 0, i32 0
+  %66 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %57, i32 0, i32 0
+  %67 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 2
+  %68 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 0
+  store i1 true, ptr %68, align 1
+  %69 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 1
+  store ptr %64, ptr %69, align 8
+  store ptr %66, ptr %67, align 8
+  %70 = getelementptr { i1, ptr, ptr, i32 }, ptr %65, i32 0, i32 3
+  store i32 1, ptr %70, align 4
+  %71 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %56, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %71, i32 1, ptr @11, ptr @8)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %then8
-  %74 = call i8* @_lfortran_get_default_allocator()
-  %75 = call i8* @_lfortran_malloc_alloc(i8* %74, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %75, i8 0, i32 8, i1 false)
-  %76 = bitcast i8* %75 to %complex_4*
-  store %complex_4* %76, %complex_4** %c, align 8
+  %72 = call ptr @_lfortran_get_default_allocator()
+  %73 = call ptr @_lfortran_malloc_alloc(ptr %72, i64 8)
+  call void @llvm.memset.p0.i32(ptr %73, i8 0, i32 8, i1 false)
+  store ptr %73, ptr %c, align 8
   br label %ifcont12
 
 else11:                                           ; preds = %ifcont7
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %ifcont10
-  %77 = load %complex_4*, %complex_4** %c, align 8
-  store %complex_4 <{ float 1.000000e+00, float 2.000000e+00 }>, %complex_4* %77, align 1
-  %78 = load i32*, i32** %l, align 8
-  %79 = icmp eq i32* %78, null
-  br i1 %79, label %then13, label %else16
+  %74 = load ptr, ptr %c, align 8
+  store %complex_4 <{ float 1.000000e+00, float 2.000000e+00 }>, ptr %74, align 1
+  %75 = load ptr, ptr %l, align 8
+  %76 = icmp eq ptr %75, null
+  br i1 %76, label %then13, label %else16
 
 then13:                                           ; preds = %ifcont12
-  %80 = load i32*, i32** %l, align 8
-  %81 = ptrtoint i32* %80 to i64
-  %82 = icmp ne i64 %81, 0
-  br i1 %82, label %then14, label %ifcont15
+  %77 = load ptr, ptr %l, align 8
+  %78 = ptrtoint ptr %77 to i64
+  %79 = icmp ne i64 %78, 0
+  br i1 %79, label %then14, label %ifcont15
 
 then14:                                           ; preds = %then13
-  %83 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %84 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %85 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %84, i32 0, i32 0
-  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %85, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @13, i32 0, i32 0), i8** %86, align 8
-  %87 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %85, i32 0, i32 1
-  store i32 12, i32* %87, align 4
-  %88 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %85, i32 0, i32 2
-  store i32 5, i32* %88, align 4
-  %89 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %85, i32 0, i32 3
-  store i32 12, i32* %89, align 4
-  %90 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %85, i32 0, i32 4
-  store i32 5, i32* %90, align 4
-  %91 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @14, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
-  %92 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %83, i32 0, i32 0
-  %93 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %84, i32 0, i32 0
-  %94 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %92, i32 0, i32 2
-  %95 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %92, i32 0, i32 0
-  store i1 true, i1* %95, align 1
-  %96 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %92, i32 0, i32 1
-  store i8* %91, i8** %96, align 8
-  store { i8*, i32, i32, i32, i32 }* %93, { i8*, i32, i32, i32, i32 }** %94, align 8
-  %97 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %92, i32 0, i32 3
-  store i32 1, i32* %97, align 4
-  %98 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %83, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %98, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  %80 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %81 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %82 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %81, i32 0, i32 0
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 0
+  store ptr @13, ptr %83, align 8
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 1
+  store i32 12, ptr %84, align 4
+  %85 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 2
+  store i32 5, ptr %85, align 4
+  %86 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 3
+  store i32 12, ptr %86, align 4
+  %87 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 4
+  store i32 5, ptr %87, align 4
+  %88 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @14, ptr @12)
+  %89 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %80, i32 0, i32 0
+  %90 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %81, i32 0, i32 0
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 2
+  %92 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 0
+  store i1 true, ptr %92, align 1
+  %93 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 1
+  store ptr %88, ptr %93, align 8
+  store ptr %90, ptr %91, align 8
+  %94 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 3
+  store i32 1, ptr %94, align 4
+  %95 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %80, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %95, i32 1, ptr @15, ptr @12)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %then13
-  %99 = call i8* @_lfortran_get_default_allocator()
-  %100 = call i8* @_lfortran_malloc_alloc(i8* %99, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %100, i8 0, i32 4, i1 false)
-  %101 = bitcast i8* %100 to i32*
-  store i32* %101, i32** %l, align 8
+  %96 = call ptr @_lfortran_get_default_allocator()
+  %97 = call ptr @_lfortran_malloc_alloc(ptr %96, i64 4)
+  call void @llvm.memset.p0.i32(ptr %97, i8 0, i32 4, i1 false)
+  store ptr %97, ptr %l, align 8
   br label %ifcont17
 
 else16:                                           ; preds = %ifcont12
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %ifcont15
-  %102 = load i32*, i32** %l, align 8
-  store i32 1, i32* %102, align 4
-  %103 = load i32*, i32** %i, align 8
-  %104 = ptrtoint i32* %103 to i64
-  %105 = icmp eq i64 %104, 0
-  br i1 %105, label %then18, label %ifcont19
+  %98 = load ptr, ptr %l, align 8
+  store i32 1, ptr %98, align 4
+  %99 = load ptr, ptr %i, align 8
+  %100 = ptrtoint ptr %99 to i64
+  %101 = icmp eq i64 %100, 0
+  br i1 %101, label %then18, label %ifcont19
 
 then18:                                           ; preds = %ifcont17
-  %106 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %107 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %108 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %107, i32 0, i32 0
-  %109 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @17, i32 0, i32 0), i8** %109, align 8
-  %110 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 1
-  store i32 4, i32* %110, align 4
-  %111 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 2
-  store i32 29, i32* %111, align 4
-  %112 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 3
-  store i32 4, i32* %112, align 4
-  %113 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %108, i32 0, i32 4
-  store i32 29, i32* %113, align 4
-  %114 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %115 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %106, i32 0, i32 0
-  %116 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %107, i32 0, i32 0
-  %117 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 2
-  %118 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 0
-  store i1 true, i1* %118, align 1
-  %119 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 1
-  store i8* %114, i8** %119, align 8
-  store { i8*, i32, i32, i32, i32 }* %116, { i8*, i32, i32, i32, i32 }** %117, align 8
-  %120 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %115, i32 0, i32 3
-  store i32 1, i32* %120, align 4
-  %121 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %106, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 1, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  %102 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %103 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %104 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %103, i32 0, i32 0
+  %105 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 0
+  store ptr @17, ptr %105, align 8
+  %106 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 1
+  store i32 4, ptr %106, align 4
+  %107 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 2
+  store i32 29, ptr %107, align 4
+  %108 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 3
+  store i32 4, ptr %108, align 4
+  %109 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 4
+  store i32 29, ptr %109, align 4
+  %110 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @18)
+  %111 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %102, i32 0, i32 0
+  %112 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %103, i32 0, i32 0
+  %113 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 2
+  %114 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 0
+  store i1 true, ptr %114, align 1
+  %115 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 1
+  store ptr %110, ptr %115, align 8
+  store ptr %112, ptr %113, align 8
+  %116 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 3
+  store i32 1, ptr %116, align 4
+  %117 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %102, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %117, i32 1, ptr @19, ptr @16)
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %ifcont17
-  %122 = load i32*, i32** %i, align 8
-  %123 = load i32, i32* %122, align 4
-  %124 = icmp ne i32 %123, 10
-  br i1 %124, label %then20, label %else21
+  %118 = load ptr, ptr %i, align 8
+  %119 = load i32, ptr %118, align 4
+  %120 = icmp ne i32 %119, 10
+  br i1 %120, label %then20, label %else21
 
 then20:                                           ; preds = %ifcont19
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont22
@@ -325,49 +322,49 @@ else21:                                           ; preds = %ifcont19
   br label %ifcont22
 
 ifcont22:                                         ; preds = %else21, %then20
-  %125 = load float*, float** %r, align 8
-  %126 = ptrtoint float* %125 to i64
-  %127 = icmp eq i64 %126, 0
-  br i1 %127, label %then23, label %ifcont24
+  %121 = load ptr, ptr %r, align 8
+  %122 = ptrtoint ptr %121 to i64
+  %123 = icmp eq i64 %122, 0
+  br i1 %123, label %then23, label %ifcont24
 
 then23:                                           ; preds = %ifcont22
-  %128 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %129 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %130 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %129, i32 0, i32 0
-  %131 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @23, i32 0, i32 0), i8** %131, align 8
-  %132 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 1
-  store i32 5, i32* %132, align 4
-  %133 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 2
-  store i32 26, i32* %133, align 4
-  %134 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 3
-  store i32 5, i32* %134, align 4
-  %135 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %130, i32 0, i32 4
-  store i32 26, i32* %135, align 4
-  %136 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @24, i32 0, i32 0))
-  %137 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %128, i32 0, i32 0
-  %138 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %129, i32 0, i32 0
-  %139 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 2
-  %140 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 0
-  store i1 true, i1* %140, align 1
-  %141 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 1
-  store i8* %136, i8** %141, align 8
-  store { i8*, i32, i32, i32, i32 }* %138, { i8*, i32, i32, i32, i32 }** %139, align 8
-  %142 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %137, i32 0, i32 3
-  store i32 1, i32* %142, align 4
-  %143 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %128, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %143, i32 1, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  %124 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %125 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %126 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %125, i32 0, i32 0
+  %127 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 0
+  store ptr @23, ptr %127, align 8
+  %128 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 1
+  store i32 5, ptr %128, align 4
+  %129 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 2
+  store i32 26, ptr %129, align 4
+  %130 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 3
+  store i32 5, ptr %130, align 4
+  %131 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %126, i32 0, i32 4
+  store i32 26, ptr %131, align 4
+  %132 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @24)
+  %133 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %124, i32 0, i32 0
+  %134 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %125, i32 0, i32 0
+  %135 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 2
+  %136 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 0
+  store i1 true, ptr %136, align 1
+  %137 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 1
+  store ptr %132, ptr %137, align 8
+  store ptr %134, ptr %135, align 8
+  %138 = getelementptr { i1, ptr, ptr, i32 }, ptr %133, i32 0, i32 3
+  store i32 1, ptr %138, align 4
+  %139 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %124, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %139, i32 1, ptr @25, ptr @22)
   call void @exit(i32 1)
   unreachable
 
 ifcont24:                                         ; preds = %ifcont22
-  %144 = load float*, float** %r, align 8
-  %145 = load float, float* %144, align 4
-  %146 = fcmp une float %145, 0x40119999A0000000
-  br i1 %146, label %then25, label %else26
+  %140 = load ptr, ptr %r, align 8
+  %141 = load float, ptr %140, align 4
+  %142 = fcmp une float %141, 0x40119999A0000000
+  br i1 %142, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @27, ptr @"ERROR STOP", ptr @26)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -376,53 +373,53 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %147 = load %complex_4*, %complex_4** %c, align 8
-  %148 = ptrtoint %complex_4* %147 to i64
-  %149 = icmp eq i64 %148, 0
-  br i1 %149, label %then28, label %ifcont29
+  %143 = load ptr, ptr %c, align 8
+  %144 = ptrtoint ptr %143 to i64
+  %145 = icmp eq i64 %144, 0
+  br i1 %145, label %then28, label %ifcont29
 
 then28:                                           ; preds = %ifcont27
-  %150 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %151 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %152 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %151, i32 0, i32 0
-  %153 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %152, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @29, i32 0, i32 0), i8** %153, align 8
-  %154 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %152, i32 0, i32 1
-  store i32 6, i32* %154, align 4
-  %155 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %152, i32 0, i32 2
-  store i32 29, i32* %155, align 4
-  %156 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %152, i32 0, i32 3
-  store i32 6, i32* %156, align 4
-  %157 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %152, i32 0, i32 4
-  store i32 29, i32* %157, align 4
-  %158 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @30, i32 0, i32 0))
-  %159 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %150, i32 0, i32 0
-  %160 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %151, i32 0, i32 0
-  %161 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %159, i32 0, i32 2
-  %162 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %159, i32 0, i32 0
-  store i1 true, i1* %162, align 1
-  %163 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %159, i32 0, i32 1
-  store i8* %158, i8** %163, align 8
-  store { i8*, i32, i32, i32, i32 }* %160, { i8*, i32, i32, i32, i32 }** %161, align 8
-  %164 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %159, i32 0, i32 3
-  store i32 1, i32* %164, align 4
-  %165 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %150, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %165, i32 1, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  %146 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %147 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %148 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %147, i32 0, i32 0
+  %149 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %148, i32 0, i32 0
+  store ptr @29, ptr %149, align 8
+  %150 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %148, i32 0, i32 1
+  store i32 6, ptr %150, align 4
+  %151 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %148, i32 0, i32 2
+  store i32 29, ptr %151, align 4
+  %152 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %148, i32 0, i32 3
+  store i32 6, ptr %152, align 4
+  %153 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %148, i32 0, i32 4
+  store i32 29, ptr %153, align 4
+  %154 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @30)
+  %155 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %146, i32 0, i32 0
+  %156 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %147, i32 0, i32 0
+  %157 = getelementptr { i1, ptr, ptr, i32 }, ptr %155, i32 0, i32 2
+  %158 = getelementptr { i1, ptr, ptr, i32 }, ptr %155, i32 0, i32 0
+  store i1 true, ptr %158, align 1
+  %159 = getelementptr { i1, ptr, ptr, i32 }, ptr %155, i32 0, i32 1
+  store ptr %154, ptr %159, align 8
+  store ptr %156, ptr %157, align 8
+  %160 = getelementptr { i1, ptr, ptr, i32 }, ptr %155, i32 0, i32 3
+  store i32 1, ptr %160, align 4
+  %161 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %146, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %161, i32 1, ptr @31, ptr @28)
   call void @exit(i32 1)
   unreachable
 
 ifcont29:                                         ; preds = %ifcont27
-  %166 = load %complex_4*, %complex_4** %c, align 8
-  %167 = load %complex_4, %complex_4* %166, align 1
-  %168 = extractvalue %complex_4 %167, 0
-  %169 = extractvalue %complex_4 %167, 1
-  %170 = fcmp one float %168, 1.000000e+00
-  %171 = fcmp one float %169, 2.000000e+00
-  %172 = or i1 %170, %171
-  br i1 %172, label %then30, label %else31
+  %162 = load ptr, ptr %c, align 8
+  %163 = load %complex_4, ptr %162, align 1
+  %164 = extractvalue %complex_4 %163, 0
+  %165 = extractvalue %complex_4 %163, 1
+  %166 = fcmp one float %164, 1.000000e+00
+  %167 = fcmp one float %165, 2.000000e+00
+  %168 = or i1 %166, %167
+  br i1 %168, label %then30, label %else31
 
 then30:                                           ; preds = %ifcont29
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @33, ptr @"ERROR STOP", ptr @32)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont32
@@ -431,50 +428,50 @@ else31:                                           ; preds = %ifcont29
   br label %ifcont32
 
 ifcont32:                                         ; preds = %else31, %then30
-  %173 = load i32*, i32** %l, align 8
-  %174 = ptrtoint i32* %173 to i64
-  %175 = icmp eq i64 %174, 0
-  br i1 %175, label %then33, label %ifcont34
+  %169 = load ptr, ptr %l, align 8
+  %170 = ptrtoint ptr %169 to i64
+  %171 = icmp eq i64 %170, 0
+  br i1 %171, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  %176 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %177 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %178 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
-  %179 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 0
-  store i8* getelementptr inbounds ([55 x i8], [55 x i8]* @35, i32 0, i32 0), i8** %179, align 8
-  %180 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 1
-  store i32 7, i32* %180, align 4
-  %181 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 2
-  store i32 29, i32* %181, align 4
-  %182 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 3
-  store i32 7, i32* %182, align 4
-  %183 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %178, i32 0, i32 4
-  store i32 29, i32* %183, align 4
-  %184 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @36, i32 0, i32 0))
-  %185 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
-  %186 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %177, i32 0, i32 0
-  %187 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 2
-  %188 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 0
-  store i1 true, i1* %188, align 1
-  %189 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 1
-  store i8* %184, i8** %189, align 8
-  store { i8*, i32, i32, i32, i32 }* %186, { i8*, i32, i32, i32, i32 }** %187, align 8
-  %190 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %185, i32 0, i32 3
-  store i32 1, i32* %190, align 4
-  %191 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %176, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %191, i32 1, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  %172 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %173 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %174 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %173, i32 0, i32 0
+  %175 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %174, i32 0, i32 0
+  store ptr @35, ptr %175, align 8
+  %176 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %174, i32 0, i32 1
+  store i32 7, ptr %176, align 4
+  %177 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %174, i32 0, i32 2
+  store i32 29, ptr %177, align 4
+  %178 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %174, i32 0, i32 3
+  store i32 7, ptr %178, align 4
+  %179 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %174, i32 0, i32 4
+  store i32 29, ptr %179, align 4
+  %180 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @36)
+  %181 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %172, i32 0, i32 0
+  %182 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %173, i32 0, i32 0
+  %183 = getelementptr { i1, ptr, ptr, i32 }, ptr %181, i32 0, i32 2
+  %184 = getelementptr { i1, ptr, ptr, i32 }, ptr %181, i32 0, i32 0
+  store i1 true, ptr %184, align 1
+  %185 = getelementptr { i1, ptr, ptr, i32 }, ptr %181, i32 0, i32 1
+  store ptr %180, ptr %185, align 8
+  store ptr %182, ptr %183, align 8
+  %186 = getelementptr { i1, ptr, ptr, i32 }, ptr %181, i32 0, i32 3
+  store i32 1, ptr %186, align 4
+  %187 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %172, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %187, i32 1, ptr @37, ptr @34)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %192 = load i32*, i32** %l, align 8
-  %193 = load i32, i32* %192, align 4
-  %194 = xor i32 %193, 1
-  %195 = icmp ne i32 %194, 0
-  br i1 %195, label %then35, label %else36
+  %188 = load ptr, ptr %l, align 8
+  %189 = load i32, ptr %188, align 4
+  %190 = xor i32 %189, 1
+  %191 = icmp ne i32 %190, 0
+  br i1 %191, label %then35, label %else36
 
 then35:                                           ; preds = %ifcont34
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @39, ptr @"ERROR STOP", ptr @38)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont37
@@ -483,72 +480,68 @@ else36:                                           ; preds = %ifcont34
   br label %ifcont37
 
 ifcont37:                                         ; preds = %else36, %then35
-  %196 = load i32*, i32** %i, align 8
-  %197 = ptrtoint i32* %196 to i64
-  %198 = icmp ne i64 %197, 0
-  br i1 %198, label %then38, label %else39
+  %192 = load ptr, ptr %i, align 8
+  %193 = ptrtoint ptr %192 to i64
+  %194 = icmp ne i64 %193, 0
+  br i1 %194, label %then38, label %else39
 
 then38:                                           ; preds = %ifcont37
-  %199 = alloca i8*, align 8
-  %200 = bitcast i32* %196 to i8*
-  store i8* %200, i8** %199, align 8
-  %201 = load i8*, i8** %199, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %201)
-  store i32* null, i32** %i, align 8
+  %195 = alloca ptr, align 8
+  store ptr %192, ptr %195, align 8
+  %196 = load ptr, ptr %195, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %196)
+  store ptr null, ptr %i, align 8
   br label %ifcont40
 
 else39:                                           ; preds = %ifcont37
   br label %ifcont40
 
 ifcont40:                                         ; preds = %else39, %then38
-  %202 = load float*, float** %r, align 8
-  %203 = ptrtoint float* %202 to i64
-  %204 = icmp ne i64 %203, 0
-  br i1 %204, label %then41, label %else42
+  %197 = load ptr, ptr %r, align 8
+  %198 = ptrtoint ptr %197 to i64
+  %199 = icmp ne i64 %198, 0
+  br i1 %199, label %then41, label %else42
 
 then41:                                           ; preds = %ifcont40
-  %205 = alloca i8*, align 8
-  %206 = bitcast float* %202 to i8*
-  store i8* %206, i8** %205, align 8
-  %207 = load i8*, i8** %205, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %207)
-  store float* null, float** %r, align 8
+  %200 = alloca ptr, align 8
+  store ptr %197, ptr %200, align 8
+  %201 = load ptr, ptr %200, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %201)
+  store ptr null, ptr %r, align 8
   br label %ifcont43
 
 else42:                                           ; preds = %ifcont40
   br label %ifcont43
 
 ifcont43:                                         ; preds = %else42, %then41
-  %208 = load %complex_4*, %complex_4** %c, align 8
-  %209 = ptrtoint %complex_4* %208 to i64
-  %210 = icmp ne i64 %209, 0
-  br i1 %210, label %then44, label %else45
+  %202 = load ptr, ptr %c, align 8
+  %203 = ptrtoint ptr %202 to i64
+  %204 = icmp ne i64 %203, 0
+  br i1 %204, label %then44, label %else45
 
 then44:                                           ; preds = %ifcont43
-  %211 = alloca i8*, align 8
-  %212 = bitcast %complex_4* %208 to i8*
-  store i8* %212, i8** %211, align 8
-  %213 = load i8*, i8** %211, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %213)
-  store %complex_4* null, %complex_4** %c, align 8
+  %205 = alloca ptr, align 8
+  store ptr %202, ptr %205, align 8
+  %206 = load ptr, ptr %205, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %206)
+  store ptr null, ptr %c, align 8
   br label %ifcont46
 
 else45:                                           ; preds = %ifcont43
   br label %ifcont46
 
 ifcont46:                                         ; preds = %else45, %then44
-  %214 = load i32*, i32** %l, align 8
-  %215 = ptrtoint i32* %214 to i64
-  %216 = icmp ne i64 %215, 0
-  br i1 %216, label %then47, label %else48
+  %207 = load ptr, ptr %l, align 8
+  %208 = ptrtoint ptr %207 to i64
+  %209 = icmp ne i64 %208, 0
+  br i1 %209, label %then47, label %else48
 
 then47:                                           ; preds = %ifcont46
-  %217 = alloca i8*, align 8
-  %218 = bitcast i32* %214 to i8*
-  store i8* %218, i8** %217, align 8
-  %219 = load i8*, i8** %217, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %219)
-  store i32* null, i32** %l, align 8
+  %210 = alloca ptr, align 8
+  store ptr %207, ptr %210, align 8
+  %211 = load ptr, ptr %210, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %211)
+  store ptr null, ptr %l, align 8
   br label %ifcont49
 
 else48:                                           ; preds = %ifcont46
@@ -564,50 +557,46 @@ FINALIZE_SYMTABLE_automatic_allocation_02:        ; preds = %return
   br label %Finalize_Variable_c
 
 Finalize_Variable_c:                              ; preds = %FINALIZE_SYMTABLE_automatic_allocation_02
-  %220 = load %complex_4*, %complex_4** %c, align 8
-  %221 = bitcast %complex_4* %220 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %221)
+  %212 = load ptr, ptr %c, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %212)
   br label %Finalize_Variable_i
 
 Finalize_Variable_i:                              ; preds = %Finalize_Variable_c
-  %222 = load i32*, i32** %i, align 8
-  %223 = bitcast i32* %222 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %223)
+  %213 = load ptr, ptr %i, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %213)
   br label %Finalize_Variable_l
 
 Finalize_Variable_l:                              ; preds = %Finalize_Variable_i
-  %224 = load i32*, i32** %l, align 8
-  %225 = bitcast i32* %224 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %225)
+  %214 = load ptr, ptr %l, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %214)
   br label %Finalize_Variable_r
 
 Finalize_Variable_r:                              ; preds = %Finalize_Variable_l
-  %226 = load float*, float** %r, align 8
-  %227 = bitcast float* %226 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %227)
+  %215 = load ptr, ptr %r, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %215)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "9463fa88fb15879cfe8f677d825e6bd47eea351555b3b01a7e112904",
+    "stdout_hash": "e2a6f48230cc0e23b87690f08512c1f24c5bd59158399f062831575b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_8 = type <{ double, double }>
 %complex_4 = type <{ float, float }>
 
@@ -10,37 +11,37 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [32 x i8] c"{R4,R4},{R8,R8},{R4,R4},{R8,R8}\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %u = alloca %complex_8, align 8
   %v = alloca %complex_8, align 8
   %x = alloca %complex_4, align 8
   %zero = alloca %complex_4, align 8
-  store %complex_4 <{ float 0x3FC24924A0000000, float 0.000000e+00 }>, %complex_4* %zero, align 1
-  store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, %complex_8* %u, align 1
-  store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, %complex_8* %v, align 1
-  store %complex_4 <{ float 0x3FC24924A0000000, float 0.000000e+00 }>, %complex_4* %x, align 1
+  store %complex_4 <{ float 0x3FC24924A0000000, float 0.000000e+00 }>, ptr %zero, align 1
+  store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, ptr %u, align 1
+  store %complex_8 <{ double 0x3FC2492492492492, double 0.000000e+00 }>, ptr %v, align 1
+  store %complex_4 <{ float 0x3FC24924A0000000, float 0.000000e+00 }>, ptr %x, align 1
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([32 x i8], [32 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %zero, %complex_8* %v, %complex_4* %x, %complex_8* %u)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %zero, ptr %v, ptr %x, ptr %u)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -54,14 +55,14 @@ FINALIZE_SYMTABLE_bin_op_complex_dp:              ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "625b88edc6e0fccc466cc14993612bc977bfde820d4030b93fef9795",
+    "stdout_hash": "cb15cbdb13343e2b09c5400b0d2c2e7c08e9f28d86b9ec04b3d0ea0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -1,44 +1,45 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"R4,R8,R4,R8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
   %x = alloca float, align 4
   %zero = alloca float, align 4
-  store float 0x3FC24924A0000000, float* %zero, align 4
-  store double 0x3FC2492492492492, double* %u, align 8
-  store double 0x3FC2492492492492, double* %v, align 8
-  store float 0x3FC24924A0000000, float* %x, align 4
+  store float 0x3FC24924A0000000, ptr %zero, align 4
+  store double 0x3FC2492492492492, ptr %u, align 8
+  store double 0x3FC2492492492492, ptr %v, align 8
+  store float 0x3FC24924A0000000, ptr %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %zero, ptr %v, ptr %x, ptr %u)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -52,14 +53,14 @@ FINALIZE_SYMTABLE_bin_op_real_dp:                 ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bindc1-345b88c.json
+++ b/tests/reference/llvm-bindc1-345b88c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc1-345b88c.stdout",
-    "stdout_hash": "448437a91e56972bb6c3bf99afdc98f8f6696775ee01062d423583b8",
+    "stdout_hash": "00696cdc77c02033876e8f329bf04def33c3d011fbca50fa79ba7f1c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc1-345b88c.stdout
+++ b/tests/reference/llvm-bindc1-345b88c.stdout
@@ -1,16 +1,16 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %p = alloca void*, align 8
-  %x = alloca i32*, align 8
-  store i32* null, i32** %x, align 8
-  %2 = load i32*, i32** %x, align 8
-  %3 = bitcast i32* %2 to void*
-  store void* %3, void** %p, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %p = alloca ptr, align 8
+  %x = alloca ptr, align 8
+  store ptr null, ptr %x, align 8
+  %2 = load ptr, ptr %x, align 8
+  store ptr %2, ptr %p, align 8
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,6 +21,6 @@ FINALIZE_SYMTABLE_bindc1:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "b1921503d30e4aa1baee1b5c9136ac723db34167790af4b84fccd2ca",
+    "stdout_hash": "26301dc07663f7db43b31a7736284d1c343523ea0e52471f91d5cf17",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @bindc3.idx = internal global i32 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -12,89 +13,81 @@ target datalayout = "..."
 @serialization_info.1 = private unnamed_addr constant [6 x i8] c"I8,I8\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
-  %bitcast_cptr_source3 = alloca void*, align 8
-  %bitcast_cptr_source2 = alloca void*, align 8
+  %bitcast_cptr_source3 = alloca ptr, align 8
+  %bitcast_cptr_source2 = alloca ptr, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  %bitcast_cptr_source1 = alloca void*, align 8
-  %bitcast_cptr_source = alloca void*, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %queries = alloca void*, align 8
-  %x = alloca i16*, align 8
-  store i16* null, i16** %x, align 8
+  %2 = call ptr @_lfortran_get_default_allocator()
+  %bitcast_cptr_source1 = alloca ptr, align 8
+  %bitcast_cptr_source = alloca ptr, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %queries = alloca ptr, align 8
+  %x = alloca ptr, align 8
+  store ptr null, ptr %x, align 8
   %y = alloca i16, align 2
-  %3 = load void*, void** %queries, align 8
-  %4 = bitcast void* %3 to i16*
-  store i16* %4, i16** %x, align 8
-  %5 = alloca i64, align 8
-  %6 = load i16*, i16** %x, align 8
-  %7 = bitcast i16* %6 to void*
-  store void* %7, void** %bitcast_cptr_source, align 8
-  %8 = bitcast void** %bitcast_cptr_source to i64*
-  %9 = load i64, i64* %8, align 8
+  %3 = load ptr, ptr %queries, align 8
+  store ptr %3, ptr %x, align 8
+  %4 = alloca i64, align 8
+  %5 = load ptr, ptr %x, align 8
+  store ptr %5, ptr %bitcast_cptr_source, align 8
+  %6 = load i64, ptr %bitcast_cptr_source, align 8
+  %7 = alloca i64, align 8
+  store i64 %6, ptr %7, align 8
+  %8 = load ptr, ptr %queries, align 8
+  store ptr %8, ptr %bitcast_cptr_source1, align 8
+  %9 = load i64, ptr %bitcast_cptr_source1, align 8
   %10 = alloca i64, align 8
-  store i64 %9, i64* %10, align 8
-  %11 = load void*, void** %queries, align 8
-  store void* %11, void** %bitcast_cptr_source1, align 8
-  %12 = bitcast void** %bitcast_cptr_source1 to i64*
-  %13 = load i64, i64* %12, align 8
-  %14 = alloca i64, align 8
-  store i64 %13, i64* %14, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %10, i64* %14)
-  %16 = load i64, i64* %5, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %15, i8** %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %16, i64* %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
-  %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %24 = icmp eq i8* %15, null
-  br i1 %24, label %free_done, label %free_nonnull
+  store i64 %9, ptr %10, align 8
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %7, ptr %10)
+  %12 = load i64, ptr %4, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
+  %19 = trunc i64 %18 to i32
+  call void @_lfortran_printf(ptr @1, ptr %16, i32 %19, ptr @0, i32 1)
+  %20 = icmp eq ptr %11, null
+  br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  call void @_lfortran_free_alloc(ptr %2, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i16* %y, i16** %x, align 8
-  %25 = alloca i64, align 8
-  %26 = load i16*, i16** %x, align 8
-  %27 = bitcast i16* %26 to void*
-  store void* %27, void** %bitcast_cptr_source2, align 8
-  %28 = bitcast void** %bitcast_cptr_source2 to i64*
-  %29 = load i64, i64* %28, align 8
-  %30 = alloca i64, align 8
-  store i64 %29, i64* %30, align 8
-  %31 = bitcast i16* %y to void*
-  store void* %31, void** %bitcast_cptr_source3, align 8
-  %32 = bitcast void** %bitcast_cptr_source3 to i64*
-  %33 = load i64, i64* %32, align 8
-  %34 = alloca i64, align 8
-  store i64 %33, i64* %34, align 8
-  %35 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %25, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %30, i64* %34)
-  %36 = load i64, i64* %25, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %35, i8** %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %36, i64* %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %42 = load i64, i64* %41, align 8
-  %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %44 = icmp eq i8* %35, null
-  br i1 %44, label %free_done6, label %free_nonnull5
+  store ptr %y, ptr %x, align 8
+  %21 = alloca i64, align 8
+  %22 = load ptr, ptr %x, align 8
+  store ptr %22, ptr %bitcast_cptr_source2, align 8
+  %23 = load i64, ptr %bitcast_cptr_source2, align 8
+  %24 = alloca i64, align 8
+  store i64 %23, ptr %24, align 8
+  store ptr %y, ptr %bitcast_cptr_source3, align 8
+  %25 = load i64, ptr %bitcast_cptr_source3, align 8
+  %26 = alloca i64, align 8
+  store i64 %25, ptr %26, align 8
+  %27 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %21, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %24, ptr %26)
+  %28 = load i64, ptr %21, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %27, ptr %29, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %28, ptr %30, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %32 = load ptr, ptr %31, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %34 = load i64, ptr %33, align 8
+  %35 = trunc i64 %34 to i32
+  call void @_lfortran_printf(ptr @3, ptr %32, i32 %35, ptr @2, i32 1)
+  %36 = icmp eq ptr %27, null
+  br i1 %36, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %35)
+  call void @_lfortran_free_alloc(ptr %2, ptr %27)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done
@@ -108,14 +101,14 @@ FINALIZE_SYMTABLE_bindc3:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "f3e3083a1639935d2ac46adc550ed153fa34df4a6741292b3024a999",
+    "stdout_hash": "356a1f86b4b2566b73d8abb2328c4f7d2d170b104de3c18f10531978",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I8\00", align 1
@@ -16,45 +17,45 @@ target datalayout = "..."
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca i64, align 8
   %y = alloca double, align 8
-  store i64 665663010, i64* %x, align 8
-  %3 = load i64, i64* %x, align 8
+  store i64 665663010, ptr %x, align 8
+  %3 = load i64, ptr %x, align 8
   %simplified_pow_operation = mul i64 %3, %3
-  store i64 %simplified_pow_operation, i64* %x, align 8
+  store i64 %simplified_pow_operation, ptr %x, align 8
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %x)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @1, ptr %10, i32 %13, ptr @0, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %15 = load i64, i64* %x, align 8
+  %15 = load i64, ptr %x, align 8
   %16 = icmp ne i64 %15, 443107242882260100
   br i1 %16, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -63,39 +64,39 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  store double 0x41C3D69B11000000, double* %y, align 8
-  %17 = load double, double* %y, align 8
+  store double 0x41C3D69B11000000, ptr %y, align 8
+  %17 = load double, ptr %y, align 8
   %simplified_pow_operation1 = fmul double %17, %17
-  store double %simplified_pow_operation1, double* %y, align 8
+  store double %simplified_pow_operation1, ptr %y, align 8
   %18 = alloca i64, align 8
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, i32 0, i32 0, i32 0, double* %y)
-  %20 = load i64, i64* %18, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  store i8* %19, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  store i64 %20, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  %26 = load i64, i64* %25, align 8
+  %19 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %18, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %y)
+  %20 = load i64, ptr %18, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  store ptr %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  store i64 %20, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  %26 = load i64, ptr %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %28 = icmp eq i8* %19, null
+  call void @_lfortran_printf(ptr @5, ptr %24, i32 %27, ptr @4, i32 1)
+  %28 = icmp eq ptr %19, null
   br i1 %28, label %free_done4, label %free_nonnull3
 
 free_nonnull3:                                    ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %19)
+  call void @_lfortran_free_alloc(ptr %2, ptr %19)
   br label %free_done4
 
 free_done4:                                       ; preds = %free_nonnull3, %ifcont
-  %29 = load double, double* %y, align 8
+  %29 = load double, ptr %y, align 8
   %30 = fsub double %29, 0x439898EEC2459972
   %31 = call double @llvm.fabs.f64(double %30)
   %32 = fcmp ogt double %31, 0x3BFD83C940000000
   br i1 %32, label %then5, label %else6
 
 then5:                                            ; preds = %free_done4
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont7
@@ -114,23 +115,23 @@ FINALIZE_SYMTABLE_binop_03:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare double @llvm.fabs.f64(double) #0
 
-attributes #0 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "0493419a432257b0ee42df53b0d406a7960b36f2306a5e49db58e867",
+    "stdout_hash": "24755beaeba0618670eb8577a6ae580b441f4ffb71274d2b50d85978",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -14,85 +15,85 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [3 x i8] c"I8\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %all_ones = alloca i64, align 8
-  store i64 -1, i64* %all_ones, align 8
+  store i64 -1, ptr %all_ones, align 8
   %all_zeros = alloca i64, align 8
-  store i64 0, i64* %all_zeros, align 8
+  store i64 0, ptr %all_zeros, align 8
   %block_size = alloca i32, align 4
-  store i32 64, i32* %block_size, align 4
+  store i32 64, ptr %block_size, align 4
   %3 = alloca i64, align 8
   %4 = alloca i32, align 4
-  store i32 64, i32* %4, align 4
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4)
-  %6 = load i64, i64* %3, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  store i32 64, ptr %4, align 4
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %4)
+  %6 = load i64, ptr %3, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @1, ptr %10, i32 %13, ptr @0, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %15 = alloca i64, align 8
   %16 = alloca i64, align 8
-  store i64 0, i64* %16, align 8
-  %17 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %15, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %16)
-  %18 = load i64, i64* %15, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %18, i64* %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %24 = load i64, i64* %23, align 8
+  store i64 0, ptr %16, align 8
+  %17 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %15, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %16)
+  %18 = load i64, ptr %15, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %17, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %22 = load ptr, ptr %21, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %24 = load i64, ptr %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
+  call void @_lfortran_printf(ptr @3, ptr %22, i32 %25, ptr @2, i32 1)
+  %26 = icmp eq ptr %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %17)
+  call void @_lfortran_free_alloc(ptr %2, ptr %17)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %27 = alloca i64, align 8
   %28 = alloca i64, align 8
-  store i64 -1, i64* %28, align 8
-  %29 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %27, i32 0, i32 0, i32 0, i32 0, i32 0, i64* %28)
-  %30 = load i64, i64* %27, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %29, i8** %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %30, i64* %32, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %36 = load i64, i64* %35, align 8
+  store i64 -1, ptr %28, align 8
+  %29 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %27, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %28)
+  %30 = load i64, ptr %27, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %30, ptr %32, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %38 = icmp eq i8* %29, null
+  call void @_lfortran_printf(ptr @5, ptr %34, i32 %37, ptr @4, i32 1)
+  %38 = icmp eq ptr %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %29)
+  call void @_lfortran_free_alloc(ptr %2, ptr %29)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -106,14 +107,14 @@ FINALIZE_SYMTABLE_bits_02:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "9e8eab443e96e050b2a4030243f2e595b91aa47fb05dbee5516a6e75",
+    "stdout_hash": "cc7043ab837c923a2e22451147003be8928515d4cca0485d3b15fa73",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -21,30 +22,30 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [18 x i8] c"I4,I4,I4,I4,I4,R4\00", align 1
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %boz_1 = alloca i32, align 4
   %boz_2 = alloca i32, align 4
   %boz_3 = alloca i32, align 4
   %boz_4 = alloca i32, align 4
   %boz_5 = alloca i32, align 4
   %boz_6 = alloca float, align 4
-  store i32 93, i32* %boz_1, align 4
-  store i32 1255, i32* %boz_2, align 4
-  store i32 2748, i32* %boz_3, align 4
-  store i32 180150001, i32* %boz_4, align 4
-  store i32 180150001, i32* %boz_5, align 4
-  store float 0x36DA000000000000, float* %boz_6, align 4
-  %3 = load i32, i32* %boz_4, align 4
-  %4 = load i32, i32* %boz_5, align 4
+  store i32 93, ptr %boz_1, align 4
+  store i32 1255, ptr %boz_2, align 4
+  store i32 2748, ptr %boz_3, align 4
+  store i32 180150001, ptr %boz_4, align 4
+  store i32 180150001, ptr %boz_5, align 4
+  store float 0x36DA000000000000, ptr %boz_6, align 4
+  %3 = load i32, ptr %boz_4, align 4
+  %4 = load i32, ptr %boz_5, align 4
   %5 = icmp ne i32 %3, %4
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -53,12 +54,12 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %6 = load i32, i32* %boz_1, align 4
+  %6 = load i32, ptr %boz_1, align 4
   %7 = icmp ne i32 %6, 93
   br i1 %7, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -67,12 +68,12 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %8 = load i32, i32* %boz_2, align 4
+  %8 = load i32, ptr %boz_2, align 4
   %9 = icmp ne i32 %8, 1255
   br i1 %9, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -81,12 +82,12 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %10 = load i32, i32* %boz_3, align 4
+  %10 = load i32, ptr %boz_3, align 4
   %11 = icmp ne i32 %10, 2748
   br i1 %11, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -95,12 +96,12 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %12 = load i32, i32* %boz_4, align 4
+  %12 = load i32, ptr %boz_4, align 4
   %13 = icmp ne i32 %12, 180150001
   br i1 %13, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -109,12 +110,12 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %14 = load i32, i32* %boz_5, align 4
+  %14 = load i32, ptr %boz_5, align 4
   %15 = icmp ne i32 %14, 180150001
   br i1 %15, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -124,23 +125,23 @@ else14:                                           ; preds = %ifcont12
 
 ifcont15:                                         ; preds = %else14, %then13
   %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([18 x i8], [18 x i8]* @serialization_info, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %boz_1, i32* %boz_2, i32* %boz_3, i32* %boz_4, i32* %boz_5, float* %boz_6)
-  %18 = load i64, i64* %16, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %18, i64* %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %24 = load i64, i64* %23, align 8
+  %17 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %16, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %boz_1, ptr %boz_2, ptr %boz_3, ptr %boz_4, ptr %boz_5, ptr %boz_6)
+  %18 = load i64, ptr %16, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %17, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %22 = load ptr, ptr %21, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %24 = load i64, ptr %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
+  call void @_lfortran_printf(ptr @13, ptr %22, i32 %25, ptr @12, i32 1)
+  %26 = icmp eq ptr %17, null
   br i1 %26, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont15
-  call void @_lfortran_free_alloc(i8* %2, i8* %17)
+  call void @_lfortran_free_alloc(ptr %2, ptr %17)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont15
@@ -154,18 +155,18 @@ FINALIZE_SYMTABLE_boz_01:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "e8650db0dd50f9530a86249aeb840c737cec2bff9f68f89f3bab7bea",
+    "stdout_hash": "91f647056d579ee36b4826e0b16b4e1b1ae3dcab9e879aa7bbb475ff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -1,23 +1,24 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%module_call_subroutine_without_type_01.mytype.3_class = type <{ i32 (...)**, %module_call_subroutine_without_type_01.mytype.3* }>
+%string_descriptor = type <{ ptr, i64 }>
+%module_call_subroutine_without_type_01.mytype.3_class = type <{ ptr, ptr }>
 %module_call_subroutine_without_type_01.mytype.3 = type { float }
-%string_descriptor = type <{ i8*, i64 }>
 
-@__module___lcompilers_created__nested_context__get_i__self = global %module_call_subroutine_without_type_01.mytype.3_class* null
+@__module___lcompilers_created__nested_context__get_i__self = global ptr null
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,R4\00", align 1
 @string_const_data = private constant [4 x i8] c"r = "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_mytype = private unnamed_addr constant [7 x i8] c"mytype\00", align 1
-@_Type_Info_mytype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_mytype, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_mytype = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_mytype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_module_call_subroutine_without_type_01_mytype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly to i8*), i8* bitcast (void (%module_call_subroutine_without_type_01.mytype.3_class*)* @__module_module_call_subroutine_without_type_01_get_i to i8*)] }, align 8
+@_Type_Info_mytype = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_mytype, ptr inttoptr (i64 4 to ptr), ptr null }, align 8
+@_VTable_mytype = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_mytype, ptr @_copy_module_call_subroutine_without_type_01_mytype, ptr @_allocate_struct_module_call_subroutine_without_type_01_mytype, ptr @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly, ptr @__module_module_call_subroutine_without_type_01_get_i] }, align 8
 @4 = private unnamed_addr constant [4 x i8] c"obj\00", align 1
 @5 = private unnamed_addr constant [63 x i8] c"tests/../integration_tests/call_subroutine_without_type_01.f90\00", align 1
 @6 = private unnamed_addr constant [22 x i8] c"'%s' unallocated here\00", align 1
@@ -27,36 +28,33 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @11 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
 
-define void @__module_module_call_subroutine_without_type_01_get_i(%module_call_subroutine_without_type_01.mytype.3_class* %self) {
+define void @__module_module_call_subroutine_without_type_01_get_i(ptr %self) {
 .entry:
-  %0 = icmp eq %module_call_subroutine_without_type_01.mytype.3_class* %self, null
+  %0 = icmp eq ptr %self, null
   br i1 %0, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  store ptr null, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %1 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %2 = icmp eq %module_call_subroutine_without_type_01.mytype.3_class* %1, null
+  %1 = load ptr, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %2 = icmp eq ptr %1, null
   br i1 %2, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 16, i1 false)
-  %5 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype.3_class*
-  store %module_call_subroutine_without_type_01.mytype.3_class* %5, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 16)
+  call void @llvm.memset.p0.i32(ptr %4, i8 0, i32 16, i1 false)
+  store ptr %4, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
   br label %ifcont
 
 else2:                                            ; preds = %else
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
-  %6 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %7 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %6 to i8*
-  %8 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %self to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i32(i8* %7, i8* %8, i32 16, i1 false)
+  %5 = load ptr, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
+  call void @llvm.memcpy.p0.p0.i32(ptr %5, ptr %self, i32 16, i1 false)
   br label %ifcont3
 
 ifcont3:                                          ; preds = %ifcont, %then
@@ -73,45 +71,45 @@ FINALIZE_SYMTABLE_get_i:                          ; preds = %return
 define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %2, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
-  %5 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %4, i32 0, i32 0
-  %6 = load float, float* %5, align 4
+  %2 = load ptr, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %2, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %4, i32 0, i32 0
+  %6 = load float, ptr %5, align 4
   %7 = alloca float, align 4
-  store float %6, float* %7, align 4
-  %8 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %7)
-  %9 = load i64, i64* %1, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %8, i8** %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %9, i64* %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %13 = load i8*, i8** %12, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %15 = load i64, i64* %14, align 8
+  store float %6, ptr %7, align 4
+  %8 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %7)
+  %9 = load i64, ptr %1, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %8, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %9, ptr %11, align 8
+  %12 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %13 = load ptr, ptr %12, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %15 = load i64, ptr %14, align 8
   %16 = trunc i64 %15 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %13, i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %17 = icmp eq i8* %8, null
+  call void @_lfortran_printf(ptr @1, ptr %13, i32 %16, ptr @0, i32 1)
+  %17 = icmp eq ptr %8, null
   br i1 %17, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %8)
+  call void @_lfortran_free_alloc(ptr %0, ptr %8)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %18 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** @__module___lcompilers_created__nested_context__get_i__self, align 8
-  %19 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %18, i32 0, i32 1
-  %20 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %19, align 8
-  %21 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %20, i32 0, i32 0
-  %22 = load float, float* %21, align 4
+  %18 = load ptr, ptr @__module___lcompilers_created__nested_context__get_i__self, align 8
+  %19 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %18, i32 0, i32 1
+  %20 = load ptr, ptr %19, align 8
+  %21 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %20, i32 0, i32 0
+  %22 = load float, ptr %21, align 4
   %23 = fcmp une float %22, 1.000000e+00
   br i1 %23, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -129,132 +127,128 @@ FINALIZE_SYMTABLE_get_r:                          ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i32(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i32, i1 immarg) #1
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i32(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i32, i1 immarg) #1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %obj = alloca %module_call_subroutine_without_type_01.mytype.3_class*, align 8
-  store %module_call_subroutine_without_type_01.mytype.3_class* null, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 16, i1 false)
-  %7 = bitcast i8* %6 to %module_call_subroutine_without_type_01.mytype.3_class*
-  store %module_call_subroutine_without_type_01.mytype.3_class* %7, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %8 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %9 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %8, i32 0, i32 1
-  %10 = bitcast i8* %4 to %module_call_subroutine_without_type_01.mytype.3*
-  store %module_call_subroutine_without_type_01.mytype.3* %10, %module_call_subroutine_without_type_01.mytype.3** %9, align 8
-  %11 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %9, align 8
-  %12 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %7 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %12, align 8
-  %13 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %11, i32 0, i32 0
-  %14 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %15 = ptrtoint %module_call_subroutine_without_type_01.mytype.3_class* %14 to i64
-  %16 = icmp eq i64 %15, 0
-  br i1 %16, label %then, label %ifcont
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %obj = alloca %module_call_subroutine_without_type_01.mytype.3_class, align 8
+  store ptr null, ptr %obj, align 8
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 4)
+  call void @llvm.memset.p0.i32(ptr %4, i8 0, i32 4, i1 false)
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 16)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 16, i1 false)
+  store ptr %6, ptr %obj, align 8
+  %7 = load ptr, ptr %obj, align 8
+  %8 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %7, i32 0, i32 1
+  store ptr %4, ptr %8, align 8
+  %9 = load ptr, ptr %8, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_mytype, i32 0, i32 0, i32 2), ptr %6, align 8
+  %10 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %9, i32 0, i32 0
+  %11 = load ptr, ptr %obj, align 8
+  %12 = ptrtoint ptr %11 to i64
+  %13 = icmp eq i64 %12, 0
+  br i1 %13, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
-  %17 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %18 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %19 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %18, i32 0, i32 0
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 0
-  store i8* getelementptr inbounds ([63 x i8], [63 x i8]* @5, i32 0, i32 0), i8** %20, align 8
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 1
-  store i32 27, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 2
-  store i32 5, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 3
-  store i32 27, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %19, i32 0, i32 4
-  store i32 9, i32* %24, align 4
-  %25 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
-  %26 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %18, i32 0, i32 0
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 2
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 0
-  store i1 true, i1* %29, align 1
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 1
-  store i8* %25, i8** %30, align 8
-  store { i8*, i32, i32, i32, i32 }* %27, { i8*, i32, i32, i32, i32 }** %28, align 8
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 0, i32 3
-  store i32 1, i32* %31, align 4
-  %32 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %17, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @4, i32 0, i32 0))
+  %14 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %15 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %16 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %15, i32 0, i32 0
+  %17 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %16, i32 0, i32 0
+  store ptr @5, ptr %17, align 8
+  %18 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %16, i32 0, i32 1
+  store i32 27, ptr %18, align 4
+  %19 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %16, i32 0, i32 2
+  store i32 5, ptr %19, align 4
+  %20 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %16, i32 0, i32 3
+  store i32 27, ptr %20, align 4
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %16, i32 0, i32 4
+  store i32 9, ptr %21, align 4
+  %22 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6, ptr @4)
+  %23 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %14, i32 0, i32 0
+  %24 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %15, i32 0, i32 0
+  %25 = getelementptr { i1, ptr, ptr, i32 }, ptr %23, i32 0, i32 2
+  %26 = getelementptr { i1, ptr, ptr, i32 }, ptr %23, i32 0, i32 0
+  store i1 true, ptr %26, align 1
+  %27 = getelementptr { i1, ptr, ptr, i32 }, ptr %23, i32 0, i32 1
+  store ptr %22, ptr %27, align 8
+  store ptr %24, ptr %25, align 8
+  %28 = getelementptr { i1, ptr, ptr, i32 }, ptr %23, i32 0, i32 3
+  store i32 1, ptr %28, align 4
+  %29 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %14, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %29, i32 1, ptr @7, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %.entry
-  %33 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %14, i32 0, i32 1
-  %34 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %33, align 8
-  %35 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %34, i32 0, i32 0
-  store float 1.000000e+00, float* %35, align 4
-  %36 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %37 = ptrtoint %module_call_subroutine_without_type_01.mytype.3_class* %36 to i64
-  %38 = icmp eq i64 %37, 0
-  br i1 %38, label %then1, label %ifcont2
+  %30 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %11, i32 0, i32 1
+  %31 = load ptr, ptr %30, align 8
+  %32 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %31, i32 0, i32 0
+  store float 1.000000e+00, ptr %32, align 4
+  %33 = load ptr, ptr %obj, align 8
+  %34 = ptrtoint ptr %33 to i64
+  %35 = icmp eq i64 %34, 0
+  br i1 %35, label %then1, label %ifcont2
 
 then1:                                            ; preds = %ifcont
-  %39 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %40 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %41 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 0
-  store i8* getelementptr inbounds ([63 x i8], [63 x i8]* @9, i32 0, i32 0), i8** %42, align 8
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 1
-  store i32 28, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 2
-  store i32 5, i32* %44, align 4
-  %45 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 3
-  store i32 28, i32* %45, align 4
-  %46 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %41, i32 0, i32 4
-  store i32 20, i32* %46, align 4
-  %47 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @10, i32 0, i32 0))
-  %48 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  %49 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %40, i32 0, i32 0
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 2
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 0
-  store i1 true, i1* %51, align 1
-  %52 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 1
-  store i8* %47, i8** %52, align 8
-  store { i8*, i32, i32, i32, i32 }* %49, { i8*, i32, i32, i32, i32 }** %50, align 8
-  %53 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %48, i32 0, i32 3
-  store i32 1, i32* %53, align 4
-  %54 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %39, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @11, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @8, i32 0, i32 0))
+  %36 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %37 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %38 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 0
+  store ptr @9, ptr %39, align 8
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 1
+  store i32 28, ptr %40, align 4
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 2
+  store i32 5, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 3
+  store i32 28, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 4
+  store i32 20, ptr %43, align 4
+  %44 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10)
+  %45 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  %46 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 2
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 0
+  store i1 true, ptr %48, align 1
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 1
+  store ptr %44, ptr %49, align 8
+  store ptr %46, ptr %47, align 8
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 3
+  store i32 1, ptr %50, align 4
+  %51 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %51, i32 1, ptr @11, i32 1, ptr @8)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %55 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  %56 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %55 to void (%module_call_subroutine_without_type_01.mytype.3_class*)***
-  %57 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)**, void (%module_call_subroutine_without_type_01.mytype.3_class*)*** %56, align 8
-  %58 = getelementptr inbounds void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %57, i32 3
-  %59 = load void (%module_call_subroutine_without_type_01.mytype.3_class*)*, void (%module_call_subroutine_without_type_01.mytype.3_class*)** %58, align 8
-  call void %59(%module_call_subroutine_without_type_01.mytype.3_class* %55)
+  %52 = load ptr, ptr %obj, align 8
+  %53 = load ptr, ptr %52, align 8
+  %54 = getelementptr inbounds ptr, ptr %53, i32 3
+  %55 = load ptr, ptr %54, align 8
+  call void %55(ptr %52)
   br label %return
 
 return:                                           ; preds = %ifcont2
@@ -264,25 +258,23 @@ FINALIZE_SYMTABLE_call_subroutine_without_type_01: ; preds = %return
   br label %Finalize_Variable_obj
 
 Finalize_Variable_obj:                            ; preds = %FINALIZE_SYMTABLE_call_subroutine_without_type_01
-  %60 = load %module_call_subroutine_without_type_01.mytype.3_class*, %module_call_subroutine_without_type_01.mytype.3_class** %obj, align 8
-  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %60)
+  %56 = load ptr, ptr %obj, align 8
+  call void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(ptr %56)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-define linkonce_odr void @_copy_module_call_subroutine_without_type_01_mytype(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_module_call_subroutine_without_type_01_mytype(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype.3*
-  %3 = bitcast i8* %1 to %module_call_subroutine_without_type_01.mytype.3*
-  %4 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %2, i32 0, i32 0
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %3, i32 0, i32 0
+  %2 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %0, i32 0, i32 0
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -292,60 +284,54 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_module_call_subroutine_without_type_01_mytype(i8** %0) {
+define linkonce_odr void @_allocate_struct_module_call_subroutine_without_type_01_mytype(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %module_call_subroutine_without_type_01.mytype.3_class*
-  %5 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_mytype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %module_call_subroutine_without_type_01.mytype.3*
-  store %module_call_subroutine_without_type_01.mytype.3* %9, %module_call_subroutine_without_type_01.mytype.3** %6, align 8
-  %10 = getelementptr %module_call_subroutine_without_type_01.mytype.3, %module_call_subroutine_without_type_01.mytype.3* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_mytype, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %module_call_subroutine_without_type_01.mytype.3, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__mytype_3_of_module_call_subroutine_without_type_01_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %module_call_subroutine_without_type_01.mytype.3*
   ret void
 }
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
-define internal void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %module_call_subroutine_without_type_01.mytype.3_class* %0, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = icmp ne ptr %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0)
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype.3*, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
-  %5 = icmp ne %module_call_subroutine_without_type_01.mytype.3* %4, null
+  call void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(ptr %0)
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %module_call_subroutine_without_type_01.mytype.3* %4 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %module_call_subroutine_without_type_01.mytype.3_class* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %7)
+  call void @_lfortran_free_alloc(ptr %1, ptr %0)
   br label %is_allocated.ifcont3
 
 is_allocated.else2:                               ; preds = %entry
@@ -355,25 +341,23 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(%module_call_subroutine_without_type_01.mytype.3_class* %0) {
+define internal void @finalize_StructType_Class__mytype_3_of_module_call_subroutine_without_type_01(ptr %0) {
 entry:
-  %1 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 0
-  %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, %module_call_subroutine_without_type_01.mytype.3_class* %0, i32 0, i32 1
-  %4 = load %module_call_subroutine_without_type_01.mytype.3**, %module_call_subroutine_without_type_01.mytype.3** %3, align 8
-  %5 = bitcast %module_call_subroutine_without_type_01.mytype.3** %4 to i8*
-  %6 = icmp ne i32 (...)** %2, null
-  br i1 %6, label %is_allocated.then, label %is_allocated.else2
+  %1 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %0, i32 0, i32 0
+  %2 = load ptr, ptr %1, align 8
+  %3 = getelementptr %module_call_subroutine_without_type_01.mytype.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %2, null
+  br i1 %5, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  %7 = getelementptr inbounds i32 (...)*, i32 (...)** %2, i32 2
-  %8 = load i8*, i32 (...)** %7, align 8
-  %9 = bitcast i8* %8 to void (i8*)*
-  %10 = icmp ne i8* %5, null
-  br i1 %10, label %is_allocated.then1, label %is_allocated.else
+  %6 = getelementptr inbounds ptr, ptr %2, i32 2
+  %7 = load ptr, ptr %6, align 8
+  %8 = icmp ne ptr %4, null
+  br i1 %8, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  call void %9(i8* %5)
+  call void %7(ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then
@@ -389,5 +373,5 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
-attributes #1 = { argmemonly nounwind willreturn }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "f313ecad99265bb798aeff16da0f56728d812c9781680fe5db4db752",
+    "stdout_hash": "ca32bf021e2cebb9c88d89aa0b6260243cb3819dd0f0e8b486f81232",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -1,61 +1,62 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_callback_01_cb(float (float*)* %f, float* %a, float* %b) {
+define float @__module_callback_01_cb(ptr %f, ptr %a, ptr %b) {
 .entry:
   %cb = alloca float, align 4
-  %0 = load float, float* %b, align 4
-  %1 = load float, float* %a, align 4
+  %0 = load float, ptr %b, align 4
+  %1 = load float, ptr %a, align 4
   %2 = fsub float %0, %1
-  %3 = call float %f(float* %a)
+  %3 = call float %f(ptr %a)
   %4 = fadd float %2, %3
-  %5 = call float %f(float* %b)
+  %5 = call float %f(ptr %b)
   %6 = fadd float %4, %5
-  store float %6, float* %cb, align 4
+  store float %6, ptr %cb, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_cb
 
 FINALIZE_SYMTABLE_cb:                             ; preds = %return
-  %7 = load float, float* %cb, align 4
+  %7 = load float, ptr %cb, align 4
   ret float %7
 }
 
-declare float @f(float*)
+declare float @f(ptr)
 
-define void @__module_callback_01_foo(float* %c, float* %d) {
+define void @__module_callback_01_foo(ptr %c, ptr %d) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call float @__module_callback_01_cb(float (float*)* @foo.__module_callback_01_f, float* %c, float* %d)
+  %2 = call float @__module_callback_01_cb(ptr @foo.__module_callback_01_f, ptr %c, ptr %d)
   %3 = alloca float, align 4
-  store float %2, float* %3, align 4
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, float* %3)
-  %5 = load i64, i64* %1, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  store float %2, ptr %3, align 4
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %3)
+  %5 = load i64, ptr %1, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %4)
+  call void @_lfortran_free_alloc(ptr %0, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -68,38 +69,38 @@ FINALIZE_SYMTABLE_foo:                            ; preds = %return
   ret void
 }
 
-define float @foo.__module_callback_01_f(float* %x) {
+define float @foo.__module_callback_01_f(ptr %x) {
 .entry:
   %f = alloca float, align 4
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = fmul float 2.000000e+00, %0
-  store float %1, float* %f, align 4
+  store float %1, ptr %f, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %2 = load float, float* %f, align 4
+  %2 = load float, ptr %f, align 4
   ret float %2
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 1.500000e+00, float* %call_arg_value, align 4
-  store float 2.000000e+00, float* %call_arg_value1, align 4
-  call void @__module_callback_01_foo(float* %call_arg_value, float* %call_arg_value1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store float 1.500000e+00, ptr %call_arg_value, align 4
+  store float 2.000000e+00, ptr %call_arg_value1, align 4
+  call void @__module_callback_01_foo(ptr %call_arg_value, ptr %call_arg_value1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -110,6 +111,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "0c801165daab85dfb27beaf23cf5ec7f5d3f78c06b310cab4d40d0fc",
+    "stdout_hash": "10f6d1ca731b0463c7695420aa46ea6c70a4693e011b286f062b23e0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -15,80 +16,80 @@ target datalayout = "..."
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @main.res = internal global float 0.000000e+00
 
-define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (float*, float*)* %f) {
+define void @__module_callback_02_cb(ptr %res, ptr %a, ptr %b, ptr %f) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
-  call void %f(float* %a, float* %res)
+  %0 = call ptr @_lfortran_get_default_allocator()
+  call void %f(ptr %a, ptr %res)
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, float* %res)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %res)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void %f(float* %b, float* %res)
+  call void %f(ptr %b, ptr %res)
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* %res)
-  %14 = load i64, i64* %12, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %14, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
+  %13 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %12, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %res)
+  %14 = load i64, ptr %12, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %18 = load ptr, ptr %17, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, ptr %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
+  call void @_lfortran_printf(ptr @3, ptr %18, i32 %21, ptr @2, i32 1)
+  %22 = icmp eq ptr %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %13)
+  call void @_lfortran_free_alloc(ptr %0, ptr %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %23 = load float, float* %b, align 4
-  %24 = load float, float* %a, align 4
+  %23 = load float, ptr %b, align 4
+  %24 = load float, ptr %a, align 4
   %25 = fsub float %23, %24
-  %26 = load float, float* %res, align 4
+  %26 = load float, ptr %res, align 4
   %27 = fmul float %25, %26
-  store float %27, float* %res, align 4
+  store float %27, ptr %res, align 4
   %28 = alloca i64, align 8
-  %29 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %28, i32 0, i32 0, i32 0, i32 0, i32 0, float* %res)
-  %30 = load i64, i64* %28, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %29, i8** %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %30, i64* %32, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %36 = load i64, i64* %35, align 8
+  %29 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.2, ptr %28, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %res)
+  %30 = load i64, ptr %28, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %30, ptr %32, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %38 = icmp eq i8* %29, null
+  call void @_lfortran_printf(ptr @5, ptr %34, i32 %37, ptr @4, i32 1)
+  %38 = icmp eq ptr %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %0, i8* %29)
+  call void @_lfortran_free_alloc(ptr %0, ptr %29)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -101,29 +102,29 @@ FINALIZE_SYMTABLE_cb:                             ; preds = %return
   ret void
 }
 
-declare void @f(float*, float*)
+declare void @f(ptr, ptr)
 
-define float @__module_callback_02_foo(float* %c, float* %d, float* %res) {
+define float @__module_callback_02_foo(ptr %c, ptr %d, ptr %res) {
 .entry:
   %foo = alloca float, align 4
-  call void @__module_callback_02_cb(float* %res, float* %c, float* %d, void (float*, float*)* @foo.__module_callback_02_f)
-  %0 = load float, float* %res, align 4
-  store float %0, float* %foo, align 4
+  call void @__module_callback_02_cb(ptr %res, ptr %c, ptr %d, ptr @foo.__module_callback_02_f)
+  %0 = load float, ptr %res, align 4
+  store float %0, ptr %foo, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_foo
 
 FINALIZE_SYMTABLE_foo:                            ; preds = %return
-  %1 = load float, float* %foo, align 4
+  %1 = load float, ptr %foo, align 4
   ret float %1
 }
 
-define void @foo.__module_callback_02_f(float* %x, float* %res) {
+define void @foo.__module_callback_02_f(ptr %x, ptr %res) {
 .entry:
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = fmul float 2.000000e+00, %0
-  store float %1, float* %res, align 4
+  store float %1, ptr %res, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -133,23 +134,23 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 1.500000e+00, float* %call_arg_value, align 4
-  store float 2.000000e+00, float* %call_arg_value1, align 4
-  %2 = call float @__module_callback_02_foo(float* %call_arg_value, float* %call_arg_value1, float* @main.res)
-  store float %2, float* @main.res, align 4
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store float 1.500000e+00, ptr %call_arg_value, align 4
+  store float 2.000000e+00, ptr %call_arg_value1, align 4
+  %2 = call float @__module_callback_02_foo(ptr %call_arg_value, ptr %call_arg_value1, ptr @main.res)
+  store float %2, ptr @main.res, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -160,6 +161,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "7d301935924f6c0036ca38da126606bdcfeb8bfee9e7fc9154d2071d",
+    "stdout_hash": "efaf402bed01ca8849c3142d6bc46c3d8fcdd3be64822a643942e8b3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -11,54 +12,54 @@ target datalayout = "..."
 @serialization_info.1 = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_callback_03_cb(float (float*)* %f, float* %a, float* %b) {
+define float @__module_callback_03_cb(ptr %f, ptr %a, ptr %b) {
 .entry:
   %cb = alloca float, align 4
-  %0 = load float, float* %b, align 4
-  %1 = load float, float* %a, align 4
+  %0 = load float, ptr %b, align 4
+  %1 = load float, ptr %a, align 4
   %2 = fsub float %0, %1
-  %3 = call float %f(float* %a)
+  %3 = call float %f(ptr %a)
   %4 = fadd float %2, %3
-  %5 = call float %f(float* %b)
+  %5 = call float %f(ptr %b)
   %6 = fadd float %4, %5
-  store float %6, float* %cb, align 4
+  store float %6, ptr %cb, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_cb
 
 FINALIZE_SYMTABLE_cb:                             ; preds = %return
-  %7 = load float, float* %cb, align 4
+  %7 = load float, ptr %cb, align 4
   ret float %7
 }
 
-declare float @f(float*)
+declare float @f(ptr)
 
-define void @__module_callback_03_foo1(float* %c, float* %d) {
+define void @__module_callback_03_foo1(ptr %c, ptr %d) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call float @__module_callback_03_cb(float (float*)* @foo1.__module_callback_03_f, float* %c, float* %d)
+  %2 = call float @__module_callback_03_cb(ptr @foo1.__module_callback_03_f, ptr %c, ptr %d)
   %3 = alloca float, align 4
-  store float %2, float* %3, align 4
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, float* %3)
-  %5 = load i64, i64* %1, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  store float %2, ptr %3, align 4
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %3)
+  %5 = load i64, ptr %1, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %4)
+  call void @_lfortran_free_alloc(ptr %0, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -71,47 +72,47 @@ FINALIZE_SYMTABLE_foo1:                           ; preds = %return
   ret void
 }
 
-define float @foo1.__module_callback_03_f(float* %x) {
+define float @foo1.__module_callback_03_f(ptr %x) {
 .entry:
   %f = alloca float, align 4
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = fmul float 2.000000e+00, %0
-  store float %1, float* %f, align 4
+  store float %1, ptr %f, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %2 = load float, float* %f, align 4
+  %2 = load float, ptr %f, align 4
   ret float %2
 }
 
-define void @__module_callback_03_foo2(float* %c, float* %d) {
+define void @__module_callback_03_foo2(ptr %c, ptr %d) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call float @__module_callback_03_cb(float (float*)* @foo2.__module_callback_03_f, float* %c, float* %d)
+  %2 = call float @__module_callback_03_cb(ptr @foo2.__module_callback_03_f, ptr %c, ptr %d)
   %3 = alloca float, align 4
-  store float %2, float* %3, align 4
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, float* %3)
-  %5 = load i64, i64* %1, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  store float %2, ptr %3, align 4
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %3)
+  %5 = load i64, ptr %1, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @3, ptr %9, i32 %12, ptr @2, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %4)
+  call void @_lfortran_free_alloc(ptr %0, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -124,41 +125,41 @@ FINALIZE_SYMTABLE_foo2:                           ; preds = %return
   ret void
 }
 
-define float @foo2.__module_callback_03_f(float* %x) {
+define float @foo2.__module_callback_03_f(ptr %x) {
 .entry:
   %f = alloca float, align 4
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = fmul float -2.000000e+00, %0
-  store float %1, float* %f, align 4
+  store float %1, ptr %f, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %2 = load float, float* %f, align 4
+  %2 = load float, ptr %f, align 4
   ret float %2
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 1.500000e+00, float* %call_arg_value, align 4
-  store float 2.000000e+00, float* %call_arg_value1, align 4
-  call void @__module_callback_03_foo1(float* %call_arg_value, float* %call_arg_value1)
-  store float 1.500000e+00, float* %call_arg_value, align 4
-  store float 2.000000e+00, float* %call_arg_value1, align 4
-  call void @__module_callback_03_foo2(float* %call_arg_value, float* %call_arg_value1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store float 1.500000e+00, ptr %call_arg_value, align 4
+  store float 2.000000e+00, ptr %call_arg_value1, align 4
+  call void @__module_callback_03_foo1(ptr %call_arg_value, ptr %call_arg_value1)
+  store float 1.500000e+00, ptr %call_arg_value, align 4
+  store float 2.000000e+00, ptr %call_arg_value1, align 4
+  call void @__module_callback_03_foo2(ptr %call_arg_value, ptr %call_arg_value1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -169,6 +170,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_04-0d9515f.json
+++ b/tests/reference/llvm-callback_04-0d9515f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_04-0d9515f.stdout",
-    "stdout_hash": "0b214109a977c8a38d7875c8f1051da6ce31a4c00642c9689baad53e",
+    "stdout_hash": "42ab2b7d3c4dbd77b4e7f1207955b5a6e81cd30589cb942c8be0cdcd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_04-0d9515f.stdout
+++ b/tests/reference/llvm-callback_04-0d9515f.stdout
@@ -1,22 +1,23 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [4 x i8] c"Dr. "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [7 x i8] c"Fortran"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.1, i32 0, i32 0), i64 7 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 7 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @__module_dr_fortran_cb_print_dr() {
 .entry:
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %0, i32 4, ptr @0, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,7 +27,7 @@ FINALIZE_SYMTABLE_print_dr:                       ; preds = %return
   ret void
 }
 
-define void @__module_dr_fortran_cb_print_dr_fortran(void ()* %title_or_name) {
+define void @__module_dr_fortran_cb_print_dr_fortran(ptr %title_or_name) {
 .entry:
   call void %title_or_name()
   br label %return
@@ -42,8 +43,8 @@ declare void @title_or_name()
 
 define void @__module_dr_fortran_cb_print_fortran() {
 .entry:
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %0 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %0, i32 7, ptr @2, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -53,13 +54,13 @@ FINALIZE_SYMTABLE_print_fortran:                  ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_dr)
-  call void @__module_dr_fortran_cb_print_dr_fortran(void ()* @__module_dr_fortran_cb_print_fortran)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  call void @__module_dr_fortran_cb_print_dr_fortran(ptr @__module_dr_fortran_cb_print_dr)
+  call void @__module_dr_fortran_cb_print_dr_fortran(ptr @__module_dr_fortran_cb_print_fortran)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -70,6 +71,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "6901359fc4953c3e632e54a96cacf3729526f6438020af2eaa4e5057",
+    "stdout_hash": "a01aadf8ce6a2fdce879ff38a47b6025656b48cb724d4ea43380b9eb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -1,17 +1,18 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @main.x = internal global i32 5
 
-define void @__module_callback_05_px_call1(i32* %x) {
+define void @__module_callback_05_px_call1(ptr %x) {
 .entry:
-  call void @__module_callback_05_px_call2(void (i32*)* @px_call1.__module_callback_05_printx, i32* %x)
+  call void @__module_callback_05_px_call2(ptr @px_call1.__module_callback_05_printx, ptr %x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,28 +22,28 @@ FINALIZE_SYMTABLE_px_call1:                       ; preds = %return
   ret void
 }
 
-define void @px_call1.__module_callback_05_printx(i32* %x) {
+define void @px_call1.__module_callback_05_printx(ptr %x) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %x)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -55,9 +56,9 @@ FINALIZE_SYMTABLE_printx:                         ; preds = %return
   ret void
 }
 
-define void @__module_callback_05_px_call2(void (i32*)* %f, i32* %x) {
+define void @__module_callback_05_px_call2(ptr %f, ptr %x) {
 .entry:
-  call void @__module_callback_05_px_call3(void (i32*)* %f, i32* %x)
+  call void @__module_callback_05_px_call3(ptr %f, ptr %x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -67,11 +68,11 @@ FINALIZE_SYMTABLE_px_call2:                       ; preds = %return
   ret void
 }
 
-declare void @f(i32*)
+declare void @f(ptr)
 
-define void @__module_callback_05_px_call3(void (i32*)* %f, i32* %x) {
+define void @__module_callback_05_px_call3(ptr %f, ptr %x) {
 .entry:
-  call void %f(i32* %x)
+  call void %f(ptr %x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -81,20 +82,20 @@ FINALIZE_SYMTABLE_px_call3:                       ; preds = %return
   ret void
 }
 
-declare void @f.1(i32*)
+declare void @f.1(ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @__module_callback_05_px_call1(i32* @main.x)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  call void @__module_callback_05_px_call1(ptr @main.x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -105,6 +106,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "611707f103a6b5fa9c7976c067bf0ea70c20155407837ad317b428e0",
+    "stdout_hash": "52bcf18ff28923658de7e6487806d8dfe1fb09c402933405b3ffdea3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -1,86 +1,87 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [1 x i8] c"1"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data, i32 0, i32 0), i64 1 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 1 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [1 x i8] c"2"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.1, i32 0, i32 0), i64 1 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 1 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [1 x i8] c"3"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.3, i32 0, i32 0), i64 1 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 1 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [1 x i8] c"4"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.5, i32 0, i32 0), i64 1 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 1 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [1 x i8] c"1"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.7, i32 0, i32 0), i64 1 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 1 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.9 = private constant [5 x i8] c"2,3,4"
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.9, i32 0, i32 0), i64 5 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 5 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i64, align 8
   %out = alloca i64, align 8
-  store i64 4, i64* %i, align 8
-  %2 = load i64, i64* %i, align 8
+  store i64 4, ptr %i, align 8
+  %2 = load i64, ptr %i, align 8
   %3 = icmp eq i64 %2, 1
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i64 10, i64* %out, align 8
-  %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  store i64 10, ptr %out, align 8
+  %4 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %4, i32 1, ptr @0, i32 1)
   br label %ifcont9
 
 else:                                             ; preds = %.entry
-  %5 = load i64, i64* %i, align 8
+  %5 = load i64, ptr %i, align 8
   %6 = icmp eq i64 %5, 2
   br i1 %6, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  store i64 20, i64* %out, align 8
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  store i64 20, ptr %out, align 8
+  %7 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %7, i32 1, ptr @2, i32 1)
   br label %ifcont8
 
 else2:                                            ; preds = %else
-  %8 = load i64, i64* %i, align 8
+  %8 = load i64, ptr %i, align 8
   %9 = icmp eq i64 %8, 3
   br i1 %9, label %then3, label %else4
 
 then3:                                            ; preds = %else2
-  store i64 30, i64* %out, align 8
-  %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  store i64 30, ptr %out, align 8
+  %10 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %10, i32 1, ptr @4, i32 1)
   br label %ifcont7
 
 else4:                                            ; preds = %else2
-  %11 = load i64, i64* %i, align 8
+  %11 = load i64, ptr %i, align 8
   %12 = icmp eq i64 %11, 4
   br i1 %12, label %then5, label %else6
 
 then5:                                            ; preds = %else4
-  store i64 40, i64* %out, align 8
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  store i64 40, ptr %out, align 8
+  %13 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @7, ptr %13, i32 1, ptr @6, i32 1)
   br label %ifcont
 
 else6:                                            ; preds = %else4
@@ -96,12 +97,12 @@ ifcont8:                                          ; preds = %ifcont7, %then1
   br label %ifcont9
 
 ifcont9:                                          ; preds = %ifcont8, %then
-  %14 = load i64, i64* %out, align 8
+  %14 = load i64, ptr %out, align 8
   %15 = icmp ne i64 %14, 40
   br i1 %15, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -110,31 +111,31 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %16 = load i64, i64* %i, align 8
+  %16 = load i64, ptr %i, align 8
   %17 = icmp eq i64 %16, 1
   br i1 %17, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  store i64 11, i64* %out, align 8
-  %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %18, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  store i64 11, ptr %out, align 8
+  %18 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @11, ptr %18, i32 1, ptr @10, i32 1)
   br label %ifcont18
 
 else14:                                           ; preds = %ifcont12
-  %19 = load i64, i64* %i, align 8
+  %19 = load i64, ptr %i, align 8
   %20 = icmp eq i64 %19, 2
-  %21 = load i64, i64* %i, align 8
+  %21 = load i64, ptr %i, align 8
   %22 = icmp eq i64 %21, 3
   %23 = or i1 %20, %22
-  %24 = load i64, i64* %i, align 8
+  %24 = load i64, ptr %i, align 8
   %25 = icmp eq i64 %24, 4
   %26 = or i1 %23, %25
   br i1 %26, label %then15, label %else16
 
 then15:                                           ; preds = %else14
-  store i64 22, i64* %out, align 8
-  %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %27, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  store i64 22, ptr %out, align 8
+  %27 = load ptr, ptr @string_const.10, align 8
+  call void @_lfortran_printf(ptr @13, ptr %27, i32 5, ptr @12, i32 1)
   br label %ifcont17
 
 else16:                                           ; preds = %else14
@@ -144,12 +145,12 @@ ifcont17:                                         ; preds = %else16, %then15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %ifcont17, %then13
-  %28 = load i64, i64* %out, align 8
+  %28 = load i64, ptr %out, align 8
   %29 = icmp ne i64 %28, 22
   br i1 %29, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -168,11 +169,11 @@ FINALIZE_SYMTABLE_case_01:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "aadaa25a27aa91b452cc8e12e3b5e58d09276a1b849ce815db2e16e2",
+    "stdout_hash": "a6c40c636647d1ad92e88a24500a713e21346aeffb68f154253713c7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -1,206 +1,207 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [10 x i8] c"Excellent!"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data, i32 0, i32 0), i64 10 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 10 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [10 x i8] c"Very good!"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.1, i32 0, i32 0), i64 10 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 10 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [10 x i8] c"Well done!"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.3, i32 0, i32 0), i64 10 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 10 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [8 x i8] c"Not bad!"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.5, i32 0, i32 0), i64 8 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 8 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [11 x i8] c"You passed!"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data.7, i32 0, i32 0), i64 11 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 11 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.9 = private constant [17 x i8] c"Better try again!"
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.9, i32 0, i32 0), i64 17 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 17 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.11 = private constant [13 x i8] c"Invalid marks"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.11, i32 0, i32 0), i64 13 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 13 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
 @string_const_data.13 = private constant [15 x i8] c"Your marks are "
-@string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.13, i32 0, i32 0), i64 15 }>
+@string_const.14 = private global %string_descriptor <{ ptr @string_const_data.13, i64 15 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @18 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.15 = private constant [10 x i8] c"Excellent!"
-@string_const.16 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.15, i32 0, i32 0), i64 10 }>
+@string_const.16 = private global %string_descriptor <{ ptr @string_const_data.15, i64 10 }>
 @19 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @20 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.17 = private constant [10 x i8] c"Very good!"
-@string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.17, i32 0, i32 0), i64 10 }>
+@string_const.18 = private global %string_descriptor <{ ptr @string_const_data.17, i64 10 }>
 @21 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @22 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.19 = private constant [10 x i8] c"Well done!"
-@string_const.20 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.19, i32 0, i32 0), i64 10 }>
+@string_const.20 = private global %string_descriptor <{ ptr @string_const_data.19, i64 10 }>
 @23 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @24 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.21 = private constant [8 x i8] c"Not bad!"
-@string_const.22 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.21, i32 0, i32 0), i64 8 }>
+@string_const.22 = private global %string_descriptor <{ ptr @string_const_data.21, i64 8 }>
 @25 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @26 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.23 = private constant [11 x i8] c"You passed!"
-@string_const.24 = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data.23, i32 0, i32 0), i64 11 }>
+@string_const.24 = private global %string_descriptor <{ ptr @string_const_data.23, i64 11 }>
 @27 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @28 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.25 = private constant [17 x i8] c"Better try again!"
-@string_const.26 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.25, i32 0, i32 0), i64 17 }>
+@string_const.26 = private global %string_descriptor <{ ptr @string_const_data.25, i64 17 }>
 @29 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @30 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.27 = private constant [13 x i8] c"Invalid marks"
-@string_const.28 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.27, i32 0, i32 0), i64 13 }>
+@string_const.28 = private global %string_descriptor <{ ptr @string_const_data.27, i64 13 }>
 @31 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @32 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.29 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
 @string_const_data.30 = private constant [15 x i8] c"Your marks are "
-@string_const.31 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.30, i32 0, i32 0), i64 15 }>
+@string_const.31 = private global %string_descriptor <{ ptr @string_const_data.30, i64 15 }>
 @33 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @34 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.32 = private constant [10 x i8] c"Excellent!"
-@string_const.33 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.32, i32 0, i32 0), i64 10 }>
+@string_const.33 = private global %string_descriptor <{ ptr @string_const_data.32, i64 10 }>
 @35 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @36 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.34 = private constant [10 x i8] c"Very good!"
-@string_const.35 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.34, i32 0, i32 0), i64 10 }>
+@string_const.35 = private global %string_descriptor <{ ptr @string_const_data.34, i64 10 }>
 @37 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @38 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.36 = private constant [10 x i8] c"Well done!"
-@string_const.37 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.36, i32 0, i32 0), i64 10 }>
+@string_const.37 = private global %string_descriptor <{ ptr @string_const_data.36, i64 10 }>
 @39 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @40 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.38 = private constant [8 x i8] c"Not bad!"
-@string_const.39 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.38, i32 0, i32 0), i64 8 }>
+@string_const.39 = private global %string_descriptor <{ ptr @string_const_data.38, i64 8 }>
 @41 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @42 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.40 = private constant [11 x i8] c"You passed!"
-@string_const.41 = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data.40, i32 0, i32 0), i64 11 }>
+@string_const.41 = private global %string_descriptor <{ ptr @string_const_data.40, i64 11 }>
 @43 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @44 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.42 = private constant [17 x i8] c"Better try again!"
-@string_const.43 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.42, i32 0, i32 0), i64 17 }>
+@string_const.43 = private global %string_descriptor <{ ptr @string_const_data.42, i64 17 }>
 @45 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @46 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.44 = private constant [13 x i8] c"Invalid marks"
-@string_const.45 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.44, i32 0, i32 0), i64 13 }>
+@string_const.45 = private global %string_descriptor <{ ptr @string_const_data.44, i64 13 }>
 @47 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @48 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.46 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
 @string_const_data.47 = private constant [15 x i8] c"Your marks are "
-@string_const.48 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.47, i32 0, i32 0), i64 15 }>
+@string_const.48 = private global %string_descriptor <{ ptr @string_const_data.47, i64 15 }>
 @49 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc58 = alloca %string_descriptor, align 8
   %stringFormat_desc37 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %marks = alloca i32, align 4
   %out = alloca i32, align 4
-  store i32 81, i32* %marks, align 4
-  %3 = load i32, i32* %marks, align 4
+  store i32 81, ptr %marks, align 4
+  %3 = load i32, ptr %marks, align 4
   %4 = icmp sle i32 91, %3
-  %5 = load i32, i32* %marks, align 4
+  %5 = load i32, ptr %marks, align 4
   %6 = icmp sle i32 %5, 100
   %7 = and i1 %4, %6
   br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 0, i32* %out, align 4
-  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  store i32 0, ptr %out, align 4
+  %8 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 10, ptr @0, i32 1)
   br label %ifcont15
 
 else:                                             ; preds = %.entry
-  %9 = load i32, i32* %marks, align 4
+  %9 = load i32, ptr %marks, align 4
   %10 = icmp sle i32 81, %9
-  %11 = load i32, i32* %marks, align 4
+  %11 = load i32, ptr %marks, align 4
   %12 = icmp sle i32 %11, 90
   %13 = and i1 %10, %12
   br i1 %13, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  store i32 1, i32* %out, align 4
-  %14 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %14, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  store i32 1, ptr %out, align 4
+  %14 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %14, i32 10, ptr @2, i32 1)
   br label %ifcont14
 
 else2:                                            ; preds = %else
-  %15 = load i32, i32* %marks, align 4
+  %15 = load i32, ptr %marks, align 4
   %16 = icmp sle i32 71, %15
-  %17 = load i32, i32* %marks, align 4
+  %17 = load i32, ptr %marks, align 4
   %18 = icmp sle i32 %17, 80
   %19 = and i1 %16, %18
   br i1 %19, label %then3, label %else4
 
 then3:                                            ; preds = %else2
-  store i32 2, i32* %out, align 4
-  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %20, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  store i32 2, ptr %out, align 4
+  %20 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %20, i32 10, ptr @4, i32 1)
   br label %ifcont13
 
 else4:                                            ; preds = %else2
-  %21 = load i32, i32* %marks, align 4
+  %21 = load i32, ptr %marks, align 4
   %22 = icmp sle i32 61, %21
-  %23 = load i32, i32* %marks, align 4
+  %23 = load i32, ptr %marks, align 4
   %24 = icmp sle i32 %23, 70
   %25 = and i1 %22, %24
   br i1 %25, label %then5, label %else6
 
 then5:                                            ; preds = %else4
-  store i32 3, i32* %out, align 4
-  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %26, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  store i32 3, ptr %out, align 4
+  %26 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @7, ptr %26, i32 8, ptr @6, i32 1)
   br label %ifcont12
 
 else6:                                            ; preds = %else4
-  %27 = load i32, i32* %marks, align 4
+  %27 = load i32, ptr %marks, align 4
   %28 = icmp sle i32 41, %27
-  %29 = load i32, i32* %marks, align 4
+  %29 = load i32, ptr %marks, align 4
   %30 = icmp sle i32 %29, 60
   %31 = and i1 %28, %30
   br i1 %31, label %then7, label %else8
 
 then7:                                            ; preds = %else6
-  store i32 4, i32* %out, align 4
-  %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %32, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  store i32 4, ptr %out, align 4
+  %32 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @9, ptr %32, i32 11, ptr @8, i32 1)
   br label %ifcont11
 
 else8:                                            ; preds = %else6
-  %33 = load i32, i32* %marks, align 4
+  %33 = load i32, ptr %marks, align 4
   %34 = icmp sle i32 %33, 40
   br i1 %34, label %then9, label %else10
 
 then9:                                            ; preds = %else8
-  store i32 5, i32* %out, align 4
-  %35 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %35, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  store i32 5, ptr %out, align 4
+  %35 = load ptr, ptr @string_const.10, align 8
+  call void @_lfortran_printf(ptr @11, ptr %35, i32 17, ptr @10, i32 1)
   br label %ifcont
 
 else10:                                           ; preds = %else8
-  store i32 6, i32* %out, align 4
-  %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %36, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  store i32 6, ptr %out, align 4
+  %36 = load ptr, ptr @string_const.12, align 8
+  call void @_lfortran_printf(ptr @13, ptr %36, i32 13, ptr @12, i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else10, %then9
@@ -220,32 +221,32 @@ ifcont14:                                         ; preds = %ifcont13, %then1
 
 ifcont15:                                         ; preds = %ifcont14, %then
   %37 = alloca i64, align 8
-  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %37, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
-  %39 = load i64, i64* %37, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %38, i8** %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %39, i64* %41, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %43 = load i8*, i8** %42, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %45 = load i64, i64* %44, align 8
+  %38 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %37, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.14, ptr %marks)
+  %39 = load i64, ptr %37, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %39, ptr %41, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %43 = load ptr, ptr %42, align 8
+  %44 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %45 = load i64, ptr %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %47 = icmp eq i8* %38, null
+  call void @_lfortran_printf(ptr @15, ptr %43, i32 %46, ptr @14, i32 1)
+  %47 = icmp eq ptr %38, null
   br i1 %47, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont15
-  call void @_lfortran_free_alloc(i8* %2, i8* %38)
+  call void @_lfortran_free_alloc(ptr %2, ptr %38)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont15
-  %48 = load i32, i32* %out, align 4
+  %48 = load i32, ptr %out, align 4
   %49 = icmp ne i32 %48, 1
   br i1 %49, label %then16, label %else17
 
 then16:                                           ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -254,83 +255,83 @@ else17:                                           ; preds = %free_done
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %50 = load i32, i32* %marks, align 4
+  %50 = load i32, ptr %marks, align 4
   %51 = icmp sle i32 91, %50
-  %52 = load i32, i32* %marks, align 4
+  %52 = load i32, ptr %marks, align 4
   %53 = icmp sle i32 %52, 100
   %54 = and i1 %51, %53
   br i1 %54, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  %55 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %55, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  %55 = load ptr, ptr @string_const.16, align 8
+  call void @_lfortran_printf(ptr @19, ptr %55, i32 10, ptr @18, i32 1)
   br label %ifcont36
 
 else20:                                           ; preds = %ifcont18
-  %56 = load i32, i32* %marks, align 4
+  %56 = load i32, ptr %marks, align 4
   %57 = icmp sle i32 81, %56
-  %58 = load i32, i32* %marks, align 4
+  %58 = load i32, ptr %marks, align 4
   %59 = icmp sle i32 %58, 90
   %60 = and i1 %57, %59
   br i1 %60, label %then21, label %else22
 
 then21:                                           ; preds = %else20
-  %61 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %61, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  %61 = load ptr, ptr @string_const.18, align 8
+  call void @_lfortran_printf(ptr @21, ptr %61, i32 10, ptr @20, i32 1)
   br label %ifcont35
 
 else22:                                           ; preds = %else20
-  %62 = load i32, i32* %marks, align 4
+  %62 = load i32, ptr %marks, align 4
   %63 = icmp sle i32 71, %62
-  %64 = load i32, i32* %marks, align 4
+  %64 = load i32, ptr %marks, align 4
   %65 = icmp sle i32 %64, 80
   %66 = and i1 %63, %65
   br i1 %66, label %then23, label %else24
 
 then23:                                           ; preds = %else22
-  %67 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %67, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  %67 = load ptr, ptr @string_const.20, align 8
+  call void @_lfortran_printf(ptr @23, ptr %67, i32 10, ptr @22, i32 1)
   br label %ifcont34
 
 else24:                                           ; preds = %else22
-  %68 = load i32, i32* %marks, align 4
+  %68 = load i32, ptr %marks, align 4
   %69 = icmp sle i32 61, %68
-  %70 = load i32, i32* %marks, align 4
+  %70 = load i32, ptr %marks, align 4
   %71 = icmp sle i32 %70, 70
   %72 = and i1 %69, %71
   br i1 %72, label %then25, label %else26
 
 then25:                                           ; preds = %else24
-  %73 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %73, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  %73 = load ptr, ptr @string_const.22, align 8
+  call void @_lfortran_printf(ptr @25, ptr %73, i32 8, ptr @24, i32 1)
   br label %ifcont33
 
 else26:                                           ; preds = %else24
-  %74 = load i32, i32* %marks, align 4
+  %74 = load i32, ptr %marks, align 4
   %75 = icmp sle i32 41, %74
-  %76 = load i32, i32* %marks, align 4
+  %76 = load i32, ptr %marks, align 4
   %77 = icmp sle i32 %76, 60
   %78 = and i1 %75, %77
   br i1 %78, label %then27, label %else28
 
 then27:                                           ; preds = %else26
-  %79 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %79, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  %79 = load ptr, ptr @string_const.24, align 8
+  call void @_lfortran_printf(ptr @27, ptr %79, i32 11, ptr @26, i32 1)
   br label %ifcont32
 
 else28:                                           ; preds = %else26
-  %80 = load i32, i32* %marks, align 4
+  %80 = load i32, ptr %marks, align 4
   %81 = icmp sle i32 %80, 40
   br i1 %81, label %then29, label %else30
 
 then29:                                           ; preds = %else28
-  %82 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %82, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
+  %82 = load ptr, ptr @string_const.26, align 8
+  call void @_lfortran_printf(ptr @29, ptr %82, i32 17, ptr @28, i32 1)
   br label %ifcont31
 
 else30:                                           ; preds = %else28
-  %83 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %83, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  %83 = load ptr, ptr @string_const.28, align 8
+  call void @_lfortran_printf(ptr @31, ptr %83, i32 13, ptr @30, i32 1)
   br label %ifcont31
 
 ifcont31:                                         ; preds = %else30, %then29
@@ -350,103 +351,103 @@ ifcont35:                                         ; preds = %ifcont34, %then21
 
 ifcont36:                                         ; preds = %ifcont35, %then19
   %84 = alloca i64, align 8
-  %85 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %84, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
-  %86 = load i64, i64* %84, align 8
-  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  store i8* %85, i8** %87, align 8
-  %88 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  store i64 %86, i64* %88, align 8
-  %89 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
-  %90 = load i8*, i8** %89, align 8
-  %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
-  %92 = load i64, i64* %91, align 8
+  %85 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.29, ptr %84, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.31, ptr %marks)
+  %86 = load i64, ptr %84, align 8
+  %87 = getelementptr %string_descriptor, ptr %stringFormat_desc37, i32 0, i32 0
+  store ptr %85, ptr %87, align 8
+  %88 = getelementptr %string_descriptor, ptr %stringFormat_desc37, i32 0, i32 1
+  store i64 %86, ptr %88, align 8
+  %89 = getelementptr %string_descriptor, ptr %stringFormat_desc37, i32 0, i32 0
+  %90 = load ptr, ptr %89, align 8
+  %91 = getelementptr %string_descriptor, ptr %stringFormat_desc37, i32 0, i32 1
+  %92 = load i64, ptr %91, align 8
   %93 = trunc i64 %92 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %90, i32 %93, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
-  %94 = icmp eq i8* %85, null
+  call void @_lfortran_printf(ptr @33, ptr %90, i32 %93, ptr @32, i32 1)
+  %94 = icmp eq ptr %85, null
   br i1 %94, label %free_done39, label %free_nonnull38
 
 free_nonnull38:                                   ; preds = %ifcont36
-  call void @_lfortran_free_alloc(i8* %2, i8* %85)
+  call void @_lfortran_free_alloc(ptr %2, ptr %85)
   br label %free_done39
 
 free_done39:                                      ; preds = %free_nonnull38, %ifcont36
-  %95 = load i32, i32* %marks, align 4
+  %95 = load i32, ptr %marks, align 4
   %96 = icmp sle i32 91, %95
-  %97 = load i32, i32* %marks, align 4
+  %97 = load i32, ptr %marks, align 4
   %98 = icmp sle i32 %97, 100
   %99 = and i1 %96, %98
   br i1 %99, label %then40, label %else41
 
 then40:                                           ; preds = %free_done39
-  %100 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.33, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %100, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  %100 = load ptr, ptr @string_const.33, align 8
+  call void @_lfortran_printf(ptr @35, ptr %100, i32 10, ptr @34, i32 1)
   br label %ifcont57
 
 else41:                                           ; preds = %free_done39
-  %101 = load i32, i32* %marks, align 4
+  %101 = load i32, ptr %marks, align 4
   %102 = icmp sle i32 81, %101
-  %103 = load i32, i32* %marks, align 4
+  %103 = load i32, ptr %marks, align 4
   %104 = icmp sle i32 %103, 90
   %105 = and i1 %102, %104
   br i1 %105, label %then42, label %else43
 
 then42:                                           ; preds = %else41
-  %106 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.35, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %106, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
+  %106 = load ptr, ptr @string_const.35, align 8
+  call void @_lfortran_printf(ptr @37, ptr %106, i32 10, ptr @36, i32 1)
   br label %ifcont56
 
 else43:                                           ; preds = %else41
-  %107 = load i32, i32* %marks, align 4
+  %107 = load i32, ptr %marks, align 4
   %108 = icmp sle i32 71, %107
-  %109 = load i32, i32* %marks, align 4
+  %109 = load i32, ptr %marks, align 4
   %110 = icmp sle i32 %109, 80
   %111 = and i1 %108, %110
   br i1 %111, label %then44, label %else45
 
 then44:                                           ; preds = %else43
-  %112 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.37, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %112, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  %112 = load ptr, ptr @string_const.37, align 8
+  call void @_lfortran_printf(ptr @39, ptr %112, i32 10, ptr @38, i32 1)
   br label %ifcont55
 
 else45:                                           ; preds = %else43
-  %113 = load i32, i32* %marks, align 4
+  %113 = load i32, ptr %marks, align 4
   %114 = icmp sle i32 61, %113
-  %115 = load i32, i32* %marks, align 4
+  %115 = load i32, ptr %marks, align 4
   %116 = icmp sle i32 %115, 70
   %117 = and i1 %114, %116
   br i1 %117, label %then46, label %else47
 
 then46:                                           ; preds = %else45
-  %118 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.39, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %118, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
+  %118 = load ptr, ptr @string_const.39, align 8
+  call void @_lfortran_printf(ptr @41, ptr %118, i32 8, ptr @40, i32 1)
   br label %ifcont54
 
 else47:                                           ; preds = %else45
-  %119 = load i32, i32* %marks, align 4
+  %119 = load i32, ptr %marks, align 4
   %120 = icmp sle i32 41, %119
-  %121 = load i32, i32* %marks, align 4
+  %121 = load i32, ptr %marks, align 4
   %122 = icmp sle i32 %121, 60
   %123 = and i1 %120, %122
   br i1 %123, label %then48, label %else49
 
 then48:                                           ; preds = %else47
-  %124 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.41, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %124, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  %124 = load ptr, ptr @string_const.41, align 8
+  call void @_lfortran_printf(ptr @43, ptr %124, i32 11, ptr @42, i32 1)
   br label %ifcont53
 
 else49:                                           ; preds = %else47
-  %125 = load i32, i32* %marks, align 4
+  %125 = load i32, ptr %marks, align 4
   %126 = icmp sle i32 %125, 40
   br i1 %126, label %then50, label %else51
 
 then50:                                           ; preds = %else49
-  %127 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.43, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %127, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
+  %127 = load ptr, ptr @string_const.43, align 8
+  call void @_lfortran_printf(ptr @45, ptr %127, i32 17, ptr @44, i32 1)
   br label %ifcont52
 
 else51:                                           ; preds = %else49
-  %128 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.45, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %128, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
+  %128 = load ptr, ptr @string_const.45, align 8
+  call void @_lfortran_printf(ptr @47, ptr %128, i32 13, ptr @46, i32 1)
   br label %ifcont52
 
 ifcont52:                                         ; preds = %else51, %then50
@@ -466,23 +467,23 @@ ifcont56:                                         ; preds = %ifcont55, %then42
 
 ifcont57:                                         ; preds = %ifcont56, %then40
   %129 = alloca i64, align 8
-  %130 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %129, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
-  %131 = load i64, i64* %129, align 8
-  %132 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
-  store i8* %130, i8** %132, align 8
-  %133 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1
-  store i64 %131, i64* %133, align 8
-  %134 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
-  %135 = load i8*, i8** %134, align 8
-  %136 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1
-  %137 = load i64, i64* %136, align 8
+  %130 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.46, ptr %129, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.48, ptr %marks)
+  %131 = load i64, ptr %129, align 8
+  %132 = getelementptr %string_descriptor, ptr %stringFormat_desc58, i32 0, i32 0
+  store ptr %130, ptr %132, align 8
+  %133 = getelementptr %string_descriptor, ptr %stringFormat_desc58, i32 0, i32 1
+  store i64 %131, ptr %133, align 8
+  %134 = getelementptr %string_descriptor, ptr %stringFormat_desc58, i32 0, i32 0
+  %135 = load ptr, ptr %134, align 8
+  %136 = getelementptr %string_descriptor, ptr %stringFormat_desc58, i32 0, i32 1
+  %137 = load i64, ptr %136, align 8
   %138 = trunc i64 %137 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %135, i32 %138, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
-  %139 = icmp eq i8* %130, null
+  call void @_lfortran_printf(ptr @49, ptr %135, i32 %138, ptr @48, i32 1)
+  %139 = icmp eq ptr %130, null
   br i1 %139, label %free_done60, label %free_nonnull59
 
 free_nonnull59:                                   ; preds = %ifcont57
-  call void @_lfortran_free_alloc(i8* %2, i8* %130)
+  call void @_lfortran_free_alloc(ptr %2, ptr %130)
   br label %free_done60
 
 free_done60:                                      ; preds = %free_nonnull59, %ifcont57
@@ -496,17 +497,17 @@ FINALIZE_SYMTABLE_case_02:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "7be68fac3906f3700b0f4511e9e251bf898da3384a2450631cd04b51",
+    "stdout_hash": "0242021ad756e86904be4148b80ce0b4844a36802b78e456f1e453b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -1,78 +1,79 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [5 x i8] c"Pass!"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data, i32 0, i32 0), i64 5 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 5 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [7 x i8] c"Failed!"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.1, i32 0, i32 0), i64 7 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 7 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [13 x i8] c"Invalid marks"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.3, i32 0, i32 0), i64 13 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 13 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
 @string_const_data.5 = private constant [15 x i8] c"Your marks are "
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.5, i32 0, i32 0), i64 15 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 15 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [5 x i8] c"Pass!"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.7, i32 0, i32 0), i64 5 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 5 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.9 = private constant [7 x i8] c"Failed!"
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.9, i32 0, i32 0), i64 7 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 7 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.11 = private constant [13 x i8] c"Invalid marks"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.11, i32 0, i32 0), i64 13 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 13 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.13 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
 @string_const_data.14 = private constant [15 x i8] c"Your marks are "
-@string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.14, i32 0, i32 0), i64 15 }>
+@string_const.15 = private global %string_descriptor <{ ptr @string_const_data.14, i64 15 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc10 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
-  store i32 1, i32* %a, align 4
+  store i32 1, ptr %a, align 4
   %b = alloca i32, align 4
-  store i32 2, i32* %b, align 4
+  store i32 2, ptr %b, align 4
   %marks = alloca i32, align 4
-  store i32 94, i32* %marks, align 4
-  %3 = load i32, i32* %marks, align 4
+  store i32 94, ptr %marks, align 4
+  %3 = load i32, ptr %marks, align 4
   %4 = icmp sle i32 42, %3
   br i1 %4, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %5 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %5 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %5, i32 5, ptr @0, i32 1)
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %6 = load i32, i32* %marks, align 4
+  %6 = load i32, ptr %marks, align 4
   %7 = icmp sle i32 %6, 38
   br i1 %7, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %8, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %8 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %8, i32 7, ptr @2, i32 1)
   br label %ifcont
 
 else2:                                            ; preds = %else
-  %9 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %9, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %9 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %9, i32 13, ptr @4, i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
@@ -80,52 +81,52 @@ ifcont:                                           ; preds = %else2, %then1
 
 ifcont3:                                          ; preds = %ifcont, %then
   %10 = alloca i64, align 8
-  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %10, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
-  %12 = load i64, i64* %10, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %11, i8** %13, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %12, i64* %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %16 = load i8*, i8** %15, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %18 = load i64, i64* %17, align 8
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %10, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.6, ptr %marks)
+  %12 = load i64, ptr %10, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %20 = icmp eq i8* %11, null
+  call void @_lfortran_printf(ptr @7, ptr %16, i32 %19, ptr @6, i32 1)
+  %20 = icmp eq ptr %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont3
-  call void @_lfortran_free_alloc(i8* %2, i8* %11)
+  call void @_lfortran_free_alloc(ptr %2, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont3
-  store i32 -1, i32* %marks, align 4
-  %21 = load i32, i32* %marks, align 4
+  store i32 -1, ptr %marks, align 4
+  %21 = load i32, ptr %marks, align 4
   %22 = icmp sle i32 42, %21
   br i1 %22, label %then4, label %else5
 
 then4:                                            ; preds = %free_done
-  %23 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %23, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  %23 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @9, ptr %23, i32 5, ptr @8, i32 1)
   br label %ifcont9
 
 else5:                                            ; preds = %free_done
-  %24 = load i32, i32* %marks, align 4
+  %24 = load i32, ptr %marks, align 4
   %25 = icmp sle i32 0, %24
-  %26 = load i32, i32* %marks, align 4
+  %26 = load i32, ptr %marks, align 4
   %27 = icmp sle i32 %26, 38
   %28 = and i1 %25, %27
   br i1 %28, label %then6, label %else7
 
 then6:                                            ; preds = %else5
-  %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  %29 = load ptr, ptr @string_const.10, align 8
+  call void @_lfortran_printf(ptr @11, ptr %29, i32 7, ptr @10, i32 1)
   br label %ifcont8
 
 else7:                                            ; preds = %else5
-  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %30, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %30 = load ptr, ptr @string_const.12, align 8
+  call void @_lfortran_printf(ptr @13, ptr %30, i32 13, ptr @12, i32 1)
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
@@ -133,23 +134,23 @@ ifcont8:                                          ; preds = %else7, %then6
 
 ifcont9:                                          ; preds = %ifcont8, %then4
   %31 = alloca i64, align 8
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
-  %33 = load i64, i64* %31, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %33, i64* %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %39 = load i64, i64* %38, align 8
+  %32 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.13, ptr %31, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.15, ptr %marks)
+  %33 = load i64, ptr %31, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %32, ptr %34, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %33, ptr %35, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %37 = load ptr, ptr %36, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %39 = load i64, ptr %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
+  call void @_lfortran_printf(ptr @15, ptr %37, i32 %40, ptr @14, i32 1)
+  %41 = icmp eq ptr %32, null
   br i1 %41, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %ifcont9
-  call void @_lfortran_free_alloc(i8* %2, i8* %32)
+  call void @_lfortran_free_alloc(ptr %2, ptr %32)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
@@ -163,14 +164,14 @@ FINALIZE_SYMTABLE_case03:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "b78533f938453da6836df7277c749551768ce05840ff655f9197f4a9",
+    "stdout_hash": "9472aa8040208cf452aec476a14b4f02cae7fba4672845576eeaa4c2",
     "stderr": "llvm-class_01-82031c0.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -1,79 +1,79 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%class_circle1.circle.3_class = type <{ i32 (...)**, %class_circle1.circle.3* }>
+%string_descriptor = type <{ ptr, i64 }>
+%class_circle1.circle.3_class = type <{ ptr, ptr }>
 %class_circle1.circle.3 = type { float }
 
 @__module_class_circle1_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
-@_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle1_for_UPoly to i8*), i8* bitcast (float (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
+@_Type_Info_circle = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_circle, ptr inttoptr (i64 4 to ptr), ptr null }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x ptr] } { [7 x ptr] [ptr null, ptr @_Type_Info_circle, ptr @_copy_class_circle1_circle, ptr @_allocate_struct_class_circle1_circle, ptr @finalize_StructType__circle_3_of_class_circle1_for_UPoly, ptr @__module_class_circle1_circle_area, ptr @__module_class_circle1_circle_print] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 12 }>
 @string_const_data.1 = private constant [8 x i8] c" area = "
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.1, i32 0, i32 0), i64 8 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_class_circle1_circle_area(%class_circle1.circle.3_class* %this) {
+define float @__module_class_circle1_circle_area(ptr %this) {
 .entry:
   %area = alloca float, align 4
-  %0 = load float, float* @__module_class_circle1_pi, align 4
-  %1 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %this, i32 0, i32 1
-  %2 = load %class_circle1.circle.3*, %class_circle1.circle.3** %1, align 8
-  %3 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %2, i32 0, i32 0
-  %4 = load float, float* %3, align 4
+  %0 = load float, ptr @__module_class_circle1_pi, align 4
+  %1 = getelementptr %class_circle1.circle.3_class, ptr %this, i32 0, i32 1
+  %2 = load ptr, ptr %1, align 8
+  %3 = getelementptr %class_circle1.circle.3, ptr %2, i32 0, i32 0
+  %4 = load float, ptr %3, align 4
   %simplified_pow_operation = fmul float %4, %4
   %5 = fmul float %0, %simplified_pow_operation
-  store float %5, float* %area, align 4
+  store float %5, ptr %area, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_circle_area
 
 FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
-  %6 = load float, float* %area, align 4
+  %6 = load float, ptr %area, align 4
   ret float %6
 }
 
-define void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %this) {
+define void @__module_class_circle1_circle_print(ptr %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %area = alloca float, align 4
-  %1 = bitcast %class_circle1.circle.3_class* %this to float (%class_circle1.circle.3_class*)***
-  %2 = load float (%class_circle1.circle.3_class*)**, float (%class_circle1.circle.3_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle1.circle.3_class*)*, float (%class_circle1.circle.3_class*)** %2, i32 3
-  %4 = load float (%class_circle1.circle.3_class*)*, float (%class_circle1.circle.3_class*)** %3, align 8
-  %5 = call float %4(%class_circle1.circle.3_class* %this)
-  store float %5, float* %area, align 4
-  %6 = alloca i64, align 8
-  %7 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %this, i32 0, i32 1
-  %8 = load %class_circle1.circle.3*, %class_circle1.circle.3** %7, align 8
-  %9 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %8, i32 0, i32 0
-  %10 = load float, float* %9, align 4
-  %11 = alloca float, align 4
-  store float %10, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
-  %13 = load i64, i64* %6, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %13, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %19 = load i64, i64* %18, align 8
-  %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
-  br i1 %21, label %free_done, label %free_nonnull
+  %1 = load ptr, ptr %this, align 8
+  %2 = getelementptr inbounds ptr, ptr %1, i32 3
+  %3 = load ptr, ptr %2, align 8
+  %4 = call float %3(ptr %this)
+  store float %4, ptr %area, align 4
+  %5 = alloca i64, align 8
+  %6 = getelementptr %class_circle1.circle.3_class, ptr %this, i32 0, i32 1
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %class_circle1.circle.3, ptr %7, i32 0, i32 0
+  %9 = load float, ptr %8, align 4
+  %10 = alloca float, align 4
+  store float %9, ptr %10, align 4
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %5, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %10, ptr @string_const.2, ptr %area)
+  %12 = load i64, ptr %5, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
+  %19 = trunc i64 %18 to i32
+  call void @_lfortran_printf(ptr @1, ptr %16, i32 %19, ptr @0, i32 1)
+  %20 = icmp eq ptr %11, null
+  br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %12)
+  call void @_lfortran_free_alloc(ptr %0, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -86,17 +86,15 @@ FINALIZE_SYMTABLE_circle_print:                   ; preds = %return
   ret void
 }
 
-define linkonce_odr void @_copy_class_circle1_circle(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_class_circle1_circle(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %class_circle1.circle.3*
-  %3 = bitcast i8* %1 to %class_circle1.circle.3*
-  %4 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %2, i32 0, i32 0
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %3, i32 0, i32 0
+  %2 = getelementptr %class_circle1.circle.3, ptr %0, i32 0, i32 0
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %class_circle1.circle.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -106,66 +104,62 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_class_circle1_circle(i8** %0) {
+define linkonce_odr void @_allocate_struct_class_circle1_circle(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %class_circle1.circle.3_class*
-  %5 = bitcast %class_circle1.circle.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %class_circle1.circle.3*
-  store %class_circle1.circle.3* %9, %class_circle1.circle.3** %6, align 8
-  %10 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %class_circle1.circle.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %class_circle1.circle.3, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__circle_3_of_class_circle1_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__circle_3_of_class_circle1_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %class_circle1.circle.3*
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %2 = alloca %class_circle1.circle.3_class, align 8
   %3 = alloca %class_circle1.circle.3_class, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %c = alloca %class_circle1.circle.3, align 8
-  %4 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
-  %5 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
-  store float 1.500000e+00, float* %5, align 4
-  %6 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %3, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
-  %7 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %3, i32 0, i32 1
-  store %class_circle1.circle.3* %c, %class_circle1.circle.3** %7, align 8
-  call void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %3)
-  %8 = getelementptr %class_circle1.circle.3, %class_circle1.circle.3* %c, i32 0, i32 0
-  store float 2.000000e+00, float* %8, align 4
-  %9 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %9, align 8
-  %10 = getelementptr %class_circle1.circle.3_class, %class_circle1.circle.3_class* %2, i32 0, i32 1
-  store %class_circle1.circle.3* %c, %class_circle1.circle.3** %10, align 8
-  call void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* %2)
+  %4 = getelementptr %class_circle1.circle.3, ptr %c, i32 0, i32 0
+  %5 = getelementptr %class_circle1.circle.3, ptr %c, i32 0, i32 0
+  store float 1.500000e+00, ptr %5, align 4
+  %6 = getelementptr %class_circle1.circle.3_class, ptr %3, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %6, align 8
+  %7 = getelementptr %class_circle1.circle.3_class, ptr %3, i32 0, i32 1
+  store ptr %c, ptr %7, align 8
+  call void @__module_class_circle1_circle_print(ptr %3)
+  %8 = getelementptr %class_circle1.circle.3, ptr %c, i32 0, i32 0
+  store float 2.000000e+00, ptr %8, align 4
+  %9 = getelementptr %class_circle1.circle.3_class, ptr %2, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %9, align 8
+  %10 = getelementptr %class_circle1.circle.3_class, ptr %2, i32 0, i32 1
+  store ptr %c, ptr %10, align 8
+  call void @__module_class_circle1_circle_print(ptr %2)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -176,8 +170,8 @@ FINALIZE_SYMTABLE_circle_test:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "c42a69db27055df0a09471939b6d933a4b90a7820b109c07b8c7a50e",
+    "stdout_hash": "ce1e048fe457fceca4bbed1d5c17b1de6c4cca1557554006ddd5a3d7",
     "stderr": "llvm-class_02-82c2f9c.stderr",
     "stderr_hash": "cbe4c6f9d712b9d5ee417de42e2ce3b69d43ea5a0b463256ad71acfe",
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -1,79 +1,79 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%class_circle2.circle.3_class = type <{ i32 (...)**, %class_circle2.circle.3* }>
+%string_descriptor = type <{ ptr, i64 }>
+%class_circle2.circle.3_class = type <{ ptr, ptr }>
 %class_circle2.circle.3 = type { float }
 
 @__module_class_circle2_pi = global float 0x400921FB60000000
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
-@_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle2_for_UPoly to i8*), i8* bitcast (float (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
+@_Type_Info_circle = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_circle, ptr inttoptr (i64 4 to ptr), ptr null }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [7 x ptr] } { [7 x ptr] [ptr null, ptr @_Type_Info_circle, ptr @_copy_class_circle2_circle, ptr @_allocate_struct_class_circle2_circle, ptr @finalize_StructType__circle_3_of_class_circle2_for_UPoly, ptr @__module_class_circle2_circle_area, ptr @__module_class_circle2_circle_print] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 12 }>
 @string_const_data.1 = private constant [8 x i8] c" area = "
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.1, i32 0, i32 0), i64 8 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_class_circle2_circle_area(%class_circle2.circle.3_class* %this) {
+define float @__module_class_circle2_circle_area(ptr %this) {
 .entry:
   %circle_area = alloca float, align 4
-  %0 = load float, float* @__module_class_circle2_pi, align 4
-  %1 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %this, i32 0, i32 1
-  %2 = load %class_circle2.circle.3*, %class_circle2.circle.3** %1, align 8
-  %3 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %2, i32 0, i32 0
-  %4 = load float, float* %3, align 4
+  %0 = load float, ptr @__module_class_circle2_pi, align 4
+  %1 = getelementptr %class_circle2.circle.3_class, ptr %this, i32 0, i32 1
+  %2 = load ptr, ptr %1, align 8
+  %3 = getelementptr %class_circle2.circle.3, ptr %2, i32 0, i32 0
+  %4 = load float, ptr %3, align 4
   %simplified_pow_operation = fmul float %4, %4
   %5 = fmul float %0, %simplified_pow_operation
-  store float %5, float* %circle_area, align 4
+  store float %5, ptr %circle_area, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_circle_area
 
 FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
-  %6 = load float, float* %circle_area, align 4
+  %6 = load float, ptr %circle_area, align 4
   ret float %6
 }
 
-define void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* %this) {
+define void @__module_class_circle2_circle_print(ptr %this) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %area = alloca float, align 4
-  %1 = bitcast %class_circle2.circle.3_class* %this to float (%class_circle2.circle.3_class*)***
-  %2 = load float (%class_circle2.circle.3_class*)**, float (%class_circle2.circle.3_class*)*** %1, align 8
-  %3 = getelementptr inbounds float (%class_circle2.circle.3_class*)*, float (%class_circle2.circle.3_class*)** %2, i32 3
-  %4 = load float (%class_circle2.circle.3_class*)*, float (%class_circle2.circle.3_class*)** %3, align 8
-  %5 = call float %4(%class_circle2.circle.3_class* %this)
-  store float %5, float* %area, align 4
-  %6 = alloca i64, align 8
-  %7 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %this, i32 0, i32 1
-  %8 = load %class_circle2.circle.3*, %class_circle2.circle.3** %7, align 8
-  %9 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %8, i32 0, i32 0
-  %10 = load float, float* %9, align 4
-  %11 = alloca float, align 4
-  store float %10, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
-  %13 = load i64, i64* %6, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %13, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %19 = load i64, i64* %18, align 8
-  %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
-  br i1 %21, label %free_done, label %free_nonnull
+  %1 = load ptr, ptr %this, align 8
+  %2 = getelementptr inbounds ptr, ptr %1, i32 3
+  %3 = load ptr, ptr %2, align 8
+  %4 = call float %3(ptr %this)
+  store float %4, ptr %area, align 4
+  %5 = alloca i64, align 8
+  %6 = getelementptr %class_circle2.circle.3_class, ptr %this, i32 0, i32 1
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %class_circle2.circle.3, ptr %7, i32 0, i32 0
+  %9 = load float, ptr %8, align 4
+  %10 = alloca float, align 4
+  store float %9, ptr %10, align 4
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %5, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %10, ptr @string_const.2, ptr %area)
+  %12 = load i64, ptr %5, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
+  %19 = trunc i64 %18 to i32
+  call void @_lfortran_printf(ptr @1, ptr %16, i32 %19, ptr @0, i32 1)
+  %20 = icmp eq ptr %11, null
+  br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %12)
+  call void @_lfortran_free_alloc(ptr %0, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -90,16 +90,16 @@ define void @__module_class_circle2__xx_lcompilers_changed_main_xx() {
 .entry:
   %0 = alloca %class_circle2.circle.3_class, align 8
   %c = alloca %class_circle2.circle.3, align 8
-  %1 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
-  %2 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
-  store float 1.000000e+00, float* %2, align 4
-  %3 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %c, i32 0, i32 0
-  store float 1.500000e+00, float* %3, align 4
-  %4 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %0, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
-  %5 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %0, i32 0, i32 1
-  store %class_circle2.circle.3* %c, %class_circle2.circle.3** %5, align 8
-  call void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* %0)
+  %1 = getelementptr %class_circle2.circle.3, ptr %c, i32 0, i32 0
+  %2 = getelementptr %class_circle2.circle.3, ptr %c, i32 0, i32 0
+  store float 1.000000e+00, ptr %2, align 4
+  %3 = getelementptr %class_circle2.circle.3, ptr %c, i32 0, i32 0
+  store float 1.500000e+00, ptr %3, align 4
+  %4 = getelementptr %class_circle2.circle.3_class, ptr %0, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %4, align 8
+  %5 = getelementptr %class_circle2.circle.3_class, ptr %0, i32 0, i32 1
+  store ptr %c, ptr %5, align 8
+  call void @__module_class_circle2_circle_print(ptr %0)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -109,17 +109,15 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret void
 }
 
-define linkonce_odr void @_copy_class_circle2_circle(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_class_circle2_circle(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %class_circle2.circle.3*
-  %3 = bitcast i8* %1 to %class_circle2.circle.3*
-  %4 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %2, i32 0, i32 0
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %3, i32 0, i32 0
+  %2 = getelementptr %class_circle2.circle.3, ptr %0, i32 0, i32 0
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %class_circle2.circle.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -129,48 +127,44 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_class_circle2_circle(i8** %0) {
+define linkonce_odr void @_allocate_struct_class_circle2_circle(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %class_circle2.circle.3_class*
-  %5 = bitcast %class_circle2.circle.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %class_circle2.circle.3_class, %class_circle2.circle.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %class_circle2.circle.3*
-  store %class_circle2.circle.3* %9, %class_circle2.circle.3** %6, align 8
-  %10 = getelementptr %class_circle2.circle.3, %class_circle2.circle.3* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %class_circle2.circle.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %class_circle2.circle.3, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__circle_3_of_class_circle2_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__circle_3_of_class_circle2_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %class_circle2.circle.3*
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @__module_class_circle2__xx_lcompilers_changed_main_xx()
   br label %return
 
@@ -182,8 +176,8 @@ FINALIZE_SYMTABLE_circle_test:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "be71c90d75876f5f3a56a47ce168203150a156c5e6dfda8dfa857107",
+    "stdout_hash": "da15542ae07d2f13660f03c52a96368ec7a86626baecea964901dd0d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %foo_c.8 = type { %foo_b.7, %bar_c.6 }
 %foo_b.7 = type { %foo_a.4, %bar_b.5 }
 %foo_a.4 = type { %bar_a.3 }
@@ -23,140 +24,140 @@ target datalayout = "..."
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %foo = alloca %foo_c.8, align 8
-  %3 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
-  %4 = getelementptr %bar_c.6, %bar_c.6* %3, i32 0, i32 1
-  %5 = getelementptr %bar_c.6, %bar_c.6* %3, i32 0, i32 0
-  %6 = getelementptr %bar_b.5, %bar_b.5* %5, i32 0, i32 1
-  %7 = getelementptr %bar_b.5, %bar_b.5* %5, i32 0, i32 0
-  %8 = getelementptr %bar_a.3, %bar_a.3* %7, i32 0, i32 0
-  %9 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %10 = getelementptr %foo_b.7, %foo_b.7* %9, i32 0, i32 1
-  %11 = getelementptr %bar_b.5, %bar_b.5* %10, i32 0, i32 1
-  %12 = getelementptr %bar_b.5, %bar_b.5* %10, i32 0, i32 0
-  %13 = getelementptr %bar_a.3, %bar_a.3* %12, i32 0, i32 0
-  %14 = getelementptr %foo_b.7, %foo_b.7* %9, i32 0, i32 0
-  %15 = getelementptr %foo_a.4, %foo_a.4* %14, i32 0, i32 0
-  %16 = getelementptr %bar_a.3, %bar_a.3* %15, i32 0, i32 0
-  %17 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %18 = getelementptr %foo_b.7, %foo_b.7* %17, i32 0, i32 0
-  %19 = getelementptr %foo_a.4, %foo_a.4* %18, i32 0, i32 0
-  %20 = getelementptr %bar_a.3, %bar_a.3* %19, i32 0, i32 0
-  store i32 -20, i32* %20, align 4
-  %21 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %22 = getelementptr %foo_b.7, %foo_b.7* %21, i32 0, i32 1
-  %23 = getelementptr %bar_b.5, %bar_b.5* %22, i32 0, i32 1
-  store i32 9, i32* %23, align 4
-  %24 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
-  %25 = getelementptr %bar_c.6, %bar_c.6* %24, i32 0, i32 1
-  store i32 11, i32* %25, align 4
+  %3 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 1
+  %4 = getelementptr %bar_c.6, ptr %3, i32 0, i32 1
+  %5 = getelementptr %bar_c.6, ptr %3, i32 0, i32 0
+  %6 = getelementptr %bar_b.5, ptr %5, i32 0, i32 1
+  %7 = getelementptr %bar_b.5, ptr %5, i32 0, i32 0
+  %8 = getelementptr %bar_a.3, ptr %7, i32 0, i32 0
+  %9 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %10 = getelementptr %foo_b.7, ptr %9, i32 0, i32 1
+  %11 = getelementptr %bar_b.5, ptr %10, i32 0, i32 1
+  %12 = getelementptr %bar_b.5, ptr %10, i32 0, i32 0
+  %13 = getelementptr %bar_a.3, ptr %12, i32 0, i32 0
+  %14 = getelementptr %foo_b.7, ptr %9, i32 0, i32 0
+  %15 = getelementptr %foo_a.4, ptr %14, i32 0, i32 0
+  %16 = getelementptr %bar_a.3, ptr %15, i32 0, i32 0
+  %17 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %18 = getelementptr %foo_b.7, ptr %17, i32 0, i32 0
+  %19 = getelementptr %foo_a.4, ptr %18, i32 0, i32 0
+  %20 = getelementptr %bar_a.3, ptr %19, i32 0, i32 0
+  store i32 -20, ptr %20, align 4
+  %21 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %22 = getelementptr %foo_b.7, ptr %21, i32 0, i32 1
+  %23 = getelementptr %bar_b.5, ptr %22, i32 0, i32 1
+  store i32 9, ptr %23, align 4
+  %24 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 1
+  %25 = getelementptr %bar_c.6, ptr %24, i32 0, i32 1
+  store i32 11, ptr %25, align 4
   %26 = alloca i64, align 8
-  %27 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %28 = getelementptr %foo_b.7, %foo_b.7* %27, i32 0, i32 0
-  %29 = getelementptr %foo_a.4, %foo_a.4* %28, i32 0, i32 0
-  %30 = getelementptr %bar_a.3, %bar_a.3* %29, i32 0, i32 0
-  %31 = load i32, i32* %30, align 4
+  %27 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %28 = getelementptr %foo_b.7, ptr %27, i32 0, i32 0
+  %29 = getelementptr %foo_a.4, ptr %28, i32 0, i32 0
+  %30 = getelementptr %bar_a.3, ptr %29, i32 0, i32 0
+  %31 = load i32, ptr %30, align 4
   %32 = alloca i32, align 4
-  store i32 %31, i32* %32, align 4
-  %33 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %26, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %32)
-  %34 = load i64, i64* %26, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %33, i8** %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %34, i64* %36, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %38 = load i8*, i8** %37, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %40 = load i64, i64* %39, align 8
+  store i32 %31, ptr %32, align 4
+  %33 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %26, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %32)
+  %34 = load i64, ptr %26, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %33, ptr %35, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %34, ptr %36, align 8
+  %37 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %38 = load ptr, ptr %37, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %40 = load i64, ptr %39, align 8
   %41 = trunc i64 %40 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %38, i32 %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %42 = icmp eq i8* %33, null
+  call void @_lfortran_printf(ptr @1, ptr %38, i32 %41, ptr @0, i32 1)
+  %42 = icmp eq ptr %33, null
   br i1 %42, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %33)
+  call void @_lfortran_free_alloc(ptr %2, ptr %33)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %43 = alloca i64, align 8
-  %44 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %45 = getelementptr %foo_b.7, %foo_b.7* %44, i32 0, i32 1
-  %46 = getelementptr %bar_b.5, %bar_b.5* %45, i32 0, i32 1
-  %47 = load i32, i32* %46, align 4
+  %44 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %45 = getelementptr %foo_b.7, ptr %44, i32 0, i32 1
+  %46 = getelementptr %bar_b.5, ptr %45, i32 0, i32 1
+  %47 = load i32, ptr %46, align 4
   %48 = alloca i32, align 4
-  store i32 %47, i32* %48, align 4
-  %49 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %43, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %48)
-  %50 = load i64, i64* %43, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %49, i8** %51, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %50, i64* %52, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %54 = load i8*, i8** %53, align 8
-  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %56 = load i64, i64* %55, align 8
+  store i32 %47, ptr %48, align 4
+  %49 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %43, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %48)
+  %50 = load i64, ptr %43, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %49, ptr %51, align 8
+  %52 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %50, ptr %52, align 8
+  %53 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %54 = load ptr, ptr %53, align 8
+  %55 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %56 = load i64, ptr %55, align 8
   %57 = trunc i64 %56 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %54, i32 %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %58 = icmp eq i8* %49, null
+  call void @_lfortran_printf(ptr @3, ptr %54, i32 %57, ptr @2, i32 1)
+  %58 = icmp eq ptr %49, null
   br i1 %58, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %49)
+  call void @_lfortran_free_alloc(ptr %2, ptr %49)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %59 = alloca i64, align 8
-  %60 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
-  %61 = getelementptr %bar_c.6, %bar_c.6* %60, i32 0, i32 1
-  %62 = load i32, i32* %61, align 4
+  %60 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 1
+  %61 = getelementptr %bar_c.6, ptr %60, i32 0, i32 1
+  %62 = load i32, ptr %61, align 4
   %63 = alloca i32, align 4
-  store i32 %62, i32* %63, align 4
-  %64 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %59, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %63)
-  %65 = load i64, i64* %59, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %64, i8** %66, align 8
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %65, i64* %67, align 8
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %69 = load i8*, i8** %68, align 8
-  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %71 = load i64, i64* %70, align 8
+  store i32 %62, ptr %63, align 4
+  %64 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %59, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %63)
+  %65 = load i64, ptr %59, align 8
+  %66 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %64, ptr %66, align 8
+  %67 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %65, ptr %67, align 8
+  %68 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %69 = load ptr, ptr %68, align 8
+  %70 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %71 = load i64, ptr %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %73 = icmp eq i8* %64, null
+  call void @_lfortran_printf(ptr @5, ptr %69, i32 %72, ptr @4, i32 1)
+  %73 = icmp eq ptr %64, null
   br i1 %73, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %64)
+  call void @_lfortran_free_alloc(ptr %2, ptr %64)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %74 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %75 = getelementptr %foo_b.7, %foo_b.7* %74, i32 0, i32 0
-  %76 = getelementptr %foo_a.4, %foo_a.4* %75, i32 0, i32 0
-  %77 = getelementptr %bar_a.3, %bar_a.3* %76, i32 0, i32 0
-  %78 = load i32, i32* %77, align 4
-  %79 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 0
-  %80 = getelementptr %foo_b.7, %foo_b.7* %79, i32 0, i32 1
-  %81 = getelementptr %bar_b.5, %bar_b.5* %80, i32 0, i32 1
-  %82 = load i32, i32* %81, align 4
+  %74 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %75 = getelementptr %foo_b.7, ptr %74, i32 0, i32 0
+  %76 = getelementptr %foo_a.4, ptr %75, i32 0, i32 0
+  %77 = getelementptr %bar_a.3, ptr %76, i32 0, i32 0
+  %78 = load i32, ptr %77, align 4
+  %79 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 0
+  %80 = getelementptr %foo_b.7, ptr %79, i32 0, i32 1
+  %81 = getelementptr %bar_b.5, ptr %80, i32 0, i32 1
+  %82 = load i32, ptr %81, align 4
   %83 = add i32 %78, %82
-  %84 = getelementptr %foo_c.8, %foo_c.8* %foo, i32 0, i32 1
-  %85 = getelementptr %bar_c.6, %bar_c.6* %84, i32 0, i32 1
-  %86 = load i32, i32* %85, align 4
+  %84 = getelementptr %foo_c.8, ptr %foo, i32 0, i32 1
+  %85 = getelementptr %bar_c.6, ptr %84, i32 0, i32 1
+  %86 = load i32, ptr %85, align 4
   %87 = add i32 %83, %86
   %88 = icmp ne i32 %87, 0
   br i1 %88, label %then, label %else
 
 then:                                             ; preds = %free_done6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -175,17 +176,17 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "54f31b894aca870b9b6a48a3a0625eac546ba6bc0e1cc5352e96859b",
+    "stdout_hash": "a1d7eeb13805c3571651faa2dfcaffee1d48c2fedddd16bed636aea9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -1,14 +1,15 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%xx.base.3_class = type <{ i32 (...)**, %xx.base.3* }>
+%xx.base.3_class = type <{ ptr, ptr }>
 %xx.base.3 = type { i32 }
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @_Name_base = private unnamed_addr constant [5 x i8] c"base\00", align 1
-@_Type_Info_base = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([5 x i8], [5 x i8]* @_Name_base, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_base = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_base to i8*), i8* bitcast (void (i8*, i8*)* @_copy_xx_base to i8*), i8* bitcast (void (i8**)* @_allocate_struct_xx_base to i8*), i8* bitcast (void (i8*)* @finalize_StructType__base_3_of_xx_for_UPoly to i8*), i8* bitcast (void (%xx.base.3_class*)* @__module_xx_show_x to i8*)] }, align 8
+@_Type_Info_base = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_base, ptr inttoptr (i64 4 to ptr), ptr null }, align 8
+@_VTable_base = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_base, ptr @_copy_xx_base, ptr @_allocate_struct_xx_base, ptr @finalize_StructType__base_3_of_xx_for_UPoly, ptr @__module_xx_show_x] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -16,12 +17,12 @@ target datalayout = "..."
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_xx_show_x(%xx.base.3_class* %this) {
+define void @__module_xx_show_x(ptr %this) {
 .entry:
-  %0 = getelementptr %xx.base.3_class, %xx.base.3_class* %this, i32 0, i32 1
-  %1 = load %xx.base.3*, %xx.base.3** %0, align 8
-  %2 = getelementptr %xx.base.3, %xx.base.3* %1, i32 0, i32 0
-  store i32 12, i32* %2, align 4
+  %0 = getelementptr %xx.base.3_class, ptr %this, i32 0, i32 1
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %xx.base.3, ptr %1, i32 0, i32 0
+  store i32 12, ptr %2, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -31,53 +32,53 @@ FINALIZE_SYMTABLE_show_x:                         ; preds = %return
   ret void
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %3 = alloca %xx.base.3_class, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %b = alloca %xx.base.3, align 8
-  %4 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
-  %5 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
-  store i32 10, i32* %5, align 4
-  %6 = getelementptr %xx.base.3_class, %xx.base.3_class* %3, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %6, align 8
-  %7 = getelementptr %xx.base.3_class, %xx.base.3_class* %3, i32 0, i32 1
-  store %xx.base.3* %b, %xx.base.3** %7, align 8
-  call void @__module_xx_show_x(%xx.base.3_class* %3)
+  %4 = getelementptr %xx.base.3, ptr %b, i32 0, i32 0
+  %5 = getelementptr %xx.base.3, ptr %b, i32 0, i32 0
+  store i32 10, ptr %5, align 4
+  %6 = getelementptr %xx.base.3_class, ptr %3, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_base, i32 0, i32 0, i32 2), ptr %6, align 8
+  %7 = getelementptr %xx.base.3_class, ptr %3, i32 0, i32 1
+  store ptr %b, ptr %7, align 8
+  call void @__module_xx_show_x(ptr %3)
   %8 = alloca i64, align 8
-  %9 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
-  %10 = load i32, i32* %9, align 4
+  %9 = getelementptr %xx.base.3, ptr %b, i32 0, i32 0
+  %10 = load i32, ptr %9, align 4
   %11 = alloca i32, align 4
-  store i32 %10, i32* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %8, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %11)
-  %13 = load i64, i64* %8, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %13, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %19 = load i64, i64* %18, align 8
+  store i32 %10, ptr %11, align 4
+  %12 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %8, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %11)
+  %13 = load i64, ptr %8, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, ptr %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
+  call void @_lfortran_printf(ptr @1, ptr %17, i32 %20, ptr @0, i32 1)
+  %21 = icmp eq ptr %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %12)
+  call void @_lfortran_free_alloc(ptr %2, ptr %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %22 = getelementptr %xx.base.3, %xx.base.3* %b, i32 0, i32 0
-  %23 = load i32, i32* %22, align 4
+  %22 = getelementptr %xx.base.3, ptr %b, i32 0, i32 0
+  %23 = load i32, ptr %22, align 4
   %24 = icmp ne i32 %23, 12
   br i1 %24, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -96,19 +97,17 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-define linkonce_odr void @_copy_xx_base(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_xx_base(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %xx.base.3*
-  %3 = bitcast i8* %1 to %xx.base.3*
-  %4 = getelementptr %xx.base.3, %xx.base.3* %2, i32 0, i32 0
-  %5 = load i32, i32* %4, align 4
-  %6 = getelementptr %xx.base.3, %xx.base.3* %3, i32 0, i32 0
+  %2 = getelementptr %xx.base.3, ptr %0, i32 0, i32 0
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr %xx.base.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store i32 %5, i32* %6, align 4
+  store i32 %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -118,49 +117,45 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_xx_base(i8** %0) {
+define linkonce_odr void @_allocate_struct_xx_base(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %xx.base.3_class*
-  %5 = bitcast %xx.base.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_base, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %xx.base.3_class, %xx.base.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %xx.base.3*
-  store %xx.base.3* %9, %xx.base.3** %6, align 8
-  %10 = getelementptr %xx.base.3, %xx.base.3* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_base, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %xx.base.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %xx.base.3, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__base_3_of_xx_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__base_3_of_xx_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %xx.base.3*
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-classes2-f926d51.json
+++ b/tests/reference/llvm-classes2-f926d51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes2-f926d51.stdout",
-    "stdout_hash": "0f3bd3d832853a7d5949aebacab368d284e81ae9d23aa03d9f9dfcb4",
+    "stdout_hash": "b2fd1f78b723b71a5c4c35c0a11c314470c926080c878d695993ea26",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes2-f926d51.stdout
+++ b/tests/reference/llvm-classes2-f926d51.stdout
@@ -1,101 +1,98 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%defs.point.3_class = type <{ i32 (...)**, %defs.point.3* }>
-%defs.point.3 = type {}
-%defs.point2d.5_class = type <{ i32 (...)**, %defs.point2d.5* }>
+%defs.point2d.5_class = type <{ ptr, ptr }>
 %defs.point2d.5 = type { %defs.point.3, float, float }
+%defs.point.3 = type {}
+%defs.point.3_class = type <{ ptr, ptr }>
 
 @_Name_point = private unnamed_addr constant [6 x i8] c"point\00", align 1
-@_Type_Info_point = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_point, i32 0, i32 0), i8* null, i8* null }, align 8
-@_VTable_point = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point_3_of_defs_for_UPoly to i8*), i8* null] }, align 8
+@_Type_Info_point = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_point, ptr null, ptr null }, align 8
+@_VTable_point = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_point, ptr @_copy_defs_point, ptr @_allocate_struct_defs_point, ptr @finalize_StructType__point_3_of_defs_for_UPoly, ptr null] }, align 8
 @_Name_point2d = private unnamed_addr constant [8 x i8] c"point2d\00", align 1
-@_Type_Info_point2d = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_Name_point2d, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point to i8*) }, align 8
-@_VTable_point2d = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_point2d to i8*), i8* bitcast (void (i8*, i8*)* @_copy_defs_point2d to i8*), i8* bitcast (void (i8**)* @_allocate_struct_defs_point2d to i8*), i8* bitcast (void (i8*)* @finalize_StructType__point2d_5_of_defs_for_UPoly to i8*), i8* bitcast (float (%defs.point2d.5_class*)* @__module_defs_r2d to i8*)] }, align 8
+@_Type_Info_point2d = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_point2d, ptr inttoptr (i64 8 to ptr), ptr @_Type_Info_point }, align 8
+@_VTable_point2d = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_point2d, ptr @_copy_defs_point2d, ptr @_allocate_struct_defs_point2d, ptr @finalize_StructType__point2d_5_of_defs_for_UPoly, ptr @__module_defs_r2d] }, align 8
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_defs_r2d(%defs.point2d.5_class* %this) {
+define float @__module_defs_r2d(ptr %this) {
 .entry:
   %r2d = alloca float, align 4
-  %0 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %this, i32 0, i32 1
-  %1 = load %defs.point2d.5*, %defs.point2d.5** %0, align 8
-  %2 = getelementptr %defs.point2d.5, %defs.point2d.5* %1, i32 0, i32 1
-  %3 = load float, float* %2, align 4
+  %0 = getelementptr %defs.point2d.5_class, ptr %this, i32 0, i32 1
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %defs.point2d.5, ptr %1, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
   %simplified_pow_operation = fmul float %3, %3
-  %4 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %this, i32 0, i32 1
-  %5 = load %defs.point2d.5*, %defs.point2d.5** %4, align 8
-  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %5, i32 0, i32 2
-  %7 = load float, float* %6, align 4
+  %4 = getelementptr %defs.point2d.5_class, ptr %this, i32 0, i32 1
+  %5 = load ptr, ptr %4, align 8
+  %6 = getelementptr %defs.point2d.5, ptr %5, i32 0, i32 2
+  %7 = load float, ptr %6, align 4
   %simplified_pow_operation1 = fmul float %7, %7
   %8 = fadd float %simplified_pow_operation, %simplified_pow_operation1
   %9 = call float @llvm.sqrt.f32(float %8)
-  store float %9, float* %r2d, align 4
+  store float %9, ptr %r2d, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_r2d
 
 FINALIZE_SYMTABLE_r2d:                            ; preds = %return
-  %10 = load float, float* %r2d, align 4
+  %10 = load float, ptr %r2d, align 4
   ret float %10
 }
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare float @llvm.sqrt.f32(float) #0
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %p2d = alloca %defs.point2d.5, align 8
-  %3 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 1
-  %4 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 2
-  %5 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 0
-  %ptr = alloca %defs.point.3_class*, align 8
-  store %defs.point.3_class* null, %defs.point.3_class** %ptr, align 8
+  %3 = getelementptr %defs.point2d.5, ptr %p2d, i32 0, i32 1
+  %4 = getelementptr %defs.point2d.5, ptr %p2d, i32 0, i32 2
+  %5 = getelementptr %defs.point2d.5, ptr %p2d, i32 0, i32 0
+  %ptr = alloca %defs.point.3_class, align 8
+  store ptr null, ptr %ptr, align 8
   %res = alloca float, align 4
-  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 1
-  store float 3.000000e+00, float* %6, align 4
-  %7 = getelementptr %defs.point2d.5, %defs.point2d.5* %p2d, i32 0, i32 2
-  store float 4.000000e+00, float* %7, align 4
-  %8 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
-  %9 = icmp eq %defs.point.3_class* %8, null
+  %6 = getelementptr %defs.point2d.5, ptr %p2d, i32 0, i32 1
+  store float 3.000000e+00, ptr %6, align 4
+  %7 = getelementptr %defs.point2d.5, ptr %p2d, i32 0, i32 2
+  store float 4.000000e+00, ptr %7, align 4
+  %8 = load ptr, ptr %ptr, align 8
+  %9 = icmp eq ptr %8, null
   br i1 %9, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %10 = call i8* @_lfortran_get_default_allocator()
-  %11 = call i8* @_lfortran_malloc_alloc(i8* %10, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %11, i8 0, i32 16, i1 false)
-  %12 = bitcast i8* %11 to %defs.point.3_class*
-  store %defs.point.3_class* %12, %defs.point.3_class** %ptr, align 8
+  %10 = call ptr @_lfortran_get_default_allocator()
+  %11 = call ptr @_lfortran_malloc_alloc(ptr %10, i64 16)
+  call void @llvm.memset.p0.i32(ptr %11, i8 0, i32 16, i1 false)
+  store ptr %11, ptr %ptr, align 8
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %13 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
-  %14 = bitcast %defs.point.3_class* %13 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %14, align 8
-  %15 = getelementptr %defs.point.3_class, %defs.point.3_class* %13, i32 0, i32 1
-  %16 = bitcast %defs.point2d.5* %p2d to %defs.point.3*
-  store %defs.point.3* %16, %defs.point.3** %15, align 8
-  %17 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
-  %18 = bitcast %defs.point.3_class* %17 to float (%defs.point.3_class*)***
-  %19 = load float (%defs.point.3_class*)**, float (%defs.point.3_class*)*** %18, align 8
-  %20 = getelementptr inbounds float (%defs.point.3_class*)*, float (%defs.point.3_class*)** %19, i32 3
-  %21 = load float (%defs.point.3_class*)*, float (%defs.point.3_class*)** %20, align 8
-  %22 = call float %21(%defs.point.3_class* %17)
-  store float %22, float* %res, align 4
-  %23 = load float, float* %res, align 4
-  %24 = fcmp une float %23, 5.000000e+00
-  br i1 %24, label %then1, label %else2
+  %12 = load ptr, ptr %ptr, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_point2d, i32 0, i32 0, i32 2), ptr %12, align 8
+  %13 = getelementptr %defs.point.3_class, ptr %12, i32 0, i32 1
+  store ptr %p2d, ptr %13, align 8
+  %14 = load ptr, ptr %ptr, align 8
+  %15 = load ptr, ptr %14, align 8
+  %16 = getelementptr inbounds ptr, ptr %15, i32 3
+  %17 = load ptr, ptr %16, align 8
+  %18 = call float %17(ptr %14)
+  store float %18, ptr %res, align 4
+  %19 = load float, ptr %res, align 4
+  %20 = fcmp une float %19, 5.000000e+00
+  br i1 %20, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -113,13 +110,12 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   br label %Finalize_Variable_ptr
 
 Finalize_Variable_ptr:                            ; preds = %FINALIZE_SYMTABLE_main
-  %25 = load %defs.point.3_class*, %defs.point.3_class** %ptr, align 8
-  %26 = icmp ne %defs.point.3_class* %25, null
-  br i1 %26, label %is_allocated.then, label %is_allocated.else
+  %21 = load ptr, ptr %ptr, align 8
+  %22 = icmp ne ptr %21, null
+  br i1 %22, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %Finalize_Variable_ptr
-  %27 = bitcast %defs.point.3_class* %25 to i8*
-  call void @_lfortran_free_alloc(i8* %2, i8* %27)
+  call void @_lfortran_free_alloc(ptr %2, ptr %21)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %Finalize_Variable_ptr
@@ -130,117 +126,105 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #1
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #1
 
-define linkonce_odr void @_copy_defs_point(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_defs_point(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %defs.point.3*
-  %3 = bitcast i8* %1 to %defs.point.3*
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_defs_point(i8** %0) {
+define linkonce_odr void @_allocate_struct_defs_point(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %defs.point.3_class*
-  %5 = bitcast %defs.point.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %defs.point.3_class, %defs.point.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
-  %9 = bitcast i8* %8 to %defs.point.3*
-  store %defs.point.3* %9, %defs.point.3** %6, align 8
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_point, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %defs.point.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 0)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 0, i1 false)
+  store ptr %6, ptr %4, align 8
   ret void
 }
 
-define internal void @finalize_StructType__point_3_of_defs_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__point_3_of_defs_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %defs.point.3*
   ret void
 }
 
-define linkonce_odr void @_copy_defs_point2d(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_defs_point2d(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %defs.point2d.5*
-  %3 = bitcast i8* %1 to %defs.point2d.5*
-  %4 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 1
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 1
+  %2 = getelementptr %defs.point2d.5, ptr %0, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %defs.point2d.5, ptr %1, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 2
-  %8 = load float, float* %7, align 4
-  %9 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 2
+  %5 = getelementptr %defs.point2d.5, ptr %0, i32 0, i32 2
+  %6 = load float, ptr %5, align 4
+  %7 = getelementptr %defs.point2d.5, ptr %1, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  store float %8, float* %9, align 4
+  store float %6, ptr %7, align 4
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %10 = getelementptr %defs.point2d.5, %defs.point2d.5* %2, i32 0, i32 0
-  %11 = getelementptr %defs.point2d.5, %defs.point2d.5* %3, i32 0, i32 0
+  %8 = getelementptr %defs.point2d.5, ptr %0, i32 0, i32 0
+  %9 = getelementptr %defs.point2d.5, ptr %1, i32 0, i32 0
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_defs_point2d(i8** %0) {
+define linkonce_odr void @_allocate_struct_defs_point2d(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %defs.point2d.5_class*
-  %5 = bitcast %defs.point2d.5_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_point2d, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %defs.point2d.5_class, %defs.point2d.5_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %defs.point2d.5*
-  store %defs.point2d.5* %9, %defs.point2d.5** %6, align 8
-  %10 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 1
-  %11 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 2
-  %12 = getelementptr %defs.point2d.5, %defs.point2d.5* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_point2d, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %defs.point2d.5_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 8)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 8, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %defs.point2d.5, ptr %6, i32 0, i32 1
+  %8 = getelementptr %defs.point2d.5, ptr %6, i32 0, i32 2
+  %9 = getelementptr %defs.point2d.5, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__point2d_5_of_defs_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__point2d_5_of_defs_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %defs.point2d.5*
   ret void
 }
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-attributes #0 = { nounwind readnone speculatable willreturn }
-attributes #1 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-codegen_function_polymorphic-834d4d1.json
+++ b/tests/reference/llvm-codegen_function_polymorphic-834d4d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-codegen_function_polymorphic-834d4d1.stdout",
-    "stdout_hash": "6f5fb1e8ee314b319ba6c82623c2832261542cd206c22254c09ba570",
+    "stdout_hash": "da20b8d2c4be641e74601fbfaa3f4356ace3381f903482b63fece3b5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-codegen_function_polymorphic-834d4d1.stdout
+++ b/tests/reference/llvm-codegen_function_polymorphic-834d4d1.stdout
@@ -1,28 +1,28 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%codegen_function_polymorphic.abstype.3_class = type <{ i32 (...)**, %codegen_function_polymorphic.abstype.3* }>
-%codegen_function_polymorphic.abstype.3 = type {}
+%codegen_function_polymorphic.abstype.3_class = type <{ ptr, ptr }>
 
-define void @__module_codegen_function_polymorphic_my_func(%codegen_function_polymorphic.abstype.3_class** %obj) {
+define void @__module_codegen_function_polymorphic_my_func(ptr %obj) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
-  %2 = ptrtoint %codegen_function_polymorphic.abstype.3_class* %1 to i64
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load ptr, ptr %obj, align 8
+  %2 = ptrtoint ptr %1 to i64
   %3 = icmp ne i64 %2, 0
   br i1 %3, label %then, label %else2
 
 then:                                             ; preds = %.entry
-  %4 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
-  %5 = load %codegen_function_polymorphic.abstype.3_class*, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
-  %6 = ptrtoint %codegen_function_polymorphic.abstype.3_class* %5 to i64
+  %4 = load ptr, ptr %obj, align 8
+  %5 = load ptr, ptr %obj, align 8
+  %6 = ptrtoint ptr %5 to i64
   %7 = icmp ne i64 %6, 0
   br i1 %7, label %then1, label %else
 
 then1:                                            ; preds = %then
-  call void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %5)
-  store %codegen_function_polymorphic.abstype.3_class* null, %codegen_function_polymorphic.abstype.3_class** %obj, align 8
+  call void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(ptr %5)
+  store ptr null, ptr %obj, align 8
   br label %ifcont
 
 else:                                             ; preds = %then
@@ -44,34 +44,32 @@ FINALIZE_SYMTABLE_my_func:                        ; preds = %return
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-define internal void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__abstype_3_of_codegen_function_polymorphic(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %codegen_function_polymorphic.abstype.3_class* %0, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = icmp ne ptr %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0)
-  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 1
-  %4 = load %codegen_function_polymorphic.abstype.3*, %codegen_function_polymorphic.abstype.3** %3, align 8
-  %5 = icmp ne %codegen_function_polymorphic.abstype.3* %4, null
+  call void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(ptr %0)
+  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %codegen_function_polymorphic.abstype.3* %4 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %codegen_function_polymorphic.abstype.3_class* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %7)
+  call void @_lfortran_free_alloc(ptr %1, ptr %0)
   br label %is_allocated.ifcont3
 
 is_allocated.else2:                               ; preds = %entry
@@ -81,25 +79,23 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(%codegen_function_polymorphic.abstype.3_class* %0) {
+define internal void @finalize_StructType_Class__abstype_3_of_codegen_function_polymorphic(ptr %0) {
 entry:
-  %1 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 0
-  %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, %codegen_function_polymorphic.abstype.3_class* %0, i32 0, i32 1
-  %4 = load %codegen_function_polymorphic.abstype.3**, %codegen_function_polymorphic.abstype.3** %3, align 8
-  %5 = bitcast %codegen_function_polymorphic.abstype.3** %4 to i8*
-  %6 = icmp ne i32 (...)** %2, null
-  br i1 %6, label %is_allocated.then, label %is_allocated.else2
+  %1 = getelementptr %codegen_function_polymorphic.abstype.3_class, ptr %0, i32 0, i32 0
+  %2 = load ptr, ptr %1, align 8
+  %3 = getelementptr %codegen_function_polymorphic.abstype.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %2, null
+  br i1 %5, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  %7 = getelementptr inbounds i32 (...)*, i32 (...)** %2, i32 2
-  %8 = load i8*, i32 (...)** %7, align 8
-  %9 = bitcast i8* %8 to void (i8*)*
-  %10 = icmp ne i8* %5, null
-  br i1 %10, label %is_allocated.then1, label %is_allocated.else
+  %6 = getelementptr inbounds ptr, ptr %2, i32 2
+  %7 = load ptr, ptr %6, align 8
+  %8 = icmp ne ptr %4, null
+  br i1 %8, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  call void %9(i8* %5)
+  call void %7(ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-common_linkage_separate_compilation_01-4003f83.stdout",
-    "stdout_hash": "86ac0b2ceac08dd70933fd94e8b7fcd7a9c5674f244183c16ceb3cbc",
+    "stdout_hash": "2cd78675e3ff784aa499f128628d1d42bbb9df37b74a984ce26d4397",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
+++ b/tests/reference/llvm-common_linkage_separate_compilation_01-4003f83.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %file_common_block_blk.blk.4 = type { i32 }
 
@@ -9,16 +10,16 @@ target datalayout = "..."
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [8 x i8] c"%s %d%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 5, i32* getelementptr inbounds (%file_common_block_blk.blk.4, %file_common_block_blk.blk.4* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
-  %2 = load i32, i32* getelementptr inbounds (%file_common_block_blk.blk.4, %file_common_block_blk.blk.4* @__module_file_common_block_blk_struct_instance_blk, i32 0, i32 0), align 4
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store i32 5, ptr @__module_file_common_block_blk_struct_instance_blk, align 4
+  %2 = load i32, ptr @__module_file_common_block_blk_struct_instance_blk, align 4
   %3 = icmp ne i32 %2, 5
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", i32 1, ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -37,9 +38,9 @@ FINALIZE_SYMTABLE_common_linkage_separate_compilation_01: ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-complex1-0e93fa9.json
+++ b/tests/reference/llvm-complex1-0e93fa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex1-0e93fa9.stdout",
-    "stdout_hash": "25adedfdc3484f838d0bc9fac6ffa8f1cc723366f034bbbe8cf0c151",
+    "stdout_hash": "f0e801d6259d38c7d408d77ca4e13b056e9e012ddbf3258bcd8f4e3b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex1-0e93fa9.stdout
+++ b/tests/reference/llvm-complex1-0e93fa9.stdout
@@ -1,14 +1,15 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %complex_4 = type <{ float, float }>
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
   br label %return
 
 return:                                           ; preds = %.entry
@@ -19,6 +20,6 @@ FINALIZE_SYMTABLE_complex1:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "62ab3b90f3c1559bebd513732e5ffbc94c43248ccd558103fb7f134b",
+    "stdout_hash": "8f792a640f77ea3a0411bb7ce64604eced3af21f9bef4307e5eb8773",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -15,74 +16,74 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %3 = load %complex_4, %complex_4* %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
+  %3 = load %complex_4, ptr %x, align 1
   %4 = extractvalue %complex_4 %3, 0
   %5 = extractvalue %complex_4 %3, 1
   %6 = fadd float %4, 4.000000e+00
   %7 = fadd float %5, 0.000000e+00
   %8 = insertvalue %complex_4 undef, float %6, 0
   %9 = insertvalue %complex_4 %8, float %7, 1
-  store %complex_4 %9, %complex_4* %x, align 1
+  store %complex_4 %9, ptr %x, align 1
   %10 = alloca i64, align 8
-  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %10, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %12 = load i64, i64* %10, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %11, i8** %13, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %12, i64* %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %16 = load i8*, i8** %15, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %18 = load i64, i64* %17, align 8
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %10, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %12 = load i64, ptr %10, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %20 = icmp eq i8* %11, null
+  call void @_lfortran_printf(ptr @1, ptr %16, i32 %19, ptr @0, i32 1)
+  %20 = icmp eq ptr %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %11)
+  call void @_lfortran_free_alloc(ptr %2, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %21 = load %complex_4, %complex_4* %x, align 1
+  %21 = load %complex_4, ptr %x, align 1
   %22 = extractvalue %complex_4 %21, 0
   %23 = extractvalue %complex_4 %21, 1
   %24 = fadd float 2.000000e+00, %22
   %25 = fadd float 0.000000e+00, %23
   %26 = insertvalue %complex_4 undef, float %24, 0
   %27 = insertvalue %complex_4 %26, float %25, 1
-  store %complex_4 %27, %complex_4* %x, align 1
+  store %complex_4 %27, ptr %x, align 1
   %28 = alloca i64, align 8
-  %29 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %28, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %30 = load i64, i64* %28, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %29, i8** %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %30, i64* %32, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %36 = load i64, i64* %35, align 8
+  %29 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %28, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %30 = load i64, ptr %28, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %30, ptr %32, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %38 = icmp eq i8* %29, null
+  call void @_lfortran_printf(ptr @3, ptr %34, i32 %37, ptr @2, i32 1)
+  %38 = icmp eq ptr %29, null
   br i1 %38, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %29)
+  call void @_lfortran_free_alloc(ptr %2, ptr %29)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %39 = load %complex_4, %complex_4* %x, align 1
+  %39 = load %complex_4, ptr %x, align 1
   %40 = extractvalue %complex_4 %39, 0
   %41 = extractvalue %complex_4 %39, 1
   %42 = fadd float 2.000000e+00, %40
@@ -95,25 +96,25 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %49 = fadd float %47, 3.000000e+00
   %50 = insertvalue %complex_4 undef, float %48, 0
   %51 = insertvalue %complex_4 %50, float %49, 1
-  store %complex_4 %51, %complex_4* %x, align 1
+  store %complex_4 %51, ptr %x, align 1
   %52 = alloca i64, align 8
-  %53 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %52, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %54 = load i64, i64* %52, align 8
-  %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %53, i8** %55, align 8
-  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %54, i64* %56, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %58 = load i8*, i8** %57, align 8
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %60 = load i64, i64* %59, align 8
+  %53 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %52, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %54 = load i64, ptr %52, align 8
+  %55 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %53, ptr %55, align 8
+  %56 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %54, ptr %56, align 8
+  %57 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %58 = load ptr, ptr %57, align 8
+  %59 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %60 = load i64, ptr %59, align 8
   %61 = trunc i64 %60 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %58, i32 %61, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %62 = icmp eq i8* %53, null
+  call void @_lfortran_printf(ptr @5, ptr %58, i32 %61, ptr @4, i32 1)
+  %62 = icmp eq ptr %53, null
   br i1 %62, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %53)
+  call void @_lfortran_free_alloc(ptr %2, ptr %53)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -127,14 +128,14 @@ FINALIZE_SYMTABLE_complex2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "5087456b6dc1ab4106e3d337dd2986ad8a7a0c286bfade0719395077",
+    "stdout_hash": "ecd61ad6b4ccf892a7a03db757320e9e1c2f3ef65544302e78ffdcca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -15,16 +16,16 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc10 = alloca %string_descriptor, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %3 = load %complex_4, %complex_4* %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
+  %3 = load %complex_4, ptr %x, align 1
   %4 = extractvalue %complex_4 %3, 0
   %5 = extractvalue %complex_4 %3, 1
   %6 = call float @llvm.fabs.f32(float 4.000000e+00)
@@ -55,29 +56,29 @@ complex_div_cont:                                 ; preds = %complex_div_r_lt_s,
   %22 = phi float [ %14, %complex_div_r_ge_s ], [ %20, %complex_div_r_lt_s ]
   %23 = insertvalue %complex_4 undef, float %21, 0
   %24 = insertvalue %complex_4 %23, float %22, 1
-  store %complex_4 %24, %complex_4* %x, align 1
+  store %complex_4 %24, ptr %x, align 1
   %25 = alloca i64, align 8
-  %26 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %25, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %27 = load i64, i64* %25, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %26, i8** %28, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %27, i64* %29, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %31 = load i8*, i8** %30, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %33 = load i64, i64* %32, align 8
+  %26 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %25, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %27 = load i64, ptr %25, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %26, ptr %28, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %27, ptr %29, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %31 = load ptr, ptr %30, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %33 = load i64, ptr %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %35 = icmp eq i8* %26, null
+  call void @_lfortran_printf(ptr @1, ptr %31, i32 %34, ptr @0, i32 1)
+  %35 = icmp eq ptr %26, null
   br i1 %35, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %complex_div_cont
-  call void @_lfortran_free_alloc(i8* %2, i8* %26)
+  call void @_lfortran_free_alloc(ptr %2, ptr %26)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %complex_div_cont
-  %36 = load %complex_4, %complex_4* %x, align 1
+  %36 = load %complex_4, ptr %x, align 1
   %37 = extractvalue %complex_4 %36, 0
   %38 = extractvalue %complex_4 %36, 1
   %39 = call float @llvm.fabs.f32(float %37)
@@ -114,29 +115,29 @@ complex_div_cont3:                                ; preds = %complex_div_r_lt_s2
   %61 = phi float [ %50, %complex_div_r_ge_s1 ], [ %59, %complex_div_r_lt_s2 ]
   %62 = insertvalue %complex_4 undef, float %60, 0
   %63 = insertvalue %complex_4 %62, float %61, 1
-  store %complex_4 %63, %complex_4* %x, align 1
+  store %complex_4 %63, ptr %x, align 1
   %64 = alloca i64, align 8
-  %65 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %64, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %66 = load i64, i64* %64, align 8
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %65, i8** %67, align 8
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %66, i64* %68, align 8
-  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %70 = load i8*, i8** %69, align 8
-  %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %72 = load i64, i64* %71, align 8
+  %65 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %64, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %66 = load i64, ptr %64, align 8
+  %67 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %65, ptr %67, align 8
+  %68 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %66, ptr %68, align 8
+  %69 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %70 = load ptr, ptr %69, align 8
+  %71 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %72 = load i64, ptr %71, align 8
   %73 = trunc i64 %72 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %70, i32 %73, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %74 = icmp eq i8* %65, null
+  call void @_lfortran_printf(ptr @3, ptr %70, i32 %73, ptr @2, i32 1)
+  %74 = icmp eq ptr %65, null
   br i1 %74, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %complex_div_cont3
-  call void @_lfortran_free_alloc(i8* %2, i8* %65)
+  call void @_lfortran_free_alloc(ptr %2, ptr %65)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %complex_div_cont3
-  %75 = load %complex_4, %complex_4* %x, align 1
+  %75 = load %complex_4, ptr %x, align 1
   %76 = extractvalue %complex_4 %75, 0
   %77 = extractvalue %complex_4 %75, 1
   %78 = fadd float %76, 0.000000e+00
@@ -179,25 +180,25 @@ complex_div_cont9:                                ; preds = %complex_div_r_lt_s8
   %106 = phi float [ %95, %complex_div_r_ge_s7 ], [ %104, %complex_div_r_lt_s8 ]
   %107 = insertvalue %complex_4 undef, float %105, 0
   %108 = insertvalue %complex_4 %107, float %106, 1
-  store %complex_4 %108, %complex_4* %x, align 1
+  store %complex_4 %108, ptr %x, align 1
   %109 = alloca i64, align 8
-  %110 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %109, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %111 = load i64, i64* %109, align 8
-  %112 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %110, i8** %112, align 8
-  %113 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %111, i64* %113, align 8
-  %114 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %115 = load i8*, i8** %114, align 8
-  %116 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %117 = load i64, i64* %116, align 8
+  %110 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %109, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %111 = load i64, ptr %109, align 8
+  %112 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %110, ptr %112, align 8
+  %113 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %111, ptr %113, align 8
+  %114 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %115 = load ptr, ptr %114, align 8
+  %116 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %117 = load i64, ptr %116, align 8
   %118 = trunc i64 %117 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %115, i32 %118, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %119 = icmp eq i8* %110, null
+  call void @_lfortran_printf(ptr @5, ptr %115, i32 %118, ptr @4, i32 1)
+  %119 = icmp eq ptr %110, null
   br i1 %119, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %complex_div_cont9
-  call void @_lfortran_free_alloc(i8* %2, i8* %110)
+  call void @_lfortran_free_alloc(ptr %2, ptr %110)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %complex_div_cont9
@@ -211,19 +212,19 @@ FINALIZE_SYMTABLE_complex2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare float @llvm.fabs.f32(float) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "1ab472e71cf9d28daea819611df3753b0deb2370dd82ec599b70d2c4",
+    "stdout_hash": "76d841743201266001bf601caa1694c44704ecb83cb13a99288ddc15",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_8 = type <{ double, double }>
 %complex_4 = type <{ float, float }>
 
@@ -10,35 +11,35 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [24 x i8] c"{R8,R8},{R4,R4},{R4,R4}\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %v = alloca %complex_8, align 8
   %x = alloca %complex_4, align 8
   %zero = alloca %complex_4, align 8
-  store %complex_4 zeroinitializer, %complex_4* %zero, align 1
-  store %complex_8 <{ double 0x3FF0CCCCC0000000, double 0x3FF0CCCCC0000000 }>, %complex_8* %v, align 1
-  store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, %complex_4* %x, align 1
+  store %complex_4 zeroinitializer, ptr %zero, align 1
+  store %complex_8 <{ double 0x3FF0CCCCC0000000, double 0x3FF0CCCCC0000000 }>, ptr %v, align 1
+  store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, ptr %x, align 1
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_8* %v, %complex_4* %x, %complex_4* %zero)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %v, ptr %x, ptr %zero)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -52,14 +53,14 @@ FINALIZE_SYMTABLE_complex_dp:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "aa6de0c128626de468525684391f07ca3f513daba639c2463704e61a",
+    "stdout_hash": "830c053761976754680caff011af8f547c060d8d442429add1484d0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %complex_4 = type <{ float, float }>
 %complex_8 = type <{ double, double }>
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @complex_dp_param.u = internal global %complex_4 zeroinitializer
 @complex_dp_param.v = internal global %complex_8 zeroinitializer
@@ -13,36 +14,36 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [24 x i8] c"{R4,R4},{R8,R8},{R8,R8}\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %prec1 = alloca i32, align 4
-  store i32 4, i32* %prec1, align 4
+  store i32 4, ptr %prec1, align 4
   %prec2 = alloca i32, align 4
-  store i32 8, i32* %prec2, align 4
-  store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, %complex_4* @complex_dp_param.u, align 1
-  store %complex_8 <{ double 0x3FF0CCCCC0000000, double 1.050000e+00 }>, %complex_8* @complex_dp_param.v, align 1
-  store %complex_8 zeroinitializer, %complex_8* @complex_dp_param.zero, align 1
+  store i32 8, ptr %prec2, align 4
+  store %complex_4 <{ float 0x3FF0CCCCC0000000, float 0x3FF0CCCCC0000000 }>, ptr @complex_dp_param.u, align 1
+  store %complex_8 <{ double 0x3FF0CCCCC0000000, double 1.050000e+00 }>, ptr @complex_dp_param.v, align 1
+  store %complex_8 zeroinitializer, ptr @complex_dp_param.zero, align 1
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([24 x i8], [24 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* @complex_dp_param.u, %complex_8* @complex_dp_param.v, %complex_8* @complex_dp_param.zero)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @complex_dp_param.u, ptr @complex_dp_param.v, ptr @complex_dp_param.zero)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -56,14 +57,14 @@ FINALIZE_SYMTABLE_complex_dp_param:               ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "44d5dec9dc4da918de8df62ee311317c599c472c0c2978d0b672a464",
+    "stdout_hash": "f9bbe00d6db147f3b9b1a0d057f4255b2b5f2fb76005236db6951de1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -15,16 +16,16 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %3 = load %complex_4, %complex_4* %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
+  %3 = load %complex_4, ptr %x, align 1
   %4 = extractvalue %complex_4 %3, 0
   %5 = extractvalue %complex_4 %3, 1
   %6 = fmul float %4, 4.000000e+00
@@ -35,29 +36,29 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = fadd float %8, %9
   %12 = insertvalue %complex_4 undef, float %10, 0
   %13 = insertvalue %complex_4 %12, float %11, 1
-  store %complex_4 %13, %complex_4* %x, align 1
+  store %complex_4 %13, ptr %x, align 1
   %14 = alloca i64, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %16 = load i64, i64* %14, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %15, i8** %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %16, i64* %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %15 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %14, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %16 = load i64, ptr %14, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %16, ptr %18, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %24 = icmp eq i8* %15, null
+  call void @_lfortran_printf(ptr @1, ptr %20, i32 %23, ptr @0, i32 1)
+  %24 = icmp eq ptr %15, null
   br i1 %24, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  call void @_lfortran_free_alloc(ptr %2, ptr %15)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %25 = load %complex_4, %complex_4* %x, align 1
+  %25 = load %complex_4, ptr %x, align 1
   %26 = extractvalue %complex_4 %25, 0
   %27 = extractvalue %complex_4 %25, 1
   %28 = fmul float 2.000000e+00, %26
@@ -68,29 +69,29 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %33 = fadd float %30, %31
   %34 = insertvalue %complex_4 undef, float %32, 0
   %35 = insertvalue %complex_4 %34, float %33, 1
-  store %complex_4 %35, %complex_4* %x, align 1
+  store %complex_4 %35, ptr %x, align 1
   %36 = alloca i64, align 8
-  %37 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %36, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %38 = load i64, i64* %36, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %38, i64* %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %44 = load i64, i64* %43, align 8
+  %37 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %36, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %38 = load i64, ptr %36, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %44 = load i64, ptr %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %46 = icmp eq i8* %37, null
+  call void @_lfortran_printf(ptr @3, ptr %42, i32 %45, ptr @2, i32 1)
+  %46 = icmp eq ptr %37, null
   br i1 %46, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %37)
+  call void @_lfortran_free_alloc(ptr %2, ptr %37)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %47 = load %complex_4, %complex_4* %x, align 1
+  %47 = load %complex_4, ptr %x, align 1
   %48 = extractvalue %complex_4 %47, 0
   %49 = extractvalue %complex_4 %47, 1
   %50 = fmul float %48, 0.000000e+00
@@ -101,25 +102,25 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %55 = fadd float %52, %53
   %56 = insertvalue %complex_4 undef, float %54, 0
   %57 = insertvalue %complex_4 %56, float %55, 1
-  store %complex_4 %57, %complex_4* %x, align 1
+  store %complex_4 %57, ptr %x, align 1
   %58 = alloca i64, align 8
-  %59 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %58, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %60 = load i64, i64* %58, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %59, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %60, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
+  %59 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %58, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %60 = load i64, ptr %58, align 8
+  %61 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %59, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %60, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %64 = load ptr, ptr %63, align 8
+  %65 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %66 = load i64, ptr %65, align 8
   %67 = trunc i64 %66 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %68 = icmp eq i8* %59, null
+  call void @_lfortran_printf(ptr @5, ptr %64, i32 %67, ptr @4, i32 1)
+  %68 = icmp eq ptr %59, null
   br i1 %68, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %59)
+  call void @_lfortran_free_alloc(ptr %2, ptr %59)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -133,14 +134,14 @@ FINALIZE_SYMTABLE_complex2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "004884fb21f8c88daddbb83cb0213ae6c820977883bdc0ee06df0d9f",
+    "stdout_hash": "b5f40cf3fea7990bacf942eca07e11be53b3ec0508b3d73afe04bd6b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -1,56 +1,57 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %3 = alloca %complex_4, align 8
   %4 = alloca %complex_4, align 8
   %5 = alloca %complex_4, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
   %y = alloca %complex_4, align 8
   %z = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  store %complex_4 <{ float 3.000000e+00, float 2.000000e+00 }>, %complex_4* %y, align 1
-  %6 = load %complex_4, %complex_4* %x, align 1
-  %7 = load %complex_4, %complex_4* %y, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 2.000000e+00 }>, ptr %y, align 1
+  %6 = load %complex_4, ptr %x, align 1
+  %7 = load %complex_4, ptr %y, align 1
   %8 = extractvalue %complex_4 %6, 0
   %9 = extractvalue %complex_4 %6, 1
   %10 = extractvalue %complex_4 %7, 0
   %11 = extractvalue %complex_4 %7, 1
-  store %complex_4 %6, %complex_4* %5, align 1
-  store %complex_4 %7, %complex_4* %4, align 1
-  call void @_lfortran_complex_pow_32(%complex_4* %5, %complex_4* %4, %complex_4* %3)
-  %12 = load %complex_4, %complex_4* %3, align 1
-  store %complex_4 %12, %complex_4* %z, align 1
+  store %complex_4 %6, ptr %5, align 1
+  store %complex_4 %7, ptr %4, align 1
+  call void @_lfortran_complex_pow_32(ptr %5, ptr %4, ptr %3)
+  %12 = load %complex_4, ptr %3, align 1
+  store %complex_4 %12, ptr %z, align 1
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %z)
-  %15 = load i64, i64* %13, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %15, i64* %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %21 = load i64, i64* %20, align 8
+  %14 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %13, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %z)
+  %15 = load i64, ptr %13, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %19 = load ptr, ptr %18, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %21 = load i64, ptr %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
+  call void @_lfortran_printf(ptr @1, ptr %19, i32 %22, ptr @0, i32 1)
+  %23 = icmp eq ptr %14, null
   br i1 %23, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %14)
+  call void @_lfortran_free_alloc(ptr %2, ptr %14)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -64,16 +65,16 @@ FINALIZE_SYMTABLE_complex2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_complex_pow_32(%complex_4*, %complex_4*, %complex_4*)
+declare void @_lfortran_complex_pow_32(ptr, ptr, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "d6421afd327db58bbc727e3a1bf0f600222763dff8ff4e2dfd554a99",
+    "stdout_hash": "29288c66260b3633169f606e6a0ae5801544a234a67adb6213eb22d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -15,107 +16,107 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [8 x i8] c"{R4,R4}\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %x, align 1
-  %3 = load %complex_4, %complex_4* %x, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %x, align 1
+  %3 = load %complex_4, ptr %x, align 1
   %4 = extractvalue %complex_4 %3, 0
   %5 = extractvalue %complex_4 %3, 1
   %6 = fsub float %4, 4.000000e+00
   %7 = fsub float %5, 0.000000e+00
   %8 = insertvalue %complex_4 undef, float %6, 0
   %9 = insertvalue %complex_4 %8, float %7, 1
-  store %complex_4 %9, %complex_4* %x, align 1
-  %10 = load %complex_4, %complex_4* %x, align 1
+  store %complex_4 %9, ptr %x, align 1
+  %10 = load %complex_4, ptr %x, align 1
   %11 = extractvalue %complex_4 %10, 0
   %12 = extractvalue %complex_4 %10, 1
   %13 = fsub float 4.000000e+00, %11
   %14 = fsub float 0.000000e+00, %12
   %15 = insertvalue %complex_4 undef, float %13, 0
   %16 = insertvalue %complex_4 %15, float %14, 1
-  store %complex_4 %16, %complex_4* %x, align 1
+  store %complex_4 %16, ptr %x, align 1
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @1, ptr %23, i32 %26, ptr @0, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %18)
+  call void @_lfortran_free_alloc(ptr %2, ptr %18)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %28 = load %complex_4, %complex_4* %x, align 1
+  %28 = load %complex_4, ptr %x, align 1
   %29 = extractvalue %complex_4 %28, 0
   %30 = extractvalue %complex_4 %28, 1
   %31 = fsub float 2.000000e+00, %29
   %32 = fsub float 0.000000e+00, %30
   %33 = insertvalue %complex_4 undef, float %31, 0
   %34 = insertvalue %complex_4 %33, float %32, 1
-  store %complex_4 %34, %complex_4* %x, align 1
+  store %complex_4 %34, ptr %x, align 1
   %35 = alloca i64, align 8
-  %36 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.1, i32 0, i32 0), i64* %35, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %37 = load i64, i64* %35, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %36, i8** %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %37, i64* %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %43 = load i64, i64* %42, align 8
+  %36 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %35, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %37 = load i64, ptr %35, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %36, ptr %38, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %41 = load ptr, ptr %40, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %43 = load i64, ptr %42, align 8
   %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %45 = icmp eq i8* %36, null
+  call void @_lfortran_printf(ptr @3, ptr %41, i32 %44, ptr @2, i32 1)
+  %45 = icmp eq ptr %36, null
   br i1 %45, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %36)
+  call void @_lfortran_free_alloc(ptr %2, ptr %36)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %46 = load %complex_4, %complex_4* %x, align 1
+  %46 = load %complex_4, ptr %x, align 1
   %47 = extractvalue %complex_4 %46, 0
   %48 = extractvalue %complex_4 %46, 1
   %49 = fsub float %47, 0.000000e+00
   %50 = fsub float %48, 3.000000e+00
   %51 = insertvalue %complex_4 undef, float %49, 0
   %52 = insertvalue %complex_4 %51, float %50, 1
-  store %complex_4 %52, %complex_4* %x, align 1
+  store %complex_4 %52, ptr %x, align 1
   %53 = alloca i64, align 8
-  %54 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info.2, i32 0, i32 0), i64* %53, i32 0, i32 0, i32 0, i32 0, i32 0, %complex_4* %x)
-  %55 = load i64, i64* %53, align 8
-  %56 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %54, i8** %56, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %55, i64* %57, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %59 = load i8*, i8** %58, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %61 = load i64, i64* %60, align 8
+  %54 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %53, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %55 = load i64, ptr %53, align 8
+  %56 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %54, ptr %56, align 8
+  %57 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %55, ptr %57, align 8
+  %58 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %59 = load ptr, ptr %58, align 8
+  %60 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %61 = load i64, ptr %60, align 8
   %62 = trunc i64 %61 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %59, i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %63 = icmp eq i8* %54, null
+  call void @_lfortran_printf(ptr @5, ptr %59, i32 %62, ptr @4, i32 1)
+  %63 = icmp eq ptr %54, null
   br i1 %63, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %54)
+  call void @_lfortran_free_alloc(ptr %2, ptr %54)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -129,14 +130,14 @@ FINALIZE_SYMTABLE_complex2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "e46655177b7bd04727c51632bdd2bf3a744097bba5dee6b2d885b6f4",
+    "stdout_hash": "4a3c3270750d0946eb4d49210a049c1dfeff743601770fa91618464b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -1,44 +1,45 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"R4,R8,R4,R8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %u = alloca double, align 8
   %v = alloca double, align 8
   %x = alloca float, align 4
   %zero = alloca float, align 4
-  store float 0.000000e+00, float* %zero, align 4
-  store double 0x3FF0CCCCC0000000, double* %u, align 8
-  store double 1.050000e+00, double* %v, align 8
-  store float 0x3FF0CCCCC0000000, float* %x, align 4
+  store float 0.000000e+00, ptr %zero, align 4
+  store double 0x3FF0CCCCC0000000, ptr %u, align 8
+  store double 1.050000e+00, ptr %v, align 8
+  store float 0x3FF0CCCCC0000000, ptr %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %zero, double* %v, float* %x, double* %u)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %zero, ptr %v, ptr %x, ptr %u)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -52,14 +53,14 @@ FINALIZE_SYMTABLE_const_real_dp:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "a85bb846d5580291fbd2a7412b3d1cec7ca8c82fdb982ac977c50b5c",
+    "stdout_hash": "2520fe50ceccd49050f8f74ca206dff7e8c7b617a83f78207fed301d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -1,36 +1,37 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [4 x i8] c"(g0)"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @serialization_info = private unnamed_addr constant [3 x i8] c"R8\00", align 1
 @2 = private unnamed_addr constant [3 x i8] c"%s\00", align 1
 @__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
 @string_const_data.1 = private constant [1 x i8] c" "
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.1, i32 0, i32 0), i64 1 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 1 }>
 @3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.3 = private unnamed_addr constant [7 x i8] c"S-DESC\00", align 1
 @4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.4 = private constant [18 x i8] c"10.000000000000000"
-@string_const.5 = private global %string_descriptor <{ i8* getelementptr inbounds ([18 x i8], [18 x i8]* @string_const_data.4, i32 0, i32 0), i64 18 }>
+@string_const.5 = private global %string_descriptor <{ ptr @string_const_data.4, i64 18 }>
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @5 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @6 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
+define i32 @_lcompilers_len_trim_str(ptr %str) {
 .entry:
   %StringItem = alloca %string_descriptor, align 8
   %result = alloca i32, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %1 = load i64, i64* %0, align 8
+  %0 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %1 = load i64, ptr %0, align 8
   %2 = trunc i64 %1 to i32
-  store i32 %2, i32* %result, align 4
-  %3 = load i32, i32* %result, align 4
+  store i32 %2, ptr %result, align 4
+  %3 = load i32, ptr %result, align 4
   %4 = icmp ne i32 %3, 0
   br i1 %4, label %then, label %else2
 
@@ -38,29 +39,29 @@ then:                                             ; preds = %.entry
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %then
-  %5 = load i32, i32* %result, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
+  %5 = load i32, ptr %result, align 4
+  %6 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
   %8 = sext i32 %5 to i64
   %9 = sub i64 %8, 1
-  %10 = getelementptr i8, i8* %7, i64 %9
-  %11 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  store i8* %10, i8** %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
-  store i64 1, i64* %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  %16 = load i8, i8* %14, align 1
-  %17 = load i8, i8* %15, align 1
+  %10 = getelementptr i8, ptr %7, i64 %9
+  %11 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 0
+  store ptr %10, ptr %11, align 8
+  %12 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 1
+  store i64 1, ptr %12, align 8
+  %13 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 0
+  %14 = load ptr, ptr %13, align 8
+  %15 = load ptr, ptr @string_const.2, align 8
+  %16 = load i8, ptr %14, align 1
+  %17 = load i8, ptr %15, align 1
   %18 = icmp eq i8 %16, %17
   br i1 %18, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %19 = load i32, i32* %result, align 4
+  %19 = load i32, ptr %result, align 4
   %20 = sub i32 %19, 1
-  store i32 %20, i32* %result, align 4
-  %21 = load i32, i32* %result, align 4
+  store i32 %20, ptr %result, align 4
+  %21 = load i32, ptr %result, align 4
   %22 = icmp eq i32 %21, 0
   br i1 %22, label %then1, label %else
 
@@ -89,34 +90,34 @@ return:                                           ; preds = %ifcont3
   br label %FINALIZE_SYMTABLE__lcompilers_len_trim_str
 
 FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
-  %23 = load i32, i32* %result, align 4
+  %23 = load i32, ptr %result, align 4
   ret i32 %23
 }
 
-define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
+define void @_lcompilers_trim_str(ptr %str, ptr %result) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %StrSlice_StrView = alloca %string_descriptor, align 8
-  %1 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %str)
+  %1 = call i32 @_lcompilers_len_trim_str(ptr %str)
   %2 = sext i32 %1 to i64
   %3 = sub i64 %2, 1
   %4 = add i64 %3, 1
   %5 = icmp slt i64 %4, 0
   %6 = select i1 %5, i64 0, i64 %4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %StrSliceGEP = getelementptr i8, i8* %8, i64 0
-  %9 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %6, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 0
-  %12 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 1
-  %13 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %16 = load i64, i64* %15, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %11, i64* %12, i8 0, i8 0, i8* %14, i64 %16, i32 1)
+  %7 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %StrSliceGEP = getelementptr i8, ptr %8, i64 0
+  %9 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 %6, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %result, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, ptr %result, i32 0, i32 1
+  %13 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %14 = load ptr, ptr %13, align 8
+  %15 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %11, ptr %12, i8 0, i8 0, ptr %14, i64 %16, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -126,89 +127,89 @@ FINALIZE_SYMTABLE__lcompilers_trim_str:           ; preds = %return
   ret void
 }
 
-define void @__module_testdrive_derived_types_32_real_dp_to_string(double* %val, %string_descriptor* %string) {
+define void @__module_testdrive_derived_types_32_real_dp_to_string(ptr %val, ptr %string) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %lfortran_iomsg = alloca %string_descriptor, align 8
   %buffer = alloca %string_descriptor, align 8
   %__libasr__created__var__2_return_slot = alloca %string_descriptor, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__2_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %buffer, align 1
-  %1 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
-  store i64 128, i64* %1, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
-  %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 128)
-  store i8* %4, i8** %2, align 8
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__2_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %buffer, align 1
+  %1 = getelementptr %string_descriptor, ptr %buffer, i32 0, i32 1
+  store i64 128, ptr %1, align 8
+  %2 = getelementptr %string_descriptor, ptr %buffer, i32 0, i32 0
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 128)
+  store ptr %4, ptr %2, align 8
   %buffer_len = alloca i32, align 4
-  store i32 128, i32* %buffer_len, align 4
-  store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
-  %5 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
-  store i64 0, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 1)
-  store i8* %8, i8** %6, align 8
-  %9 = load %string_descriptor, %string_descriptor* %string, align 1
-  %10 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = icmp ne i8* %11, null
+  store i32 128, ptr %buffer_len, align 4
+  store %string_descriptor zeroinitializer, ptr %lfortran_iomsg, align 1
+  %5 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 1
+  store i64 0, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %7 = call ptr @_lfortran_get_default_allocator()
+  %8 = call ptr @_lfortran_malloc_alloc(ptr %7, i64 1)
+  store ptr %8, ptr %6, align 8
+  %9 = load %string_descriptor, ptr %string, align 1
+  %10 = getelementptr %string_descriptor, ptr %string, i32 0, i32 0
+  %11 = load ptr, ptr %10, align 8
+  %12 = icmp ne ptr %11, null
   br i1 %12, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %13 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %14 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %15 = load i8*, i8** %13, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %15)
-  store i8* null, i8** %13, align 8
-  store i64 0, i64* %14, align 8
+  %13 = getelementptr %string_descriptor, ptr %string, i32 0, i32 0
+  %14 = getelementptr %string_descriptor, ptr %string, i32 0, i32 1
+  %15 = load ptr, ptr %13, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %15)
+  store ptr null, ptr %13, align 8
+  store i64 0, ptr %14, align 8
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %16 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
-  %17 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 1
-  %18 = alloca i32*, align 8
-  store i32* null, i32** %18, align 8
-  %19 = load i32*, i32** %18, align 8
-  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %16 = getelementptr %string_descriptor, ptr %buffer, i32 0, i32 0
+  %17 = getelementptr %string_descriptor, ptr %buffer, i32 0, i32 1
+  %18 = alloca ptr, align 8
+  store ptr null, ptr %18, align 8
+  %19 = load ptr, ptr %18, align 8
+  %20 = load ptr, ptr @string_const, align 8
   %21 = alloca i64, align 8
-  %22 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* %20, i64 4, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %21, i32 0, i32 0, i32 0, i32 0, i32 0, double* %val)
-  %23 = load i64, i64* %21, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %22, i8** %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %23, i64* %25, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %27 = load i8*, i8** %26, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %29 = load i64, i64* %28, align 8
-  call void (i8*, i8**, i8, i8, i8, i64, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8* %0, i8** %16, i8 0, i8 0, i8 0, i64 1, i64* %17, i32* %19, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %27, i64 %29)
-  %30 = icmp eq i8* %22, null
+  %22 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr %20, i64 4, ptr @serialization_info, ptr %21, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %val)
+  %23 = load i64, ptr %21, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %22, ptr %24, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %23, ptr %25, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %27 = load ptr, ptr %26, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %29 = load i64, ptr %28, align 8
+  call void (ptr, ptr, i8, i8, i8, i64, ptr, ptr, ptr, i64, ...) @_lfortran_string_write(ptr %0, ptr %16, i8 0, i8 0, i8 0, i64 1, ptr %17, ptr %19, ptr @2, i64 2, ptr %27, i64 %29)
+  %30 = icmp eq ptr %22, null
   br i1 %30, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %0, i8* %22)
+  call void @_lfortran_free_alloc(ptr %0, ptr %22)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  %31 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %32 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %33 = load i8*, i8** %31, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %33)
-  store i8* null, i8** %31, align 8
-  store i64 0, i64* %32, align 8
-  %34 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %buffer)
-  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %36 = load i8*, i8** %35, align 8
-  %37 = icmp ne i8* %36, null
+  %31 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %32 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 1
+  %33 = load ptr, ptr %31, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %33)
+  store ptr null, ptr %31, align 8
+  store i64 0, ptr %32, align 8
+  %34 = call i32 @_lcompilers_len_trim_str(ptr %buffer)
+  %35 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %36 = load ptr, ptr %35, align 8
+  %37 = icmp ne ptr %36, null
   br i1 %37, label %then1, label %else2
 
 then1:                                            ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @__Wrong_allocation)
   call void @exit(i32 1)
   br label %ifcont3
 
@@ -216,22 +217,22 @@ else2:                                            ; preds = %free_done
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %38 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %38 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
   %39 = sext i32 %34 to i64
-  %40 = call i8* @_lfortran_get_default_allocator()
-  %41 = call i8* @_lfortran_string_malloc_alloc(i8* %40, i64 %39)
-  store i8* %41, i8** %38, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
+  %40 = call ptr @_lfortran_get_default_allocator()
+  %41 = call ptr @_lfortran_string_malloc_alloc(ptr %40, i64 %39)
+  store ptr %41, ptr %38, align 8
+  %42 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 1
   %43 = sext i32 %34 to i64
-  store i64 %43, i64* %42, align 8
-  call void @_lcompilers_trim_str(%string_descriptor* %buffer, %string_descriptor* %__libasr__created__var__2_return_slot)
-  %44 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 0
-  %45 = getelementptr %string_descriptor, %string_descriptor* %string, i32 0, i32 1
-  %46 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %47 = load i8*, i8** %46, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %49 = load i64, i64* %48, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %44, i64* %45, i8 1, i8 1, i8* %47, i64 %49, i32 1)
+  store i64 %43, ptr %42, align 8
+  call void @_lcompilers_trim_str(ptr %buffer, ptr %__libasr__created__var__2_return_slot)
+  %44 = getelementptr %string_descriptor, ptr %string, i32 0, i32 0
+  %45 = getelementptr %string_descriptor, ptr %string, i32 0, i32 1
+  %46 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %47 = load ptr, ptr %46, align 8
+  %48 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 1
+  %49 = load i64, ptr %48, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %44, ptr %45, i8 1, i8 1, ptr %47, i64 %49, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont3
@@ -241,104 +242,104 @@ FINALIZE_SYMTABLE_real_dp_to_string:              ; preds = %return
   br label %Finalize_Variable___libasr__created__var__2_return_slot
 
 Finalize_Variable___libasr__created__var__2_return_slot: ; preds = %FINALIZE_SYMTABLE_real_dp_to_string
-  %50 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %51 = load i8*, i8** %50, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %51)
+  %50 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %51 = load ptr, ptr %50, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %51)
   br label %Finalize_Variable_buffer
 
 Finalize_Variable_buffer:                         ; preds = %Finalize_Variable___libasr__created__var__2_return_slot
-  %52 = getelementptr %string_descriptor, %string_descriptor* %buffer, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %53)
+  %52 = getelementptr %string_descriptor, ptr %buffer, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %53)
   br label %Finalize_Variable_lfortran_iomsg
 
 Finalize_Variable_lfortran_iomsg:                 ; preds = %Finalize_Variable_buffer
-  %54 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %55 = load i8*, i8** %54, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %55)
+  %54 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %55 = load ptr, ptr %54, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %55)
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_string_write(i8*, i8**, i8, i8, i8, i64, i64*, i32*, i8*, i64, ...)
+declare void @_lfortran_string_write(ptr, ptr, i8, i8, i8, i64, ptr, ptr, ptr, i64, ...)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_string_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_string_malloc_alloc(ptr, i64)
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %__libasr__created__var__1_return_slot = alloca %string_descriptor, align 8
   %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__1_return_slot, align 1
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__0_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__1_return_slot, align 1
   %value = alloca double, align 8
-  store double 1.000000e+01, double* %value, align 8
-  %3 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %4 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %5 = load i8*, i8** %3, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
-  store i8* null, i8** %3, align 8
-  store i64 0, i64* %4, align 8
-  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__0_return_slot)
+  store double 1.000000e+01, ptr %value, align 8
+  %3 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %4 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %5 = load ptr, ptr %3, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
+  store ptr null, ptr %3, align 8
+  store i64 0, ptr %4, align 8
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(ptr %value, ptr %__libasr__created__var__0_return_slot)
   %6 = alloca i64, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %8 = load i64, i64* %7, align 8
-  %9 = load %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
+  %7 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %8 = load i64, ptr %7, align 8
+  %9 = load %string_descriptor, ptr %__libasr__created__var__0_return_slot, align 1
   %10 = alloca %string_descriptor, align 8
-  store %string_descriptor %9, %string_descriptor* %10, align 1
-  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %6, i32 0, i32 1, i32 0, i32 0, i32 0, i64 %8, %string_descriptor* %10)
-  %12 = load i64, i64* %6, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %11, i8** %13, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %12, i64* %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %16 = load i8*, i8** %15, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %18 = load i64, i64* %17, align 8
+  store %string_descriptor %9, ptr %10, align 1
+  %11 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %6, i32 0, i32 1, i32 0, i32 0, i32 0, i64 %8, ptr %10)
+  %12 = load i64, ptr %6, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %11, ptr %13, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %16 = load ptr, ptr %15, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
-  %20 = icmp eq i8* %11, null
+  call void @_lfortran_printf(ptr @4, ptr %16, i32 %19, ptr @3, i32 1)
+  %20 = icmp eq ptr %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %11)
+  call void @_lfortran_free_alloc(ptr %2, ptr %11)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %21 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %23 = load i8*, i8** %21, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %23)
-  store i8* null, i8** %21, align 8
-  store i64 0, i64* %22, align 8
-  call void @__module_testdrive_derived_types_32_real_dp_to_string(double* %value, %string_descriptor* %__libasr__created__var__1_return_slot)
-  %24 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %25 = load i8*, i8** %24, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %27 = load i64, i64* %26, align 8
-  %28 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.5, i32 0, i32 0), align 8
-  %29 = call i32 @str_compare(i8* %25, i64 %27, i8* %28, i64 18)
+  %21 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %22 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %23 = load ptr, ptr %21, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %23)
+  store ptr null, ptr %21, align 8
+  store i64 0, ptr %22, align 8
+  call void @__module_testdrive_derived_types_32_real_dp_to_string(ptr %value, ptr %__libasr__created__var__1_return_slot)
+  %24 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %25 = load ptr, ptr %24, align 8
+  %26 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %27 = load i64, ptr %26, align 8
+  %28 = load ptr, ptr @string_const.5, align 8
+  %29 = call i32 @str_compare(ptr %25, i64 %27, ptr %28, i64 18)
   %30 = icmp ne i32 %29, 0
   br i1 %30, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @6, ptr @"ERROR STOP", ptr @5)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -356,23 +357,23 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   br label %Finalize_Variable___libasr__created__var__0_return_slot
 
 Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_main
-  %31 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %32 = load i8*, i8** %31, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %32)
+  %31 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %32 = load ptr, ptr %31, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %32)
   br label %Finalize_Variable___libasr__created__var__1_return_slot
 
 Finalize_Variable___libasr__created__var__1_return_slot: ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
-  %33 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %34)
+  %33 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %34)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare i32 @str_compare(i8*, i64, i8*, i64)
+declare i32 @str_compare(ptr, i64, ptr, i64)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-derived_types_45-ae31b1c.json
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_45-ae31b1c.stdout",
-    "stdout_hash": "af1628df27940e0c59e79f47f249c1653a0a946e6343597206ecebea",
+    "stdout_hash": "3350c024b016ef954121b874183ba5e0b14f47fc95f63065d4972315",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_45-ae31b1c.stdout
+++ b/tests/reference/llvm-derived_types_45-ae31b1c.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %derived_types_45_mod.myint.3 = type { i32 }
 
@@ -12,91 +13,90 @@ target datalayout = "..."
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %ins = alloca %derived_types_45_mod.myint.3*, align 8
-  store %derived_types_45_mod.myint.3* null, %derived_types_45_mod.myint.3** %ins, align 8
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %ins = alloca ptr, align 8
+  store ptr null, ptr %ins, align 8
   %temp_struct_var__ = alloca %derived_types_45_mod.myint.3, align 8
-  %3 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
-  %4 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
-  store i32 44, i32* %4, align 4
-  %5 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
-  %6 = icmp eq %derived_types_45_mod.myint.3* %5, null
+  %3 = getelementptr %derived_types_45_mod.myint.3, ptr %temp_struct_var__, i32 0, i32 0
+  %4 = getelementptr %derived_types_45_mod.myint.3, ptr %temp_struct_var__, i32 0, i32 0
+  store i32 44, ptr %4, align 4
+  %5 = load ptr, ptr %ins, align 8
+  %6 = icmp eq ptr %5, null
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %derived_types_45_mod.myint.3*
-  store %derived_types_45_mod.myint.3* %9, %derived_types_45_mod.myint.3** %ins, align 8
-  %10 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
-  %11 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %10, i32 0, i32 0
+  %7 = call ptr @_lfortran_get_default_allocator()
+  %8 = call ptr @_lfortran_malloc_alloc(ptr %7, i64 4)
+  call void @llvm.memset.p0.i32(ptr %8, i8 0, i32 4, i1 false)
+  store ptr %8, ptr %ins, align 8
+  %9 = load ptr, ptr %ins, align 8
+  %10 = getelementptr %derived_types_45_mod.myint.3, ptr %9, i32 0, i32 0
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %12 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
-  %13 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %temp_struct_var__, i32 0, i32 0
-  %14 = load i32, i32* %13, align 4
-  %15 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %12, i32 0, i32 0
+  %11 = load ptr, ptr %ins, align 8
+  %12 = getelementptr %derived_types_45_mod.myint.3, ptr %temp_struct_var__, i32 0, i32 0
+  %13 = load i32, ptr %12, align 4
+  %14 = getelementptr %derived_types_45_mod.myint.3, ptr %11, i32 0, i32 0
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  store i32 %14, i32* %15, align 4
+  store i32 %13, ptr %14, align 4
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %16 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
-  %17 = ptrtoint %derived_types_45_mod.myint.3* %16 to i64
-  %18 = icmp eq i64 %17, 0
-  br i1 %18, label %then4, label %ifcont5
+  %15 = load ptr, ptr %ins, align 8
+  %16 = ptrtoint ptr %15 to i64
+  %17 = icmp eq i64 %16, 0
+  br i1 %17, label %then4, label %ifcont5
 
 then4:                                            ; preds = %ifcont3
-  %19 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %20 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %21 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 0
-  store i8* getelementptr inbounds ([48 x i8], [48 x i8]* @1, i32 0, i32 0), i8** %22, align 8
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 1
-  store i32 15, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 2
-  store i32 9, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 3
-  store i32 15, i32* %25, align 4
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 4
-  store i32 13, i32* %26, align 4
-  %27 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
-  %28 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
-  %29 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 2
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 0
-  store i1 true, i1* %31, align 1
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 1
-  store i8* %27, i8** %32, align 8
-  store { i8*, i32, i32, i32, i32 }* %29, { i8*, i32, i32, i32, i32 }** %30, align 8
-  %33 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 3
-  store i32 1, i32* %33, align 4
-  %34 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %34, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
+  %18 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %19 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %20 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 0
+  store ptr @1, ptr %21, align 8
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 1
+  store i32 15, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 2
+  store i32 9, ptr %23, align 4
+  %24 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 3
+  store i32 15, ptr %24, align 4
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 4
+  store i32 13, ptr %25, align 4
+  %26 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2, ptr @0)
+  %27 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %18, i32 0, i32 0
+  %28 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 2
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 0
+  store i1 true, ptr %30, align 1
+  %31 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 1
+  store ptr %26, ptr %31, align 8
+  store ptr %28, ptr %29, align 8
+  %32 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 3
+  store i32 1, ptr %32, align 4
+  %33 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %18, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %33, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %ifcont3
-  %35 = getelementptr %derived_types_45_mod.myint.3, %derived_types_45_mod.myint.3* %16, i32 0, i32 0
-  %36 = load i32, i32* %35, align 4
-  %37 = icmp ne i32 %36, 44
-  br i1 %37, label %then6, label %else7
+  %34 = getelementptr %derived_types_45_mod.myint.3, ptr %15, i32 0, i32 0
+  %35 = load i32, ptr %34, align 4
+  %36 = icmp ne i32 %35, 44
+  br i1 %36, label %then6, label %else7
 
 then6:                                            ; preds = %ifcont5
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -114,40 +114,39 @@ FINALIZE_SYMTABLE_derived_types_45:               ; preds = %return
   br label %Finalize_Variable_ins
 
 Finalize_Variable_ins:                            ; preds = %FINALIZE_SYMTABLE_derived_types_45
-  %38 = load %derived_types_45_mod.myint.3*, %derived_types_45_mod.myint.3** %ins, align 8
-  call void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint.3* %38)
+  %37 = load ptr, ptr %ins, align 8
+  call void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(ptr %37)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-define internal void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(%derived_types_45_mod.myint.3* %0) {
+define internal void @finalize_allocatable__StructType__myint_3_of_derived_types_45_mod(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %derived_types_45_mod.myint.3* %0, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = icmp ne ptr %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  %3 = bitcast %derived_types_45_mod.myint.3* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %3)
+  call void @_lfortran_free_alloc(ptr %1, ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -157,6 +156,6 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-do7-8069d7a.json
+++ b/tests/reference/llvm-do7-8069d7a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-do7-8069d7a.stdout",
-    "stdout_hash": "532178cb249c6d5168d5678a8809ca29e37a81ebd4b8ab720298b4d9",
+    "stdout_hash": "59f8cda4076e77fe2a191026215fd6ea01a76f6941d4587c890c4ec5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-do7-8069d7a.stdout
+++ b/tests/reference/llvm-do7-8069d7a.stdout
@@ -1,29 +1,30 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
   %i = alloca i32, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, ptr %i, align 4
   %3 = add i32 %2, 1
   %4 = icmp sle i32 %3, 10
   br i1 %4, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %5 = load i32, i32* %i, align 4
+  %5 = load i32, ptr %i, align 4
   %6 = add i32 %5, 1
-  store i32 %6, i32* %i, align 4
-  store i32 5, i32* %call_arg_value, align 4
-  %7 = call i32 @f(i32* %call_arg_value)
-  store i32 %7, i32* %a, align 4
+  store i32 %6, ptr %i, align 4
+  store i32 5, ptr %call_arg_value, align 4
+  %7 = call i32 @f(ptr %call_arg_value)
+  store i32 %7, ptr %a, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
@@ -37,22 +38,22 @@ FINALIZE_SYMTABLE_do7:                            ; preds = %return
   ret i32 0
 }
 
-define i32 @f(i32* %a) {
+define i32 @f(ptr %a) {
 .entry:
   %f = alloca i32, align 4
-  %0 = load i32, i32* %a, align 4
+  %0 = load i32, ptr %a, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* %f, align 4
+  store i32 %1, ptr %f, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %2 = load i32, i32* %f, align 4
+  %2 = load i32, ptr %f, align 4
   ret i32 %2
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "194d4a29b465876298b30033a439532c54f895842c3fde439fcbb01e",
+    "stdout_hash": "ac91800863346d5f8c58ee7c4861188c2f2c2663cae29b04cbdfa901",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -61,7 +62,7 @@ target datalayout = "..."
 @serialization_info.10 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @43 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc88 = alloca %string_descriptor, align 8
   %stringFormat_desc79 = alloca %string_descriptor, align 8
@@ -74,37 +75,37 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc16 = alloca %string_descriptor, align 8
   %stringFormat_desc7 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 10
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %j, align 4
-  %9 = load i32, i32* %i, align 4
+  store i32 %7, ptr %i, align 4
+  %8 = load i32, ptr %j, align 4
+  %9 = load i32, ptr %i, align 4
   %10 = add i32 %8, %9
-  store i32 %10, i32* %j, align 4
+  store i32 %10, ptr %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %11 = load i32, i32* %j, align 4
+  %11 = load i32, ptr %j, align 4
   %12 = icmp ne i32 %11, 55
   br i1 %12, label %then, label %else
 
 then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -114,53 +115,53 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %15 = load i64, i64* %13, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %15, i64* %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %21 = load i64, i64* %20, align 8
+  %14 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %13, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %15 = load i64, ptr %13, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %19 = load ptr, ptr %18, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %21 = load i64, ptr %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
+  call void @_lfortran_printf(ptr @3, ptr %19, i32 %22, ptr @2, i32 1)
+  %23 = icmp eq ptr %14, null
   br i1 %23, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %14)
+  call void @_lfortran_free_alloc(ptr %2, ptr %14)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %j, align 4
-  store i32 11, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 11, ptr %i, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.body2, %free_done
-  %24 = load i32, i32* %i, align 4
+  %24 = load i32, ptr %i, align 4
   %25 = add i32 %24, -1
   %26 = icmp sge i32 %25, 1
   br i1 %26, label %loop.body2, label %loop.end3
 
 loop.body2:                                       ; preds = %loop.head1
-  %27 = load i32, i32* %i, align 4
+  %27 = load i32, ptr %i, align 4
   %28 = add i32 %27, -1
-  store i32 %28, i32* %i, align 4
-  %29 = load i32, i32* %j, align 4
-  %30 = load i32, i32* %i, align 4
+  store i32 %28, ptr %i, align 4
+  %29 = load i32, ptr %j, align 4
+  %30 = load i32, ptr %i, align 4
   %31 = add i32 %29, %30
-  store i32 %31, i32* %j, align 4
+  store i32 %31, ptr %j, align 4
   br label %loop.head1
 
 loop.end3:                                        ; preds = %loop.head1
-  %32 = load i32, i32* %j, align 4
+  %32 = load i32, ptr %j, align 4
   %33 = icmp ne i32 %32, 55
   br i1 %33, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -170,53 +171,53 @@ else5:                                            ; preds = %loop.end3
 
 ifcont6:                                          ; preds = %else5, %then4
   %34 = alloca i64, align 8
-  %35 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %34, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %36 = load i64, i64* %34, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %35, i8** %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %36, i64* %38, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %42 = load i64, i64* %41, align 8
+  %35 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %34, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %36 = load i64, ptr %34, align 8
+  %37 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %35, ptr %37, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %36, ptr %38, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %40 = load ptr, ptr %39, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %42 = load i64, ptr %41, align 8
   %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %44 = icmp eq i8* %35, null
+  call void @_lfortran_printf(ptr @7, ptr %40, i32 %43, ptr @6, i32 1)
+  %44 = icmp eq ptr %35, null
   br i1 %44, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %ifcont6
-  call void @_lfortran_free_alloc(i8* %2, i8* %35)
+  call void @_lfortran_free_alloc(ptr %2, ptr %35)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %ifcont6
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 -1, ptr %i, align 4
   br label %loop.head10
 
 loop.head10:                                      ; preds = %loop.body11, %free_done9
-  %45 = load i32, i32* %i, align 4
+  %45 = load i32, ptr %i, align 4
   %46 = add i32 %45, 2
   %47 = icmp sle i32 %46, 9
   br i1 %47, label %loop.body11, label %loop.end12
 
 loop.body11:                                      ; preds = %loop.head10
-  %48 = load i32, i32* %i, align 4
+  %48 = load i32, ptr %i, align 4
   %49 = add i32 %48, 2
-  store i32 %49, i32* %i, align 4
-  %50 = load i32, i32* %j, align 4
-  %51 = load i32, i32* %i, align 4
+  store i32 %49, ptr %i, align 4
+  %50 = load i32, ptr %j, align 4
+  %51 = load i32, ptr %i, align 4
   %52 = add i32 %50, %51
-  store i32 %52, i32* %j, align 4
+  store i32 %52, ptr %j, align 4
   br label %loop.head10
 
 loop.end12:                                       ; preds = %loop.head10
-  %53 = load i32, i32* %j, align 4
+  %53 = load i32, ptr %j, align 4
   %54 = icmp ne i32 %53, 25
   br i1 %54, label %then13, label %else14
 
 then13:                                           ; preds = %loop.end12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -226,53 +227,53 @@ else14:                                           ; preds = %loop.end12
 
 ifcont15:                                         ; preds = %else14, %then13
   %55 = alloca i64, align 8
-  %56 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %57 = load i64, i64* %55, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %56, i8** %58, align 8
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %57, i64* %59, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %61 = load i8*, i8** %60, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %63 = load i64, i64* %62, align 8
+  %56 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %55, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %57 = load i64, ptr %55, align 8
+  %58 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %56, ptr %58, align 8
+  %59 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %57, ptr %59, align 8
+  %60 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %61 = load ptr, ptr %60, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %63 = load i64, ptr %62, align 8
   %64 = trunc i64 %63 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %61, i32 %64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %65 = icmp eq i8* %56, null
+  call void @_lfortran_printf(ptr @11, ptr %61, i32 %64, ptr @10, i32 1)
+  %65 = icmp eq ptr %56, null
   br i1 %65, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %ifcont15
-  call void @_lfortran_free_alloc(i8* %2, i8* %56)
+  call void @_lfortran_free_alloc(ptr %2, ptr %56)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %ifcont15
-  store i32 0, i32* %j, align 4
-  store i32 11, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 11, ptr %i, align 4
   br label %loop.head19
 
 loop.head19:                                      ; preds = %loop.body20, %free_done18
-  %66 = load i32, i32* %i, align 4
+  %66 = load i32, ptr %i, align 4
   %67 = add i32 %66, -2
   %68 = icmp sge i32 %67, 1
   br i1 %68, label %loop.body20, label %loop.end21
 
 loop.body20:                                      ; preds = %loop.head19
-  %69 = load i32, i32* %i, align 4
+  %69 = load i32, ptr %i, align 4
   %70 = add i32 %69, -2
-  store i32 %70, i32* %i, align 4
-  %71 = load i32, i32* %j, align 4
-  %72 = load i32, i32* %i, align 4
+  store i32 %70, ptr %i, align 4
+  %71 = load i32, ptr %j, align 4
+  %72 = load i32, ptr %i, align 4
   %73 = add i32 %71, %72
-  store i32 %73, i32* %j, align 4
+  store i32 %73, ptr %j, align 4
   br label %loop.head19
 
 loop.end21:                                       ; preds = %loop.head19
-  %74 = load i32, i32* %j, align 4
+  %74 = load i32, ptr %j, align 4
   %75 = icmp ne i32 %74, 25
   br i1 %75, label %then22, label %else23
 
 then22:                                           ; preds = %loop.end21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -282,53 +283,53 @@ else23:                                           ; preds = %loop.end21
 
 ifcont24:                                         ; preds = %else23, %then22
   %76 = alloca i64, align 8
-  %77 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %76, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %78 = load i64, i64* %76, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
-  store i8* %77, i8** %79, align 8
-  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
-  store i64 %78, i64* %80, align 8
-  %81 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 0
-  %82 = load i8*, i8** %81, align 8
-  %83 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
-  %84 = load i64, i64* %83, align 8
+  %77 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %76, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %78 = load i64, ptr %76, align 8
+  %79 = getelementptr %string_descriptor, ptr %stringFormat_desc25, i32 0, i32 0
+  store ptr %77, ptr %79, align 8
+  %80 = getelementptr %string_descriptor, ptr %stringFormat_desc25, i32 0, i32 1
+  store i64 %78, ptr %80, align 8
+  %81 = getelementptr %string_descriptor, ptr %stringFormat_desc25, i32 0, i32 0
+  %82 = load ptr, ptr %81, align 8
+  %83 = getelementptr %string_descriptor, ptr %stringFormat_desc25, i32 0, i32 1
+  %84 = load i64, ptr %83, align 8
   %85 = trunc i64 %84 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %82, i32 %85, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %86 = icmp eq i8* %77, null
+  call void @_lfortran_printf(ptr @15, ptr %82, i32 %85, ptr @14, i32 1)
+  %86 = icmp eq ptr %77, null
   br i1 %86, label %free_done27, label %free_nonnull26
 
 free_nonnull26:                                   ; preds = %ifcont24
-  call void @_lfortran_free_alloc(i8* %2, i8* %77)
+  call void @_lfortran_free_alloc(ptr %2, ptr %77)
   br label %free_done27
 
 free_done27:                                      ; preds = %free_nonnull26, %ifcont24
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 -1, ptr %i, align 4
   br label %loop.head28
 
 loop.head28:                                      ; preds = %loop.body29, %free_done27
-  %87 = load i32, i32* %i, align 4
+  %87 = load i32, ptr %i, align 4
   %88 = add i32 %87, 2
   %89 = icmp sle i32 %88, 10
   br i1 %89, label %loop.body29, label %loop.end30
 
 loop.body29:                                      ; preds = %loop.head28
-  %90 = load i32, i32* %i, align 4
+  %90 = load i32, ptr %i, align 4
   %91 = add i32 %90, 2
-  store i32 %91, i32* %i, align 4
-  %92 = load i32, i32* %j, align 4
-  %93 = load i32, i32* %i, align 4
+  store i32 %91, ptr %i, align 4
+  %92 = load i32, ptr %j, align 4
+  %93 = load i32, ptr %i, align 4
   %94 = add i32 %92, %93
-  store i32 %94, i32* %j, align 4
+  store i32 %94, ptr %j, align 4
   br label %loop.head28
 
 loop.end30:                                       ; preds = %loop.head28
-  %95 = load i32, i32* %j, align 4
+  %95 = load i32, ptr %j, align 4
   %96 = icmp ne i32 %95, 25
   br i1 %96, label %then31, label %else32
 
 then31:                                           ; preds = %loop.end30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -338,53 +339,53 @@ else32:                                           ; preds = %loop.end30
 
 ifcont33:                                         ; preds = %else32, %then31
   %97 = alloca i64, align 8
-  %98 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %97, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %99 = load i64, i64* %97, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
-  store i8* %98, i8** %100, align 8
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
-  store i64 %99, i64* %101, align 8
-  %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 0
-  %103 = load i8*, i8** %102, align 8
-  %104 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
-  %105 = load i64, i64* %104, align 8
+  %98 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %97, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %99 = load i64, ptr %97, align 8
+  %100 = getelementptr %string_descriptor, ptr %stringFormat_desc34, i32 0, i32 0
+  store ptr %98, ptr %100, align 8
+  %101 = getelementptr %string_descriptor, ptr %stringFormat_desc34, i32 0, i32 1
+  store i64 %99, ptr %101, align 8
+  %102 = getelementptr %string_descriptor, ptr %stringFormat_desc34, i32 0, i32 0
+  %103 = load ptr, ptr %102, align 8
+  %104 = getelementptr %string_descriptor, ptr %stringFormat_desc34, i32 0, i32 1
+  %105 = load i64, ptr %104, align 8
   %106 = trunc i64 %105 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %103, i32 %106, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
-  %107 = icmp eq i8* %98, null
+  call void @_lfortran_printf(ptr @19, ptr %103, i32 %106, ptr @18, i32 1)
+  %107 = icmp eq ptr %98, null
   br i1 %107, label %free_done36, label %free_nonnull35
 
 free_nonnull35:                                   ; preds = %ifcont33
-  call void @_lfortran_free_alloc(i8* %2, i8* %98)
+  call void @_lfortran_free_alloc(ptr %2, ptr %98)
   br label %free_done36
 
 free_done36:                                      ; preds = %free_nonnull35, %ifcont33
-  store i32 0, i32* %j, align 4
-  store i32 -2, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 -2, ptr %i, align 4
   br label %loop.head37
 
 loop.head37:                                      ; preds = %loop.body38, %free_done36
-  %108 = load i32, i32* %i, align 4
+  %108 = load i32, ptr %i, align 4
   %109 = add i32 %108, 3
   %110 = icmp sle i32 %109, 10
   br i1 %110, label %loop.body38, label %loop.end39
 
 loop.body38:                                      ; preds = %loop.head37
-  %111 = load i32, i32* %i, align 4
+  %111 = load i32, ptr %i, align 4
   %112 = add i32 %111, 3
-  store i32 %112, i32* %i, align 4
-  %113 = load i32, i32* %j, align 4
-  %114 = load i32, i32* %i, align 4
+  store i32 %112, ptr %i, align 4
+  %113 = load i32, ptr %j, align 4
+  %114 = load i32, ptr %i, align 4
   %115 = add i32 %113, %114
-  store i32 %115, i32* %j, align 4
+  store i32 %115, ptr %j, align 4
   br label %loop.head37
 
 loop.end39:                                       ; preds = %loop.head37
-  %116 = load i32, i32* %j, align 4
+  %116 = load i32, ptr %j, align 4
   %117 = icmp ne i32 %116, 22
   br i1 %117, label %then40, label %else41
 
 then40:                                           ; preds = %loop.end39
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -394,53 +395,53 @@ else41:                                           ; preds = %loop.end39
 
 ifcont42:                                         ; preds = %else41, %then40
   %118 = alloca i64, align 8
-  %119 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %118, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %120 = load i64, i64* %118, align 8
-  %121 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
-  store i8* %119, i8** %121, align 8
-  %122 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
-  store i64 %120, i64* %122, align 8
-  %123 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 0
-  %124 = load i8*, i8** %123, align 8
-  %125 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
-  %126 = load i64, i64* %125, align 8
+  %119 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.5, ptr %118, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %120 = load i64, ptr %118, align 8
+  %121 = getelementptr %string_descriptor, ptr %stringFormat_desc43, i32 0, i32 0
+  store ptr %119, ptr %121, align 8
+  %122 = getelementptr %string_descriptor, ptr %stringFormat_desc43, i32 0, i32 1
+  store i64 %120, ptr %122, align 8
+  %123 = getelementptr %string_descriptor, ptr %stringFormat_desc43, i32 0, i32 0
+  %124 = load ptr, ptr %123, align 8
+  %125 = getelementptr %string_descriptor, ptr %stringFormat_desc43, i32 0, i32 1
+  %126 = load i64, ptr %125, align 8
   %127 = trunc i64 %126 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %124, i32 %127, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
-  %128 = icmp eq i8* %119, null
+  call void @_lfortran_printf(ptr @23, ptr %124, i32 %127, ptr @22, i32 1)
+  %128 = icmp eq ptr %119, null
   br i1 %128, label %free_done45, label %free_nonnull44
 
 free_nonnull44:                                   ; preds = %ifcont42
-  call void @_lfortran_free_alloc(i8* %2, i8* %119)
+  call void @_lfortran_free_alloc(ptr %2, ptr %119)
   br label %free_done45
 
 free_done45:                                      ; preds = %free_nonnull44, %ifcont42
-  store i32 0, i32* %j, align 4
-  store i32 13, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 13, ptr %i, align 4
   br label %loop.head46
 
 loop.head46:                                      ; preds = %loop.body47, %free_done45
-  %129 = load i32, i32* %i, align 4
+  %129 = load i32, ptr %i, align 4
   %130 = add i32 %129, -3
   %131 = icmp sge i32 %130, 1
   br i1 %131, label %loop.body47, label %loop.end48
 
 loop.body47:                                      ; preds = %loop.head46
-  %132 = load i32, i32* %i, align 4
+  %132 = load i32, ptr %i, align 4
   %133 = add i32 %132, -3
-  store i32 %133, i32* %i, align 4
-  %134 = load i32, i32* %j, align 4
-  %135 = load i32, i32* %i, align 4
+  store i32 %133, ptr %i, align 4
+  %134 = load i32, ptr %j, align 4
+  %135 = load i32, ptr %i, align 4
   %136 = add i32 %134, %135
-  store i32 %136, i32* %j, align 4
+  store i32 %136, ptr %j, align 4
   br label %loop.head46
 
 loop.end48:                                       ; preds = %loop.head46
-  %137 = load i32, i32* %j, align 4
+  %137 = load i32, ptr %j, align 4
   %138 = icmp ne i32 %137, 22
   br i1 %138, label %then49, label %else50
 
 then49:                                           ; preds = %loop.end48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @25, ptr @"ERROR STOP", ptr @24)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -450,53 +451,53 @@ else50:                                           ; preds = %loop.end48
 
 ifcont51:                                         ; preds = %else50, %then49
   %139 = alloca i64, align 8
-  %140 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %139, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %141 = load i64, i64* %139, align 8
-  %142 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
-  store i8* %140, i8** %142, align 8
-  %143 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
-  store i64 %141, i64* %143, align 8
-  %144 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 0
-  %145 = load i8*, i8** %144, align 8
-  %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
-  %147 = load i64, i64* %146, align 8
+  %140 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.6, ptr %139, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %141 = load i64, ptr %139, align 8
+  %142 = getelementptr %string_descriptor, ptr %stringFormat_desc52, i32 0, i32 0
+  store ptr %140, ptr %142, align 8
+  %143 = getelementptr %string_descriptor, ptr %stringFormat_desc52, i32 0, i32 1
+  store i64 %141, ptr %143, align 8
+  %144 = getelementptr %string_descriptor, ptr %stringFormat_desc52, i32 0, i32 0
+  %145 = load ptr, ptr %144, align 8
+  %146 = getelementptr %string_descriptor, ptr %stringFormat_desc52, i32 0, i32 1
+  %147 = load i64, ptr %146, align 8
   %148 = trunc i64 %147 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %145, i32 %148, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
-  %149 = icmp eq i8* %140, null
+  call void @_lfortran_printf(ptr @27, ptr %145, i32 %148, ptr @26, i32 1)
+  %149 = icmp eq ptr %140, null
   br i1 %149, label %free_done54, label %free_nonnull53
 
 free_nonnull53:                                   ; preds = %ifcont51
-  call void @_lfortran_free_alloc(i8* %2, i8* %140)
+  call void @_lfortran_free_alloc(ptr %2, ptr %140)
   br label %free_done54
 
 free_done54:                                      ; preds = %free_nonnull53, %ifcont51
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head55
 
 loop.head55:                                      ; preds = %loop.body56, %free_done54
-  %150 = load i32, i32* %i, align 4
+  %150 = load i32, ptr %i, align 4
   %151 = add i32 %150, 1
   %152 = icmp sle i32 %151, 1
   br i1 %152, label %loop.body56, label %loop.end57
 
 loop.body56:                                      ; preds = %loop.head55
-  %153 = load i32, i32* %i, align 4
+  %153 = load i32, ptr %i, align 4
   %154 = add i32 %153, 1
-  store i32 %154, i32* %i, align 4
-  %155 = load i32, i32* %j, align 4
-  %156 = load i32, i32* %i, align 4
+  store i32 %154, ptr %i, align 4
+  %155 = load i32, ptr %j, align 4
+  %156 = load i32, ptr %i, align 4
   %157 = add i32 %155, %156
-  store i32 %157, i32* %j, align 4
+  store i32 %157, ptr %j, align 4
   br label %loop.head55
 
 loop.end57:                                       ; preds = %loop.head55
-  %158 = load i32, i32* %j, align 4
+  %158 = load i32, ptr %j, align 4
   %159 = icmp ne i32 %158, 1
   br i1 %159, label %then58, label %else59
 
 then58:                                           ; preds = %loop.end57
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @29, ptr @"ERROR STOP", ptr @28)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont60
@@ -506,53 +507,53 @@ else59:                                           ; preds = %loop.end57
 
 ifcont60:                                         ; preds = %else59, %then58
   %160 = alloca i64, align 8
-  %161 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.7, i32 0, i32 0), i64* %160, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %162 = load i64, i64* %160, align 8
-  %163 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
-  store i8* %161, i8** %163, align 8
-  %164 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
-  store i64 %162, i64* %164, align 8
-  %165 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 0
-  %166 = load i8*, i8** %165, align 8
-  %167 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
-  %168 = load i64, i64* %167, align 8
+  %161 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.7, ptr %160, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %162 = load i64, ptr %160, align 8
+  %163 = getelementptr %string_descriptor, ptr %stringFormat_desc61, i32 0, i32 0
+  store ptr %161, ptr %163, align 8
+  %164 = getelementptr %string_descriptor, ptr %stringFormat_desc61, i32 0, i32 1
+  store i64 %162, ptr %164, align 8
+  %165 = getelementptr %string_descriptor, ptr %stringFormat_desc61, i32 0, i32 0
+  %166 = load ptr, ptr %165, align 8
+  %167 = getelementptr %string_descriptor, ptr %stringFormat_desc61, i32 0, i32 1
+  %168 = load i64, ptr %167, align 8
   %169 = trunc i64 %168 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %166, i32 %169, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  %170 = icmp eq i8* %161, null
+  call void @_lfortran_printf(ptr @31, ptr %166, i32 %169, ptr @30, i32 1)
+  %170 = icmp eq ptr %161, null
   br i1 %170, label %free_done63, label %free_nonnull62
 
 free_nonnull62:                                   ; preds = %ifcont60
-  call void @_lfortran_free_alloc(i8* %2, i8* %161)
+  call void @_lfortran_free_alloc(ptr %2, ptr %161)
   br label %free_done63
 
 free_done63:                                      ; preds = %free_nonnull62, %ifcont60
-  store i32 0, i32* %j, align 4
-  store i32 2, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 2, ptr %i, align 4
   br label %loop.head64
 
 loop.head64:                                      ; preds = %loop.body65, %free_done63
-  %171 = load i32, i32* %i, align 4
+  %171 = load i32, ptr %i, align 4
   %172 = add i32 %171, -1
   %173 = icmp sge i32 %172, 1
   br i1 %173, label %loop.body65, label %loop.end66
 
 loop.body65:                                      ; preds = %loop.head64
-  %174 = load i32, i32* %i, align 4
+  %174 = load i32, ptr %i, align 4
   %175 = add i32 %174, -1
-  store i32 %175, i32* %i, align 4
-  %176 = load i32, i32* %j, align 4
-  %177 = load i32, i32* %i, align 4
+  store i32 %175, ptr %i, align 4
+  %176 = load i32, ptr %j, align 4
+  %177 = load i32, ptr %i, align 4
   %178 = add i32 %176, %177
-  store i32 %178, i32* %j, align 4
+  store i32 %178, ptr %j, align 4
   br label %loop.head64
 
 loop.end66:                                       ; preds = %loop.head64
-  %179 = load i32, i32* %j, align 4
+  %179 = load i32, ptr %j, align 4
   %180 = icmp ne i32 %179, 1
   br i1 %180, label %then67, label %else68
 
 then67:                                           ; preds = %loop.end66
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @33, ptr @"ERROR STOP", ptr @32)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -562,53 +563,53 @@ else68:                                           ; preds = %loop.end66
 
 ifcont69:                                         ; preds = %else68, %then67
   %181 = alloca i64, align 8
-  %182 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.8, i32 0, i32 0), i64* %181, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %183 = load i64, i64* %181, align 8
-  %184 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
-  store i8* %182, i8** %184, align 8
-  %185 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
-  store i64 %183, i64* %185, align 8
-  %186 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 0
-  %187 = load i8*, i8** %186, align 8
-  %188 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
-  %189 = load i64, i64* %188, align 8
+  %182 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.8, ptr %181, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %183 = load i64, ptr %181, align 8
+  %184 = getelementptr %string_descriptor, ptr %stringFormat_desc70, i32 0, i32 0
+  store ptr %182, ptr %184, align 8
+  %185 = getelementptr %string_descriptor, ptr %stringFormat_desc70, i32 0, i32 1
+  store i64 %183, ptr %185, align 8
+  %186 = getelementptr %string_descriptor, ptr %stringFormat_desc70, i32 0, i32 0
+  %187 = load ptr, ptr %186, align 8
+  %188 = getelementptr %string_descriptor, ptr %stringFormat_desc70, i32 0, i32 1
+  %189 = load i64, ptr %188, align 8
   %190 = trunc i64 %189 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %187, i32 %190, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
-  %191 = icmp eq i8* %182, null
+  call void @_lfortran_printf(ptr @35, ptr %187, i32 %190, ptr @34, i32 1)
+  %191 = icmp eq ptr %182, null
   br i1 %191, label %free_done72, label %free_nonnull71
 
 free_nonnull71:                                   ; preds = %ifcont69
-  call void @_lfortran_free_alloc(i8* %2, i8* %182)
+  call void @_lfortran_free_alloc(ptr %2, ptr %182)
   br label %free_done72
 
 free_done72:                                      ; preds = %free_nonnull71, %ifcont69
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head73
 
 loop.head73:                                      ; preds = %loop.body74, %free_done72
-  %192 = load i32, i32* %i, align 4
+  %192 = load i32, ptr %i, align 4
   %193 = add i32 %192, 1
   %194 = icmp sle i32 %193, 0
   br i1 %194, label %loop.body74, label %loop.end75
 
 loop.body74:                                      ; preds = %loop.head73
-  %195 = load i32, i32* %i, align 4
+  %195 = load i32, ptr %i, align 4
   %196 = add i32 %195, 1
-  store i32 %196, i32* %i, align 4
-  %197 = load i32, i32* %j, align 4
-  %198 = load i32, i32* %i, align 4
+  store i32 %196, ptr %i, align 4
+  %197 = load i32, ptr %j, align 4
+  %198 = load i32, ptr %i, align 4
   %199 = add i32 %197, %198
-  store i32 %199, i32* %j, align 4
+  store i32 %199, ptr %j, align 4
   br label %loop.head73
 
 loop.end75:                                       ; preds = %loop.head73
-  %200 = load i32, i32* %j, align 4
+  %200 = load i32, ptr %j, align 4
   %201 = icmp ne i32 %200, 0
   br i1 %201, label %then76, label %else77
 
 then76:                                           ; preds = %loop.end75
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @37, ptr @"ERROR STOP", ptr @36)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont78
@@ -618,53 +619,53 @@ else77:                                           ; preds = %loop.end75
 
 ifcont78:                                         ; preds = %else77, %then76
   %202 = alloca i64, align 8
-  %203 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.9, i32 0, i32 0), i64* %202, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %204 = load i64, i64* %202, align 8
-  %205 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
-  store i8* %203, i8** %205, align 8
-  %206 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
-  store i64 %204, i64* %206, align 8
-  %207 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 0
-  %208 = load i8*, i8** %207, align 8
-  %209 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
-  %210 = load i64, i64* %209, align 8
+  %203 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.9, ptr %202, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %204 = load i64, ptr %202, align 8
+  %205 = getelementptr %string_descriptor, ptr %stringFormat_desc79, i32 0, i32 0
+  store ptr %203, ptr %205, align 8
+  %206 = getelementptr %string_descriptor, ptr %stringFormat_desc79, i32 0, i32 1
+  store i64 %204, ptr %206, align 8
+  %207 = getelementptr %string_descriptor, ptr %stringFormat_desc79, i32 0, i32 0
+  %208 = load ptr, ptr %207, align 8
+  %209 = getelementptr %string_descriptor, ptr %stringFormat_desc79, i32 0, i32 1
+  %210 = load i64, ptr %209, align 8
   %211 = trunc i64 %210 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %208, i32 %211, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
-  %212 = icmp eq i8* %203, null
+  call void @_lfortran_printf(ptr @39, ptr %208, i32 %211, ptr @38, i32 1)
+  %212 = icmp eq ptr %203, null
   br i1 %212, label %free_done81, label %free_nonnull80
 
 free_nonnull80:                                   ; preds = %ifcont78
-  call void @_lfortran_free_alloc(i8* %2, i8* %203)
+  call void @_lfortran_free_alloc(ptr %2, ptr %203)
   br label %free_done81
 
 free_done81:                                      ; preds = %free_nonnull80, %ifcont78
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 1, ptr %i, align 4
   br label %loop.head82
 
 loop.head82:                                      ; preds = %loop.body83, %free_done81
-  %213 = load i32, i32* %i, align 4
+  %213 = load i32, ptr %i, align 4
   %214 = add i32 %213, -1
   %215 = icmp sge i32 %214, 1
   br i1 %215, label %loop.body83, label %loop.end84
 
 loop.body83:                                      ; preds = %loop.head82
-  %216 = load i32, i32* %i, align 4
+  %216 = load i32, ptr %i, align 4
   %217 = add i32 %216, -1
-  store i32 %217, i32* %i, align 4
-  %218 = load i32, i32* %j, align 4
-  %219 = load i32, i32* %i, align 4
+  store i32 %217, ptr %i, align 4
+  %218 = load i32, ptr %j, align 4
+  %219 = load i32, ptr %i, align 4
   %220 = add i32 %218, %219
-  store i32 %220, i32* %j, align 4
+  store i32 %220, ptr %j, align 4
   br label %loop.head82
 
 loop.end84:                                       ; preds = %loop.head82
-  %221 = load i32, i32* %j, align 4
+  %221 = load i32, ptr %j, align 4
   %222 = icmp ne i32 %221, 0
   br i1 %222, label %then85, label %else86
 
 then85:                                           ; preds = %loop.end84
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @41, ptr @"ERROR STOP", ptr @40)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont87
@@ -674,23 +675,23 @@ else86:                                           ; preds = %loop.end84
 
 ifcont87:                                         ; preds = %else86, %then85
   %223 = alloca i64, align 8
-  %224 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.10, i32 0, i32 0), i64* %223, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %225 = load i64, i64* %223, align 8
-  %226 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
-  store i8* %224, i8** %226, align 8
-  %227 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1
-  store i64 %225, i64* %227, align 8
-  %228 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 0
-  %229 = load i8*, i8** %228, align 8
-  %230 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1
-  %231 = load i64, i64* %230, align 8
+  %224 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.10, ptr %223, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %225 = load i64, ptr %223, align 8
+  %226 = getelementptr %string_descriptor, ptr %stringFormat_desc88, i32 0, i32 0
+  store ptr %224, ptr %226, align 8
+  %227 = getelementptr %string_descriptor, ptr %stringFormat_desc88, i32 0, i32 1
+  store i64 %225, ptr %227, align 8
+  %228 = getelementptr %string_descriptor, ptr %stringFormat_desc88, i32 0, i32 0
+  %229 = load ptr, ptr %228, align 8
+  %230 = getelementptr %string_descriptor, ptr %stringFormat_desc88, i32 0, i32 1
+  %231 = load i64, ptr %230, align 8
   %232 = trunc i64 %231 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %229, i32 %232, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
-  %233 = icmp eq i8* %224, null
+  call void @_lfortran_printf(ptr @43, ptr %229, i32 %232, ptr @42, i32 1)
+  %233 = icmp eq ptr %224, null
   br i1 %233, label %free_done90, label %free_nonnull89
 
 free_nonnull89:                                   ; preds = %ifcont87
-  call void @_lfortran_free_alloc(i8* %2, i8* %224)
+  call void @_lfortran_free_alloc(ptr %2, ptr %224)
   br label %free_done90
 
 free_done90:                                      ; preds = %free_nonnull89, %ifcont87
@@ -704,18 +705,18 @@ FINALIZE_SYMTABLE_doloop_01:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "6ee9a8bd660f873376ea08d67fda4f71e6c0f7dc92807e327f4126ab",
+    "stdout_hash": "268b48dc4cdce5794cfdd83068ccc2ca184a7e67266f6e8fa32d478b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -21,53 +22,53 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc22 = alloca %string_descriptor, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %a, align 4
-  store i32 10, i32* %b, align 4
-  %3 = load i32, i32* %b, align 4
-  store i32 %3, i32* %__do_loop_end, align 4
-  %4 = load i32, i32* %a, align 4
+  store i32 0, ptr %j, align 4
+  store i32 1, ptr %a, align 4
+  store i32 10, ptr %b, align 4
+  %3 = load i32, ptr %b, align 4
+  store i32 %3, ptr %__do_loop_end, align 4
+  %4 = load i32, ptr %a, align 4
   %5 = sub i32 %4, 1
-  store i32 %5, i32* %i, align 4
+  store i32 %5, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  %8 = load i32, i32* %__do_loop_end, align 4
+  %8 = load i32, ptr %__do_loop_end, align 4
   %9 = icmp sle i32 %7, %8
   br i1 %9, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %10 = load i32, i32* %i, align 4
+  %10 = load i32, ptr %i, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %i, align 4
-  %12 = load i32, i32* %j, align 4
-  %13 = load i32, i32* %i, align 4
+  store i32 %11, ptr %i, align 4
+  %12 = load i32, ptr %j, align 4
+  %13 = load i32, ptr %i, align 4
   %14 = add i32 %12, %13
-  store i32 %14, i32* %j, align 4
+  store i32 %14, ptr %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %15 = load i32, i32* %j, align 4
+  %15 = load i32, ptr %j, align 4
   %16 = icmp ne i32 %15, 55
   br i1 %16, label %then, label %else
 
 then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -77,73 +78,73 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %18)
+  call void @_lfortran_free_alloc(ptr %2, ptr %18)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %a, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %a, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.end5, %free_done
-  %28 = load i32, i32* %i, align 4
+  %28 = load i32, ptr %i, align 4
   %29 = add i32 %28, 1
   %30 = icmp sle i32 %29, 10
   br i1 %30, label %loop.body2, label %loop.end6
 
 loop.body2:                                       ; preds = %loop.head1
-  %31 = load i32, i32* %i, align 4
+  %31 = load i32, ptr %i, align 4
   %32 = add i32 %31, 1
-  store i32 %32, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %32, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head3
 
 loop.head3:                                       ; preds = %loop.body4, %loop.body2
-  %33 = load i32, i32* %j, align 4
+  %33 = load i32, ptr %j, align 4
   %34 = add i32 %33, 1
   %35 = icmp sle i32 %34, 10
   br i1 %35, label %loop.body4, label %loop.end5
 
 loop.body4:                                       ; preds = %loop.head3
-  %36 = load i32, i32* %j, align 4
+  %36 = load i32, ptr %j, align 4
   %37 = add i32 %36, 1
-  store i32 %37, i32* %j, align 4
-  %38 = load i32, i32* %a, align 4
-  %39 = load i32, i32* %i, align 4
+  store i32 %37, ptr %j, align 4
+  %38 = load i32, ptr %a, align 4
+  %39 = load i32, ptr %i, align 4
   %40 = sub i32 %39, 1
   %41 = mul i32 %40, 10
   %42 = add i32 %38, %41
-  %43 = load i32, i32* %j, align 4
+  %43 = load i32, ptr %j, align 4
   %44 = add i32 %42, %43
-  store i32 %44, i32* %a, align 4
+  store i32 %44, ptr %a, align 4
   br label %loop.head3
 
 loop.end5:                                        ; preds = %loop.head3
   br label %loop.head1
 
 loop.end6:                                        ; preds = %loop.head1
-  %45 = load i32, i32* %a, align 4
+  %45 = load i32, ptr %a, align 4
   %46 = icmp ne i32 %45, 5050
   br i1 %46, label %then7, label %else8
 
 then7:                                            ; preds = %loop.end6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -153,72 +154,72 @@ else8:                                            ; preds = %loop.end6
 
 ifcont9:                                          ; preds = %else8, %then7
   %47 = alloca i64, align 8
-  %48 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %47, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a)
-  %49 = load i64, i64* %47, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %48, i8** %50, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %49, i64* %51, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %55 = load i64, i64* %54, align 8
+  %48 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %47, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a)
+  %49 = load i64, ptr %47, align 8
+  %50 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %48, ptr %50, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %49, ptr %51, align 8
+  %52 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %55 = load i64, ptr %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %57 = icmp eq i8* %48, null
+  call void @_lfortran_printf(ptr @7, ptr %53, i32 %56, ptr @6, i32 1)
+  %57 = icmp eq ptr %48, null
   br i1 %57, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %ifcont9
-  call void @_lfortran_free_alloc(i8* %2, i8* %48)
+  call void @_lfortran_free_alloc(ptr %2, ptr %48)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
-  store i32 0, i32* %a, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %a, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head13
 
 loop.head13:                                      ; preds = %loop.end17, %free_done12
-  %58 = load i32, i32* %i, align 4
+  %58 = load i32, ptr %i, align 4
   %59 = add i32 %58, 1
   %60 = icmp sle i32 %59, 10
   br i1 %60, label %loop.body14, label %loop.end18
 
 loop.body14:                                      ; preds = %loop.head13
-  %61 = load i32, i32* %i, align 4
+  %61 = load i32, ptr %i, align 4
   %62 = add i32 %61, 1
-  store i32 %62, i32* %i, align 4
-  %63 = load i32, i32* %i, align 4
-  store i32 %63, i32* %__do_loop_end1, align 4
-  store i32 0, i32* %j, align 4
+  store i32 %62, ptr %i, align 4
+  %63 = load i32, ptr %i, align 4
+  store i32 %63, ptr %__do_loop_end1, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head15
 
 loop.head15:                                      ; preds = %loop.body16, %loop.body14
-  %64 = load i32, i32* %j, align 4
+  %64 = load i32, ptr %j, align 4
   %65 = add i32 %64, 1
-  %66 = load i32, i32* %__do_loop_end1, align 4
+  %66 = load i32, ptr %__do_loop_end1, align 4
   %67 = icmp sle i32 %65, %66
   br i1 %67, label %loop.body16, label %loop.end17
 
 loop.body16:                                      ; preds = %loop.head15
-  %68 = load i32, i32* %j, align 4
+  %68 = load i32, ptr %j, align 4
   %69 = add i32 %68, 1
-  store i32 %69, i32* %j, align 4
-  %70 = load i32, i32* %a, align 4
-  %71 = load i32, i32* %j, align 4
+  store i32 %69, ptr %j, align 4
+  %70 = load i32, ptr %a, align 4
+  %71 = load i32, ptr %j, align 4
   %72 = add i32 %70, %71
-  store i32 %72, i32* %a, align 4
+  store i32 %72, ptr %a, align 4
   br label %loop.head15
 
 loop.end17:                                       ; preds = %loop.head15
   br label %loop.head13
 
 loop.end18:                                       ; preds = %loop.head13
-  %73 = load i32, i32* %a, align 4
+  %73 = load i32, ptr %a, align 4
   %74 = icmp ne i32 %73, 220
   br i1 %74, label %then19, label %else20
 
 then19:                                           ; preds = %loop.end18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -228,23 +229,23 @@ else20:                                           ; preds = %loop.end18
 
 ifcont21:                                         ; preds = %else20, %then19
   %75 = alloca i64, align 8
-  %76 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %75, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a)
-  %77 = load i64, i64* %75, align 8
-  %78 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
-  store i8* %76, i8** %78, align 8
-  %79 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1
-  store i64 %77, i64* %79, align 8
-  %80 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 0
-  %81 = load i8*, i8** %80, align 8
-  %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1
-  %83 = load i64, i64* %82, align 8
+  %76 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %75, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a)
+  %77 = load i64, ptr %75, align 8
+  %78 = getelementptr %string_descriptor, ptr %stringFormat_desc22, i32 0, i32 0
+  store ptr %76, ptr %78, align 8
+  %79 = getelementptr %string_descriptor, ptr %stringFormat_desc22, i32 0, i32 1
+  store i64 %77, ptr %79, align 8
+  %80 = getelementptr %string_descriptor, ptr %stringFormat_desc22, i32 0, i32 0
+  %81 = load ptr, ptr %80, align 8
+  %82 = getelementptr %string_descriptor, ptr %stringFormat_desc22, i32 0, i32 1
+  %83 = load i64, ptr %82, align 8
   %84 = trunc i64 %83 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %81, i32 %84, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %85 = icmp eq i8* %76, null
+  call void @_lfortran_printf(ptr @11, ptr %81, i32 %84, ptr @10, i32 1)
+  %85 = icmp eq ptr %76, null
   br i1 %85, label %free_done24, label %free_nonnull23
 
 free_nonnull23:                                   ; preds = %ifcont21
-  call void @_lfortran_free_alloc(i8* %2, i8* %76)
+  call void @_lfortran_free_alloc(ptr %2, ptr %76)
   br label %free_done24
 
 free_done24:                                      ; preds = %free_nonnull23, %ifcont21
@@ -258,18 +259,18 @@ FINALIZE_SYMTABLE_doloop_02:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "035bc0136927213fe459bcb7d595aef9a4986c2f8893507d0ecbe4b4",
+    "stdout_hash": "1ba6cf462f1350d7804a0cbab41a3ea44fc1fd1c15dc04768a12c747",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -21,34 +22,34 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc29 = alloca %string_descriptor, align 8
   %stringFormat_desc17 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont3, %.entry
-  %3 = load i32, i32* %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 10
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %i, align 4
+  %6 = load i32, ptr %i, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %i, align 4
-  %8 = load i32, i32* %j, align 4
-  %9 = load i32, i32* %i, align 4
+  store i32 %7, ptr %i, align 4
+  %8 = load i32, ptr %j, align 4
+  %9 = load i32, ptr %i, align 4
   %10 = add i32 %8, %9
-  store i32 %10, i32* %j, align 4
-  %11 = load i32, i32* %i, align 4
+  store i32 %10, ptr %j, align 4
+  %11 = load i32, ptr %i, align 4
   %12 = icmp eq i32 %11, 3
   br i1 %12, label %then, label %else
 
@@ -59,7 +60,7 @@ else:                                             ; preds = %loop.body
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %13 = load i32, i32* %i, align 4
+  %13 = load i32, ptr %i, align 4
   %14 = icmp eq i32 %13, 2
   br i1 %14, label %then1, label %else2
 
@@ -76,12 +77,12 @@ ifcont3:                                          ; preds = %else2, %unreachable
   br label %loop.head
 
 loop.end:                                         ; preds = %then1, %loop.head
-  %15 = load i32, i32* %j, align 4
+  %15 = load i32, ptr %j, align 4
   %16 = icmp ne i32 %15, 3
   br i1 %16, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -91,41 +92,41 @@ else5:                                            ; preds = %loop.end
 
 ifcont6:                                          ; preds = %else5, %then4
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont6
-  call void @_lfortran_free_alloc(i8* %2, i8* %18)
+  call void @_lfortran_free_alloc(ptr %2, ptr %18)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head7
 
 loop.head7:                                       ; preds = %ifcont12, %free_done
-  %28 = load i32, i32* %i, align 4
+  %28 = load i32, ptr %i, align 4
   %29 = add i32 %28, 1
   %30 = icmp sle i32 %29, 10
   br i1 %30, label %loop.body8, label %loop.end13
 
 loop.body8:                                       ; preds = %loop.head7
-  %31 = load i32, i32* %i, align 4
+  %31 = load i32, ptr %i, align 4
   %32 = add i32 %31, 1
-  store i32 %32, i32* %i, align 4
-  %33 = load i32, i32* %i, align 4
+  store i32 %32, ptr %i, align 4
+  %33 = load i32, ptr %i, align 4
   %34 = icmp eq i32 %33, 2
   br i1 %34, label %then9, label %else11
 
@@ -139,19 +140,19 @@ else11:                                           ; preds = %loop.body8
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %unreachable_after_exit10
-  %35 = load i32, i32* %j, align 4
-  %36 = load i32, i32* %i, align 4
+  %35 = load i32, ptr %j, align 4
+  %36 = load i32, ptr %i, align 4
   %37 = add i32 %35, %36
-  store i32 %37, i32* %j, align 4
+  store i32 %37, ptr %j, align 4
   br label %loop.head7
 
 loop.end13:                                       ; preds = %then9, %loop.head7
-  %38 = load i32, i32* %j, align 4
+  %38 = load i32, ptr %j, align 4
   %39 = icmp ne i32 %38, 1
   br i1 %39, label %then14, label %else15
 
 then14:                                           ; preds = %loop.end13
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont16
@@ -161,41 +162,41 @@ else15:                                           ; preds = %loop.end13
 
 ifcont16:                                         ; preds = %else15, %then14
   %40 = alloca i64, align 8
-  %41 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %40, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %42 = load i64, i64* %40, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
-  store i8* %41, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
-  store i64 %42, i64* %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
+  %41 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %40, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %42 = load i64, ptr %40, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc17, i32 0, i32 0
+  store ptr %41, ptr %43, align 8
+  %44 = getelementptr %string_descriptor, ptr %stringFormat_desc17, i32 0, i32 1
+  store i64 %42, ptr %44, align 8
+  %45 = getelementptr %string_descriptor, ptr %stringFormat_desc17, i32 0, i32 0
+  %46 = load ptr, ptr %45, align 8
+  %47 = getelementptr %string_descriptor, ptr %stringFormat_desc17, i32 0, i32 1
+  %48 = load i64, ptr %47, align 8
   %49 = trunc i64 %48 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %50 = icmp eq i8* %41, null
+  call void @_lfortran_printf(ptr @7, ptr %46, i32 %49, ptr @6, i32 1)
+  %50 = icmp eq ptr %41, null
   br i1 %50, label %free_done19, label %free_nonnull18
 
 free_nonnull18:                                   ; preds = %ifcont16
-  call void @_lfortran_free_alloc(i8* %2, i8* %41)
+  call void @_lfortran_free_alloc(ptr %2, ptr %41)
   br label %free_done19
 
 free_done19:                                      ; preds = %free_nonnull18, %ifcont16
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %loop.head20
 
 loop.head20:                                      ; preds = %ifcont24, %then22, %free_done19
-  %51 = load i32, i32* %i, align 4
+  %51 = load i32, ptr %i, align 4
   %52 = add i32 %51, 1
   %53 = icmp sle i32 %52, 10
   br i1 %53, label %loop.body21, label %loop.end25
 
 loop.body21:                                      ; preds = %loop.head20
-  %54 = load i32, i32* %i, align 4
+  %54 = load i32, ptr %i, align 4
   %55 = add i32 %54, 1
-  store i32 %55, i32* %i, align 4
-  %56 = load i32, i32* %i, align 4
+  store i32 %55, ptr %i, align 4
+  %56 = load i32, ptr %i, align 4
   %57 = icmp eq i32 %56, 2
   br i1 %57, label %then22, label %else23
 
@@ -209,19 +210,19 @@ else23:                                           ; preds = %loop.body21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %unreachable_after_cycle
-  %58 = load i32, i32* %j, align 4
-  %59 = load i32, i32* %i, align 4
+  %58 = load i32, ptr %j, align 4
+  %59 = load i32, ptr %i, align 4
   %60 = add i32 %58, %59
-  store i32 %60, i32* %j, align 4
+  store i32 %60, ptr %j, align 4
   br label %loop.head20
 
 loop.end25:                                       ; preds = %loop.head20
-  %61 = load i32, i32* %j, align 4
+  %61 = load i32, ptr %j, align 4
   %62 = icmp ne i32 %61, 53
   br i1 %62, label %then26, label %else27
 
 then26:                                           ; preds = %loop.end25
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont28
@@ -231,23 +232,23 @@ else27:                                           ; preds = %loop.end25
 
 ifcont28:                                         ; preds = %else27, %then26
   %63 = alloca i64, align 8
-  %64 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %63, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %65 = load i64, i64* %63, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
-  store i8* %64, i8** %66, align 8
-  %67 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1
-  store i64 %65, i64* %67, align 8
-  %68 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 0
-  %69 = load i8*, i8** %68, align 8
-  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1
-  %71 = load i64, i64* %70, align 8
+  %64 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %63, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %65 = load i64, ptr %63, align 8
+  %66 = getelementptr %string_descriptor, ptr %stringFormat_desc29, i32 0, i32 0
+  store ptr %64, ptr %66, align 8
+  %67 = getelementptr %string_descriptor, ptr %stringFormat_desc29, i32 0, i32 1
+  store i64 %65, ptr %67, align 8
+  %68 = getelementptr %string_descriptor, ptr %stringFormat_desc29, i32 0, i32 0
+  %69 = load ptr, ptr %68, align 8
+  %70 = getelementptr %string_descriptor, ptr %stringFormat_desc29, i32 0, i32 1
+  %71 = load i64, ptr %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %73 = icmp eq i8* %64, null
+  call void @_lfortran_printf(ptr @11, ptr %69, i32 %72, ptr @10, i32 1)
+  %73 = icmp eq ptr %64, null
   br i1 %73, label %free_done31, label %free_nonnull30
 
 free_nonnull30:                                   ; preds = %ifcont28
-  call void @_lfortran_free_alloc(i8* %2, i8* %64)
+  call void @_lfortran_free_alloc(ptr %2, ptr %64)
   br label %free_done31
 
 free_done31:                                      ; preds = %free_nonnull30, %ifcont28
@@ -261,18 +262,18 @@ FINALIZE_SYMTABLE_doloop_03:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "7f4df1d6f87de9fcf3ec8ef3b2f34730e26406a04620b1db36f02a54",
+    "stdout_hash": "2a752fc4c424eda8a15a9c8bea2ccb183c244f4d8a6182e563d56f4e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -22,39 +23,39 @@ target datalayout = "..."
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc7 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__do_loop_inc = alloca i32, align 4
   %__do_loop_inc1 = alloca i32, align 4
   %__do_loop_inc2 = alloca i32, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
   %k = alloca i32, align 4
-  store i32 0, i32* %j, align 4
-  store i32 2, i32* %k, align 4
-  %3 = load i32, i32* %k, align 4
-  store i32 %3, i32* %__do_loop_inc, align 4
-  %4 = load i32, i32* %__do_loop_inc, align 4
+  store i32 0, ptr %j, align 4
+  store i32 2, ptr %k, align 4
+  %3 = load i32, ptr %k, align 4
+  store i32 %3, ptr %__do_loop_inc, align 4
+  %4 = load i32, ptr %__do_loop_inc, align 4
   %5 = sub i32 1, %4
-  store i32 %5, i32* %i, align 4
+  store i32 %5, ptr %i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %6 = load i32, i32* %__do_loop_inc, align 4
+  %6 = load i32, ptr %__do_loop_inc, align 4
   %7 = icmp sgt i32 %6, 0
-  %8 = load i32, i32* %i, align 4
-  %9 = load i32, i32* %__do_loop_inc, align 4
+  %8 = load i32, ptr %i, align 4
+  %9 = load i32, ptr %__do_loop_inc, align 4
   %10 = add i32 %8, %9
   %11 = icmp sle i32 %10, 10
   %12 = and i1 %7, %11
-  %13 = load i32, i32* %__do_loop_inc, align 4
+  %13 = load i32, ptr %__do_loop_inc, align 4
   %14 = icmp sle i32 %13, 0
-  %15 = load i32, i32* %i, align 4
-  %16 = load i32, i32* %__do_loop_inc, align 4
+  %15 = load i32, ptr %i, align 4
+  %16 = load i32, ptr %__do_loop_inc, align 4
   %17 = add i32 %15, %16
   %18 = icmp sge i32 %17, 10
   %19 = and i1 %14, %18
@@ -62,23 +63,23 @@ loop.head:                                        ; preds = %loop.body, %.entry
   br i1 %20, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %21 = load i32, i32* %i, align 4
-  %22 = load i32, i32* %__do_loop_inc, align 4
+  %21 = load i32, ptr %i, align 4
+  %22 = load i32, ptr %__do_loop_inc, align 4
   %23 = add i32 %21, %22
-  store i32 %23, i32* %i, align 4
-  %24 = load i32, i32* %j, align 4
-  %25 = load i32, i32* %i, align 4
+  store i32 %23, ptr %i, align 4
+  %24 = load i32, ptr %j, align 4
+  %25 = load i32, ptr %i, align 4
   %26 = add i32 %24, %25
-  store i32 %26, i32* %j, align 4
+  store i32 %26, ptr %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %27 = load i32, i32* %j, align 4
+  %27 = load i32, ptr %j, align 4
   %28 = icmp ne i32 %27, 25
   br i1 %28, label %then, label %else
 
 then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -88,47 +89,47 @@ else:                                             ; preds = %loop.end
 
 ifcont:                                           ; preds = %else, %then
   %29 = alloca i64, align 8
-  %30 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %31 = load i64, i64* %29, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %30, i8** %32, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %31, i64* %33, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %35 = load i8*, i8** %34, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %37 = load i64, i64* %36, align 8
+  %30 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %29, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %31 = load i64, ptr %29, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %30, ptr %32, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %31, ptr %33, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %35 = load ptr, ptr %34, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %37 = load i64, ptr %36, align 8
   %38 = trunc i64 %37 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %35, i32 %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %39 = icmp eq i8* %30, null
+  call void @_lfortran_printf(ptr @3, ptr %35, i32 %38, ptr @2, i32 1)
+  %39 = icmp eq ptr %30, null
   br i1 %39, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %30)
+  call void @_lfortran_free_alloc(ptr %2, ptr %30)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  store i32 0, i32* %j, align 4
-  store i32 -2, i32* %k, align 4
-  %40 = load i32, i32* %k, align 4
-  store i32 %40, i32* %__do_loop_inc1, align 4
-  %41 = load i32, i32* %__do_loop_inc1, align 4
+  store i32 0, ptr %j, align 4
+  store i32 -2, ptr %k, align 4
+  %40 = load i32, ptr %k, align 4
+  store i32 %40, ptr %__do_loop_inc1, align 4
+  %41 = load i32, ptr %__do_loop_inc1, align 4
   %42 = sub i32 10, %41
-  store i32 %42, i32* %i, align 4
+  store i32 %42, ptr %i, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %loop.body2, %free_done
-  %43 = load i32, i32* %__do_loop_inc1, align 4
+  %43 = load i32, ptr %__do_loop_inc1, align 4
   %44 = icmp sgt i32 %43, 0
-  %45 = load i32, i32* %i, align 4
-  %46 = load i32, i32* %__do_loop_inc1, align 4
+  %45 = load i32, ptr %i, align 4
+  %46 = load i32, ptr %__do_loop_inc1, align 4
   %47 = add i32 %45, %46
   %48 = icmp sle i32 %47, 1
   %49 = and i1 %44, %48
-  %50 = load i32, i32* %__do_loop_inc1, align 4
+  %50 = load i32, ptr %__do_loop_inc1, align 4
   %51 = icmp sle i32 %50, 0
-  %52 = load i32, i32* %i, align 4
-  %53 = load i32, i32* %__do_loop_inc1, align 4
+  %52 = load i32, ptr %i, align 4
+  %53 = load i32, ptr %__do_loop_inc1, align 4
   %54 = add i32 %52, %53
   %55 = icmp sge i32 %54, 1
   %56 = and i1 %51, %55
@@ -136,23 +137,23 @@ loop.head1:                                       ; preds = %loop.body2, %free_d
   br i1 %57, label %loop.body2, label %loop.end3
 
 loop.body2:                                       ; preds = %loop.head1
-  %58 = load i32, i32* %i, align 4
-  %59 = load i32, i32* %__do_loop_inc1, align 4
+  %58 = load i32, ptr %i, align 4
+  %59 = load i32, ptr %__do_loop_inc1, align 4
   %60 = add i32 %58, %59
-  store i32 %60, i32* %i, align 4
-  %61 = load i32, i32* %j, align 4
-  %62 = load i32, i32* %i, align 4
+  store i32 %60, ptr %i, align 4
+  %61 = load i32, ptr %j, align 4
+  %62 = load i32, ptr %i, align 4
   %63 = add i32 %61, %62
-  store i32 %63, i32* %j, align 4
+  store i32 %63, ptr %j, align 4
   br label %loop.head1
 
 loop.end3:                                        ; preds = %loop.head1
-  %64 = load i32, i32* %j, align 4
+  %64 = load i32, ptr %j, align 4
   %65 = icmp ne i32 %64, 30
   br i1 %65, label %then4, label %else5
 
 then4:                                            ; preds = %loop.end3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -162,45 +163,45 @@ else5:                                            ; preds = %loop.end3
 
 ifcont6:                                          ; preds = %else5, %then4
   %66 = alloca i64, align 8
-  %67 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %66, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %68 = load i64, i64* %66, align 8
-  %69 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %67, i8** %69, align 8
-  %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %68, i64* %70, align 8
-  %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %72 = load i8*, i8** %71, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %74 = load i64, i64* %73, align 8
+  %67 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %66, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %68 = load i64, ptr %66, align 8
+  %69 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %67, ptr %69, align 8
+  %70 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %68, ptr %70, align 8
+  %71 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %72 = load ptr, ptr %71, align 8
+  %73 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %74 = load i64, ptr %73, align 8
   %75 = trunc i64 %74 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %72, i32 %75, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %76 = icmp eq i8* %67, null
+  call void @_lfortran_printf(ptr @7, ptr %72, i32 %75, ptr @6, i32 1)
+  %76 = icmp eq ptr %67, null
   br i1 %76, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %ifcont6
-  call void @_lfortran_free_alloc(i8* %2, i8* %67)
+  call void @_lfortran_free_alloc(ptr %2, ptr %67)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %ifcont6
-  store i32 0, i32* %j, align 4
-  store i32 0, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 0, ptr %i, align 4
   br label %a.head
 
 a.head:                                           ; preds = %ifcont12, %free_done9
-  %77 = load i32, i32* %i, align 4
+  %77 = load i32, ptr %i, align 4
   %78 = add i32 %77, 1
   %79 = icmp sle i32 %78, 10
   br i1 %79, label %a.body, label %a.end
 
 a.body:                                           ; preds = %a.head
-  %80 = load i32, i32* %i, align 4
+  %80 = load i32, ptr %i, align 4
   %81 = add i32 %80, 1
-  store i32 %81, i32* %i, align 4
-  %82 = load i32, i32* %j, align 4
-  %83 = load i32, i32* %i, align 4
+  store i32 %81, ptr %i, align 4
+  %82 = load i32, ptr %j, align 4
+  %83 = load i32, ptr %i, align 4
   %84 = add i32 %82, %83
-  store i32 %84, i32* %j, align 4
-  %85 = load i32, i32* %i, align 4
+  store i32 %84, ptr %j, align 4
+  %85 = load i32, ptr %i, align 4
   %86 = icmp eq i32 %85, 2
   br i1 %86, label %then10, label %else11
 
@@ -217,12 +218,12 @@ ifcont12:                                         ; preds = %else11, %unreachabl
   br label %a.head
 
 a.end:                                            ; preds = %then10, %a.head
-  %87 = load i32, i32* %j, align 4
+  %87 = load i32, ptr %j, align 4
   %88 = icmp ne i32 %87, 3
   br i1 %88, label %then13, label %else14
 
 then13:                                           ; preds = %a.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -231,25 +232,25 @@ else14:                                           ; preds = %a.end
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  store i32 0, i32* %j, align 4
-  store i32 -1, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 -1, ptr %i, align 4
   br label %b.head
 
 b.head:                                           ; preds = %ifcont19, %ifcont15
-  %89 = load i32, i32* %i, align 4
+  %89 = load i32, ptr %i, align 4
   %90 = add i32 %89, 2
   %91 = icmp sle i32 %90, 10
   br i1 %91, label %b.body, label %b.end
 
 b.body:                                           ; preds = %b.head
-  %92 = load i32, i32* %i, align 4
+  %92 = load i32, ptr %i, align 4
   %93 = add i32 %92, 2
-  store i32 %93, i32* %i, align 4
-  %94 = load i32, i32* %j, align 4
-  %95 = load i32, i32* %i, align 4
+  store i32 %93, ptr %i, align 4
+  %94 = load i32, ptr %j, align 4
+  %95 = load i32, ptr %i, align 4
   %96 = add i32 %94, %95
-  store i32 %96, i32* %j, align 4
-  %97 = load i32, i32* %i, align 4
+  store i32 %96, ptr %j, align 4
+  %97 = load i32, ptr %i, align 4
   %98 = icmp eq i32 %97, 3
   br i1 %98, label %then16, label %else18
 
@@ -266,12 +267,12 @@ ifcont19:                                         ; preds = %else18, %unreachabl
   br label %b.head
 
 b.end:                                            ; preds = %then16, %b.head
-  %99 = load i32, i32* %j, align 4
+  %99 = load i32, ptr %j, align 4
   %100 = icmp ne i32 %99, 4
   br i1 %100, label %then20, label %else21
 
 then20:                                           ; preds = %b.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont22
@@ -280,19 +281,19 @@ else21:                                           ; preds = %b.end
   br label %ifcont22
 
 ifcont22:                                         ; preds = %else21, %then20
-  store i32 0, i32* %j, align 4
-  store i32 1, i32* %i, align 4
+  store i32 0, ptr %j, align 4
+  store i32 1, ptr %i, align 4
   br label %c.head
 
 c.head:                                           ; preds = %ifcont26, %ifcont22
   br i1 true, label %c.body, label %c.end
 
 c.body:                                           ; preds = %c.head
-  %101 = load i32, i32* %j, align 4
-  %102 = load i32, i32* %i, align 4
+  %101 = load i32, ptr %j, align 4
+  %102 = load i32, ptr %i, align 4
   %103 = add i32 %101, %102
-  store i32 %103, i32* %j, align 4
-  %104 = load i32, i32* %i, align 4
+  store i32 %103, ptr %j, align 4
+  %104 = load i32, ptr %i, align 4
   %105 = icmp eq i32 %104, 2
   br i1 %105, label %then23, label %else25
 
@@ -306,18 +307,18 @@ else25:                                           ; preds = %c.body
   br label %ifcont26
 
 ifcont26:                                         ; preds = %else25, %unreachable_after_exit24
-  %106 = load i32, i32* %i, align 4
+  %106 = load i32, ptr %i, align 4
   %107 = add i32 %106, 1
-  store i32 %107, i32* %i, align 4
+  store i32 %107, ptr %i, align 4
   br label %c.head
 
 c.end:                                            ; preds = %then23, %c.head
-  %108 = load i32, i32* %j, align 4
+  %108 = load i32, ptr %j, align 4
   %109 = icmp ne i32 %108, 3
   br i1 %109, label %then27, label %else28
 
 then27:                                           ; preds = %c.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont29
@@ -326,26 +327,26 @@ else28:                                           ; preds = %c.end
   br label %ifcont29
 
 ifcont29:                                         ; preds = %else28, %then27
-  store i32 2, i32* %k, align 4
-  %110 = load i32, i32* %k, align 4
-  store i32 %110, i32* %__do_loop_inc2, align 4
-  %111 = load i32, i32* %__do_loop_inc2, align 4
+  store i32 2, ptr %k, align 4
+  %110 = load i32, ptr %k, align 4
+  store i32 %110, ptr %__do_loop_inc2, align 4
+  %111 = load i32, ptr %__do_loop_inc2, align 4
   %112 = sub i32 1, %111
-  store i32 %112, i32* %i, align 4
+  store i32 %112, ptr %i, align 4
   br label %loop.head30
 
 loop.head30:                                      ; preds = %goto_target, %ifcont29
-  %113 = load i32, i32* %__do_loop_inc2, align 4
+  %113 = load i32, ptr %__do_loop_inc2, align 4
   %114 = icmp sgt i32 %113, 0
-  %115 = load i32, i32* %i, align 4
-  %116 = load i32, i32* %__do_loop_inc2, align 4
+  %115 = load i32, ptr %i, align 4
+  %116 = load i32, ptr %__do_loop_inc2, align 4
   %117 = add i32 %115, %116
   %118 = icmp sle i32 %117, 10
   %119 = and i1 %114, %118
-  %120 = load i32, i32* %__do_loop_inc2, align 4
+  %120 = load i32, ptr %__do_loop_inc2, align 4
   %121 = icmp sle i32 %120, 0
-  %122 = load i32, i32* %i, align 4
-  %123 = load i32, i32* %__do_loop_inc2, align 4
+  %122 = load i32, ptr %i, align 4
+  %123 = load i32, ptr %__do_loop_inc2, align 4
   %124 = add i32 %122, %123
   %125 = icmp sge i32 %124, 10
   %126 = and i1 %121, %125
@@ -353,10 +354,10 @@ loop.head30:                                      ; preds = %goto_target, %ifcon
   br i1 %127, label %loop.body31, label %loop.end32
 
 loop.body31:                                      ; preds = %loop.head30
-  %128 = load i32, i32* %i, align 4
-  %129 = load i32, i32* %__do_loop_inc2, align 4
+  %128 = load i32, ptr %i, align 4
+  %129 = load i32, ptr %__do_loop_inc2, align 4
   %130 = add i32 %128, %129
-  store i32 %130, i32* %i, align 4
+  store i32 %130, ptr %i, align 4
   br label %goto_target
 
 goto_target:                                      ; preds = %loop.body31
@@ -373,18 +374,18 @@ FINALIZE_SYMTABLE_doloop_04:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-empty-cb5d1b4.json
+++ b/tests/reference/llvm-empty-cb5d1b4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-empty-cb5d1b4.stdout",
-    "stdout_hash": "a146b393d2e0f35cf565405c5e6092f8b905119fa2d30272983cb44e",
+    "stdout_hash": "e13426ef4ca6c7944f9ea16bd383417e6ab4479beb89d70cc5cd8bca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-empty-cb5d1b4.stdout
+++ b/tests/reference/llvm-empty-cb5d1b4.stdout
@@ -1,3 +1,4 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"

--- a/tests/reference/llvm-execute_command_line-0e9cd63.json
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-execute_command_line-0e9cd63.stdout",
-    "stdout_hash": "f2ea6c742324a963e43e392fca6847b1dee12d61f139e39d0265ff19",
+    "stdout_hash": "948213c3d9085a6a0f66928a98517e15b5320d448eefc4ea553c88d0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-execute_command_line-0e9cd63.stdout
+++ b/tests/reference/llvm-execute_command_line-0e9cd63.stdout
@@ -1,26 +1,27 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @string_const_data = private constant [18 x i8] c"echo \22Hello World\22"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([18 x i8], [18 x i8]* @string_const_data, i32 0, i32 0), i64 18 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 18 }>
 @string_const_data.1 = private constant [2 x i8] c"ls"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data.1, i32 0, i32 0), i64 2 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 2 }>
 
-define void @_lcompilers_execute_command_line_(%string_descriptor* %command, i32* %wait) {
+define void @_lcompilers_execute_command_line_(ptr %command, ptr %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
-  %1 = load i8*, i8** %0, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
-  %3 = load i8*, i8** %2, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
-  %5 = load i64, i64* %4, align 8
+  %0 = getelementptr %string_descriptor, ptr %command, i32 0, i32 0
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %string_descriptor, ptr %command, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr %string_descriptor, ptr %command, i32 0, i32 1
+  %5 = load i64, ptr %4, align 8
   %6 = trunc i64 %5 to i32
-  %7 = call i32 @_lfortran_exec_command(i8* %3, i32 %6)
-  store i32 %7, i32* %_lcompilers_exit_status, align 4
+  %7 = call i32 @_lfortran_exec_command(ptr %3, i32 %6)
+  store i32 %7, ptr %_lcompilers_exit_status, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -30,20 +31,20 @@ FINALIZE_SYMTABLE__lcompilers_execute_command_line_: ; preds = %return
   ret void
 }
 
-declare i32 @_lfortran_exec_command(i8*, i32)
+declare i32 @_lfortran_exec_command(ptr, i32)
 
-define void @_lcompilers_execute_command_line_1(%string_descriptor* %command, i32* %wait) {
+define void @_lcompilers_execute_command_line_1(ptr %command, ptr %wait) {
 .entry:
   %_lcompilers_exit_status = alloca i32, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
-  %1 = load i8*, i8** %0, align 8
-  %2 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 0
-  %3 = load i8*, i8** %2, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %command, i32 0, i32 1
-  %5 = load i64, i64* %4, align 8
+  %0 = getelementptr %string_descriptor, ptr %command, i32 0, i32 0
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %string_descriptor, ptr %command, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr %string_descriptor, ptr %command, i32 0, i32 1
+  %5 = load i64, ptr %4, align 8
   %6 = trunc i64 %5 to i32
-  %7 = call i32 @_lfortran_exec_command(i8* %3, i32 %6)
-  store i32 %7, i32* %_lcompilers_exit_status, align 4
+  %7 = call i32 @_lfortran_exec_command(ptr %3, i32 %6)
+  store i32 %7, ptr %_lcompilers_exit_status, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -53,14 +54,14 @@ FINALIZE_SYMTABLE__lcompilers_execute_command_line_1: ; preds = %return
   ret void
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 1, i32* %call_arg_value, align 4
-  call void @_lcompilers_execute_command_line_(%string_descriptor* @string_const, i32* %call_arg_value)
-  store i32 1, i32* %call_arg_value, align 4
-  call void @_lcompilers_execute_command_line_1(%string_descriptor* @string_const.2, i32* %call_arg_value)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store i32 1, ptr %call_arg_value, align 4
+  call void @_lcompilers_execute_command_line_(ptr @string_const, ptr %call_arg_value)
+  store i32 1, ptr %call_arg_value, align 4
+  call void @_lcompilers_execute_command_line_1(ptr @string_const.2, ptr %call_arg_value)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -71,6 +72,6 @@ FINALIZE_SYMTABLE_execute_command_line:           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-expr1-03e6c2a.json
+++ b/tests/reference/llvm-expr1-03e6c2a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr1-03e6c2a.stdout",
-    "stdout_hash": "aa54d7427435a140bfea2d83deb34b8e3a668a042c38fc7953f0e090",
+    "stdout_hash": "e870c238466230dd194bdc582267ca377bde2e33b879398f6231ff63",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr1-03e6c2a.stdout
+++ b/tests/reference/llvm-expr1-03e6c2a.stdout
@@ -1,17 +1,18 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define i32 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  store i32 5, i32* %__lfortran_evaluate_11, align 4
+  store i32 5, ptr %__lfortran_evaluate_11, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %0 = load i32, i32* %__lfortran_evaluate_11, align 4
+  %0 = load i32, ptr %__lfortran_evaluate_11, align 4
   ret i32 %0
 }

--- a/tests/reference/llvm-expr2-6f9abe8.json
+++ b/tests/reference/llvm-expr2-6f9abe8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr2-6f9abe8.stdout",
-    "stdout_hash": "a175968f5745486d7618fda724fb908517cf92395cb9c770646f5ae2",
+    "stdout_hash": "f726885585c889a3a965f823467bc3a5c972fe69e7ecc60b5c5d71be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr2-6f9abe8.stdout
+++ b/tests/reference/llvm-expr2-6f9abe8.stdout
@@ -1,17 +1,18 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define i32 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  store i32 8, i32* %__lfortran_evaluate_11, align 4
+  store i32 8, ptr %__lfortran_evaluate_11, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %0 = load i32, i32* %__lfortran_evaluate_11, align 4
+  %0 = load i32, ptr %__lfortran_evaluate_11, align 4
   ret i32 %0
 }

--- a/tests/reference/llvm-expr3-3036522.json
+++ b/tests/reference/llvm-expr3-3036522.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr3-3036522.stdout",
-    "stdout_hash": "11b57bb4bfb4c057730cf8856e19522dd975d1ab859bb8b0430b9a51",
+    "stdout_hash": "f335da67ccc580f3bb925f82d0a5469c1e59cf15df931ae8c3643da5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr3-3036522.stdout
+++ b/tests/reference/llvm-expr3-3036522.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define i32 @__lfortran_evaluate_1() {
 .entry:
@@ -12,20 +13,20 @@ define i32 @__lfortran_evaluate_1() {
   %__lfortran_evaluate_16 = alloca i32, align 4
   %__lfortran_evaluate_17 = alloca i32, align 4
   %__lfortran_evaluate_18 = alloca i32, align 4
-  store i32 5, i32* %__lfortran_evaluate_11, align 4
-  store i32 8, i32* %__lfortran_evaluate_12, align 4
-  store i32 16, i32* %__lfortran_evaluate_13, align 4
-  store i32 11, i32* %__lfortran_evaluate_14, align 4
-  store i32 2, i32* %__lfortran_evaluate_15, align 4
-  store i32 64, i32* %__lfortran_evaluate_16, align 4
-  store i32 8, i32* %__lfortran_evaluate_17, align 4
-  store i32 8, i32* %__lfortran_evaluate_18, align 4
+  store i32 5, ptr %__lfortran_evaluate_11, align 4
+  store i32 8, ptr %__lfortran_evaluate_12, align 4
+  store i32 16, ptr %__lfortran_evaluate_13, align 4
+  store i32 11, ptr %__lfortran_evaluate_14, align 4
+  store i32 2, ptr %__lfortran_evaluate_15, align 4
+  store i32 64, ptr %__lfortran_evaluate_16, align 4
+  store i32 8, ptr %__lfortran_evaluate_17, align 4
+  store i32 8, ptr %__lfortran_evaluate_18, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %0 = load i32, i32* %__lfortran_evaluate_18, align 4
+  %0 = load i32, ptr %__lfortran_evaluate_18, align 4
   ret i32 %0
 }

--- a/tests/reference/llvm-expr4-ffedfc3.json
+++ b/tests/reference/llvm-expr4-ffedfc3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr4-ffedfc3.stdout",
-    "stdout_hash": "a71366c6410823314eb942b37c6b612003d9c0fc2f547adc6fa208be",
+    "stdout_hash": "4d8e2ab27596c17fd6065da7601408ab6f989a5d6791598d5121bb38",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr4-ffedfc3.stdout
+++ b/tests/reference/llvm-expr4-ffedfc3.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define float @__lfortran_evaluate_1() {
 .entry:
@@ -10,18 +11,18 @@ define float @__lfortran_evaluate_1() {
   %__lfortran_evaluate_14 = alloca float, align 4
   %__lfortran_evaluate_15 = alloca float, align 4
   %__lfortran_evaluate_16 = alloca float, align 4
-  store float 5.000000e+00, float* %__lfortran_evaluate_11, align 4
-  store float 8.000000e+00, float* %__lfortran_evaluate_12, align 4
-  store float 1.600000e+01, float* %__lfortran_evaluate_13, align 4
-  store float 1.100000e+01, float* %__lfortran_evaluate_14, align 4
-  store float 2.000000e+00, float* %__lfortran_evaluate_15, align 4
-  store float 6.400000e+01, float* %__lfortran_evaluate_16, align 4
+  store float 5.000000e+00, ptr %__lfortran_evaluate_11, align 4
+  store float 8.000000e+00, ptr %__lfortran_evaluate_12, align 4
+  store float 1.600000e+01, ptr %__lfortran_evaluate_13, align 4
+  store float 1.100000e+01, ptr %__lfortran_evaluate_14, align 4
+  store float 2.000000e+00, ptr %__lfortran_evaluate_15, align 4
+  store float 6.400000e+01, ptr %__lfortran_evaluate_16, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %0 = load float, float* %__lfortran_evaluate_16, align 4
+  %0 = load float, ptr %__lfortran_evaluate_16, align 4
   ret float %0
 }

--- a/tests/reference/llvm-expr5-00f7fd9.json
+++ b/tests/reference/llvm-expr5-00f7fd9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr5-00f7fd9.stdout",
-    "stdout_hash": "99ea41baf2b3077e169c233e08c0cedc080eb6f89f904424a5f7b11e",
+    "stdout_hash": "8510acca81e39e3f64b2535f43287e7b9dcccbc00e477b0e34b011b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr5-00f7fd9.stdout
+++ b/tests/reference/llvm-expr5-00f7fd9.stdout
@@ -1,22 +1,23 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  store i32 25, ptr %x, align 4
+  %2 = load i32, ptr %x, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -35,9 +36,9 @@ FINALIZE_SYMTABLE_expr_05:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-expr6-914a051.json
+++ b/tests/reference/llvm-expr6-914a051.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr6-914a051.stdout",
-    "stdout_hash": "8d9bac4bc2121dd065ef1e0e8ddd38e035922ff7112dd751e19ed9c4",
+    "stdout_hash": "3643ad364b4d6143343bc61803be1be815e53cc7593a1c8ca6f5c85e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr6-914a051.stdout
+++ b/tests/reference/llvm-expr6-914a051.stdout
@@ -1,19 +1,20 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define float @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
   %__lfortran_evaluate_12 = alloca float, align 4
-  store i32 8, i32* %__lfortran_evaluate_11, align 4
-  store float 0x4015333340000000, float* %__lfortran_evaluate_12, align 4
+  store i32 8, ptr %__lfortran_evaluate_11, align 4
+  store float 0x4015333340000000, ptr %__lfortran_evaluate_12, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %0 = load float, float* %__lfortran_evaluate_12, align 4
+  %0 = load float, ptr %__lfortran_evaluate_12, align 4
   ret float %0
 }

--- a/tests/reference/llvm-external_02-99f90be.json
+++ b/tests/reference/llvm-external_02-99f90be.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_02-99f90be.stdout",
-    "stdout_hash": "4e5dde64a2f5c6ebd5f77afc8fce74f898b79d4753132cce6fd005ce",
+    "stdout_hash": "19ac9cad3a6afe25ad888db388a7b993ad36b113136d3996eb79b7fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_02-99f90be.stdout
+++ b/tests/reference/llvm-external_02-99f90be.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define void @cobyla(void (double*)* %calcfc) {
+define void @cobyla(ptr %calcfc) {
 .entry:
-  call void @cobylb(void (double*)* %calcfc)
+  call void @cobylb(ptr %calcfc)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -17,12 +18,12 @@ FINALIZE_SYMTABLE_cobyla:                         ; preds = %return
   ret void
 }
 
-declare void @calcfc(double*)
+declare void @calcfc(ptr)
 
-define void @cobylb(void (double*)* %calcfc) {
+define void @cobylb(ptr %calcfc) {
 .entry:
   %con = alloca double, align 8
-  call void %calcfc(double* %con)
+  call void %calcfc(ptr %con)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -35,4 +36,4 @@ FINALIZE_SYMTABLE_cobylb:                         ; preds = %return
   ret void
 }
 
-declare void @calcfc.1(double*)
+declare void @calcfc.1(ptr)

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "326d816fcba3e1950dee57dfba2201f9889ab012b051a6a0cde7d03f",
+    "stdout_hash": "d5be9d8edee5cb94afc5e698b319fc7f427f5c5e2bc8723dca32f9b3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -1,40 +1,41 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @a(float (float*)* %f) {
+define void @a(ptr %f) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value = alloca float, align 4
   %r = alloca float, align 4
-  store float 2.000000e+00, float* %call_arg_value, align 4
-  %1 = call float %f(float* %call_arg_value)
-  store float %1, float* %r, align 4
+  store float 2.000000e+00, ptr %call_arg_value, align 4
+  %1 = call float %f(ptr %call_arg_value)
+  store float %1, ptr %r, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, float* %r)
-  %4 = load i64, i64* %2, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %2, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %r)
+  %4 = load i64, ptr %2, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -47,11 +48,11 @@ FINALIZE_SYMTABLE_a:                              ; preds = %return
   ret void
 }
 
-declare float @f(float*)
+declare float @f(ptr)
 
 define void @b() {
 .entry:
-  call void @a(float (float*)* @f.1)
+  call void @a(ptr @f.1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -61,19 +62,19 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
   ret void
 }
 
-declare float @f.1(float*)
+declare float @f.1(ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @b()
   br label %return
 
@@ -85,6 +86,6 @@ FINALIZE_SYMTABLE_external_03:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-external_04-30bc1c7.json
+++ b/tests/reference/llvm-external_04-30bc1c7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_04-30bc1c7.stdout",
-    "stdout_hash": "b2a2d7d11049e1890bd87d1d3801d224c2d47c1f2b9fade964fc84e0",
+    "stdout_hash": "c4c15f1770d4c2693980ffd98f4f30a2f21d86c0b913f117089df7fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_04-30bc1c7.stdout
+++ b/tests/reference/llvm-external_04-30bc1c7.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define void @a() {
 .entry:
-  call void @b(float ()* @f, float ()* @g)
+  call void @b(ptr @f, ptr @g)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -14,7 +15,7 @@ FINALIZE_SYMTABLE_a:                              ; preds = %return
   ret void
 }
 
-declare void @b(float ()*, float ()*)
+declare void @b(ptr, ptr)
 
 declare float @f()
 

--- a/tests/reference/llvm-finalize_01-5496007.json
+++ b/tests/reference/llvm-finalize_01-5496007.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_01-5496007.stdout",
-    "stdout_hash": "57f68ae3bfc9fe2a95fcb8cb6e9e69427487b36fcff902e5a50a7bee",
+    "stdout_hash": "e3607deb2437f4fcabb23bbb573fcd50b2fd9239f6c8914e9293ad8a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_01-5496007.stdout
+++ b/tests/reference/llvm-finalize_01-5496007.stdout
@@ -1,11 +1,12 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%array.1 = type { i32*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%array.1 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
-%string_descriptor = type <{ i8*, i64 }>
-%array.2 = type { float*, i64, i32, i8, i8, i8, i8, i64, [2 x %dimension_descriptor] }
+%string_descriptor = type <{ ptr, i64 }>
+%array.2 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [2 x %dimension_descriptor] }
 
 @0 = private unnamed_addr constant [4 x i8] c"arr\00", align 1
 @1 = private unnamed_addr constant [22 x i8] c"tests/finalize_01.f90\00", align 1
@@ -15,33 +16,33 @@ target datalayout = "..."
 
 define void @__module_finalize_01_mod_ss() {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %arr_desc = alloca %array.1, align 8
-  %arr = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %arr, align 8
-  %1 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 8
-  %2 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %1, i32 0, i32 0
-  %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 1, i64* %4, align 8
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
-  store i64 1, i64* %5, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 0, i64* %6, align 8
-  %7 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
-  store i8 1, i8* %7, align 1
-  %8 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %8, align 8
-  store %array.1* %arr_desc, %array.1** %arr, align 8
-  %9 = load %array.1*, %array.1** %arr, align 8
-  %10 = ptrtoint %array.1* %9 to i64
+  %arr = alloca ptr, align 8
+  store ptr null, ptr %arr, align 8
+  %1 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 8
+  %2 = getelementptr [1 x %dimension_descriptor], ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %dimension_descriptor, ptr %2, i32 0
+  %4 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 0
+  store i64 1, ptr %4, align 8
+  %5 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 1
+  store i64 1, ptr %5, align 8
+  %6 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 2
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 3
+  store i8 1, ptr %7, align 1
+  %8 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %8, align 8
+  store ptr %arr_desc, ptr %arr, align 8
+  %9 = load ptr, ptr %arr, align 8
+  %10 = ptrtoint ptr %9 to i64
   %11 = icmp eq i64 %10, 0
   br i1 %11, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %12 = getelementptr %array.1, %array.1* %9, i32 0, i32 0
-  %13 = load i32*, i32** %12, align 8
-  %14 = ptrtoint i32* %13 to i64
+  %12 = getelementptr %array.1, ptr %9, i32 0, i32 0
+  %13 = load ptr, ptr %12, align 8
+  %14 = ptrtoint ptr %13 to i64
   %15 = icmp ne i64 %14, 0
   br label %merge_allocated
 
@@ -50,55 +51,54 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %is_allocated, label %then, label %ifcont
 
 then:                                             ; preds = %merge_allocated
-  %16 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %17 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %18 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %19 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 0
-  store i8* getelementptr inbounds ([22 x i8], [22 x i8]* @1, i32 0, i32 0), i8** %19, align 8
-  %20 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 1
-  store i32 15, i32* %20, align 4
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 2
-  store i32 18, i32* %21, align 4
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 3
-  store i32 15, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %18, i32 0, i32 4
-  store i32 24, i32* %23, align 4
-  %24 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
-  %25 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  %26 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %17, i32 0, i32 0
-  %27 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 2
-  %28 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 0
-  store i1 true, i1* %28, align 1
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 1
-  store i8* %24, i8** %29, align 8
-  store { i8*, i32, i32, i32, i32 }* %26, { i8*, i32, i32, i32, i32 }** %27, align 8
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %25, i32 0, i32 3
-  store i32 1, i32* %30, align 4
-  %31 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %16, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %31, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0))
+  %16 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %17 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %18 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %19 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 0
+  store ptr @1, ptr %19, align 8
+  %20 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 1
+  store i32 15, ptr %20, align 4
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 2
+  store i32 18, ptr %21, align 4
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 3
+  store i32 15, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %18, i32 0, i32 4
+  store i32 24, ptr %23, align 4
+  %24 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @2, ptr @0)
+  %25 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  %26 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %17, i32 0, i32 0
+  %27 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 2
+  %28 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 0
+  store i1 true, ptr %28, align 1
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 1
+  store ptr %24, ptr %29, align 8
+  store ptr %26, ptr %27, align 8
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %25, i32 0, i32 3
+  store i32 1, ptr %30, align 4
+  %31 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %16, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %31, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %merge_allocated
-  %32 = load %array.1*, %array.1** %arr, align 8
-  %33 = getelementptr %array.1, %array.1* %32, i32 0, i32 7
-  store i64 0, i64* %33, align 8
-  %34 = getelementptr %array.1, %array.1* %32, i32 0, i32 3
-  store i8 1, i8* %34, align 1
-  %35 = getelementptr %array.1, %array.1* %32, i32 0, i32 8
-  %36 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %35, i32 0, i32 0
-  %37 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %36, i32 0
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 2
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 0
-  %40 = getelementptr %dimension_descriptor, %dimension_descriptor* %37, i32 0, i32 1
-  store i64 1, i64* %38, align 8
-  store i64 1, i64* %39, align 8
-  store i64 10, i64* %40, align 8
-  %41 = getelementptr %array.1, %array.1* %32, i32 0, i32 0
-  %42 = call i8* @_lfortran_get_default_allocator()
-  %43 = call i8* @_lfortran_malloc_alloc(i8* %42, i64 40)
-  %44 = bitcast i8* %43 to i32*
-  store i32* %44, i32** %41, align 8
+  %32 = load ptr, ptr %arr, align 8
+  %33 = getelementptr %array.1, ptr %32, i32 0, i32 7
+  store i64 0, ptr %33, align 8
+  %34 = getelementptr %array.1, ptr %32, i32 0, i32 3
+  store i8 1, ptr %34, align 1
+  %35 = getelementptr %array.1, ptr %32, i32 0, i32 8
+  %36 = getelementptr [1 x %dimension_descriptor], ptr %35, i32 0, i32 0
+  %37 = getelementptr inbounds %dimension_descriptor, ptr %36, i32 0
+  %38 = getelementptr %dimension_descriptor, ptr %37, i32 0, i32 2
+  %39 = getelementptr %dimension_descriptor, ptr %37, i32 0, i32 0
+  %40 = getelementptr %dimension_descriptor, ptr %37, i32 0, i32 1
+  store i64 1, ptr %38, align 8
+  store i64 1, ptr %39, align 8
+  store i64 10, ptr %40, align 8
+  %41 = getelementptr %array.1, ptr %32, i32 0, i32 0
+  %42 = call ptr @_lfortran_get_default_allocator()
+  %43 = call ptr @_lfortran_malloc_alloc(ptr %42, i64 40)
+  store ptr %43, ptr %41, align 8
   br i1 true, label %then1, label %else
 
 then1:                                            ; preds = %ifcont
@@ -123,28 +123,28 @@ FINALIZE_SYMTABLE_ss:                             ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_ss
-  %45 = load %array.1*, %array.1** %arr, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %45)
+  %44 = load ptr, ptr %arr, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %44)
   ret void
 }
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-define internal void @finalize_allocatable__Array_1_i32(%array.1* %0) {
+define internal void @finalize_allocatable__Array_1_i32(ptr %0) {
 entry:
-  %1 = icmp ne %array.1* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_1_i32(%array.1* %0)
+  call void @finalize_descriptorArray_Array_1_i32(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -154,18 +154,17 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_1_i32(%array.1* %0) {
+define internal void @finalize_descriptorArray_Array_1_i32(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.1, %array.1* %0, i32 0, i32 0
-  %3 = load i32*, i32** %2, align 8
-  %4 = ptrtoint i32* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.1, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = ptrtoint ptr %3 to i64
   %5 = icmp ne i64 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = bitcast i32* %3 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %3)
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -175,38 +174,38 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %str = alloca %string_descriptor, align 8
   %arr_desc = alloca %array.1, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %arr = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %arr, align 8
-  %3 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 8
-  %4 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %3, i32 0, i32 0
-  %5 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %4, i32 0
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 0
-  store i64 1, i64* %6, align 8
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 1
-  store i64 1, i64* %7, align 8
-  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %5, i32 0, i32 2
-  store i64 0, i64* %8, align 8
-  %9 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
-  store i8 1, i8* %9, align 1
-  %10 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store i32* null, i32** %10, align 8
-  store %array.1* %arr_desc, %array.1** %arr, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %str, align 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = icmp ne i8* %12, null
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %arr = alloca ptr, align 8
+  store ptr null, ptr %arr, align 8
+  %3 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 8
+  %4 = getelementptr [1 x %dimension_descriptor], ptr %3, i32 0, i32 0
+  %5 = getelementptr inbounds %dimension_descriptor, ptr %4, i32 0
+  %6 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 0
+  store i64 1, ptr %6, align 8
+  %7 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 1
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %dimension_descriptor, ptr %5, i32 0, i32 2
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 3
+  store i8 1, ptr %9, align 1
+  %10 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %10, align 8
+  store ptr %arr_desc, ptr %arr, align 8
+  store %string_descriptor zeroinitializer, ptr %str, align 1
+  %11 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = icmp ne ptr %12, null
   br i1 %13, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @__Wrong_allocation)
   call void @exit(i32 1)
   br label %ifcont
 
@@ -214,12 +213,12 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %14 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %15 = call i8* @_lfortran_get_default_allocator()
-  %16 = call i8* @_lfortran_malloc_alloc(i8* %15, i64 10)
-  store i8* %16, i8** %14, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  store i64 10, i64* %17, align 8
+  %14 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %15 = call ptr @_lfortran_get_default_allocator()
+  %16 = call ptr @_lfortran_malloc_alloc(ptr %15, i64 10)
+  store ptr %16, ptr %14, align 8
+  %17 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  store i64 10, ptr %17, align 8
   call void @__module_finalize_01_mod_ss()
   call void @internal_sub()
   br label %return
@@ -234,68 +233,68 @@ FINALIZE_SYMTABLE_finalize_01:                    ; preds = %return
   br label %Finalize_Variable_arr
 
 Finalize_Variable_arr:                            ; preds = %FINALIZE_SYMTABLE_finalize_01
-  %18 = load %array.1*, %array.1** %arr, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %18)
+  %18 = load ptr, ptr %arr, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %18)
   br label %Finalize_Variable_str
 
 Finalize_Variable_str:                            ; preds = %Finalize_Variable_arr
-  %19 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %20)
+  %19 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %20)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
 define void @internal_sub() {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %arr_desc1 = alloca %array.1, align 8
   %str = alloca %string_descriptor, align 8
   %arr_desc = alloca %array.2, align 8
-  %arr_real = alloca %array.2*, align 8
-  store %array.2* null, %array.2** %arr_real, align 8
-  %1 = getelementptr %array.2, %array.2* %arr_desc, i32 0, i32 8
-  %2 = getelementptr [2 x %dimension_descriptor], [2 x %dimension_descriptor]* %1, i32 0, i32 0
-  %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 1, i64* %4, align 8
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
-  store i64 1, i64* %5, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 0, i64* %6, align 8
-  %7 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 1
-  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 0
-  store i64 1, i64* %8, align 8
-  %9 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 1
-  store i64 1, i64* %9, align 8
-  %10 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 2
-  store i64 0, i64* %10, align 8
-  %11 = getelementptr %array.2, %array.2* %arr_desc, i32 0, i32 3
-  store i8 2, i8* %11, align 1
-  %12 = getelementptr %array.2, %array.2* %arr_desc, i32 0, i32 0
-  store float* null, float** %12, align 8
-  store %array.2* %arr_desc, %array.2** %arr_real, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %str, align 1
+  %arr_real = alloca ptr, align 8
+  store ptr null, ptr %arr_real, align 8
+  %1 = getelementptr %array.2, ptr %arr_desc, i32 0, i32 8
+  %2 = getelementptr [2 x %dimension_descriptor], ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %dimension_descriptor, ptr %2, i32 0
+  %4 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 0
+  store i64 1, ptr %4, align 8
+  %5 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 1
+  store i64 1, ptr %5, align 8
+  %6 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 2
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr inbounds %dimension_descriptor, ptr %2, i32 1
+  %8 = getelementptr %dimension_descriptor, ptr %7, i32 0, i32 0
+  store i64 1, ptr %8, align 8
+  %9 = getelementptr %dimension_descriptor, ptr %7, i32 0, i32 1
+  store i64 1, ptr %9, align 8
+  %10 = getelementptr %dimension_descriptor, ptr %7, i32 0, i32 2
+  store i64 0, ptr %10, align 8
+  %11 = getelementptr %array.2, ptr %arr_desc, i32 0, i32 3
+  store i8 2, ptr %11, align 1
+  %12 = getelementptr %array.2, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %12, align 8
+  store ptr %arr_desc, ptr %arr_real, align 8
+  store %string_descriptor zeroinitializer, ptr %str, align 1
   br label %bl.start
 
 bl.start:                                         ; preds = %.entry
-  %13 = call i8* @llvm.stacksave()
-  %arr_in_block = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %arr_in_block, align 8
-  %14 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 8
-  %15 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %14, i32 0, i32 0
-  %16 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %15, i32 0
-  %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 0
-  store i64 1, i64* %17, align 8
-  %18 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 1
-  store i64 1, i64* %18, align 8
-  %19 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 2
-  store i64 0, i64* %19, align 8
-  %20 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 3
-  store i8 1, i8* %20, align 1
-  %21 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 0
-  store i32* null, i32** %21, align 8
-  store %array.1* %arr_desc1, %array.1** %arr_in_block, align 8
+  %13 = call ptr @llvm.stacksave.p0()
+  %arr_in_block = alloca ptr, align 8
+  store ptr null, ptr %arr_in_block, align 8
+  %14 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 8
+  %15 = getelementptr [1 x %dimension_descriptor], ptr %14, i32 0, i32 0
+  %16 = getelementptr inbounds %dimension_descriptor, ptr %15, i32 0
+  %17 = getelementptr %dimension_descriptor, ptr %16, i32 0, i32 0
+  store i64 1, ptr %17, align 8
+  %18 = getelementptr %dimension_descriptor, ptr %16, i32 0, i32 1
+  store i64 1, ptr %18, align 8
+  %19 = getelementptr %dimension_descriptor, ptr %16, i32 0, i32 2
+  store i64 0, ptr %19, align 8
+  %20 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 3
+  store i8 1, ptr %20, align 1
+  %21 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 0
+  store ptr null, ptr %21, align 8
+  store ptr %arr_desc1, ptr %arr_in_block, align 8
   br label %bl.end
 
 unreachable_after_exit:                           ; No predecessors!
@@ -311,9 +310,9 @@ FINALIZE_SYMTABLE_bl:                             ; preds = %bl.end
   br label %Finalize_Variable_arr_in_block
 
 Finalize_Variable_arr_in_block:                   ; preds = %FINALIZE_SYMTABLE_bl
-  %22 = load %array.1*, %array.1** %arr_in_block, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1* %22)
-  call void @llvm.stackrestore(i8* %13)
+  %22 = load ptr, ptr %arr_in_block, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %22)
+  call void @llvm.stackrestore.p0(ptr %13)
   br label %loop.head
 
 loop.head:                                        ; preds = %unreachable_after_return2, %Finalize_Variable_arr_in_block
@@ -335,30 +334,30 @@ FINALIZE_SYMTABLE_internal_sub:                   ; preds = %return
   br label %Finalize_Variable_arr_real
 
 Finalize_Variable_arr_real:                       ; preds = %FINALIZE_SYMTABLE_internal_sub
-  %23 = load %array.2*, %array.2** %arr_real, align 8
-  call void @finalize_allocatable__Array_2_r32(%array.2* %23)
+  %23 = load ptr, ptr %arr_real, align 8
+  call void @finalize_allocatable__Array_2_r32(ptr %23)
   br label %Finalize_Variable_str
 
 Finalize_Variable_str:                            ; preds = %Finalize_Variable_arr_real
-  %24 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %25 = load i8*, i8** %24, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %25)
+  %24 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %25 = load ptr, ptr %24, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %25)
   ret void
 }
 
-; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare ptr @llvm.stacksave.p0() #0
 
-; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #0
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare void @llvm.stackrestore.p0(ptr) #0
 
-define internal void @finalize_allocatable__Array_2_r32(%array.2* %0) {
+define internal void @finalize_allocatable__Array_2_r32(ptr %0) {
 entry:
-  %1 = icmp ne %array.2* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_2_r32(%array.2* %0)
+  call void @finalize_descriptorArray_Array_2_r32(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -368,18 +367,17 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_2_r32(%array.2* %0) {
+define internal void @finalize_descriptorArray_Array_2_r32(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.2, %array.2* %0, i32 0, i32 0
-  %3 = load float*, float** %2, align 8
-  %4 = ptrtoint float* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.2, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = ptrtoint ptr %3 to i64
   %5 = icmp ne i64 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = bitcast float* %3 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %3)
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -389,10 +387,10 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { nounwind }
+attributes #0 = { nocallback nofree nosync nounwind willreturn }

--- a/tests/reference/llvm-finalize_02-cfb24d5.json
+++ b/tests/reference/llvm-finalize_02-cfb24d5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-finalize_02-cfb24d5.stdout",
-    "stdout_hash": "4abb0d7747c5163ad52a8e33fc02b47ce7288bad61a139dc23c8acef",
+    "stdout_hash": "da11a64b2c009cd02529a34d75836bf7261459eb5886ee7f6e66bdad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-finalize_02-cfb24d5.stdout
+++ b/tests/reference/llvm-finalize_02-cfb24d5.stdout
@@ -1,23 +1,24 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%array.1.1 = type { %string_descriptor*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%string_descriptor = type <{ ptr, i64 }>
+%array.1.1 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
-%array.1.0 = type { i32*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
-%array.1 = type { %tt.4*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%array.1.0 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%array.1 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %tt.4 = type { float, %t.3 }
 %t.3 = type { i32 }
 
 @deep_0 = internal global i32 0
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 200, i32* %call_arg_value, align 4
-  call void @ss(i32* %call_arg_value)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store i32 200, ptr %call_arg_value, align 4
+  call void @ss(ptr %call_arg_value)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -28,129 +29,128 @@ FINALIZE_SYMTABLE_finalize_02:                    ; preds = %return
   ret i32 0
 }
 
-define void @ss(i32* %nang) {
+define void @ss(ptr %nang) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = call ptr @_lfortran_get_default_allocator()
   %arr_desc_str_desc5 = alloca %string_descriptor, align 8
   %arr_desc4 = alloca %array.1.1, align 8
+  %arr_08 = alloca %array.1.1, align 8
   %arr_07 = alloca %string_descriptor, align 8
   %arr_desc3 = alloca %array.1.0, align 8
   %arr_05 = alloca %string_descriptor, align 8
   %arr_desc_str_desc = alloca %string_descriptor, align 8
   %arr_desc2 = alloca %array.1.1, align 8
+  %arr_04 = alloca %array.1.1, align 8
   %arr_desc1 = alloca %array.1.0, align 8
   %arr_desc = alloca %array.1, align 8
-  %arr_01 = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %arr_01, align 8
-  %2 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 8
-  %3 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %2, i32 0, i32 0
-  %4 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %3, i32 0
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 0
-  store i64 1, i64* %5, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 1
-  store i64 1, i64* %6, align 8
-  %7 = getelementptr %dimension_descriptor, %dimension_descriptor* %4, i32 0, i32 2
-  store i64 0, i64* %7, align 8
-  %8 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
-  store i8 1, i8* %8, align 1
-  %9 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store %tt.4* null, %tt.4** %9, align 8
-  store %array.1* %arr_desc, %array.1** %arr_01, align 8
-  %arr_02 = alloca %array.1.0*, align 8
-  store %array.1.0* null, %array.1.0** %arr_02, align 8
-  %10 = getelementptr %array.1.0, %array.1.0* %arr_desc1, i32 0, i32 8
-  %11 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %10, i32 0, i32 0
-  %12 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %11, i32 0
-  %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 0
-  store i64 1, i64* %13, align 8
-  %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 1
-  store i64 1, i64* %14, align 8
-  %15 = getelementptr %dimension_descriptor, %dimension_descriptor* %12, i32 0, i32 2
-  store i64 0, i64* %15, align 8
-  %16 = getelementptr %array.1.0, %array.1.0* %arr_desc1, i32 0, i32 3
-  store i8 1, i8* %16, align 1
-  %17 = getelementptr %array.1.0, %array.1.0* %arr_desc1, i32 0, i32 0
-  store i32* null, i32** %17, align 8
-  store %array.1.0* %arr_desc1, %array.1.0** %arr_02, align 8
-  %arr_03 = alloca i32*, align 8
-  store i32* null, i32** %arr_03, align 8
-  %arr_04 = alloca %array.1.1*, align 8
-  store %array.1.1* null, %array.1.1** %arr_04, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 0
-  store i8* null, i8** %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc, i32 0, i32 1
-  store i64 0, i64* %19, align 8
-  %20 = getelementptr %array.1.1, %array.1.1* %arr_desc2, i32 0, i32 0
-  store %string_descriptor* %arr_desc_str_desc, %string_descriptor** %20, align 8
-  %21 = getelementptr %array.1.1, %array.1.1* %arr_desc2, i32 0, i32 8
-  %22 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %21, i32 0, i32 0
-  %23 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %22, i32 0
-  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 0
-  store i64 1, i64* %24, align 8
-  %25 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 1
-  store i64 1, i64* %25, align 8
-  %26 = getelementptr %dimension_descriptor, %dimension_descriptor* %23, i32 0, i32 2
-  store i64 0, i64* %26, align 8
-  %27 = getelementptr %array.1.1, %array.1.1* %arr_desc2, i32 0, i32 3
-  store i8 1, i8* %27, align 1
-  store %array.1.1* %arr_desc2, %array.1.1** %arr_04, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
-  store i8* null, i8** %28, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
-  store i64 0, i64* %29, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 1
-  store i64 20, i64* %30, align 8
-  %31 = call i8* @_lfortran_get_default_allocator()
-  %32 = call i8* @_lfortran_malloc_alloc(i8* %31, i64 100)
-  %33 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
-  store i8* %32, i8** %33, align 8
-  %arr_06 = alloca %array.1.0*, align 8
-  store %array.1.0* null, %array.1.0** %arr_06, align 8
-  %34 = getelementptr %array.1.0, %array.1.0* %arr_desc3, i32 0, i32 8
-  %35 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %34, i32 0, i32 0
-  %36 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %35, i32 0
-  %37 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 0
-  store i64 1, i64* %37, align 8
-  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 1
-  store i64 1, i64* %38, align 8
-  %39 = getelementptr %dimension_descriptor, %dimension_descriptor* %36, i32 0, i32 2
-  store i64 0, i64* %39, align 8
-  %40 = getelementptr %array.1.0, %array.1.0* %arr_desc3, i32 0, i32 3
-  store i8 1, i8* %40, align 1
-  %41 = getelementptr %array.1.0, %array.1.0* %arr_desc3, i32 0, i32 0
-  store i32* null, i32** %41, align 8
-  store %array.1.0* %arr_desc3, %array.1.0** %arr_06, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %arr_07, align 1
-  %arr_08 = alloca %array.1.1*, align 8
-  store %array.1.1* null, %array.1.1** %arr_08, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 0
-  store i8* null, i8** %42, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %arr_desc_str_desc5, i32 0, i32 1
-  store i64 0, i64* %43, align 8
-  %44 = getelementptr %array.1.1, %array.1.1* %arr_desc4, i32 0, i32 0
-  store %string_descriptor* %arr_desc_str_desc5, %string_descriptor** %44, align 8
-  %45 = getelementptr %array.1.1, %array.1.1* %arr_desc4, i32 0, i32 8
-  %46 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %45, i32 0, i32 0
-  %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
-  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 0
-  store i64 1, i64* %48, align 8
-  %49 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
-  store i64 1, i64* %49, align 8
-  %50 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
-  store i64 0, i64* %50, align 8
-  %51 = getelementptr %array.1.1, %array.1.1* %arr_desc4, i32 0, i32 3
-  store i8 1, i8* %51, align 1
-  store %array.1.1* %arr_desc4, %array.1.1** %arr_08, align 8
-  %52 = load i32, i32* %nang, align 4
-  store i32 %52, i32* @deep_0, align 4
-  %53 = load i32, i32* @deep_0, align 4
+  %arr_01 = alloca ptr, align 8
+  store ptr null, ptr %arr_01, align 8
+  %2 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 8
+  %3 = getelementptr [1 x %dimension_descriptor], ptr %2, i32 0, i32 0
+  %4 = getelementptr inbounds %dimension_descriptor, ptr %3, i32 0
+  %5 = getelementptr %dimension_descriptor, ptr %4, i32 0, i32 0
+  store i64 1, ptr %5, align 8
+  %6 = getelementptr %dimension_descriptor, ptr %4, i32 0, i32 1
+  store i64 1, ptr %6, align 8
+  %7 = getelementptr %dimension_descriptor, ptr %4, i32 0, i32 2
+  store i64 0, ptr %7, align 8
+  %8 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 3
+  store i8 1, ptr %8, align 1
+  %9 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %9, align 8
+  store ptr %arr_desc, ptr %arr_01, align 8
+  %arr_02 = alloca ptr, align 8
+  store ptr null, ptr %arr_02, align 8
+  %10 = getelementptr %array.1.0, ptr %arr_desc1, i32 0, i32 8
+  %11 = getelementptr [1 x %dimension_descriptor], ptr %10, i32 0, i32 0
+  %12 = getelementptr inbounds %dimension_descriptor, ptr %11, i32 0
+  %13 = getelementptr %dimension_descriptor, ptr %12, i32 0, i32 0
+  store i64 1, ptr %13, align 8
+  %14 = getelementptr %dimension_descriptor, ptr %12, i32 0, i32 1
+  store i64 1, ptr %14, align 8
+  %15 = getelementptr %dimension_descriptor, ptr %12, i32 0, i32 2
+  store i64 0, ptr %15, align 8
+  %16 = getelementptr %array.1.0, ptr %arr_desc1, i32 0, i32 3
+  store i8 1, ptr %16, align 1
+  %17 = getelementptr %array.1.0, ptr %arr_desc1, i32 0, i32 0
+  store ptr null, ptr %17, align 8
+  store ptr %arr_desc1, ptr %arr_02, align 8
+  %arr_03 = alloca ptr, align 8
+  store ptr null, ptr %arr_03, align 8
+  store ptr null, ptr %arr_04, align 8
+  %18 = getelementptr %string_descriptor, ptr %arr_desc_str_desc, i32 0, i32 0
+  store ptr null, ptr %18, align 8
+  %19 = getelementptr %string_descriptor, ptr %arr_desc_str_desc, i32 0, i32 1
+  store i64 0, ptr %19, align 8
+  %20 = getelementptr %array.1.1, ptr %arr_desc2, i32 0, i32 0
+  store ptr %arr_desc_str_desc, ptr %20, align 8
+  %21 = getelementptr %array.1.1, ptr %arr_desc2, i32 0, i32 8
+  %22 = getelementptr [1 x %dimension_descriptor], ptr %21, i32 0, i32 0
+  %23 = getelementptr inbounds %dimension_descriptor, ptr %22, i32 0
+  %24 = getelementptr %dimension_descriptor, ptr %23, i32 0, i32 0
+  store i64 1, ptr %24, align 8
+  %25 = getelementptr %dimension_descriptor, ptr %23, i32 0, i32 1
+  store i64 1, ptr %25, align 8
+  %26 = getelementptr %dimension_descriptor, ptr %23, i32 0, i32 2
+  store i64 0, ptr %26, align 8
+  %27 = getelementptr %array.1.1, ptr %arr_desc2, i32 0, i32 3
+  store i8 1, ptr %27, align 1
+  store ptr %arr_desc2, ptr %arr_04, align 8
+  %28 = getelementptr %string_descriptor, ptr %arr_05, i32 0, i32 0
+  store ptr null, ptr %28, align 8
+  %29 = getelementptr %string_descriptor, ptr %arr_05, i32 0, i32 1
+  store i64 0, ptr %29, align 8
+  %30 = getelementptr %string_descriptor, ptr %arr_05, i32 0, i32 1
+  store i64 20, ptr %30, align 8
+  %31 = call ptr @_lfortran_get_default_allocator()
+  %32 = call ptr @_lfortran_malloc_alloc(ptr %31, i64 100)
+  %33 = getelementptr %string_descriptor, ptr %arr_05, i32 0, i32 0
+  store ptr %32, ptr %33, align 8
+  %arr_06 = alloca ptr, align 8
+  store ptr null, ptr %arr_06, align 8
+  %34 = getelementptr %array.1.0, ptr %arr_desc3, i32 0, i32 8
+  %35 = getelementptr [1 x %dimension_descriptor], ptr %34, i32 0, i32 0
+  %36 = getelementptr inbounds %dimension_descriptor, ptr %35, i32 0
+  %37 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 0
+  store i64 1, ptr %37, align 8
+  %38 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 1
+  store i64 1, ptr %38, align 8
+  %39 = getelementptr %dimension_descriptor, ptr %36, i32 0, i32 2
+  store i64 0, ptr %39, align 8
+  %40 = getelementptr %array.1.0, ptr %arr_desc3, i32 0, i32 3
+  store i8 1, ptr %40, align 1
+  %41 = getelementptr %array.1.0, ptr %arr_desc3, i32 0, i32 0
+  store ptr null, ptr %41, align 8
+  store ptr %arr_desc3, ptr %arr_06, align 8
+  store %string_descriptor zeroinitializer, ptr %arr_07, align 1
+  store ptr null, ptr %arr_08, align 8
+  %42 = getelementptr %string_descriptor, ptr %arr_desc_str_desc5, i32 0, i32 0
+  store ptr null, ptr %42, align 8
+  %43 = getelementptr %string_descriptor, ptr %arr_desc_str_desc5, i32 0, i32 1
+  store i64 0, ptr %43, align 8
+  %44 = getelementptr %array.1.1, ptr %arr_desc4, i32 0, i32 0
+  store ptr %arr_desc_str_desc5, ptr %44, align 8
+  %45 = getelementptr %array.1.1, ptr %arr_desc4, i32 0, i32 8
+  %46 = getelementptr [1 x %dimension_descriptor], ptr %45, i32 0, i32 0
+  %47 = getelementptr inbounds %dimension_descriptor, ptr %46, i32 0
+  %48 = getelementptr %dimension_descriptor, ptr %47, i32 0, i32 0
+  store i64 1, ptr %48, align 8
+  %49 = getelementptr %dimension_descriptor, ptr %47, i32 0, i32 1
+  store i64 1, ptr %49, align 8
+  %50 = getelementptr %dimension_descriptor, ptr %47, i32 0, i32 2
+  store i64 0, ptr %50, align 8
+  %51 = getelementptr %array.1.1, ptr %arr_desc4, i32 0, i32 3
+  store i8 1, ptr %51, align 1
+  store ptr %arr_desc4, ptr %arr_08, align 8
+  %52 = load i32, ptr %nang, align 4
+  store i32 %52, ptr @deep_0, align 4
+  %53 = load i32, ptr @deep_0, align 4
   %54 = mul i32 1, %53
   %55 = mul i32 %54, 4
   %56 = sext i32 %55 to i64
-  %57 = call i8* @_lfortran_get_default_allocator()
-  %58 = call i8* @_lfortran_malloc_alloc(i8* %57, i64 %56)
-  %59 = bitcast i8* %58 to i32*
+  %57 = call ptr @_lfortran_get_default_allocator()
+  %58 = call ptr @_lfortran_malloc_alloc(ptr %57, i64 %56)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -160,33 +160,32 @@ FINALIZE_SYMTABLE_ss:                             ; preds = %return
   br label %Finalize_Variable_arr_01
 
 Finalize_Variable_arr_01:                         ; preds = %FINALIZE_SYMTABLE_ss
-  %60 = load %array.1*, %array.1** %arr_01, align 8
-  call void @finalize_allocatable__Array_1_StructType__tt_4(%array.1* %60)
+  %59 = load ptr, ptr %arr_01, align 8
+  call void @finalize_allocatable__Array_1_StructType__tt_4(ptr %59)
   br label %Finalize_Variable_arr_02
 
 Finalize_Variable_arr_02:                         ; preds = %Finalize_Variable_arr_01
-  %61 = load %array.1.0*, %array.1.0** %arr_02, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1.0* %61)
+  %60 = load ptr, ptr %arr_02, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %60)
   br label %Finalize_Variable_arr_03
 
 Finalize_Variable_arr_03:                         ; preds = %Finalize_Variable_arr_02
-  %62 = load i32*, i32** %arr_03, align 8
-  %63 = bitcast i32* %62 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %63)
+  %61 = load ptr, ptr %arr_03, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %61)
   br label %Finalize_Variable_arr_04
 
 Finalize_Variable_arr_04:                         ; preds = %Finalize_Variable_arr_03
-  %64 = load %array.1.1*, %array.1.1** %arr_04, align 8
-  call void @finalize_allocatable__Array_1_str(%array.1.1* %64)
+  %62 = load ptr, ptr %arr_04, align 8
+  call void @finalize_allocatable__Array_1_str(ptr %62)
   br label %Finalize_Variable_arr_05
 
 Finalize_Variable_arr_05:                         ; preds = %Finalize_Variable_arr_04
-  %65 = getelementptr %string_descriptor, %string_descriptor* %arr_05, i32 0, i32 0
-  %66 = load i8*, i8** %65, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %66)
-  %67 = ptrtoint %string_descriptor* %arr_05 to i64
-  %68 = icmp ne i64 %67, 0
-  br i1 %68, label %then, label %else
+  %63 = getelementptr %string_descriptor, ptr %arr_05, i32 0, i32 0
+  %64 = load ptr, ptr %63, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %64)
+  %65 = ptrtoint ptr %arr_05 to i64
+  %66 = icmp ne i64 %65, 0
+  br i1 %66, label %then, label %else
 
 then:                                             ; preds = %Finalize_Variable_arr_05
   br label %ifcont
@@ -198,29 +197,28 @@ ifcont:                                           ; preds = %else, %then
   br label %Finalize_Variable_arr_06
 
 Finalize_Variable_arr_06:                         ; preds = %ifcont
-  %69 = load %array.1.0*, %array.1.0** %arr_06, align 8
-  call void @finalize_allocatable__Array_1_i32(%array.1.0* %69)
+  %67 = load ptr, ptr %arr_06, align 8
+  call void @finalize_allocatable__Array_1_i32(ptr %67)
   br label %Finalize_Variable_arr_07
 
 Finalize_Variable_arr_07:                         ; preds = %Finalize_Variable_arr_06
-  %70 = getelementptr %string_descriptor, %string_descriptor* %arr_07, i32 0, i32 0
-  %71 = load i8*, i8** %70, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %71)
+  %68 = getelementptr %string_descriptor, ptr %arr_07, i32 0, i32 0
+  %69 = load ptr, ptr %68, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %69)
   br label %Finalize_Variable_arr_08
 
 Finalize_Variable_arr_08:                         ; preds = %Finalize_Variable_arr_07
-  %72 = load %array.1.1*, %array.1.1** %arr_08, align 8
-  call void @finalize_allocatable__Array_1_str(%array.1.1* %72)
+  %70 = load ptr, ptr %arr_08, align 8
+  call void @finalize_allocatable__Array_1_str(ptr %70)
   br label %Finalize_Variable_arr_09
 
 Finalize_Variable_arr_09:                         ; preds = %Finalize_Variable_arr_08
-  %73 = ptrtoint i32* %59 to i64
-  %74 = icmp ne i64 %73, 0
-  br i1 %74, label %then6, label %else7
+  %71 = ptrtoint ptr %58 to i64
+  %72 = icmp ne i64 %71, 0
+  br i1 %72, label %then6, label %else7
 
 then6:                                            ; preds = %Finalize_Variable_arr_09
-  %75 = bitcast i32* %59 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %75)
+  call void @_lfortran_free_alloc(ptr %0, ptr %58)
   br label %ifcont8
 
 else7:                                            ; preds = %Finalize_Variable_arr_09
@@ -230,17 +228,17 @@ ifcont8:                                          ; preds = %else7, %then6
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-define internal void @finalize_allocatable__Array_1_StructType__tt_4(%array.1* %0) {
+define internal void @finalize_allocatable__Array_1_StructType__tt_4(ptr %0) {
 entry:
-  %1 = icmp ne %array.1* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_1_StructType__tt_4(%array.1* %0)
+  call void @finalize_descriptorArray_Array_1_StructType__tt_4(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -250,62 +248,61 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_1_StructType__tt_4(%array.1* %0) {
+define internal void @finalize_descriptorArray_Array_1_StructType__tt_4(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
+  %1 = call ptr @_lfortran_get_default_allocator()
   %2 = alloca i32, align 4
   %3 = alloca i64, align 8
-  %4 = getelementptr %array.1, %array.1* %0, i32 0, i32 0
-  %5 = load %tt.4*, %tt.4** %4, align 8
-  %6 = icmp ne %tt.4* %5, null
+  %4 = getelementptr %array.1, ptr %0, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  %6 = icmp ne ptr %5, null
   br i1 %6, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
   br label %Calculate_arraySize
 
 Calculate_arraySize:                              ; preds = %is_allocated.then
-  %7 = getelementptr %array.1, %array.1* %0, i32 0, i32 8
-  %8 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %7, i32 0, i32 0
-  %9 = getelementptr %array.1, %array.1* %0, i32 0, i32 3
-  %10 = load i8, i8* %9, align 1
+  %7 = getelementptr %array.1, ptr %0, i32 0, i32 8
+  %8 = getelementptr [1 x %dimension_descriptor], ptr %7, i32 0, i32 0
+  %9 = getelementptr %array.1, ptr %0, i32 0, i32 3
+  %10 = load i8, ptr %9, align 1
   %11 = zext i8 %10 to i32
-  store i64 1, i64* %3, align 8
-  store i32 0, i32* %2, align 4
+  store i64 1, ptr %3, align 8
+  store i32 0, ptr %2, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %Calculate_arraySize
-  %12 = load i32, i32* %2, align 4
+  %12 = load i32, ptr %2, align 4
   %13 = icmp slt i32 %12, %11
   br i1 %13, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %14 = load i32, i32* %2, align 4
-  %15 = load i64, i64* %3, align 8
-  %16 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %8, i32 %14
-  %17 = getelementptr %dimension_descriptor, %dimension_descriptor* %16, i32 0, i32 1
-  %18 = load i64, i64* %17, align 8
+  %14 = load i32, ptr %2, align 4
+  %15 = load i64, ptr %3, align 8
+  %16 = getelementptr inbounds %dimension_descriptor, ptr %8, i32 %14
+  %17 = getelementptr %dimension_descriptor, ptr %16, i32 0, i32 1
+  %18 = load i64, ptr %17, align 8
   %19 = mul i64 %15, %18
-  store i64 %19, i64* %3, align 8
+  store i64 %19, ptr %3, align 8
   %20 = add i32 %14, 1
-  store i32 %20, i32* %2, align 4
+  store i32 %20, ptr %2, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %21 = load i64, i64* %3, align 8
-  call void @finalize_array_data_StructType__tt_4(%tt.4* %5, i64 %21)
+  %21 = load i64, ptr %3, align 8
+  call void @finalize_array_data_StructType__tt_4(ptr %5, i64 %21)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %loop.end
-  %22 = ptrtoint %tt.4* %5 to i64
+  %22 = ptrtoint ptr %5 to i64
   %23 = icmp ne i64 %22, 0
   br i1 %23, label %then, label %else
 
 then:                                             ; preds = %is_allocated.ifcont
-  %24 = bitcast %tt.4* %5 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %24)
+  call void @_lfortran_free_alloc(ptr %1, ptr %5)
   br label %ifcont
 
 else:                                             ; preds = %is_allocated.ifcont
@@ -315,37 +312,37 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define internal void @finalize_array_data_StructType__tt_4(%tt.4* %0, i64 %1) {
+define internal void @finalize_array_data_StructType__tt_4(ptr %0, i64 %1) {
 entry:
   %arrSize_iter = alloca i64, align 8
-  store i64 -1, i64* %arrSize_iter, align 8
+  store i64 -1, ptr %arrSize_iter, align 8
   br label %Finalize_array_of_structs.head
 
 Finalize_array_of_structs.head:                   ; preds = %Finalize_array_of_structs.body, %entry
-  %2 = load i64, i64* %arrSize_iter, align 8
+  %2 = load i64, ptr %arrSize_iter, align 8
   %3 = add i64 %2, 1
-  store i64 %3, i64* %arrSize_iter, align 8
+  store i64 %3, ptr %arrSize_iter, align 8
   %4 = icmp slt i64 %3, %1
   br i1 %4, label %Finalize_array_of_structs.body, label %Finalize_array_of_structs.end
 
 Finalize_array_of_structs.body:                   ; preds = %Finalize_array_of_structs.head
-  %5 = load i64, i64* %arrSize_iter, align 8
-  %6 = getelementptr inbounds %tt.4, %tt.4* %0, i64 %5
+  %5 = load i64, ptr %arrSize_iter, align 8
+  %6 = getelementptr inbounds %tt.4, ptr %0, i64 %5
   br label %Finalize_array_of_structs.head
 
 Finalize_array_of_structs.end:                    ; preds = %Finalize_array_of_structs.head
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define internal void @finalize_allocatable__Array_1_i32(%array.1.0* %0) {
+define internal void @finalize_allocatable__Array_1_i32(ptr %0) {
 entry:
-  %1 = icmp ne %array.1.0* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_1_i32(%array.1.0* %0)
+  call void @finalize_descriptorArray_Array_1_i32(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -355,18 +352,17 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_1_i32(%array.1.0* %0) {
+define internal void @finalize_descriptorArray_Array_1_i32(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.1.0, %array.1.0* %0, i32 0, i32 0
-  %3 = load i32*, i32** %2, align 8
-  %4 = ptrtoint i32* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.1.0, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = ptrtoint ptr %3 to i64
   %5 = icmp ne i64 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %entry
-  %6 = bitcast i32* %3 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %3)
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -376,13 +372,13 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define internal void @finalize_allocatable__Array_1_str(%array.1.1* %0) {
+define internal void @finalize_allocatable__Array_1_str(ptr %0) {
 entry:
-  %1 = icmp ne %array.1.1* %0, null
+  %1 = icmp ne ptr %0, null
   br i1 %1, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_descriptorArray_Array_1_str(%array.1.1* %0)
+  call void @finalize_descriptorArray_Array_1_str(ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -392,15 +388,15 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @finalize_descriptorArray_Array_1_str(%array.1.1* %0) {
+define internal void @finalize_descriptorArray_Array_1_str(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %array.1.1, %array.1.1* %0, i32 0, i32 0
-  %3 = load %string_descriptor*, %string_descriptor** %2, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %3, i32 0, i32 0
-  %5 = load i8*, i8** %4, align 8
-  call void @_lfortran_free_alloc(i8* %1, i8* %5)
-  %6 = ptrtoint %string_descriptor* %3 to i64
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %array.1.1, ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr %string_descriptor, ptr %3, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %5)
+  %6 = ptrtoint ptr %3 to i64
   %7 = icmp ne i64 %6, 0
   br i1 %7, label %then, label %else
 
@@ -414,6 +410,6 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "f6d0cffc76f3c1ba18ebda3cbfc5e81804c95a26ec1c63b3e5fba250",
+    "stdout_hash": "6413709dd5c384b269fce65c110ccad75e455ad5b7ca42b0500641fe",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -1,40 +1,41 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [5 x i8] c"(3l3)"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data, i32 0, i32 0), i64 5 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 5 }>
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
-  %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %3 = load ptr, ptr @string_const, align 8
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* %3, i64 5, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr %3, i64 5, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @1, ptr %10, i32 %13, ptr @0, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -48,14 +49,14 @@ FINALIZE_SYMTABLE_format2:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-functions_14-f13c087.json
+++ b/tests/reference/llvm-functions_14-f13c087.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-functions_14-f13c087.stdout",
-    "stdout_hash": "95e4f6dd96236ef5b5b72b5526d44921bea3f812e11c629185112883",
+    "stdout_hash": "f7fdca6c157c1883971b6fbe9b41d48cafbac9e161afd59b4444f6f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-functions_14-f13c087.stdout
+++ b/tests/reference/llvm-functions_14-f13c087.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define void @find_fit(i32 ()* %expr) {
+define void @find_fit(ptr %expr) {
 .entry:
   br label %return
 
@@ -15,9 +16,9 @@ FINALIZE_SYMTABLE_find_fit:                       ; preds = %return
 
 declare i32 @expr()
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -28,6 +29,6 @@ FINALIZE_SYMTABLE_functions_14:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "d234d25eb0558c1ba9fe38fb862b2295e26f9742767f59270f3b4272",
+    "stdout_hash": "03d9245c13ce582eb0d67bd02a04077219301aa4c728f72caf251893",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -1,22 +1,23 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%complex_module.complextype.3_class = type <{ i32 (...)**, %complex_module.complextype.3* }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_module.complextype.3 = type { float, float }
+%complex_module.complextype.3_class = type <{ ptr, ptr }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [27 x i8] c"Calling integer_add_subrout"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data, i32 0, i32 0), i64 27 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 27 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [24 x i8] c"Calling real_add_subrout"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([24 x i8], [24 x i8]* @string_const_data.1, i32 0, i32 0), i64 24 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 24 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @_Name_complextype = private unnamed_addr constant [12 x i8] c"complextype\00", align 1
-@_Type_Info_complextype = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([12 x i8], [12 x i8]* @_Name_complextype, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* null }, align 8
-@_VTable_complextype = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_complextype to i8*), i8* bitcast (void (i8*, i8*)* @_copy_complex_module_complextype to i8*), i8* bitcast (void (i8**)* @_allocate_struct_complex_module_complextype to i8*), i8* bitcast (void (i8*)* @finalize_StructType__complextype_3_of_complex_module_for_UPoly to i8*), i8* bitcast (void (%complex_module.complextype.3_class*, i32*, i32*, %complex_module.complextype.3*)* @__module_complex_module_integer_add_subrout to i8*), i8* bitcast (void (%complex_module.complextype.3_class*, float*, float*, %complex_module.complextype.3*)* @__module_complex_module_real_add_subrout to i8*)] }, align 8
+@_Type_Info_complextype = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_complextype, ptr inttoptr (i64 8 to ptr), ptr null }, align 8
+@_VTable_complextype = linkonce_odr unnamed_addr constant { [7 x ptr] } { [7 x ptr] [ptr null, ptr @_Type_Info_complextype, ptr @_copy_complex_module_complextype, ptr @_allocate_struct_complex_module_complextype, ptr @finalize_StructType__complextype_3_of_complex_module_for_UPoly, ptr @__module_complex_module_integer_add_subrout, ptr @__module_complex_module_real_add_subrout] }, align 8
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [6 x i8] c"R4,R4\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -33,30 +34,30 @@ target datalayout = "..."
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_complex_module_integer_add_subrout(%complex_module.complextype.3_class* %this, i32* %r, i32* %i, %complex_module.complextype.3* %sum) {
+define void @__module_complex_module_integer_add_subrout(ptr %this, ptr %r, ptr %i, ptr %sum) {
 .entry:
-  %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
-  %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
-  %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
-  %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
-  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %5, i32 0, i32 0
-  %7 = load float, float* %6, align 4
-  %8 = load i32, i32* %r, align 4
+  %0 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 1
+  %1 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 0
+  %2 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %2, i32 27, ptr @0, i32 1)
+  %3 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 0
+  %4 = getelementptr %complex_module.complextype.3_class, ptr %this, i32 0, i32 1
+  %5 = load ptr, ptr %4, align 8
+  %6 = getelementptr %complex_module.complextype.3, ptr %5, i32 0, i32 0
+  %7 = load float, ptr %6, align 4
+  %8 = load i32, ptr %r, align 4
   %9 = sitofp i32 %8 to float
   %10 = fadd float %7, %9
-  store float %10, float* %3, align 4
-  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
-  %12 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
-  %13 = load %complex_module.complextype.3*, %complex_module.complextype.3** %12, align 8
-  %14 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %13, i32 0, i32 1
-  %15 = load float, float* %14, align 4
-  %16 = load i32, i32* %i, align 4
+  store float %10, ptr %3, align 4
+  %11 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 1
+  %12 = getelementptr %complex_module.complextype.3_class, ptr %this, i32 0, i32 1
+  %13 = load ptr, ptr %12, align 8
+  %14 = getelementptr %complex_module.complextype.3, ptr %13, i32 0, i32 1
+  %15 = load float, ptr %14, align 4
+  %16 = load i32, ptr %i, align 4
   %17 = sitofp i32 %16 to float
   %18 = fadd float %15, %17
-  store float %18, float* %11, align 4
+  store float %18, ptr %11, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -66,28 +67,28 @@ FINALIZE_SYMTABLE_integer_add_subrout:            ; preds = %return
   ret void
 }
 
-define void @__module_complex_module_real_add_subrout(%complex_module.complextype.3_class* %this, float* %r, float* %i, %complex_module.complextype.3* %sum) {
+define void @__module_complex_module_real_add_subrout(ptr %this, ptr %r, ptr %i, ptr %sum) {
 .entry:
-  %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
-  %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i32 24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
-  %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
-  %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
-  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %5, i32 0, i32 0
-  %7 = load float, float* %6, align 4
-  %8 = load float, float* %r, align 4
+  %0 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 1
+  %1 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 0
+  %2 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %2, i32 24, ptr @2, i32 1)
+  %3 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 0
+  %4 = getelementptr %complex_module.complextype.3_class, ptr %this, i32 0, i32 1
+  %5 = load ptr, ptr %4, align 8
+  %6 = getelementptr %complex_module.complextype.3, ptr %5, i32 0, i32 0
+  %7 = load float, ptr %6, align 4
+  %8 = load float, ptr %r, align 4
   %9 = fadd float %7, %8
-  store float %9, float* %3, align 4
-  %10 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
-  %11 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
-  %12 = load %complex_module.complextype.3*, %complex_module.complextype.3** %11, align 8
-  %13 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %12, i32 0, i32 1
-  %14 = load float, float* %13, align 4
-  %15 = load float, float* %i, align 4
+  store float %9, ptr %3, align 4
+  %10 = getelementptr %complex_module.complextype.3, ptr %sum, i32 0, i32 1
+  %11 = getelementptr %complex_module.complextype.3_class, ptr %this, i32 0, i32 1
+  %12 = load ptr, ptr %11, align 8
+  %13 = getelementptr %complex_module.complextype.3, ptr %12, i32 0, i32 1
+  %14 = load float, ptr %13, align 4
+  %15 = load float, ptr %i, align 4
   %16 = fadd float %14, %15
-  store float %16, float* %10, align 4
+  store float %16, ptr %10, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -97,81 +98,81 @@ FINALIZE_SYMTABLE_real_add_subrout:               ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %2 = alloca %complex_module.complextype.3_class, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %3 = call i8* @_lfortran_get_default_allocator()
+  %3 = call ptr @_lfortran_get_default_allocator()
   %4 = alloca %complex_module.complextype.3_class, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca %complex_module.complextype.3, align 8
-  %5 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
-  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
+  %5 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 1
+  %6 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 0
   %c = alloca %complex_module.complextype.3, align 8
-  %7 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 1
-  %8 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 0
+  %7 = getelementptr %complex_module.complextype.3, ptr %c, i32 0, i32 1
+  %8 = getelementptr %complex_module.complextype.3, ptr %c, i32 0, i32 0
   %fpone = alloca float, align 4
   %fptwo = alloca float, align 4
   %fpzero = alloca float, align 4
   %ione = alloca i32, align 4
   %izero = alloca i32, align 4
   %negfpone = alloca float, align 4
-  store float 1.000000e+00, float* %fpone, align 4
-  store float 2.000000e+00, float* %fptwo, align 4
-  store float 0.000000e+00, float* %fpzero, align 4
-  store i32 1, i32* %ione, align 4
-  store i32 0, i32* %izero, align 4
-  store float -1.000000e+00, float* %negfpone, align 4
-  %9 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 0
-  %10 = load float, float* %fpone, align 4
-  store float %10, float* %9, align 4
-  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %c, i32 0, i32 1
-  %12 = load float, float* %fptwo, align 4
-  store float %12, float* %11, align 4
-  %13 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
-  %14 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 1
-  store %complex_module.complextype.3* %c, %complex_module.complextype.3** %14, align 8
-  call void @__module_complex_module_integer_add_subrout(%complex_module.complextype.3_class* %4, i32* %ione, i32* %izero, %complex_module.complextype.3* %a)
+  store float 1.000000e+00, ptr %fpone, align 4
+  store float 2.000000e+00, ptr %fptwo, align 4
+  store float 0.000000e+00, ptr %fpzero, align 4
+  store i32 1, ptr %ione, align 4
+  store i32 0, ptr %izero, align 4
+  store float -1.000000e+00, ptr %negfpone, align 4
+  %9 = getelementptr %complex_module.complextype.3, ptr %c, i32 0, i32 0
+  %10 = load float, ptr %fpone, align 4
+  store float %10, ptr %9, align 4
+  %11 = getelementptr %complex_module.complextype.3, ptr %c, i32 0, i32 1
+  %12 = load float, ptr %fptwo, align 4
+  store float %12, ptr %11, align 4
+  %13 = getelementptr %complex_module.complextype.3_class, ptr %4, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_complextype, i32 0, i32 0, i32 2), ptr %13, align 8
+  %14 = getelementptr %complex_module.complextype.3_class, ptr %4, i32 0, i32 1
+  store ptr %c, ptr %14, align 8
+  call void @__module_complex_module_integer_add_subrout(ptr %4, ptr %ione, ptr %izero, ptr %a)
   %15 = alloca i64, align 8
-  %16 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
-  %17 = load float, float* %16, align 4
+  %16 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 0
+  %17 = load float, ptr %16, align 4
   %18 = alloca float, align 4
-  store float %17, float* %18, align 4
-  %19 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
-  %20 = load float, float* %19, align 4
+  store float %17, ptr %18, align 4
+  %19 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 1
+  %20 = load float, ptr %19, align 4
   %21 = alloca float, align 4
-  store float %20, float* %21, align 4
-  %22 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %3, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %15, i32 0, i32 0, i32 0, i32 0, i32 0, float* %18, float* %21)
-  %23 = load i64, i64* %15, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %22, i8** %24, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %23, i64* %25, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %27 = load i8*, i8** %26, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %29 = load i64, i64* %28, align 8
+  store float %20, ptr %21, align 4
+  %22 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %3, ptr null, i64 0, ptr @serialization_info, ptr %15, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %18, ptr %21)
+  %23 = load i64, ptr %15, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %22, ptr %24, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %23, ptr %25, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %27 = load ptr, ptr %26, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %29 = load i64, ptr %28, align 8
   %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %31 = icmp eq i8* %22, null
+  call void @_lfortran_printf(ptr @5, ptr %27, i32 %30, ptr @4, i32 1)
+  %31 = icmp eq ptr %22, null
   br i1 %31, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %3, i8* %22)
+  call void @_lfortran_free_alloc(ptr %3, ptr %22)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %32 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
-  %33 = load float, float* %32, align 4
+  %32 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 0
+  %33 = load float, ptr %32, align 4
   %34 = fcmp une float %33, 2.000000e+00
   br i1 %34, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -180,13 +181,13 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %35 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
-  %36 = load float, float* %35, align 4
+  %35 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 1
+  %36 = load float, ptr %35, align 4
   %37 = fcmp une float %36, 2.000000e+00
   br i1 %37, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -195,47 +196,47 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %38 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %38, align 8
-  %39 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %2, i32 0, i32 1
-  store %complex_module.complextype.3* %c, %complex_module.complextype.3** %39, align 8
-  call void @__module_complex_module_real_add_subrout(%complex_module.complextype.3_class* %2, float* %fpzero, float* %negfpone, %complex_module.complextype.3* %a)
+  %38 = getelementptr %complex_module.complextype.3_class, ptr %2, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_complextype, i32 0, i32 0, i32 2), ptr %38, align 8
+  %39 = getelementptr %complex_module.complextype.3_class, ptr %2, i32 0, i32 1
+  store ptr %c, ptr %39, align 8
+  call void @__module_complex_module_real_add_subrout(ptr %2, ptr %fpzero, ptr %negfpone, ptr %a)
   %40 = alloca i64, align 8
-  %41 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
-  %42 = load float, float* %41, align 4
+  %41 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 0
+  %42 = load float, ptr %41, align 4
   %43 = alloca float, align 4
-  store float %42, float* %43, align 4
-  %44 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
-  %45 = load float, float* %44, align 4
+  store float %42, ptr %43, align 4
+  %44 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 1
+  %45 = load float, ptr %44, align 4
   %46 = alloca float, align 4
-  store float %45, float* %46, align 4
-  %47 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %3, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.3, i32 0, i32 0), i64* %40, i32 0, i32 0, i32 0, i32 0, i32 0, float* %43, float* %46)
-  %48 = load i64, i64* %40, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %47, i8** %49, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %48, i64* %50, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %52 = load i8*, i8** %51, align 8
-  %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %54 = load i64, i64* %53, align 8
+  store float %45, ptr %46, align 4
+  %47 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %3, ptr null, i64 0, ptr @serialization_info.3, ptr %40, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %43, ptr %46)
+  %48 = load i64, ptr %40, align 8
+  %49 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %47, ptr %49, align 8
+  %50 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %48, ptr %50, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %52 = load ptr, ptr %51, align 8
+  %53 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %54 = load i64, ptr %53, align 8
   %55 = trunc i64 %54 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %56 = icmp eq i8* %47, null
+  call void @_lfortran_printf(ptr @11, ptr %52, i32 %55, ptr @10, i32 1)
+  %56 = icmp eq ptr %47, null
   br i1 %56, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %ifcont3
-  call void @_lfortran_free_alloc(i8* %3, i8* %47)
+  call void @_lfortran_free_alloc(ptr %3, ptr %47)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %ifcont3
-  %57 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 0
-  %58 = load float, float* %57, align 4
+  %57 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 0
+  %58 = load float, ptr %57, align 4
   %59 = fcmp une float %58, 1.000000e+00
   br i1 %59, label %then7, label %else8
 
 then7:                                            ; preds = %free_done6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -244,13 +245,13 @@ else8:                                            ; preds = %free_done6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %60 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %a, i32 0, i32 1
-  %61 = load float, float* %60, align 4
+  %60 = getelementptr %complex_module.complextype.3, ptr %a, i32 0, i32 1
+  %61 = load float, ptr %60, align 4
   %62 = fcmp une float %61, 1.000000e+00
   br i1 %62, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -269,32 +270,30 @@ FINALIZE_SYMTABLE_generic_name_01:                ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-define linkonce_odr void @_copy_complex_module_complextype(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_complex_module_complextype(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %complex_module.complextype.3*
-  %3 = bitcast i8* %1 to %complex_module.complextype.3*
-  %4 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %2, i32 0, i32 0
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %3, i32 0, i32 0
+  %2 = getelementptr %complex_module.complextype.3, ptr %0, i32 0, i32 0
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %complex_module.complextype.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %2, i32 0, i32 1
-  %8 = load float, float* %7, align 4
-  %9 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %3, i32 0, i32 1
+  %5 = getelementptr %complex_module.complextype.3, ptr %0, i32 0, i32 1
+  %6 = load float, ptr %5, align 4
+  %7 = getelementptr %complex_module.complextype.3, ptr %1, i32 0, i32 1
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  store float %8, float* %9, align 4
+  store float %6, ptr %7, align 4
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
@@ -304,48 +303,44 @@ ifcont3:                                          ; preds = %else2, %then1
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_complex_module_complextype(i8** %0) {
+define linkonce_odr void @_allocate_struct_complex_module_complextype(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %complex_module.complextype.3_class*
-  %5 = bitcast %complex_module.complextype.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [7 x i8*] }, { [7 x i8*] }* @_VTable_complextype, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %complex_module.complextype.3*
-  store %complex_module.complextype.3* %9, %complex_module.complextype.3** %6, align 8
-  %10 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %9, i32 0, i32 1
-  %11 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [7 x ptr] }, ptr @_VTable_complextype, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %complex_module.complextype.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 8)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 8, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %complex_module.complextype.3, ptr %6, i32 0, i32 1
+  %8 = getelementptr %complex_module.complextype.3, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__complextype_3_of_complex_module_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__complextype_3_of_complex_module_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %complex_module.complextype.3*
   ret void
 }
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-global_scope1-b0a630a.json
+++ b/tests/reference/llvm-global_scope1-b0a630a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope1-b0a630a.stdout",
-    "stdout_hash": "e0db7383318d561c1a3f21ae469ae39fe06ed9586268cf23ae8e7b7f",
+    "stdout_hash": "707ead9d3bc6a47756c09f38309ee4f82a8b1aeda52698dc03136f1e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope1-b0a630a.stdout
+++ b/tests/reference/llvm-global_scope1-b0a630a.stdout
@@ -1,5 +1,6 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0

--- a/tests/reference/llvm-global_scope2-ccffd68.json
+++ b/tests/reference/llvm-global_scope2-ccffd68.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope2-ccffd68.stdout",
-    "stdout_hash": "9a4dba0229c330d45e4cf43387ac64b525875e012692d5444445f97c",
+    "stdout_hash": "cb862fc60ef0caa3df1eb76c5a3549e7be808021bd5004f84a3fb715",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope2-ccffd68.stdout
+++ b/tests/reference/llvm-global_scope2-ccffd68.stdout
@@ -1,12 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
 define void @__lfortran_evaluate_1() {
 .entry:
-  store i32 6, i32* @x, align 4
+  store i32 6, ptr @x, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-global_scope3-00a245c.json
+++ b/tests/reference/llvm-global_scope3-00a245c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope3-00a245c.stdout",
-    "stdout_hash": "87ccc9c2503be3395fea204167eecb6aa9d6f58c616c4930a185f1bb",
+    "stdout_hash": "47370bfc69db995c956bc42cd33eabbe22a79fc9d13dd1e9a2fd34c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope3-00a245c.stdout
+++ b/tests/reference/llvm-global_scope3-00a245c.stdout
@@ -1,15 +1,16 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
 define void @__lfortran_evaluate_1() {
 .entry:
-  store i32 6, i32* @x, align 4
-  %0 = load i32, i32* @x, align 4
+  store i32 6, ptr @x, align 4
+  %0 = load i32, ptr @x, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* @x, align 4
+  store i32 %1, ptr @x, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-global_scope4-10fa534.json
+++ b/tests/reference/llvm-global_scope4-10fa534.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope4-10fa534.stdout",
-    "stdout_hash": "60e13c1121d2031cbc028ead9b19da83a8f74d585aeed58a7a5b6380",
+    "stdout_hash": "26e3b34597479dbd2a9639cc41cb4882e24b6b15110a7015a2317d62",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope4-10fa534.stdout
+++ b/tests/reference/llvm-global_scope4-10fa534.stdout
@@ -1,25 +1,26 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
 define i32 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  store i32 6, i32* @x, align 4
-  %0 = load i32, i32* @x, align 4
+  store i32 6, ptr @x, align 4
+  %0 = load i32, ptr @x, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* @x, align 4
-  %2 = load i32, i32* @x, align 4
+  store i32 %1, ptr @x, align 4
+  %2 = load i32, ptr @x, align 4
   %3 = mul i32 3, %2
-  store i32 %3, i32* %__lfortran_evaluate_11, align 4
+  store i32 %3, ptr %__lfortran_evaluate_11, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %4 = load i32, i32* %__lfortran_evaluate_11, align 4
+  %4 = load i32, ptr %__lfortran_evaluate_11, align 4
   ret i32 %4
 }

--- a/tests/reference/llvm-global_scope5-688b5a0.json
+++ b/tests/reference/llvm-global_scope5-688b5a0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope5-688b5a0.stdout",
-    "stdout_hash": "e653139ebfa6e172da0b75425f42ce70d0f0671c3fd5ec8a8f98d190",
+    "stdout_hash": "1f422aaf6b7718e4fdcac5c104a0f7e2fd6294d82427ba19fc73c2c3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope5-688b5a0.stdout
+++ b/tests/reference/llvm-global_scope5-688b5a0.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
@@ -8,22 +9,22 @@ define i32 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
   %__lfortran_evaluate_12 = alloca i32, align 4
-  store i32 6, i32* @x, align 4
-  %0 = load i32, i32* @x, align 4
+  store i32 6, ptr @x, align 4
+  %0 = load i32, ptr @x, align 4
   %1 = mul i32 2, %0
-  store i32 %1, i32* %__lfortran_evaluate_11, align 4
-  %2 = load i32, i32* @x, align 4
+  store i32 %1, ptr %__lfortran_evaluate_11, align 4
+  %2 = load i32, ptr @x, align 4
   %3 = add i32 %2, 1
-  store i32 %3, i32* @x, align 4
-  %4 = load i32, i32* @x, align 4
+  store i32 %3, ptr @x, align 4
+  %4 = load i32, ptr @x, align 4
   %5 = mul i32 3, %4
-  store i32 %5, i32* %__lfortran_evaluate_12, align 4
+  store i32 %5, ptr %__lfortran_evaluate_12, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %6 = load i32, i32* %__lfortran_evaluate_12, align 4
+  %6 = load i32, ptr %__lfortran_evaluate_12, align 4
   ret i32 %6
 }

--- a/tests/reference/llvm-global_scope6-3cbd5d2.json
+++ b/tests/reference/llvm-global_scope6-3cbd5d2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope6-3cbd5d2.stdout",
-    "stdout_hash": "53a0e38cc51b49f1c77cd6ab043b12afa96b0b3046e4d37e9a4c60a3",
+    "stdout_hash": "617c277f2444cccafff07d537635da3e23c3ff95d9f5c1c41b628c52",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope6-3cbd5d2.stdout
+++ b/tests/reference/llvm-global_scope6-3cbd5d2.stdout
@@ -1,19 +1,20 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
 define void @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  store i32 6, i32* @x, align 4
-  %0 = load i32, i32* @x, align 4
+  store i32 6, ptr @x, align 4
+  %0 = load i32, ptr @x, align 4
   %1 = mul i32 2, %0
-  store i32 %1, i32* %__lfortran_evaluate_11, align 4
-  %2 = load i32, i32* @x, align 4
+  store i32 %1, ptr %__lfortran_evaluate_11, align 4
+  %2 = load i32, ptr @x, align 4
   %3 = add i32 %2, 1
-  store i32 %3, i32* @x, align 4
+  store i32 %3, ptr @x, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-global_scope7-69a167f.json
+++ b/tests/reference/llvm-global_scope7-69a167f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope7-69a167f.stdout",
-    "stdout_hash": "3fff9b0cb1b64310f41a8590519bbf98c87a3b33c6472c43a7cb47fb",
+    "stdout_hash": "da36430c94b8f57eb3d1a80eb53d17916934785332ce1ea10e5412fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope7-69a167f.stdout
+++ b/tests/reference/llvm-global_scope7-69a167f.stdout
@@ -1,18 +1,19 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 6
 
 define void @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  %0 = load i32, i32* @x, align 4
+  %0 = load i32, ptr @x, align 4
   %1 = mul i32 2, %0
-  store i32 %1, i32* %__lfortran_evaluate_11, align 4
-  %2 = load i32, i32* @x, align 4
+  store i32 %1, ptr %__lfortran_evaluate_11, align 4
+  %2 = load i32, ptr @x, align 4
   %3 = add i32 %2, 1
-  store i32 %3, i32* @x, align 4
+  store i32 %3, ptr @x, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-global_scope8-240995c.json
+++ b/tests/reference/llvm-global_scope8-240995c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope8-240995c.stdout",
-    "stdout_hash": "b357b09bc099bdcdbad64b654d9ae98362ce4138c8ee672cba8373b9",
+    "stdout_hash": "38c84f49b9421baa8a317b4f0d9a37de55944861d8af50f58e645f34",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope8-240995c.stdout
+++ b/tests/reference/llvm-global_scope8-240995c.stdout
@@ -1,21 +1,22 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i32 0
 
 define i32 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i32, align 4
-  store i32 6, i32* @x, align 4
-  %0 = load i32, i32* @x, align 4
-  store i32 %0, i32* %__lfortran_evaluate_11, align 4
+  store i32 6, ptr @x, align 4
+  %0 = load i32, ptr @x, align 4
+  store i32 %0, ptr %__lfortran_evaluate_11, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %1 = load i32, i32* %__lfortran_evaluate_11, align 4
+  %1 = load i32, ptr %__lfortran_evaluate_11, align 4
   ret i32 %1
 }

--- a/tests/reference/llvm-global_scope9-bdf4288.json
+++ b/tests/reference/llvm-global_scope9-bdf4288.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-global_scope9-bdf4288.stdout",
-    "stdout_hash": "8e19a49eebedb89e1d18b5c154c1e7f5c353709f04de833b058b6d9b",
+    "stdout_hash": "28f1860f1c8f7a2f6e6e3e1f79e8b6107a29cc03718218df1f06079d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-global_scope9-bdf4288.stdout
+++ b/tests/reference/llvm-global_scope9-bdf4288.stdout
@@ -1,21 +1,22 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @x = global i64 0
 
 define i64 @__lfortran_evaluate_1() {
 .entry:
   %__lfortran_evaluate_11 = alloca i64, align 8
-  store i64 6, i64* @x, align 8
-  %0 = load i64, i64* @x, align 8
-  store i64 %0, i64* %__lfortran_evaluate_11, align 8
+  store i64 6, ptr @x, align 8
+  %0 = load i64, ptr @x, align 8
+  store i64 %0, ptr %__lfortran_evaluate_11, align 8
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE___lfortran_evaluate_1
 
 FINALIZE_SYMTABLE___lfortran_evaluate_1:          ; preds = %return
-  %1 = load i64, i64* %__lfortran_evaluate_11, align 8
+  %1 = load i64, ptr %__lfortran_evaluate_11, align 8
   ret i64 %1
 }

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "2e0da382defc08fba824d8149312d767ab8d77533a5e67906f4d4910",
+    "stdout_hash": "ca401d66085fb198018f634dfd98a4d160ef70973aed0efcb9e966ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -53,13 +54,13 @@ target datalayout = "..."
 @42 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @43 = private unnamed_addr constant [143 x i8] c"Runtime error: Array shape mismatch in subroutine '%s'\0A\0ATried to match size %d of dimension %d of argument number %d, but expected size is %d\0A\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__1_k = alloca i32, align 4
-  store i32 1, i32* %__1_k, align 4
-  %3 = load i32, i32* %__1_k, align 4
+  store i32 1, ptr %__1_k, align 4
+  %3 = load i32, ptr %__1_k, align 4
   %4 = sext i32 %3 to i64
   %5 = sub i64 %4, 1
   %6 = mul i64 1, %5
@@ -70,40 +71,40 @@ define i32 @main(i32 %0, i8** %1) {
   br i1 %10, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
-  %11 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %12 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %13 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %12, i32 0, i32 0
-  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @29, i32 0, i32 0), i8** %14, align 8
-  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 1
-  store i32 3, i32* %15, align 4
-  %16 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 2
-  store i32 12, i32* %16, align 4
-  %17 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 3
-  store i32 3, i32* %17, align 4
-  %18 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 4
-  store i32 30, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @30, i32 0, i32 0))
-  %20 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %11, i32 0, i32 0
-  %21 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %12, i32 0, i32 0
-  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 2
-  %23 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 0
-  store i1 true, i1* %23, align 1
-  %24 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 1
-  store i8* %19, i8** %24, align 8
-  store { i8*, i32, i32, i32, i32 }* %21, { i8*, i32, i32, i32, i32 }** %22, align 8
-  %25 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 3
-  store i32 1, i32* %25, align 4
-  %26 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %11, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i64 %4, i32 1, i64 1, i64 3)
+  %11 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %12 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %13 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %12, i32 0, i32 0
+  %14 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 0
+  store ptr @29, ptr %14, align 8
+  %15 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 1
+  store i32 3, ptr %15, align 4
+  %16 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 2
+  store i32 12, ptr %16, align 4
+  %17 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 3
+  store i32 3, ptr %17, align 4
+  %18 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 4
+  store i32 30, ptr %18, align 4
+  %19 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @30)
+  %20 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %11, i32 0, i32 0
+  %21 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %12, i32 0, i32 0
+  %22 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 2
+  %23 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 0
+  store i1 true, ptr %23, align 1
+  %24 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 1
+  store ptr %19, ptr %24, align 8
+  store ptr %21, ptr %22, align 8
+  %25 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 3
+  store i32 1, ptr %25, align 4
+  %26 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %11, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %26, i32 1, ptr @31, ptr @28, i64 %4, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %.entry
-  %27 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i64 %7
-  store i32 10, i32* %27, align 4
-  store i32 2, i32* %__1_k, align 4
-  %28 = load i32, i32* %__1_k, align 4
+  %27 = getelementptr [3 x i32], ptr @main.b, i32 0, i64 %7
+  store i32 10, ptr %27, align 4
+  store i32 2, ptr %__1_k, align 4
+  %28 = load i32, ptr %__1_k, align 4
   %29 = sext i32 %28 to i64
   %30 = sub i64 %29, 1
   %31 = mul i64 1, %30
@@ -114,40 +115,40 @@ ifcont:                                           ; preds = %.entry
   br i1 %35, label %then1, label %ifcont2
 
 then1:                                            ; preds = %ifcont
-  %36 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %37 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %38 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
-  %39 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @33, i32 0, i32 0), i8** %39, align 8
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 1
-  store i32 3, i32* %40, align 4
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 2
-  store i32 12, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 3
-  store i32 3, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %38, i32 0, i32 4
-  store i32 30, i32* %43, align 4
-  %44 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @34, i32 0, i32 0))
-  %45 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
-  %46 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %37, i32 0, i32 0
-  %47 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 2
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 0
-  store i1 true, i1* %48, align 1
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 1
-  store i8* %44, i8** %49, align 8
-  store { i8*, i32, i32, i32, i32 }* %46, { i8*, i32, i32, i32, i32 }** %47, align 8
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %45, i32 0, i32 3
-  store i32 1, i32* %50, align 4
-  %51 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %36, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %51, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i64 %29, i32 1, i64 1, i64 3)
+  %36 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %37 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %38 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %39 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 0
+  store ptr @33, ptr %39, align 8
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 1
+  store i32 3, ptr %40, align 4
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 2
+  store i32 12, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 3
+  store i32 3, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %38, i32 0, i32 4
+  store i32 30, ptr %43, align 4
+  %44 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @34)
+  %45 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  %46 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 2
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 0
+  store i1 true, ptr %48, align 1
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 1
+  store ptr %44, ptr %49, align 8
+  store ptr %46, ptr %47, align 8
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %45, i32 0, i32 3
+  store i32 1, ptr %50, align 4
+  %51 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %36, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %51, i32 1, ptr @35, ptr @32, i64 %29, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont2:                                          ; preds = %ifcont
-  %52 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i64 %32
-  store i32 20, i32* %52, align 4
-  store i32 3, i32* %__1_k, align 4
-  %53 = load i32, i32* %__1_k, align 4
+  %52 = getelementptr [3 x i32], ptr @main.b, i32 0, i64 %32
+  store i32 20, ptr %52, align 4
+  store i32 3, ptr %__1_k, align 4
+  %53 = load i32, ptr %__1_k, align 4
   %54 = sext i32 %53 to i64
   %55 = sub i64 %54, 1
   %56 = mul i64 1, %55
@@ -158,74 +159,74 @@ ifcont2:                                          ; preds = %ifcont
   br i1 %60, label %then3, label %ifcont4
 
 then3:                                            ; preds = %ifcont2
-  %61 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %62 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %63 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %62, i32 0, i32 0
-  %64 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @37, i32 0, i32 0), i8** %64, align 8
-  %65 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 1
-  store i32 3, i32* %65, align 4
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 2
-  store i32 12, i32* %66, align 4
-  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 3
-  store i32 3, i32* %67, align 4
-  %68 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %63, i32 0, i32 4
-  store i32 30, i32* %68, align 4
-  %69 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @38, i32 0, i32 0))
-  %70 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %61, i32 0, i32 0
-  %71 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %62, i32 0, i32 0
-  %72 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 2
-  %73 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 0
-  store i1 true, i1* %73, align 1
-  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 1
-  store i8* %69, i8** %74, align 8
-  store { i8*, i32, i32, i32, i32 }* %71, { i8*, i32, i32, i32, i32 }** %72, align 8
-  %75 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %70, i32 0, i32 3
-  store i32 1, i32* %75, align 4
-  %76 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %61, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %76, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i64 %54, i32 1, i64 1, i64 3)
+  %61 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %62 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %63 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %62, i32 0, i32 0
+  %64 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 0
+  store ptr @37, ptr %64, align 8
+  %65 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 1
+  store i32 3, ptr %65, align 4
+  %66 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 2
+  store i32 12, ptr %66, align 4
+  %67 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 3
+  store i32 3, ptr %67, align 4
+  %68 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %63, i32 0, i32 4
+  store i32 30, ptr %68, align 4
+  %69 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @38)
+  %70 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %61, i32 0, i32 0
+  %71 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %62, i32 0, i32 0
+  %72 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 2
+  %73 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 0
+  store i1 true, ptr %73, align 1
+  %74 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 1
+  store ptr %69, ptr %74, align 8
+  store ptr %71, ptr %72, align 8
+  %75 = getelementptr { i1, ptr, ptr, i32 }, ptr %70, i32 0, i32 3
+  store i32 1, ptr %75, align 4
+  %76 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %61, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %76, i32 1, ptr @39, ptr @36, i64 %54, i32 1, i64 1, i64 3)
   call void @exit(i32 1)
   unreachable
 
 ifcont4:                                          ; preds = %ifcont2
-  %77 = getelementptr [3 x i32], [3 x i32]* @main.b, i32 0, i64 %57
-  store i32 30, i32* %77, align 4
-  %78 = load i32, i32* @main.n, align 4
+  %77 = getelementptr [3 x i32], ptr @main.b, i32 0, i64 %57
+  store i32 30, ptr %77, align 4
+  %78 = load i32, ptr @main.n, align 4
   %79 = icmp slt i32 3, %78
   br i1 %79, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %80 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %81 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %82 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @41, i32 0, i32 0), i8** %83, align 8
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 1
-  store i32 6, i32* %84, align 4
-  %85 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 2
-  store i32 39, i32* %85, align 4
-  %86 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 3
-  store i32 6, i32* %86, align 4
-  %87 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %82, i32 0, i32 4
-  store i32 39, i32* %87, align 4
-  %88 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @42, i32 0, i32 0))
-  %89 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
-  %90 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %81, i32 0, i32 0
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 2
-  %92 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 0
-  store i1 true, i1* %92, align 1
-  %93 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 1
-  store i8* %88, i8** %93, align 8
-  store { i8*, i32, i32, i32, i32 }* %90, { i8*, i32, i32, i32, i32 }** %91, align 8
-  %94 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 0, i32 3
-  store i32 1, i32* %94, align 4
-  %95 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %80, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %95, i32 1, i8* getelementptr inbounds ([143 x i8], [143 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([7 x i8], [7 x i8]* @40, i32 0, i32 0), i32 3, i32 1, i32 2, i32 %78)
+  %80 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %81 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %82 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %81, i32 0, i32 0
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 0
+  store ptr @41, ptr %83, align 8
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 1
+  store i32 6, ptr %84, align 4
+  %85 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 2
+  store i32 39, ptr %85, align 4
+  %86 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 3
+  store i32 6, ptr %86, align 4
+  %87 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %82, i32 0, i32 4
+  store i32 39, ptr %87, align 4
+  %88 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @42)
+  %89 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %80, i32 0, i32 0
+  %90 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %81, i32 0, i32 0
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 2
+  %92 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 0
+  store i1 true, ptr %92, align 1
+  %93 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 1
+  store ptr %88, ptr %93, align 8
+  store ptr %90, ptr %91, align 8
+  %94 = getelementptr { i1, ptr, ptr, i32 }, ptr %89, i32 0, i32 3
+  store i32 1, ptr %94, align 4
+  %95 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %80, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %95, i32 1, ptr @43, ptr @40, i32 3, i32 1, i32 2, i32 %78)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %ifcont4
-  call void @driver(void (i32*, i32*, i32*)* @implicit_interface_check, i32* getelementptr inbounds ([3 x i32], [3 x i32]* @main.b, i32 0, i32 0), i32* @main.n)
+  call void @driver(ptr @implicit_interface_check, ptr @main.b, ptr @main.n)
   br label %return
 
 return:                                           ; preds = %ifcont6
@@ -236,34 +237,34 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
+define void @driver(ptr %fnc, ptr %arr, ptr %m) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
   %2 = alloca float, align 4
-  store float 1.000000e+00, float* %2, align 4
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, float* %2)
-  %4 = load i64, i64* %1, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  store float 1.000000e+00, ptr %2, align 4
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %2)
+  %4 = load i64, ptr %1, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %13 = load i32, i32* %m, align 4
+  %13 = load i32, ptr %m, align 4
   %14 = sext i32 %13 to i64
   %15 = add i64 1, %14
   %16 = sub i64 %15, 1
@@ -272,39 +273,39 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   br i1 %18, label %then, label %ifcont
 
 then:                                             ; preds = %free_done
-  %19 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %20 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %21 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @3, i32 0, i32 0), i8** %22, align 8
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 1
-  store i32 13, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 2
-  store i32 18, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 3
-  store i32 13, i32* %25, align 4
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %21, i32 0, i32 4
-  store i32 23, i32* %26, align 4
-  %27 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @4, i32 0, i32 0))
-  %28 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
-  %29 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %20, i32 0, i32 0
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 2
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 0
-  store i1 true, i1* %31, align 1
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 1
-  store i8* %27, i8** %32, align 8
-  store { i8*, i32, i32, i32, i32 }* %29, { i8*, i32, i32, i32, i32 }** %30, align 8
-  %33 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %28, i32 0, i32 3
-  store i32 1, i32* %33, align 4
-  %34 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %19, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %34, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([4 x i8], [4 x i8]* @2, i32 0, i32 0), i64 3, i32 1, i64 1, i64 %16)
+  %19 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %20 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %21 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %20, i32 0, i32 0
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %21, i32 0, i32 0
+  store ptr @3, ptr %22, align 8
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %21, i32 0, i32 1
+  store i32 13, ptr %23, align 4
+  %24 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %21, i32 0, i32 2
+  store i32 18, ptr %24, align 4
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %21, i32 0, i32 3
+  store i32 13, ptr %25, align 4
+  %26 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %21, i32 0, i32 4
+  store i32 23, ptr %26, align 4
+  %27 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @4)
+  %28 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %19, i32 0, i32 0
+  %29 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %20, i32 0, i32 0
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %28, i32 0, i32 2
+  %31 = getelementptr { i1, ptr, ptr, i32 }, ptr %28, i32 0, i32 0
+  store i1 true, ptr %31, align 1
+  %32 = getelementptr { i1, ptr, ptr, i32 }, ptr %28, i32 0, i32 1
+  store ptr %27, ptr %32, align 8
+  store ptr %29, ptr %30, align 8
+  %33 = getelementptr { i1, ptr, ptr, i32 }, ptr %28, i32 0, i32 3
+  store i32 1, ptr %33, align 4
+  %34 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %19, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %34, i32 1, ptr @5, ptr @2, i64 3, i32 1, i64 1, i64 %16)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %free_done
   %35 = mul i64 1, %14
-  %36 = getelementptr inbounds i32, i32* %arr, i64 2
-  call void %fnc(i32* %arr, i32* %m, i32* %36)
+  %36 = getelementptr inbounds i32, ptr %arr, i64 2
+  call void %fnc(ptr %arr, ptr %m, ptr %36)
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -314,17 +315,17 @@ FINALIZE_SYMTABLE_driver:                         ; preds = %return
   ret void
 }
 
-declare void @fnc(i32*, i32*, i32*)
+declare void @fnc(ptr, ptr, ptr)
 
-define void @implicit_interface_check(i32* %arr1, i32* %m, i32* %c) {
+define void @implicit_interface_check(ptr %arr1, ptr %m, ptr %c) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load i32, i32* %m, align 4
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load i32, ptr %m, align 4
   %2 = icmp ne i32 %1, 3
   br i1 %2, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -333,12 +334,12 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %3 = load i32, i32* %c, align 4
+  %3 = load i32, ptr %c, align 4
   %4 = icmp ne i32 %3, 30
   br i1 %4, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -347,7 +348,7 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %5 = load i32, i32* %m, align 4
+  %5 = load i32, ptr %m, align 4
   %6 = sext i32 %5 to i64
   %7 = add i64 1, %6
   %8 = sub i64 %7, 1
@@ -356,44 +357,44 @@ ifcont3:                                          ; preds = %else2, %then1
   br i1 %10, label %then4, label %ifcont5
 
 then4:                                            ; preds = %ifcont3
-  %11 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %12 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %13 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %12, i32 0, i32 0
-  %14 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @11, i32 0, i32 0), i8** %14, align 8
-  %15 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 1
-  store i32 20, i32* %15, align 4
-  %16 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 2
-  store i32 5, i32* %16, align 4
-  %17 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 3
-  store i32 20, i32* %17, align 4
-  %18 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %13, i32 0, i32 4
-  store i32 11, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @12, i32 0, i32 0))
-  %20 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %11, i32 0, i32 0
-  %21 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %12, i32 0, i32 0
-  %22 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 2
-  %23 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 0
-  store i1 true, i1* %23, align 1
-  %24 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 1
-  store i8* %19, i8** %24, align 8
-  store { i8*, i32, i32, i32, i32 }* %21, { i8*, i32, i32, i32, i32 }** %22, align 8
-  %25 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %20, i32 0, i32 3
-  store i32 1, i32* %25, align 4
-  %26 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %11, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %26, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i64 1, i32 1, i64 1, i64 %8)
+  %11 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %12 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %13 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %12, i32 0, i32 0
+  %14 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 0
+  store ptr @11, ptr %14, align 8
+  %15 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 1
+  store i32 20, ptr %15, align 4
+  %16 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 2
+  store i32 5, ptr %16, align 4
+  %17 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 3
+  store i32 20, ptr %17, align 4
+  %18 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %13, i32 0, i32 4
+  store i32 11, ptr %18, align 4
+  %19 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @12)
+  %20 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %11, i32 0, i32 0
+  %21 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %12, i32 0, i32 0
+  %22 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 2
+  %23 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 0
+  store i1 true, ptr %23, align 1
+  %24 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 1
+  store ptr %19, ptr %24, align 8
+  store ptr %21, ptr %22, align 8
+  %25 = getelementptr { i1, ptr, ptr, i32 }, ptr %20, i32 0, i32 3
+  store i32 1, ptr %25, align 4
+  %26 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %11, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %26, i32 1, ptr @13, ptr @10, i64 1, i32 1, i64 1, i64 %8)
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %ifcont3
   %27 = mul i64 1, %6
-  %28 = getelementptr inbounds i32, i32* %arr1, i64 0
-  %29 = load i32, i32* %28, align 4
+  %28 = getelementptr inbounds i32, ptr %arr1, i64 0
+  %29 = load i32, ptr %28, align 4
   %30 = icmp ne i32 %29, 10
   br i1 %30, label %then6, label %else7
 
 then6:                                            ; preds = %ifcont5
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont8
@@ -402,7 +403,7 @@ else7:                                            ; preds = %ifcont5
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
-  %31 = load i32, i32* %m, align 4
+  %31 = load i32, ptr %m, align 4
   %32 = sext i32 %31 to i64
   %33 = add i64 1, %32
   %34 = sub i64 %33, 1
@@ -411,44 +412,44 @@ ifcont8:                                          ; preds = %else7, %then6
   br i1 %36, label %then9, label %ifcont10
 
 then9:                                            ; preds = %ifcont8
-  %37 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %38 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %39 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @17, i32 0, i32 0), i8** %40, align 8
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 1
-  store i32 21, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 2
-  store i32 5, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 3
-  store i32 21, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 4
-  store i32 11, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %46 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  %47 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 2
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 0
-  store i1 true, i1* %49, align 1
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 1
-  store i8* %45, i8** %50, align 8
-  store { i8*, i32, i32, i32, i32 }* %47, { i8*, i32, i32, i32, i32 }** %48, align 8
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 3
-  store i32 1, i32* %51, align 4
-  %52 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %52, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i64 2, i32 1, i64 1, i64 %34)
+  %37 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %38 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %39 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %38, i32 0, i32 0
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 0
+  store ptr @17, ptr %40, align 8
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 1
+  store i32 21, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 2
+  store i32 5, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 3
+  store i32 21, ptr %43, align 4
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 4
+  store i32 11, ptr %44, align 4
+  %45 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @18)
+  %46 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %38, i32 0, i32 0
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 2
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 0
+  store i1 true, ptr %49, align 1
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 1
+  store ptr %45, ptr %50, align 8
+  store ptr %47, ptr %48, align 8
+  %51 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 3
+  store i32 1, ptr %51, align 4
+  %52 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %37, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %52, i32 1, ptr @19, ptr @16, i64 2, i32 1, i64 1, i64 %34)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
   %53 = mul i64 1, %32
-  %54 = getelementptr inbounds i32, i32* %arr1, i64 1
-  %55 = load i32, i32* %54, align 4
+  %54 = getelementptr inbounds i32, ptr %arr1, i64 1
+  %55 = load i32, ptr %54, align 4
   %56 = icmp ne i32 %55, 20
   br i1 %56, label %then11, label %else12
 
 then11:                                           ; preds = %ifcont10
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -457,7 +458,7 @@ else12:                                           ; preds = %ifcont10
   br label %ifcont13
 
 ifcont13:                                         ; preds = %else12, %then11
-  %57 = load i32, i32* %m, align 4
+  %57 = load i32, ptr %m, align 4
   %58 = sext i32 %57 to i64
   %59 = add i64 1, %58
   %60 = sub i64 %59, 1
@@ -466,44 +467,44 @@ ifcont13:                                         ; preds = %else12, %then11
   br i1 %62, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  %63 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %64 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %65 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %64, i32 0, i32 0
-  %66 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 0
-  store i8* getelementptr inbounds ([53 x i8], [53 x i8]* @23, i32 0, i32 0), i8** %66, align 8
-  %67 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 1
-  store i32 22, i32* %67, align 4
-  %68 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 2
-  store i32 5, i32* %68, align 4
-  %69 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 3
-  store i32 22, i32* %69, align 4
-  %70 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %65, i32 0, i32 4
-  store i32 11, i32* %70, align 4
-  %71 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @24, i32 0, i32 0))
-  %72 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %63, i32 0, i32 0
-  %73 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %64, i32 0, i32 0
-  %74 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 2
-  %75 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 0
-  store i1 true, i1* %75, align 1
-  %76 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 1
-  store i8* %71, i8** %76, align 8
-  store { i8*, i32, i32, i32, i32 }* %73, { i8*, i32, i32, i32, i32 }** %74, align 8
-  %77 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %72, i32 0, i32 3
-  store i32 1, i32* %77, align 4
-  %78 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %63, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %78, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @22, i32 0, i32 0), i64 3, i32 1, i64 1, i64 %60)
+  %63 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %64 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %65 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %64, i32 0, i32 0
+  %66 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %65, i32 0, i32 0
+  store ptr @23, ptr %66, align 8
+  %67 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %65, i32 0, i32 1
+  store i32 22, ptr %67, align 4
+  %68 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %65, i32 0, i32 2
+  store i32 5, ptr %68, align 4
+  %69 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %65, i32 0, i32 3
+  store i32 22, ptr %69, align 4
+  %70 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %65, i32 0, i32 4
+  store i32 11, ptr %70, align 4
+  %71 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @24)
+  %72 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %63, i32 0, i32 0
+  %73 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %64, i32 0, i32 0
+  %74 = getelementptr { i1, ptr, ptr, i32 }, ptr %72, i32 0, i32 2
+  %75 = getelementptr { i1, ptr, ptr, i32 }, ptr %72, i32 0, i32 0
+  store i1 true, ptr %75, align 1
+  %76 = getelementptr { i1, ptr, ptr, i32 }, ptr %72, i32 0, i32 1
+  store ptr %71, ptr %76, align 8
+  store ptr %73, ptr %74, align 8
+  %77 = getelementptr { i1, ptr, ptr, i32 }, ptr %72, i32 0, i32 3
+  store i32 1, ptr %77, align 4
+  %78 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %63, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %78, i32 1, ptr @25, ptr @22, i64 3, i32 1, i64 1, i64 %60)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
   %79 = mul i64 1, %58
-  %80 = getelementptr inbounds i32, i32* %arr1, i64 2
-  %81 = load i32, i32* %80, align 4
+  %80 = getelementptr inbounds i32, ptr %arr1, i64 2
+  %81 = load i32, ptr %80, align 4
   %82 = icmp ne i32 %81, 30
   br i1 %82, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @27, ptr @"ERROR STOP", ptr @26)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -521,22 +522,22 @@ FINALIZE_SYMTABLE_implicit_interface_check:       ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "a34bab8b37c5031da78f323242b24989ba12ec0a436834d5d48ab90a",
+    "stdout_hash": "7d3bfad336d1c0499e25da90eec141378b85bd9f8a923a9150c42fb3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -1,77 +1,78 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 %complex_4 = type <{ float, float }>
 
 @s_data = private global [4 x i8] c"left"
-@s = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @s_data, i32 0, i32 0), i64 4 }>
+@s = private global %string_descriptor <{ ptr @s_data, i64 4 }>
 @s1_data = private global [1 x i8] c"l"
-@s1 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @s1_data, i32 0, i32 0), i64 1 }>
+@s1 = private global %string_descriptor <{ ptr @s1_data, i64 1 }>
 @s2_data = private global [3 x i8] c"eft"
-@s2 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @s2_data, i32 0, i32 0), i64 3 }>
+@s2 = private global %string_descriptor <{ ptr @s2_data, i64 3 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [40 x i8] c"I4,I4,R4,{R4,R4},I4,L32,L32,R4,S-DESC-4\00", align 1
 @string_const_data = private constant [4 x i8] c"left"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
-  store i32 1, i32* %i, align 4
+  store i32 1, ptr %i, align 4
   %j = alloca i32, align 4
-  store i32 2, i32* %j, align 4
+  store i32 2, ptr %j, align 4
   %a = alloca i32, align 4
-  store i32 3, i32* %a, align 4
+  store i32 3, ptr %a, align 4
   %l = alloca i32, align 4
-  store i32 1, i32* %l, align 4
+  store i32 1, ptr %l, align 4
   %b = alloca i32, align 4
-  store i32 1, i32* %b, align 4
+  store i32 1, ptr %b, align 4
   %c = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %c, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %c, align 1
   %r = alloca float, align 4
-  store float 4.000000e+00, float* %r, align 4
+  store float 4.000000e+00, ptr %r, align 4
   %r_minus = alloca float, align 4
-  store float -4.000000e+00, float* %r_minus, align 4
+  store float -4.000000e+00, ptr %r_minus, align 4
   %3 = alloca i64, align 8
   %4 = alloca i32, align 4
-  store i32 1, i32* %4, align 4
+  store i32 1, ptr %4, align 4
   %5 = alloca i32, align 4
-  store i32 2, i32* %5, align 4
+  store i32 2, ptr %5, align 4
   %6 = alloca float, align 4
-  store float 4.000000e+00, float* %6, align 4
+  store float 4.000000e+00, ptr %6, align 4
   %7 = alloca %complex_4, align 8
-  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, %complex_4* %7, align 1
+  store %complex_4 <{ float 3.000000e+00, float 4.000000e+00 }>, ptr %7, align 1
   %8 = alloca i32, align 4
-  store i32 3, i32* %8, align 4
+  store i32 3, ptr %8, align 4
   %9 = alloca i32, align 4
-  store i32 1, i32* %9, align 4
+  store i32 1, ptr %9, align 4
   %10 = alloca i32, align 4
-  store i32 1, i32* %10, align 4
+  store i32 1, ptr %10, align 4
   %11 = alloca float, align 4
-  store float -4.000000e+00, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([40 x i8], [40 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4, i32* %5, float* %6, %complex_4* %7, i32* %8, i32* %9, i32* %10, float* %11, %string_descriptor* @string_const)
-  %13 = load i64, i64* %3, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %13, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %19 = load i64, i64* %18, align 8
+  store float -4.000000e+00, ptr %11, align 4
+  %12 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %4, ptr %5, ptr %6, ptr %7, ptr %8, ptr %9, ptr %10, ptr %11, ptr @string_const)
+  %13 = load i64, ptr %3, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, ptr %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
+  call void @_lfortran_printf(ptr @1, ptr %17, i32 %20, ptr @0, i32 1)
+  %21 = icmp eq ptr %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %12)
+  call void @_lfortran_free_alloc(ptr %2, ptr %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -85,14 +86,14 @@ FINALIZE_SYMTABLE_init_values:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "1a77e40ae8be629218f6ff9992c46d80c83ce781db827783358aafcb",
+    "stdout_hash": "6cb2983d5e37b4a98f52df39b349fc229b5cab05c4d500c0d9642420",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @int_dp.u = internal global i32 2147483647
 @int_dp.v = internal global i64 2147483647
@@ -10,29 +11,29 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [6 x i8] c"I4,I8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @int_dp.u, i64* @int_dp.v)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @int_dp.u, ptr @int_dp.v)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -46,14 +47,14 @@ FINALIZE_SYMTABLE_int_dp:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "3bd9af05fdb28d24753ae39ec9b05abbca79b32b2231f0766dc45354",
+    "stdout_hash": "423d1ca7d333073e206c62eec8bda57454b355dc883f7753eee98671",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @int_dp_param.u = internal global i32 2147483647
 @int_dp_param.v = internal global i64 2147483647
@@ -10,33 +11,33 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [6 x i8] c"I4,I8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %prec1 = alloca i32, align 4
-  store i32 4, i32* %prec1, align 4
+  store i32 4, ptr %prec1, align 4
   %prec2 = alloca i32, align 4
-  store i32 8, i32* %prec2, align 4
+  store i32 8, ptr %prec2, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @int_dp_param.u, i64* @int_dp_param.v)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @int_dp_param.u, ptr @int_dp_param.v)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -50,14 +51,14 @@ FINALIZE_SYMTABLE_int_dp_param:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "b076c288c6704e82f7170cd1f2c88c4c60a7fadb933f6a0dd343bbfe",
+    "stdout_hash": "75fe5e8098a859c3a9299ff8aab9cef21558ed989e1684e2ec95392d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -1,21 +1,22 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_dflt_intent_foo(float* %c, float* %d) {
+define void @__module_dflt_intent_foo(ptr %c, ptr %d) {
 .entry:
   %e = alloca float, align 4
   %g = alloca float, align 4
-  %0 = call float @foo.__module_dflt_intent_f(float* %c)
-  store float %0, float* %e, align 4
-  %1 = call float @foo.__module_dflt_intent_f(float* %d)
-  store float %1, float* %g, align 4
+  %0 = call float @foo.__module_dflt_intent_f(ptr %c)
+  store float %0, ptr %e, align 4
+  %1 = call float @foo.__module_dflt_intent_f(ptr %d)
+  store float %1, ptr %g, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -25,32 +26,32 @@ FINALIZE_SYMTABLE_foo:                            ; preds = %return
   ret void
 }
 
-define float @foo.__module_dflt_intent_f(float* %x) {
+define float @foo.__module_dflt_intent_f(ptr %x) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %f = alloca float, align 4
-  %1 = load float, float* %x, align 4
+  %1 = load float, ptr %x, align 4
   %2 = fmul float 2.000000e+00, %1
-  store float %2, float* %f, align 4
+  store float %2, ptr %f, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %f)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %f)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %4)
+  call void @_lfortran_free_alloc(ptr %0, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -60,26 +61,26 @@ return:                                           ; preds = %free_done
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %14 = load float, float* %f, align 4
+  %14 = load float, ptr %f, align 4
   ret float %14
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value1 = alloca float, align 4
   %call_arg_value = alloca float, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 0.000000e+00, float* %call_arg_value, align 4
-  store float 2.000000e+00, float* %call_arg_value1, align 4
-  call void @__module_dflt_intent_foo(float* %call_arg_value, float* %call_arg_value1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store float 0.000000e+00, ptr %call_arg_value, align 4
+  store float 2.000000e+00, ptr %call_arg_value1, align 4
+  call void @__module_dflt_intent_foo(ptr %call_arg_value, ptr %call_arg_value1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -90,6 +91,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-interface_12-2e5ecb8.json
+++ b/tests/reference/llvm-interface_12-2e5ecb8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-interface_12-2e5ecb8.stdout",
-    "stdout_hash": "2e534532eeb5b3bed3140b2707f3687ad2ed6e493cf91d9c421e634c",
+    "stdout_hash": "050fcbd9a389615bf56d1351453a2f6bff5925f62edf6aa5d66c9d00",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-interface_12-2e5ecb8.stdout
+++ b/tests/reference/llvm-interface_12-2e5ecb8.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define void @find_fit(void ([1 x float]*)* %expr) {
+define void @find_fit(ptr %expr) {
 .entry:
   br label %return
 
@@ -13,12 +14,12 @@ FINALIZE_SYMTABLE_find_fit:                       ; preds = %return
   ret void
 }
 
-declare void @expr([1 x float]*)
+declare void @expr(ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @find_fit(void ([1 x float]*)* @expression)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  call void @find_fit(ptr @expression)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -29,7 +30,7 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-define void @expression([1 x float]* %y) {
+define void @expression(ptr %y) {
 .entry:
   br label %return
 
@@ -40,6 +41,6 @@ FINALIZE_SYMTABLE_expression:                     ; preds = %return
   ret void
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "36d631646b2e0282357e06b935ae7114348892d5b7dc329ba2b3adbe",
+    "stdout_hash": "c7f0ae0264954a5bce0f8b45b8975a107bda4b734707aeccacda8be7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @intrinsics_02.x = internal global float 0x3FEFEB7AA0000000
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -20,80 +21,80 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @_lcompilers_sin_f32(float* %x) {
+define float @_lcompilers_sin_f32(ptr %x) {
 .entry:
   %_lcompilers_sin_f32 = alloca float, align 4
-  %0 = load float, float* %x, align 4
+  %0 = load float, ptr %x, align 4
   %1 = call float @_lfortran_ssin(float %0)
-  store float %1, float* %_lcompilers_sin_f32, align 4
+  store float %1, ptr %_lcompilers_sin_f32, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE__lcompilers_sin_f32
 
 FINALIZE_SYMTABLE__lcompilers_sin_f32:            ; preds = %return
-  %2 = load float, float* %_lcompilers_sin_f32, align 4
+  %2 = load float, ptr %_lcompilers_sin_f32, align 4
   ret float %2
 }
 
 declare float @_lfortran_ssin(float)
 
-define double @_lcompilers_sin_f64(double* %x) {
+define double @_lcompilers_sin_f64(ptr %x) {
 .entry:
   %_lcompilers_sin_f64 = alloca double, align 8
-  %0 = load double, double* %x, align 8
+  %0 = load double, ptr %x, align 8
   %1 = call double @_lfortran_dsin(double %0)
-  store double %1, double* %_lcompilers_sin_f64, align 8
+  store double %1, ptr %_lcompilers_sin_f64, align 8
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE__lcompilers_sin_f64
 
 FINALIZE_SYMTABLE__lcompilers_sin_f64:            ; preds = %return
-  %2 = load double, double* %_lcompilers_sin_f64, align 8
+  %2 = load double, ptr %_lcompilers_sin_f64, align 8
   ret double %2
 }
 
 declare double @_lfortran_dsin(double)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value10 = alloca double, align 8
   %call_arg_value = alloca float, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %y = alloca double, align 8
-  store double 0x3FEFEB7A9B2C6D8B, double* %y, align 8
+  store double 0x3FEFEB7A9B2C6D8B, ptr %y, align 8
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* @intrinsics_02.x, double* %y)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @intrinsics_02.x, ptr %y)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load float, float* @intrinsics_02.x, align 4
+  %14 = load float, ptr @intrinsics_02.x, align 4
   %15 = fsub float %14, 0x3FEFEB7AA0000000
   %16 = call float @llvm.fabs.f32(float %15)
   %17 = fcmp ogt float %16, 0x3EB0C6F7A0000000
   br i1 %17, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -102,14 +103,14 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %18 = call float @_lcompilers_sin_f32(float* @intrinsics_02.x)
+  %18 = call float @_lcompilers_sin_f32(ptr @intrinsics_02.x)
   %19 = fsub float %18, 0x3FEAE238A0000000
   %20 = call float @llvm.fabs.f32(float %19)
   %21 = fcmp ogt float %20, 0x3EB0C6F7A0000000
   br i1 %21, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -118,14 +119,14 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %22 = load double, double* %y, align 8
+  %22 = load double, ptr %y, align 8
   %23 = fsub double %22, 0x3FEFEB7AA0000000
   %24 = call double @llvm.fabs.f64(double %23)
   %25 = fcmp ogt double %24, 0x3E7AD7F2A0000000
   br i1 %25, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -137,7 +138,7 @@ ifcont6:                                          ; preds = %else5, %then4
   br i1 false, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -146,23 +147,23 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %26 = call double @_lcompilers_sin_f64(double* %y)
-  %27 = load float, float* @intrinsics_02.x, align 4
-  %28 = call float @_lcompilers_sin_f32(float* @intrinsics_02.x)
+  %26 = call double @_lcompilers_sin_f64(ptr %y)
+  %27 = load float, ptr @intrinsics_02.x, align 4
+  %28 = call float @_lcompilers_sin_f32(ptr @intrinsics_02.x)
   %29 = fadd float %27, %28
-  store float %29, float* %call_arg_value, align 4
-  %30 = call float @_lcompilers_sin_f32(float* %call_arg_value)
+  store float %29, ptr %call_arg_value, align 4
+  %30 = call float @_lcompilers_sin_f32(ptr %call_arg_value)
   %31 = fpext float %30 to double
   %32 = fadd double %26, %31
-  store double %32, double* %call_arg_value10, align 8
-  %33 = call double @_lcompilers_sin_f64(double* %call_arg_value10)
+  store double %32, ptr %call_arg_value10, align 8
+  %33 = call double @_lcompilers_sin_f64(ptr %call_arg_value10)
   %34 = fsub double %33, 0x3FEF20DD80000000
   %35 = call double @llvm.fabs.f64(double %34)
   %36 = fcmp ogt double %35, 0x3E7AD7F2A0000000
   br i1 %36, label %then11, label %else12
 
 then11:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -181,26 +182,26 @@ FINALIZE_SYMTABLE_intrinsics_02:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare float @llvm.fabs.f32(float) #0
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare double @llvm.fabs.f64(double) #0
 
-attributes #0 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "c0a691677b320e98077e06350f60195b3f721682b801200f1ce1a86c",
+    "stdout_hash": "93cbac5f5d4555467ec2a12e1065972b501c9c937061d6bbb120764b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @intrinsics_03.i = internal global i32 -12
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
@@ -20,45 +21,45 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define double @_lcompilers_cos_f64(double* %x) {
+define double @_lcompilers_cos_f64(ptr %x) {
 .entry:
   %_lcompilers_cos_f64 = alloca double, align 8
-  %0 = load double, double* %x, align 8
+  %0 = load double, ptr %x, align 8
   %1 = call double @_lfortran_dcos(double %0)
-  store double %1, double* %_lcompilers_cos_f64, align 8
+  store double %1, ptr %_lcompilers_cos_f64, align 8
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE__lcompilers_cos_f64
 
 FINALIZE_SYMTABLE__lcompilers_cos_f64:            ; preds = %return
-  %2 = load double, double* %_lcompilers_cos_f64, align 8
+  %2 = load double, ptr %_lcompilers_cos_f64, align 8
   ret double %2
 }
 
 declare double @_lfortran_dcos(double)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value4 = alloca double, align 8
   %call_arg_value = alloca double, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca double, align 8
   %r1 = alloca double, align 8
   %r2 = alloca double, align 8
   %x = alloca float, align 4
-  store double 4.200000e+00, double* %a, align 8
-  store float 0xBFEFE8D5A0000000, float* %x, align 4
-  %3 = load float, float* %x, align 4
+  store double 4.200000e+00, ptr %a, align 8
+  store float 0xBFEFE8D5A0000000, ptr %x, align 4
+  %3 = load float, ptr %x, align 4
   %4 = fadd float %3, 0x3FEFE8D5A0000000
   %5 = call float @llvm.fabs.f32(float %4)
   %6 = fcmp ogt float %5, 0x3E7AD7F2A0000000
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -67,14 +68,14 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = call double @_lcompilers_cos_f64(double* %a)
+  %7 = call double @_lcompilers_cos_f64(ptr %a)
   %8 = fadd double %7, 0x3FDF606EE0000000
   %9 = call double @llvm.fabs.f64(double %8)
   %10 = fcmp ogt double %9, 0x3E7AD7F2A0000000
   br i1 %10, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -83,21 +84,21 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %11 = load double, double* %a, align 8
-  %12 = call double @_lcompilers_cos_f64(double* %a)
+  %11 = load double, ptr %a, align 8
+  %12 = call double @_lcompilers_cos_f64(ptr %a)
   %13 = fadd double %11, %12
-  store double %13, double* %call_arg_value, align 8
-  %14 = call double @_lcompilers_cos_f64(double* %call_arg_value)
+  store double %13, ptr %call_arg_value, align 8
+  %14 = call double @_lcompilers_cos_f64(ptr %call_arg_value)
   %15 = fadd double 0x3FB21BD54FC5F9A7, %14
-  store double %15, double* %call_arg_value4, align 8
-  %16 = call double @_lcompilers_cos_f64(double* %call_arg_value4)
+  store double %15, ptr %call_arg_value4, align 8
+  %16 = call double @_lcompilers_cos_f64(ptr %call_arg_value4)
   %17 = fsub double %16, 0x3FE6ECC720000000
   %18 = call double @llvm.fabs.f64(double %17)
   %19 = fcmp ogt double %18, 0x3E7AD7F2A0000000
   br i1 %19, label %then5, label %else6
 
 then5:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont7
@@ -106,18 +107,18 @@ else6:                                            ; preds = %ifcont3
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %20 = call double @_lcompilers_cos_f64(double* %a)
-  store double %20, double* %r1, align 8
-  store double 0xBFDF606EEC8AC71E, double* %r2, align 8
-  %21 = load double, double* %r1, align 8
-  %22 = load double, double* %r2, align 8
+  %20 = call double @_lcompilers_cos_f64(ptr %a)
+  store double %20, ptr %r1, align 8
+  store double 0xBFDF606EEC8AC71E, ptr %r2, align 8
+  %21 = load double, ptr %r1, align 8
+  %22 = load double, ptr %r2, align 8
   %23 = fsub double %21, %22
   %24 = call double @llvm.fabs.f64(double %23)
   %25 = fcmp ogt double %24, 1.000000e-15
   br i1 %25, label %then8, label %else9
 
 then8:                                            ; preds = %ifcont7
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont10
@@ -127,33 +128,33 @@ else9:                                            ; preds = %ifcont7
 
 ifcont10:                                         ; preds = %else9, %then8
   %26 = alloca i64, align 8
-  %27 = load i32, i32* @intrinsics_03.i, align 4
+  %27 = load i32, ptr @intrinsics_03.i, align 4
   %28 = sub i32 0, %27
   %29 = icmp sge i32 %27, 0
   %30 = select i1 %29, i32 %27, i32 %28
   %31 = alloca i32, align 4
-  store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %26, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %31)
-  %33 = load i64, i64* %26, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %33, i64* %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %39 = load i64, i64* %38, align 8
+  store i32 %30, ptr %31, align 4
+  %32 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %26, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %31)
+  %33 = load i64, ptr %26, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %32, ptr %34, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %33, ptr %35, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %37 = load ptr, ptr %36, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %39 = load i64, ptr %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
+  call void @_lfortran_printf(ptr @9, ptr %37, i32 %40, ptr @8, i32 1)
+  %41 = icmp eq ptr %32, null
   br i1 %41, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont10
-  call void @_lfortran_free_alloc(i8* %2, i8* %32)
+  call void @_lfortran_free_alloc(ptr %2, ptr %32)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont10
-  %42 = load i32, i32* @intrinsics_03.i, align 4
+  %42 = load i32, ptr @intrinsics_03.i, align 4
   %43 = sub i32 0, %42
   %44 = icmp sge i32 %42, 0
   %45 = select i1 %44, i32 %42, i32 %43
@@ -161,7 +162,7 @@ free_done:                                        ; preds = %free_nonnull, %ifco
   br i1 %46, label %then11, label %else12
 
 then11:                                           ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -180,26 +181,26 @@ FINALIZE_SYMTABLE_intrinsics_03:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare float @llvm.fabs.f32(float) #0
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare double @llvm.fabs.f64(double) #0
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-attributes #0 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "bb43d977b1176d148ea81b2971011450eac7982e7724d82bf7305924",
+    "stdout_hash": "6a0067a27040b058e35398554c524482e6f4e002b0c0762c1bf95985",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -14,77 +15,77 @@ target datalayout = "..."
 @serialization_info.2 = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca float, align 4
-  store float 0x3FF2CD9FC0000000, float* %x, align 4
+  store float 0x3FF2CD9FC0000000, ptr %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store float 0x3FF8B07560000000, float* %x, align 4
+  store float 0x3FF8B07560000000, ptr %x, align 4
   %14 = alloca i64, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %16 = load i64, i64* %14, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %15, i8** %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %16, i64* %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %15 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %14, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %16 = load i64, ptr %14, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %16, ptr %18, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %24 = icmp eq i8* %15, null
+  call void @_lfortran_printf(ptr @3, ptr %20, i32 %23, ptr @2, i32 1)
+  %24 = icmp eq ptr %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  call void @_lfortran_free_alloc(ptr %2, ptr %15)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  store float 0x3FE85EFAC0000000, float* %x, align 4
+  store float 0x3FE85EFAC0000000, ptr %x, align 4
   %25 = alloca i64, align 8
-  %26 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %25, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %27 = load i64, i64* %25, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %26, i8** %28, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %27, i64* %29, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %31 = load i8*, i8** %30, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %33 = load i64, i64* %32, align 8
+  %26 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %25, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %27 = load i64, ptr %25, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %26, ptr %28, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %27, ptr %29, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %31 = load ptr, ptr %30, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %33 = load i64, ptr %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %35 = icmp eq i8* %26, null
+  call void @_lfortran_printf(ptr @5, ptr %31, i32 %34, ptr @4, i32 1)
+  %35 = icmp eq ptr %26, null
   br i1 %35, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %26)
+  call void @_lfortran_free_alloc(ptr %2, ptr %26)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
@@ -98,14 +99,14 @@ FINALIZE_SYMTABLE_intrinsics_05:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "d1c3b589d6d49309e5505b13ad3b910ec49e34c12aa4dac6f7cb62cd",
+    "stdout_hash": "a260cf56884beefc515e5fa939a792678ac4a33f67e25e9ce9d34dd6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -26,7 +27,7 @@ target datalayout = "..."
 @serialization_info.6 = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc16 = alloca %string_descriptor, align 8
   %stringFormat_desc13 = alloca %string_descriptor, align 8
@@ -35,162 +36,162 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %dp = alloca i32, align 4
-  store i32 8, i32* %dp, align 4
+  store i32 8, ptr %dp, align 4
   %x = alloca float, align 4
-  store float 0x3FEFFFFFE0000000, float* %x, align 4
+  store float 0x3FEFFFFFE0000000, ptr %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store float 0x3FEFFFFFE0000000, float* %x, align 4
+  store float 0x3FEFFFFFE0000000, ptr %x, align 4
   %14 = alloca i64, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %16 = load i64, i64* %14, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %15, i8** %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %16, i64* %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %15 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %14, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %16 = load i64, ptr %14, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %16, ptr %18, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %24 = icmp eq i8* %15, null
+  call void @_lfortran_printf(ptr @3, ptr %20, i32 %23, ptr @2, i32 1)
+  %24 = icmp eq ptr %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  call void @_lfortran_free_alloc(ptr %2, ptr %15)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  store float 1.000000e+00, float* %x, align 4
+  store float 1.000000e+00, ptr %x, align 4
   %25 = alloca i64, align 8
-  %26 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %25, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %27 = load i64, i64* %25, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %26, i8** %28, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %27, i64* %29, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %31 = load i8*, i8** %30, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %33 = load i64, i64* %32, align 8
+  %26 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %25, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %27 = load i64, ptr %25, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %26, ptr %28, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %27, ptr %29, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %31 = load ptr, ptr %30, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %33 = load i64, ptr %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %35 = icmp eq i8* %26, null
+  call void @_lfortran_printf(ptr @5, ptr %31, i32 %34, ptr @4, i32 1)
+  %35 = icmp eq ptr %26, null
   br i1 %35, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %26)
+  call void @_lfortran_free_alloc(ptr %2, ptr %26)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  store float 1.000000e+00, float* %x, align 4
+  store float 1.000000e+00, ptr %x, align 4
   %36 = alloca i64, align 8
-  %37 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %36, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %38 = load i64, i64* %36, align 8
-  %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %37, i8** %39, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %38, i64* %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %44 = load i64, i64* %43, align 8
+  %37 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %36, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %38 = load i64, ptr %36, align 8
+  %39 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %37, ptr %39, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %44 = load i64, ptr %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %46 = icmp eq i8* %37, null
+  call void @_lfortran_printf(ptr @7, ptr %42, i32 %45, ptr @6, i32 1)
+  %46 = icmp eq ptr %37, null
   br i1 %46, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %37)
+  call void @_lfortran_free_alloc(ptr %2, ptr %37)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
-  store float 1.000000e+00, float* %x, align 4
+  store float 1.000000e+00, ptr %x, align 4
   %47 = alloca i64, align 8
-  %48 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %47, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %49 = load i64, i64* %47, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %48, i8** %50, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %49, i64* %51, align 8
-  %52 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %55 = load i64, i64* %54, align 8
+  %48 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %47, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %49 = load i64, ptr %47, align 8
+  %50 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %48, ptr %50, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %49, ptr %51, align 8
+  %52 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %55 = load i64, ptr %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %57 = icmp eq i8* %48, null
+  call void @_lfortran_printf(ptr @9, ptr %53, i32 %56, ptr @8, i32 1)
+  %57 = icmp eq ptr %48, null
   br i1 %57, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free_alloc(i8* %2, i8* %48)
+  call void @_lfortran_free_alloc(ptr %2, ptr %48)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
-  store float 0x3FEFFFFFE0000000, float* %x, align 4
+  store float 0x3FEFFFFFE0000000, ptr %x, align 4
   %58 = alloca i64, align 8
-  %59 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %58, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %60 = load i64, i64* %58, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %59, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %60, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
+  %59 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.5, ptr %58, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %60 = load i64, ptr %58, align 8
+  %61 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %59, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %60, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %64 = load ptr, ptr %63, align 8
+  %65 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %66 = load i64, ptr %65, align 8
   %67 = trunc i64 %66 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %68 = icmp eq i8* %59, null
+  call void @_lfortran_printf(ptr @11, ptr %64, i32 %67, ptr @10, i32 1)
+  %68 = icmp eq ptr %59, null
   br i1 %68, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free_alloc(i8* %2, i8* %59)
+  call void @_lfortran_free_alloc(ptr %2, ptr %59)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
-  store float 1.000000e+00, float* %x, align 4
+  store float 1.000000e+00, ptr %x, align 4
   %69 = alloca i64, align 8
-  %70 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.6, i32 0, i32 0), i64* %69, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x)
-  %71 = load i64, i64* %69, align 8
-  %72 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %70, i8** %72, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %71, i64* %73, align 8
-  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %75 = load i8*, i8** %74, align 8
-  %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %77 = load i64, i64* %76, align 8
+  %70 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.6, ptr %69, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %71 = load i64, ptr %69, align 8
+  %72 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %70, ptr %72, align 8
+  %73 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %71, ptr %73, align 8
+  %74 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %75 = load ptr, ptr %74, align 8
+  %76 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %77 = load i64, ptr %76, align 8
   %78 = trunc i64 %77 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %79 = icmp eq i8* %70, null
+  call void @_lfortran_printf(ptr @13, ptr %75, i32 %78, ptr @12, i32 1)
+  %79 = icmp eq ptr %70, null
   br i1 %79, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free_alloc(i8* %2, i8* %70)
+  call void @_lfortran_free_alloc(ptr %2, ptr %70)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
@@ -204,14 +205,14 @@ FINALIZE_SYMTABLE_intrinsics_06:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-issue532-d63b703.json
+++ b/tests/reference/llvm-issue532-d63b703.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-issue532-d63b703.stdout",
-    "stdout_hash": "0e306cadb7a93ad7b7a90f688ed68c3b5c752ec2cbf65bf6a830b45a",
+    "stdout_hash": "9a6c70f69220b7e24d38aa056ea2da06ce4279bf21e51013c27a025a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-issue532-d63b703.stdout
+++ b/tests/reference/llvm-issue532-d63b703.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -15,6 +16,6 @@ FINALIZE_SYMTABLE_issue532:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "b8d1aaa19d54737b6da20e145f87cbe17db0e1f8a74df10f8b449c1b",
+    "stdout_hash": "0aa5f50fd4b42f2b35acac0ed352a8d0225371dddaedefde3d3fbcd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%array.1 = type { double*, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
+%array.1 = type { ptr, i64, i32, i8, i8, i8, i8, i64, [1 x %dimension_descriptor] }
 %dimension_descriptor = type { i64, i64, i64 }
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [37 x i8] c"__libasr_created__subroutine_call_b1\00", align 1
 @1 = private unnamed_addr constant [56 x i8] c"tests/../integration_tests/legacy_array_sections_01.f90\00", align 1
@@ -51,73 +52,73 @@ target datalayout = "..."
 @40 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @41 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @a(double* %w) {
+define void @a(ptr %w) {
 .entry:
   %arr_desc17 = alloca %array.1, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %array_section_descriptor = alloca %array.1, align 8
   %arr_desc1 = alloca %array.1, align 8
   %arr_desc = alloca %array.1, align 8
   %__do_loop_end = alloca i32, align 4
   %__do_loop_end1 = alloca i32, align 4
   %__lcompilers_i_0 = alloca i32, align 4
-  %__libasr_created__subroutine_call_b = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %1 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 8
-  %2 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %1, i32 0, i32 0
-  %3 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %2, i32 0
-  %4 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 0
-  store i64 1, i64* %4, align 8
-  %5 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 1
-  store i64 1, i64* %5, align 8
-  %6 = getelementptr %dimension_descriptor, %dimension_descriptor* %3, i32 0, i32 2
-  store i64 0, i64* %6, align 8
-  %7 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 3
-  store i8 1, i8* %7, align 1
-  %8 = getelementptr %array.1, %array.1* %arr_desc, i32 0, i32 0
-  store double* null, double** %8, align 8
-  store %array.1* %arr_desc, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %__libasr_created__subroutine_call_b1 = alloca %array.1*, align 8
-  store %array.1* null, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %9 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 8
-  %10 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %9, i32 0, i32 0
-  %11 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %10, i32 0
-  %12 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 0
-  store i64 1, i64* %12, align 8
-  %13 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 1
-  store i64 1, i64* %13, align 8
-  %14 = getelementptr %dimension_descriptor, %dimension_descriptor* %11, i32 0, i32 2
-  store i64 0, i64* %14, align 8
-  %15 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 3
-  store i8 1, i8* %15, align 1
-  %16 = getelementptr %array.1, %array.1* %arr_desc1, i32 0, i32 0
-  store double* null, double** %16, align 8
-  store %array.1* %arr_desc1, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  %__libasr_created__subroutine_call_b = alloca ptr, align 8
+  store ptr null, ptr %__libasr_created__subroutine_call_b, align 8
+  %1 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 8
+  %2 = getelementptr [1 x %dimension_descriptor], ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %dimension_descriptor, ptr %2, i32 0
+  %4 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 0
+  store i64 1, ptr %4, align 8
+  %5 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 1
+  store i64 1, ptr %5, align 8
+  %6 = getelementptr %dimension_descriptor, ptr %3, i32 0, i32 2
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 3
+  store i8 1, ptr %7, align 1
+  %8 = getelementptr %array.1, ptr %arr_desc, i32 0, i32 0
+  store ptr null, ptr %8, align 8
+  store ptr %arr_desc, ptr %__libasr_created__subroutine_call_b, align 8
+  %__libasr_created__subroutine_call_b1 = alloca ptr, align 8
+  store ptr null, ptr %__libasr_created__subroutine_call_b1, align 8
+  %9 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 8
+  %10 = getelementptr [1 x %dimension_descriptor], ptr %9, i32 0, i32 0
+  %11 = getelementptr inbounds %dimension_descriptor, ptr %10, i32 0
+  %12 = getelementptr %dimension_descriptor, ptr %11, i32 0, i32 0
+  store i64 1, ptr %12, align 8
+  %13 = getelementptr %dimension_descriptor, ptr %11, i32 0, i32 1
+  store i64 1, ptr %13, align 8
+  %14 = getelementptr %dimension_descriptor, ptr %11, i32 0, i32 2
+  store i64 0, ptr %14, align 8
+  %15 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 3
+  store i8 1, ptr %15, align 1
+  %16 = getelementptr %array.1, ptr %arr_desc1, i32 0, i32 0
+  store ptr null, ptr %16, align 8
+  store ptr %arr_desc1, ptr %__libasr_created__subroutine_call_b1, align 8
   %icon = alloca i32, align 4
-  store i32 2, i32* %icon, align 4
-  %17 = load i32, i32* %icon, align 4
-  %18 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 8
-  %19 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %18, i32 0, i32 0
-  %20 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %19, i32 0
-  %21 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 0
-  store i64 1, i64* %21, align 8
-  %22 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 1
-  store i64 1, i64* %22, align 8
-  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %20, i32 0, i32 2
-  store i64 0, i64* %23, align 8
-  %24 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 3
-  store i8 1, i8* %24, align 1
+  store i32 2, ptr %icon, align 4
+  %17 = load i32, ptr %icon, align 4
+  %18 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 8
+  %19 = getelementptr [1 x %dimension_descriptor], ptr %18, i32 0, i32 0
+  %20 = getelementptr inbounds %dimension_descriptor, ptr %19, i32 0
+  %21 = getelementptr %dimension_descriptor, ptr %20, i32 0, i32 0
+  store i64 1, ptr %21, align 8
+  %22 = getelementptr %dimension_descriptor, ptr %20, i32 0, i32 1
+  store i64 1, ptr %22, align 8
+  %23 = getelementptr %dimension_descriptor, ptr %20, i32 0, i32 2
+  store i64 0, ptr %23, align 8
+  %24 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 3
+  store i8 1, ptr %24, align 1
   %25 = sext i32 %17 to i64
   %26 = sub i64 %25, 1
   %27 = mul i64 1, %26
   %28 = add i64 0, %27
-  %29 = getelementptr inbounds double, double* %w, i64 %28
-  %30 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 0
-  store double* %29, double** %30, align 8
-  %31 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 7
-  store i64 0, i64* %31, align 8
-  %32 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 8
-  %33 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %32, i32 0, i32 0
+  %29 = getelementptr inbounds double, ptr %w, i64 %28
+  %30 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 0
+  store ptr %29, ptr %30, align 8
+  %31 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 7
+  store i64 0, ptr %31, align 8
+  %32 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 8
+  %33 = getelementptr [1 x %dimension_descriptor], ptr %32, i32 0, i32 0
   %34 = sext i32 %17 to i64
   %35 = sub i64 5, %34
   %36 = sdiv i64 %35, 1
@@ -128,43 +129,43 @@ define void @a(double* %w) {
   %41 = and i1 false, %39
   %42 = or i1 %40, %41
   %43 = select i1 %42, i64 0, i64 %37
-  %44 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %33, i32 0
-  %45 = getelementptr %dimension_descriptor, %dimension_descriptor* %44, i32 0, i32 2
-  store i64 1, i64* %45, align 8
-  %46 = getelementptr %dimension_descriptor, %dimension_descriptor* %44, i32 0, i32 0
-  store i64 1, i64* %46, align 8
-  %47 = getelementptr %dimension_descriptor, %dimension_descriptor* %44, i32 0, i32 1
-  store i64 %43, i64* %47, align 8
-  %48 = getelementptr %array.1, %array.1* %array_section_descriptor, i32 0, i32 3
-  store i8 1, i8* %48, align 1
-  store %array.1* %array_section_descriptor, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %49 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %50 = getelementptr %array.1, %array.1* %49, i32 0, i32 8
-  %51 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %50, i32 0, i32 0
-  %52 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %51, i32 0
-  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %52, i32 0, i32 0
-  %54 = load i64, i64* %53, align 8
-  %55 = getelementptr %dimension_descriptor, %dimension_descriptor* %52, i32 0, i32 2
-  %56 = load i64, i64* %55, align 8
+  %44 = getelementptr inbounds %dimension_descriptor, ptr %33, i32 0
+  %45 = getelementptr %dimension_descriptor, ptr %44, i32 0, i32 2
+  store i64 1, ptr %45, align 8
+  %46 = getelementptr %dimension_descriptor, ptr %44, i32 0, i32 0
+  store i64 1, ptr %46, align 8
+  %47 = getelementptr %dimension_descriptor, ptr %44, i32 0, i32 1
+  store i64 %43, ptr %47, align 8
+  %48 = getelementptr %array.1, ptr %array_section_descriptor, i32 0, i32 3
+  store i8 1, ptr %48, align 1
+  store ptr %array_section_descriptor, ptr %__libasr_created__subroutine_call_b, align 8
+  %49 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %50 = getelementptr %array.1, ptr %49, i32 0, i32 8
+  %51 = getelementptr [1 x %dimension_descriptor], ptr %50, i32 0, i32 0
+  %52 = getelementptr inbounds %dimension_descriptor, ptr %51, i32 0
+  %53 = getelementptr %dimension_descriptor, ptr %52, i32 0, i32 0
+  %54 = load i64, ptr %53, align 8
+  %55 = getelementptr %dimension_descriptor, ptr %52, i32 0, i32 2
+  %56 = load i64, ptr %55, align 8
   %57 = icmp eq i64 %56, 1
   %58 = and i1 true, %57
-  %59 = getelementptr %dimension_descriptor, %dimension_descriptor* %52, i32 0, i32 0
-  %60 = load i64, i64* %59, align 8
-  %61 = getelementptr %dimension_descriptor, %dimension_descriptor* %52, i32 0, i32 1
-  %62 = load i64, i64* %61, align 8
+  %59 = getelementptr %dimension_descriptor, ptr %52, i32 0, i32 0
+  %60 = load i64, ptr %59, align 8
+  %61 = getelementptr %dimension_descriptor, ptr %52, i32 0, i32 1
+  %62 = load i64, ptr %61, align 8
   %63 = add i64 %62, %60
   %64 = sub i64 %63, 1
   %65 = sub i64 %64, %54
   %66 = add i64 %65, 1
   %67 = mul i64 1, %66
-  %68 = ptrtoint %array.1* %49 to i64
+  %68 = ptrtoint ptr %49 to i64
   %69 = icmp eq i64 %68, 0
   br i1 %69, label %merge_allocated, label %check_data
 
 check_data:                                       ; preds = %.entry
-  %70 = getelementptr %array.1, %array.1* %49, i32 0, i32 0
-  %71 = load double*, double** %70, align 8
-  %72 = ptrtoint double* %71 to i64
+  %70 = getelementptr %array.1, ptr %49, i32 0, i32 0
+  %71 = load ptr, ptr %70, align 8
+  %72 = ptrtoint ptr %71 to i64
   %73 = icmp ne i64 %72, 0
   br label %merge_allocated
 
@@ -176,15 +177,15 @@ merge_allocated:                                  ; preds = %check_data, %.entry
   br i1 %76, label %then, label %else15
 
 then:                                             ; preds = %merge_allocated
-  %77 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %78 = ptrtoint %array.1* %77 to i64
+  %77 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %78 = ptrtoint ptr %77 to i64
   %79 = icmp eq i64 %78, 0
   br i1 %79, label %merge_allocated3, label %check_data2
 
 check_data2:                                      ; preds = %then
-  %80 = getelementptr %array.1, %array.1* %77, i32 0, i32 0
-  %81 = load double*, double** %80, align 8
-  %82 = ptrtoint double* %81 to i64
+  %80 = getelementptr %array.1, ptr %77, i32 0, i32 0
+  %81 = load ptr, ptr %80, align 8
+  %82 = ptrtoint ptr %81 to i64
   %83 = icmp ne i64 %82, 0
   br label %merge_allocated3
 
@@ -193,527 +194,522 @@ merge_allocated3:                                 ; preds = %check_data2, %then
   br i1 %is_allocated4, label %then5, label %else
 
 then5:                                            ; preds = %merge_allocated3
-  %84 = getelementptr %array.1, %array.1* %77, i32 0, i32 0
-  %85 = load double*, double** %84, align 8
-  %86 = bitcast double* %85 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %86)
-  %87 = getelementptr %array.1, %array.1* %77, i32 0, i32 0
-  store double* null, double** %87, align 8
+  %84 = getelementptr %array.1, ptr %77, i32 0, i32 0
+  %85 = load ptr, ptr %84, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %85)
+  %86 = getelementptr %array.1, ptr %77, i32 0, i32 0
+  store ptr null, ptr %86, align 8
   br label %ifcont
 
 else:                                             ; preds = %merge_allocated3
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then5
-  %88 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %89 = ptrtoint %array.1* %88 to i64
-  %90 = icmp eq i64 %89, 0
-  br i1 %90, label %merge_allocated7, label %check_data6
+  %87 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %88 = ptrtoint ptr %87 to i64
+  %89 = icmp eq i64 %88, 0
+  br i1 %89, label %merge_allocated7, label %check_data6
 
 check_data6:                                      ; preds = %ifcont
-  %91 = getelementptr %array.1, %array.1* %88, i32 0, i32 0
-  %92 = load double*, double** %91, align 8
-  %93 = ptrtoint double* %92 to i64
-  %94 = icmp ne i64 %93, 0
+  %90 = getelementptr %array.1, ptr %87, i32 0, i32 0
+  %91 = load ptr, ptr %90, align 8
+  %92 = ptrtoint ptr %91 to i64
+  %93 = icmp ne i64 %92, 0
   br label %merge_allocated7
 
 merge_allocated7:                                 ; preds = %check_data6, %ifcont
-  %is_allocated8 = phi i1 [ false, %ifcont ], [ %94, %check_data6 ]
+  %is_allocated8 = phi i1 [ false, %ifcont ], [ %93, %check_data6 ]
   br i1 %is_allocated8, label %then9, label %ifcont10
 
 then9:                                            ; preds = %merge_allocated7
-  %95 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %96 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %97 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %96, i32 0, i32 0
-  %98 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %97, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @1, i32 0, i32 0), i8** %98, align 8
-  %99 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %97, i32 0, i32 1
-  store i32 5, i32* %99, align 4
-  %100 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %97, i32 0, i32 2
-  store i32 8, i32* %100, align 4
-  %101 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %97, i32 0, i32 3
-  store i32 5, i32* %101, align 4
-  %102 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %97, i32 0, i32 4
-  store i32 14, i32* %102, align 4
-  %103 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([53 x i8], [53 x i8]* @2, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @0, i32 0, i32 0))
-  %104 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %95, i32 0, i32 0
-  %105 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %96, i32 0, i32 0
-  %106 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %104, i32 0, i32 2
-  %107 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %104, i32 0, i32 0
-  store i1 true, i1* %107, align 1
-  %108 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %104, i32 0, i32 1
-  store i8* %103, i8** %108, align 8
-  store { i8*, i32, i32, i32, i32 }* %105, { i8*, i32, i32, i32, i32 }** %106, align 8
-  %109 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %104, i32 0, i32 3
-  store i32 1, i32* %109, align 4
-  %110 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %95, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %110, i32 1, i8* getelementptr inbounds ([55 x i8], [55 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @0, i32 0, i32 0))
+  %94 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %95 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %96 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %95, i32 0, i32 0
+  %97 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %96, i32 0, i32 0
+  store ptr @1, ptr %97, align 8
+  %98 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %96, i32 0, i32 1
+  store i32 5, ptr %98, align 4
+  %99 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %96, i32 0, i32 2
+  store i32 8, ptr %99, align 4
+  %100 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %96, i32 0, i32 3
+  store i32 5, ptr %100, align 4
+  %101 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %96, i32 0, i32 4
+  store i32 14, ptr %101, align 4
+  %102 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @2, ptr @0)
+  %103 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %94, i32 0, i32 0
+  %104 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %95, i32 0, i32 0
+  %105 = getelementptr { i1, ptr, ptr, i32 }, ptr %103, i32 0, i32 2
+  %106 = getelementptr { i1, ptr, ptr, i32 }, ptr %103, i32 0, i32 0
+  store i1 true, ptr %106, align 1
+  %107 = getelementptr { i1, ptr, ptr, i32 }, ptr %103, i32 0, i32 1
+  store ptr %102, ptr %107, align 8
+  store ptr %104, ptr %105, align 8
+  %108 = getelementptr { i1, ptr, ptr, i32 }, ptr %103, i32 0, i32 3
+  store i32 1, ptr %108, align 4
+  %109 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %94, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %109, i32 1, ptr @3, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %merge_allocated7
-  %111 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %112 = getelementptr %array.1, %array.1* %111, i32 0, i32 8
-  %113 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %112, i32 0, i32 0
-  %114 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %113, i32 0
-  %115 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %113, i32 0
-  %116 = getelementptr %dimension_descriptor, %dimension_descriptor* %115, i32 0, i32 1
-  %117 = load i64, i64* %116, align 8
-  %118 = icmp eq i64 %117, 0
-  %119 = getelementptr %dimension_descriptor, %dimension_descriptor* %114, i32 0, i32 0
-  %120 = load i64, i64* %119, align 8
-  %121 = getelementptr %dimension_descriptor, %dimension_descriptor* %114, i32 0, i32 1
-  %122 = load i64, i64* %121, align 8
-  %123 = add i64 %122, %120
-  %124 = sub i64 %123, 1
-  %125 = select i1 %118, i64 0, i64 %124
-  %126 = trunc i64 %125 to i32
-  %127 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %128 = getelementptr %array.1, %array.1* %127, i32 0, i32 7
-  store i64 0, i64* %128, align 8
-  %129 = getelementptr %array.1, %array.1* %127, i32 0, i32 3
-  store i8 1, i8* %129, align 1
-  %130 = getelementptr %array.1, %array.1* %127, i32 0, i32 8
-  %131 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %130, i32 0, i32 0
-  %132 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %131, i32 0
-  %133 = getelementptr %dimension_descriptor, %dimension_descriptor* %132, i32 0, i32 2
-  %134 = getelementptr %dimension_descriptor, %dimension_descriptor* %132, i32 0, i32 0
-  %135 = getelementptr %dimension_descriptor, %dimension_descriptor* %132, i32 0, i32 1
-  %136 = sext i32 %126 to i64
-  %137 = icmp slt i64 %136, 0
-  %138 = select i1 %137, i64 0, i64 %136
-  store i64 1, i64* %133, align 8
-  store i64 1, i64* %134, align 8
-  store i64 %138, i64* %135, align 8
-  %139 = mul i64 1, %138
-  %140 = getelementptr %array.1, %array.1* %127, i32 0, i32 0
-  %141 = mul i64 %139, 8
-  %142 = call i8* @_lfortran_get_default_allocator()
-  %143 = call i8* @_lfortran_malloc_alloc(i8* %142, i64 %141)
-  %144 = bitcast i8* %143 to double*
-  store double* %144, double** %140, align 8
-  %145 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %146 = getelementptr %array.1, %array.1* %145, i32 0, i32 8
-  %147 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %146, i32 0, i32 0
-  %148 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %147, i32 0
-  %149 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %147, i32 0
-  %150 = getelementptr %dimension_descriptor, %dimension_descriptor* %149, i32 0, i32 1
-  %151 = load i64, i64* %150, align 8
-  %152 = icmp eq i64 %151, 0
-  %153 = getelementptr %dimension_descriptor, %dimension_descriptor* %148, i32 0, i32 0
-  %154 = load i64, i64* %153, align 8
-  %155 = getelementptr %dimension_descriptor, %dimension_descriptor* %148, i32 0, i32 1
-  %156 = load i64, i64* %155, align 8
-  %157 = add i64 %156, %154
-  %158 = sub i64 %157, 1
-  %159 = select i1 %152, i64 0, i64 %158
-  %160 = trunc i64 %159 to i32
-  store i32 %160, i32* %__do_loop_end, align 4
-  %161 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %162 = getelementptr %array.1, %array.1* %161, i32 0, i32 8
-  %163 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %162, i32 0, i32 0
-  %164 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 0
-  %165 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %163, i32 0
-  %166 = getelementptr %dimension_descriptor, %dimension_descriptor* %165, i32 0, i32 1
-  %167 = load i64, i64* %166, align 8
-  %168 = icmp eq i64 %167, 0
-  %169 = getelementptr %dimension_descriptor, %dimension_descriptor* %164, i32 0, i32 0
-  %170 = load i64, i64* %169, align 8
-  %171 = select i1 %168, i64 1, i64 %170
-  %172 = trunc i64 %171 to i32
-  %173 = sub i32 %172, 1
-  store i32 %173, i32* %__lcompilers_i_0, align 4
+  %110 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %111 = getelementptr %array.1, ptr %110, i32 0, i32 8
+  %112 = getelementptr [1 x %dimension_descriptor], ptr %111, i32 0, i32 0
+  %113 = getelementptr inbounds %dimension_descriptor, ptr %112, i32 0
+  %114 = getelementptr inbounds %dimension_descriptor, ptr %112, i32 0
+  %115 = getelementptr %dimension_descriptor, ptr %114, i32 0, i32 1
+  %116 = load i64, ptr %115, align 8
+  %117 = icmp eq i64 %116, 0
+  %118 = getelementptr %dimension_descriptor, ptr %113, i32 0, i32 0
+  %119 = load i64, ptr %118, align 8
+  %120 = getelementptr %dimension_descriptor, ptr %113, i32 0, i32 1
+  %121 = load i64, ptr %120, align 8
+  %122 = add i64 %121, %119
+  %123 = sub i64 %122, 1
+  %124 = select i1 %117, i64 0, i64 %123
+  %125 = trunc i64 %124 to i32
+  %126 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %127 = getelementptr %array.1, ptr %126, i32 0, i32 7
+  store i64 0, ptr %127, align 8
+  %128 = getelementptr %array.1, ptr %126, i32 0, i32 3
+  store i8 1, ptr %128, align 1
+  %129 = getelementptr %array.1, ptr %126, i32 0, i32 8
+  %130 = getelementptr [1 x %dimension_descriptor], ptr %129, i32 0, i32 0
+  %131 = getelementptr inbounds %dimension_descriptor, ptr %130, i32 0
+  %132 = getelementptr %dimension_descriptor, ptr %131, i32 0, i32 2
+  %133 = getelementptr %dimension_descriptor, ptr %131, i32 0, i32 0
+  %134 = getelementptr %dimension_descriptor, ptr %131, i32 0, i32 1
+  %135 = sext i32 %125 to i64
+  %136 = icmp slt i64 %135, 0
+  %137 = select i1 %136, i64 0, i64 %135
+  store i64 1, ptr %132, align 8
+  store i64 1, ptr %133, align 8
+  store i64 %137, ptr %134, align 8
+  %138 = mul i64 1, %137
+  %139 = getelementptr %array.1, ptr %126, i32 0, i32 0
+  %140 = mul i64 %138, 8
+  %141 = call ptr @_lfortran_get_default_allocator()
+  %142 = call ptr @_lfortran_malloc_alloc(ptr %141, i64 %140)
+  store ptr %142, ptr %139, align 8
+  %143 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %144 = getelementptr %array.1, ptr %143, i32 0, i32 8
+  %145 = getelementptr [1 x %dimension_descriptor], ptr %144, i32 0, i32 0
+  %146 = getelementptr inbounds %dimension_descriptor, ptr %145, i32 0
+  %147 = getelementptr inbounds %dimension_descriptor, ptr %145, i32 0
+  %148 = getelementptr %dimension_descriptor, ptr %147, i32 0, i32 1
+  %149 = load i64, ptr %148, align 8
+  %150 = icmp eq i64 %149, 0
+  %151 = getelementptr %dimension_descriptor, ptr %146, i32 0, i32 0
+  %152 = load i64, ptr %151, align 8
+  %153 = getelementptr %dimension_descriptor, ptr %146, i32 0, i32 1
+  %154 = load i64, ptr %153, align 8
+  %155 = add i64 %154, %152
+  %156 = sub i64 %155, 1
+  %157 = select i1 %150, i64 0, i64 %156
+  %158 = trunc i64 %157 to i32
+  store i32 %158, ptr %__do_loop_end, align 4
+  %159 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %160 = getelementptr %array.1, ptr %159, i32 0, i32 8
+  %161 = getelementptr [1 x %dimension_descriptor], ptr %160, i32 0, i32 0
+  %162 = getelementptr inbounds %dimension_descriptor, ptr %161, i32 0
+  %163 = getelementptr inbounds %dimension_descriptor, ptr %161, i32 0
+  %164 = getelementptr %dimension_descriptor, ptr %163, i32 0, i32 1
+  %165 = load i64, ptr %164, align 8
+  %166 = icmp eq i64 %165, 0
+  %167 = getelementptr %dimension_descriptor, ptr %162, i32 0, i32 0
+  %168 = load i64, ptr %167, align 8
+  %169 = select i1 %166, i64 1, i64 %168
+  %170 = trunc i64 %169 to i32
+  %171 = sub i32 %170, 1
+  store i32 %171, ptr %__lcompilers_i_0, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont14, %ifcont10
-  %174 = load i32, i32* %__lcompilers_i_0, align 4
-  %175 = add i32 %174, 1
-  %176 = load i32, i32* %__do_loop_end, align 4
-  %177 = icmp sle i32 %175, %176
-  br i1 %177, label %loop.body, label %loop.end
+  %172 = load i32, ptr %__lcompilers_i_0, align 4
+  %173 = add i32 %172, 1
+  %174 = load i32, ptr %__do_loop_end, align 4
+  %175 = icmp sle i32 %173, %174
+  br i1 %175, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %178 = load i32, i32* %__lcompilers_i_0, align 4
-  %179 = add i32 %178, 1
-  store i32 %179, i32* %__lcompilers_i_0, align 4
-  %180 = load i32, i32* %__lcompilers_i_0, align 4
-  %181 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %182 = getelementptr %array.1, %array.1* %181, i32 0, i32 8
-  %183 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %182, i32 0, i32 0
-  %184 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %183, i32 0
-  %185 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 0
-  %186 = load i64, i64* %185, align 8
-  %187 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 1
-  %188 = load i64, i64* %187, align 8
-  %189 = sext i32 %180 to i64
-  %190 = sub i64 %189, %186
-  %191 = add i64 %186, %188
-  %192 = sub i64 %191, 1
-  %193 = icmp slt i64 %189, %186
-  %194 = icmp sgt i64 %189, %192
-  %195 = or i1 %193, %194
-  br i1 %195, label %then11, label %ifcont12
+  %176 = load i32, ptr %__lcompilers_i_0, align 4
+  %177 = add i32 %176, 1
+  store i32 %177, ptr %__lcompilers_i_0, align 4
+  %178 = load i32, ptr %__lcompilers_i_0, align 4
+  %179 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %180 = getelementptr %array.1, ptr %179, i32 0, i32 8
+  %181 = getelementptr [1 x %dimension_descriptor], ptr %180, i32 0, i32 0
+  %182 = getelementptr inbounds %dimension_descriptor, ptr %181, i32 0
+  %183 = getelementptr %dimension_descriptor, ptr %182, i32 0, i32 0
+  %184 = load i64, ptr %183, align 8
+  %185 = getelementptr %dimension_descriptor, ptr %182, i32 0, i32 1
+  %186 = load i64, ptr %185, align 8
+  %187 = sext i32 %178 to i64
+  %188 = sub i64 %187, %184
+  %189 = add i64 %184, %186
+  %190 = sub i64 %189, 1
+  %191 = icmp slt i64 %187, %184
+  %192 = icmp sgt i64 %187, %190
+  %193 = or i1 %191, %192
+  br i1 %193, label %then11, label %ifcont12
 
 then11:                                           ; preds = %loop.body
-  %196 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %197 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %198 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %197, i32 0, i32 0
-  %199 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %198, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @5, i32 0, i32 0), i8** %199, align 8
-  %200 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %198, i32 0, i32 1
-  store i32 5, i32* %200, align 4
-  %201 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %198, i32 0, i32 2
-  store i32 8, i32* %201, align 4
-  %202 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %198, i32 0, i32 3
-  store i32 5, i32* %202, align 4
-  %203 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %198, i32 0, i32 4
-  store i32 14, i32* %203, align 4
-  %204 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @6, i32 0, i32 0))
-  %205 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %196, i32 0, i32 0
-  %206 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %197, i32 0, i32 0
-  %207 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %205, i32 0, i32 2
-  %208 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %205, i32 0, i32 0
-  store i1 true, i1* %208, align 1
-  %209 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %205, i32 0, i32 1
-  store i8* %204, i8** %209, align 8
-  store { i8*, i32, i32, i32, i32 }* %206, { i8*, i32, i32, i32, i32 }** %207, align 8
-  %210 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %205, i32 0, i32 3
-  store i32 1, i32* %210, align 4
-  %211 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %196, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %211, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @4, i32 0, i32 0), i64 %189, i32 1, i64 %186, i64 %192)
+  %194 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %195 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %196 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %195, i32 0, i32 0
+  %197 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %196, i32 0, i32 0
+  store ptr @5, ptr %197, align 8
+  %198 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %196, i32 0, i32 1
+  store i32 5, ptr %198, align 4
+  %199 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %196, i32 0, i32 2
+  store i32 8, ptr %199, align 4
+  %200 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %196, i32 0, i32 3
+  store i32 5, ptr %200, align 4
+  %201 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %196, i32 0, i32 4
+  store i32 14, ptr %201, align 4
+  %202 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @6)
+  %203 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %194, i32 0, i32 0
+  %204 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %195, i32 0, i32 0
+  %205 = getelementptr { i1, ptr, ptr, i32 }, ptr %203, i32 0, i32 2
+  %206 = getelementptr { i1, ptr, ptr, i32 }, ptr %203, i32 0, i32 0
+  store i1 true, ptr %206, align 1
+  %207 = getelementptr { i1, ptr, ptr, i32 }, ptr %203, i32 0, i32 1
+  store ptr %202, ptr %207, align 8
+  store ptr %204, ptr %205, align 8
+  %208 = getelementptr { i1, ptr, ptr, i32 }, ptr %203, i32 0, i32 3
+  store i32 1, ptr %208, align 4
+  %209 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %194, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %209, i32 1, ptr @7, ptr @4, i64 %187, i32 1, i64 %184, i64 %190)
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %loop.body
-  %212 = getelementptr %dimension_descriptor, %dimension_descriptor* %184, i32 0, i32 2
-  %213 = load i64, i64* %212, align 8
-  %214 = mul i64 %213, %190
-  %215 = add i64 0, %214
-  %216 = getelementptr %array.1, %array.1* %181, i32 0, i32 7
-  %217 = load i64, i64* %216, align 8
-  %218 = add i64 %215, %217
-  %219 = getelementptr %array.1, %array.1* %181, i32 0, i32 0
-  %220 = load double*, double** %219, align 8
-  %221 = getelementptr inbounds double, double* %220, i64 %218
-  %222 = load i32, i32* %__lcompilers_i_0, align 4
-  %223 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %224 = getelementptr %array.1, %array.1* %223, i32 0, i32 8
-  %225 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %224, i32 0, i32 0
-  %226 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %225, i32 0
-  %227 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 0
-  %228 = load i64, i64* %227, align 8
-  %229 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 1
-  %230 = load i64, i64* %229, align 8
-  %231 = sext i32 %222 to i64
-  %232 = sub i64 %231, %228
-  %233 = add i64 %228, %230
-  %234 = sub i64 %233, 1
-  %235 = icmp slt i64 %231, %228
-  %236 = icmp sgt i64 %231, %234
-  %237 = or i1 %235, %236
-  br i1 %237, label %then13, label %ifcont14
+  %210 = getelementptr %dimension_descriptor, ptr %182, i32 0, i32 2
+  %211 = load i64, ptr %210, align 8
+  %212 = mul i64 %211, %188
+  %213 = add i64 0, %212
+  %214 = getelementptr %array.1, ptr %179, i32 0, i32 7
+  %215 = load i64, ptr %214, align 8
+  %216 = add i64 %213, %215
+  %217 = getelementptr %array.1, ptr %179, i32 0, i32 0
+  %218 = load ptr, ptr %217, align 8
+  %219 = getelementptr inbounds double, ptr %218, i64 %216
+  %220 = load i32, ptr %__lcompilers_i_0, align 4
+  %221 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %222 = getelementptr %array.1, ptr %221, i32 0, i32 8
+  %223 = getelementptr [1 x %dimension_descriptor], ptr %222, i32 0, i32 0
+  %224 = getelementptr inbounds %dimension_descriptor, ptr %223, i32 0
+  %225 = getelementptr %dimension_descriptor, ptr %224, i32 0, i32 0
+  %226 = load i64, ptr %225, align 8
+  %227 = getelementptr %dimension_descriptor, ptr %224, i32 0, i32 1
+  %228 = load i64, ptr %227, align 8
+  %229 = sext i32 %220 to i64
+  %230 = sub i64 %229, %226
+  %231 = add i64 %226, %228
+  %232 = sub i64 %231, 1
+  %233 = icmp slt i64 %229, %226
+  %234 = icmp sgt i64 %229, %232
+  %235 = or i1 %233, %234
+  br i1 %235, label %then13, label %ifcont14
 
 then13:                                           ; preds = %ifcont12
-  %238 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %239 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %240 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @9, i32 0, i32 0), i8** %241, align 8
-  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 1
-  store i32 5, i32* %242, align 4
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 2
-  store i32 8, i32* %243, align 4
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 3
-  store i32 5, i32* %244, align 4
-  %245 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %240, i32 0, i32 4
-  store i32 14, i32* %245, align 4
-  %246 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @10, i32 0, i32 0))
-  %247 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  %248 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %239, i32 0, i32 0
-  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 2
-  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 0
-  store i1 true, i1* %250, align 1
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 1
-  store i8* %246, i8** %251, align 8
-  store { i8*, i32, i32, i32, i32 }* %248, { i8*, i32, i32, i32, i32 }** %249, align 8
-  %252 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %247, i32 0, i32 3
-  store i32 1, i32* %252, align 4
-  %253 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %238, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %253, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @8, i32 0, i32 0), i64 %231, i32 1, i64 %228, i64 %234)
+  %236 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %237 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %238 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %237, i32 0, i32 0
+  %239 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %238, i32 0, i32 0
+  store ptr @9, ptr %239, align 8
+  %240 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %238, i32 0, i32 1
+  store i32 5, ptr %240, align 4
+  %241 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %238, i32 0, i32 2
+  store i32 8, ptr %241, align 4
+  %242 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %238, i32 0, i32 3
+  store i32 5, ptr %242, align 4
+  %243 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %238, i32 0, i32 4
+  store i32 14, ptr %243, align 4
+  %244 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @10)
+  %245 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %236, i32 0, i32 0
+  %246 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %237, i32 0, i32 0
+  %247 = getelementptr { i1, ptr, ptr, i32 }, ptr %245, i32 0, i32 2
+  %248 = getelementptr { i1, ptr, ptr, i32 }, ptr %245, i32 0, i32 0
+  store i1 true, ptr %248, align 1
+  %249 = getelementptr { i1, ptr, ptr, i32 }, ptr %245, i32 0, i32 1
+  store ptr %244, ptr %249, align 8
+  store ptr %246, ptr %247, align 8
+  %250 = getelementptr { i1, ptr, ptr, i32 }, ptr %245, i32 0, i32 3
+  store i32 1, ptr %250, align 4
+  %251 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %236, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %251, i32 1, ptr @11, ptr @8, i64 %229, i32 1, i64 %226, i64 %232)
   call void @exit(i32 1)
   unreachable
 
 ifcont14:                                         ; preds = %ifcont12
-  %254 = getelementptr %dimension_descriptor, %dimension_descriptor* %226, i32 0, i32 2
-  %255 = load i64, i64* %254, align 8
-  %256 = mul i64 %255, %232
-  %257 = add i64 0, %256
-  %258 = getelementptr %array.1, %array.1* %223, i32 0, i32 7
-  %259 = load i64, i64* %258, align 8
-  %260 = add i64 %257, %259
-  %261 = getelementptr %array.1, %array.1* %223, i32 0, i32 0
-  %262 = load double*, double** %261, align 8
-  %263 = getelementptr inbounds double, double* %262, i64 %260
-  %264 = load double, double* %263, align 8
-  store double %264, double* %221, align 8
+  %252 = getelementptr %dimension_descriptor, ptr %224, i32 0, i32 2
+  %253 = load i64, ptr %252, align 8
+  %254 = mul i64 %253, %230
+  %255 = add i64 0, %254
+  %256 = getelementptr %array.1, ptr %221, i32 0, i32 7
+  %257 = load i64, ptr %256, align 8
+  %258 = add i64 %255, %257
+  %259 = getelementptr %array.1, ptr %221, i32 0, i32 0
+  %260 = load ptr, ptr %259, align 8
+  %261 = getelementptr inbounds double, ptr %260, i64 %258
+  %262 = load double, ptr %261, align 8
+  store double %262, ptr %219, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br label %ifcont20
 
 else15:                                           ; preds = %merge_allocated
-  %265 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %266 = getelementptr %array.1, %array.1* %265, i32 0, i32 3
-  %267 = load i8, i8* %266, align 1
-  %268 = zext i8 %267 to i32
-  %269 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %270 = icmp eq %array.1* %269, null
-  br i1 %270, label %then16, label %else18
+  %263 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %264 = getelementptr %array.1, ptr %263, i32 0, i32 3
+  %265 = load i8, ptr %264, align 1
+  %266 = zext i8 %265 to i32
+  %267 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %268 = icmp eq ptr %267, null
+  br i1 %268, label %then16, label %else18
 
 then16:                                           ; preds = %else15
-  %271 = bitcast %array.1* %arr_desc17 to i8*
-  call void @llvm.memset.p0i8.i64(i8* %271, i8 0, i64 8, i1 false)
-  %272 = getelementptr %array.1, %array.1* %arr_desc17, i32 0, i32 3
-  %273 = trunc i32 %268 to i8
-  store i8 %273, i8* %272, align 1
-  store %array.1* %arr_desc17, %array.1** %__libasr_created__subroutine_call_b1, align 8
+  call void @llvm.memset.p0.i64(ptr %arr_desc17, i8 0, i64 8, i1 false)
+  %269 = getelementptr %array.1, ptr %arr_desc17, i32 0, i32 3
+  %270 = trunc i32 %266 to i8
+  store i8 %270, ptr %269, align 1
+  store ptr %arr_desc17, ptr %__libasr_created__subroutine_call_b1, align 8
   br label %ifcont19
 
 else18:                                           ; preds = %else15
   br label %ifcont19
 
 ifcont19:                                         ; preds = %else18, %then16
-  %274 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %275 = getelementptr %array.1, %array.1* %265, i32 0, i32 0
-  %276 = getelementptr %array.1, %array.1* %274, i32 0, i32 0
-  %277 = load double*, double** %275, align 8
-  store double* %277, double** %276, align 8
-  %278 = getelementptr %array.1, %array.1* %265, i32 0, i32 8
-  %279 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %278, i32 0, i32 0
-  %280 = getelementptr %array.1, %array.1* %274, i32 0, i32 8
-  %281 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %280, i32 0, i32 0
-  %282 = bitcast %dimension_descriptor* %281 to i8*
-  %283 = bitcast %dimension_descriptor* %279 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %282, i8* align 8 %283, i64 24, i1 false)
-  %284 = getelementptr %array.1, %array.1* %274, i32 0, i32 3
-  %285 = trunc i32 %268 to i8
-  store i8 %285, i8* %284, align 1
-  %286 = getelementptr %array.1, %array.1* %265, i32 0, i32 7
-  %287 = load i64, i64* %286, align 8
-  %288 = getelementptr %array.1, %array.1* %274, i32 0, i32 7
-  store i64 %287, i64* %288, align 8
+  %271 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %272 = getelementptr %array.1, ptr %263, i32 0, i32 0
+  %273 = getelementptr %array.1, ptr %271, i32 0, i32 0
+  %274 = load ptr, ptr %272, align 8
+  store ptr %274, ptr %273, align 8
+  %275 = getelementptr %array.1, ptr %263, i32 0, i32 8
+  %276 = getelementptr [1 x %dimension_descriptor], ptr %275, i32 0, i32 0
+  %277 = getelementptr %array.1, ptr %271, i32 0, i32 8
+  %278 = getelementptr [1 x %dimension_descriptor], ptr %277, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %278, ptr align 8 %276, i64 24, i1 false)
+  %279 = getelementptr %array.1, ptr %271, i32 0, i32 3
+  %280 = trunc i32 %266 to i8
+  store i8 %280, ptr %279, align 1
+  %281 = getelementptr %array.1, ptr %263, i32 0, i32 7
+  %282 = load i64, ptr %281, align 8
+  %283 = getelementptr %array.1, ptr %271, i32 0, i32 7
+  store i64 %282, ptr %283, align 8
   br label %ifcont20
 
 ifcont20:                                         ; preds = %ifcont19, %loop.end
-  %289 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %290 = getelementptr %array.1, %array.1* %289, i32 0, i32 0
-  %291 = load double*, double** %290, align 8
-  %292 = getelementptr %array.1, %array.1* %289, i32 0, i32 7
-  %293 = load i64, i64* %292, align 8
-  %294 = getelementptr inbounds double, double* %291, i64 %293
-  call void @b(double* %294)
-  %295 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %296 = getelementptr %array.1, %array.1* %295, i32 0, i32 8
-  %297 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %296, i32 0, i32 0
-  %298 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %297, i32 0
-  %299 = getelementptr %dimension_descriptor, %dimension_descriptor* %298, i32 0, i32 0
-  %300 = load i64, i64* %299, align 8
-  %301 = getelementptr %dimension_descriptor, %dimension_descriptor* %298, i32 0, i32 2
-  %302 = load i64, i64* %301, align 8
-  %303 = icmp eq i64 %302, 1
-  %304 = and i1 true, %303
-  %305 = getelementptr %dimension_descriptor, %dimension_descriptor* %298, i32 0, i32 0
-  %306 = load i64, i64* %305, align 8
-  %307 = getelementptr %dimension_descriptor, %dimension_descriptor* %298, i32 0, i32 1
-  %308 = load i64, i64* %307, align 8
-  %309 = add i64 %308, %306
-  %310 = sub i64 %309, 1
-  %311 = sub i64 %310, %300
-  %312 = add i64 %311, 1
-  %313 = mul i64 1, %312
-  %314 = ptrtoint %array.1* %295 to i64
-  %315 = icmp eq i64 %314, 0
-  br i1 %315, label %merge_allocated22, label %check_data21
+  %284 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %285 = getelementptr %array.1, ptr %284, i32 0, i32 0
+  %286 = load ptr, ptr %285, align 8
+  %287 = getelementptr %array.1, ptr %284, i32 0, i32 7
+  %288 = load i64, ptr %287, align 8
+  %289 = getelementptr inbounds double, ptr %286, i64 %288
+  call void @b(ptr %289)
+  %290 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %291 = getelementptr %array.1, ptr %290, i32 0, i32 8
+  %292 = getelementptr [1 x %dimension_descriptor], ptr %291, i32 0, i32 0
+  %293 = getelementptr inbounds %dimension_descriptor, ptr %292, i32 0
+  %294 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 0
+  %295 = load i64, ptr %294, align 8
+  %296 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 2
+  %297 = load i64, ptr %296, align 8
+  %298 = icmp eq i64 %297, 1
+  %299 = and i1 true, %298
+  %300 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 0
+  %301 = load i64, ptr %300, align 8
+  %302 = getelementptr %dimension_descriptor, ptr %293, i32 0, i32 1
+  %303 = load i64, ptr %302, align 8
+  %304 = add i64 %303, %301
+  %305 = sub i64 %304, 1
+  %306 = sub i64 %305, %295
+  %307 = add i64 %306, 1
+  %308 = mul i64 1, %307
+  %309 = ptrtoint ptr %290 to i64
+  %310 = icmp eq i64 %309, 0
+  br i1 %310, label %merge_allocated22, label %check_data21
 
 check_data21:                                     ; preds = %ifcont20
-  %316 = getelementptr %array.1, %array.1* %295, i32 0, i32 0
-  %317 = load double*, double** %316, align 8
-  %318 = ptrtoint double* %317 to i64
-  %319 = icmp ne i64 %318, 0
+  %311 = getelementptr %array.1, ptr %290, i32 0, i32 0
+  %312 = load ptr, ptr %311, align 8
+  %313 = ptrtoint ptr %312 to i64
+  %314 = icmp ne i64 %313, 0
   br label %merge_allocated22
 
 merge_allocated22:                                ; preds = %check_data21, %ifcont20
-  %is_allocated23 = phi i1 [ false, %ifcont20 ], [ %319, %check_data21 ]
-  %320 = xor i1 %is_allocated23, true
-  %321 = or i1 %304, %320
-  %322 = xor i1 %321, true
-  br i1 %322, label %then24, label %else32
+  %is_allocated23 = phi i1 [ false, %ifcont20 ], [ %314, %check_data21 ]
+  %315 = xor i1 %is_allocated23, true
+  %316 = or i1 %299, %315
+  %317 = xor i1 %316, true
+  br i1 %317, label %then24, label %else32
 
 then24:                                           ; preds = %merge_allocated22
-  %323 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %324 = getelementptr %array.1, %array.1* %323, i32 0, i32 8
-  %325 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %324, i32 0, i32 0
-  %326 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %325, i32 0
-  %327 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %325, i32 0
-  %328 = getelementptr %dimension_descriptor, %dimension_descriptor* %327, i32 0, i32 1
-  %329 = load i64, i64* %328, align 8
-  %330 = icmp eq i64 %329, 0
-  %331 = getelementptr %dimension_descriptor, %dimension_descriptor* %326, i32 0, i32 0
-  %332 = load i64, i64* %331, align 8
-  %333 = getelementptr %dimension_descriptor, %dimension_descriptor* %326, i32 0, i32 1
-  %334 = load i64, i64* %333, align 8
-  %335 = add i64 %334, %332
-  %336 = sub i64 %335, 1
-  %337 = select i1 %330, i64 0, i64 %336
-  %338 = trunc i64 %337 to i32
-  store i32 %338, i32* %__do_loop_end1, align 4
-  %339 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %340 = getelementptr %array.1, %array.1* %339, i32 0, i32 8
-  %341 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %340, i32 0, i32 0
-  %342 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %341, i32 0
-  %343 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %341, i32 0
-  %344 = getelementptr %dimension_descriptor, %dimension_descriptor* %343, i32 0, i32 1
-  %345 = load i64, i64* %344, align 8
-  %346 = icmp eq i64 %345, 0
-  %347 = getelementptr %dimension_descriptor, %dimension_descriptor* %342, i32 0, i32 0
-  %348 = load i64, i64* %347, align 8
-  %349 = select i1 %346, i64 1, i64 %348
-  %350 = trunc i64 %349 to i32
-  %351 = sub i32 %350, 1
-  store i32 %351, i32* %__lcompilers_i_0, align 4
+  %318 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %319 = getelementptr %array.1, ptr %318, i32 0, i32 8
+  %320 = getelementptr [1 x %dimension_descriptor], ptr %319, i32 0, i32 0
+  %321 = getelementptr inbounds %dimension_descriptor, ptr %320, i32 0
+  %322 = getelementptr inbounds %dimension_descriptor, ptr %320, i32 0
+  %323 = getelementptr %dimension_descriptor, ptr %322, i32 0, i32 1
+  %324 = load i64, ptr %323, align 8
+  %325 = icmp eq i64 %324, 0
+  %326 = getelementptr %dimension_descriptor, ptr %321, i32 0, i32 0
+  %327 = load i64, ptr %326, align 8
+  %328 = getelementptr %dimension_descriptor, ptr %321, i32 0, i32 1
+  %329 = load i64, ptr %328, align 8
+  %330 = add i64 %329, %327
+  %331 = sub i64 %330, 1
+  %332 = select i1 %325, i64 0, i64 %331
+  %333 = trunc i64 %332 to i32
+  store i32 %333, ptr %__do_loop_end1, align 4
+  %334 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %335 = getelementptr %array.1, ptr %334, i32 0, i32 8
+  %336 = getelementptr [1 x %dimension_descriptor], ptr %335, i32 0, i32 0
+  %337 = getelementptr inbounds %dimension_descriptor, ptr %336, i32 0
+  %338 = getelementptr inbounds %dimension_descriptor, ptr %336, i32 0
+  %339 = getelementptr %dimension_descriptor, ptr %338, i32 0, i32 1
+  %340 = load i64, ptr %339, align 8
+  %341 = icmp eq i64 %340, 0
+  %342 = getelementptr %dimension_descriptor, ptr %337, i32 0, i32 0
+  %343 = load i64, ptr %342, align 8
+  %344 = select i1 %341, i64 1, i64 %343
+  %345 = trunc i64 %344 to i32
+  %346 = sub i32 %345, 1
+  store i32 %346, ptr %__lcompilers_i_0, align 4
   br label %loop.head25
 
 loop.head25:                                      ; preds = %ifcont30, %then24
-  %352 = load i32, i32* %__lcompilers_i_0, align 4
-  %353 = add i32 %352, 1
-  %354 = load i32, i32* %__do_loop_end1, align 4
-  %355 = icmp sle i32 %353, %354
-  br i1 %355, label %loop.body26, label %loop.end31
+  %347 = load i32, ptr %__lcompilers_i_0, align 4
+  %348 = add i32 %347, 1
+  %349 = load i32, ptr %__do_loop_end1, align 4
+  %350 = icmp sle i32 %348, %349
+  br i1 %350, label %loop.body26, label %loop.end31
 
 loop.body26:                                      ; preds = %loop.head25
-  %356 = load i32, i32* %__lcompilers_i_0, align 4
-  %357 = add i32 %356, 1
-  store i32 %357, i32* %__lcompilers_i_0, align 4
-  %358 = load i32, i32* %__lcompilers_i_0, align 4
-  %359 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %360 = getelementptr %array.1, %array.1* %359, i32 0, i32 8
-  %361 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %360, i32 0, i32 0
-  %362 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %361, i32 0
-  %363 = getelementptr %dimension_descriptor, %dimension_descriptor* %362, i32 0, i32 0
-  %364 = load i64, i64* %363, align 8
-  %365 = getelementptr %dimension_descriptor, %dimension_descriptor* %362, i32 0, i32 1
-  %366 = load i64, i64* %365, align 8
-  %367 = sext i32 %358 to i64
-  %368 = sub i64 %367, %364
-  %369 = add i64 %364, %366
-  %370 = sub i64 %369, 1
-  %371 = icmp slt i64 %367, %364
-  %372 = icmp sgt i64 %367, %370
-  %373 = or i1 %371, %372
-  br i1 %373, label %then27, label %ifcont28
+  %351 = load i32, ptr %__lcompilers_i_0, align 4
+  %352 = add i32 %351, 1
+  store i32 %352, ptr %__lcompilers_i_0, align 4
+  %353 = load i32, ptr %__lcompilers_i_0, align 4
+  %354 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %355 = getelementptr %array.1, ptr %354, i32 0, i32 8
+  %356 = getelementptr [1 x %dimension_descriptor], ptr %355, i32 0, i32 0
+  %357 = getelementptr inbounds %dimension_descriptor, ptr %356, i32 0
+  %358 = getelementptr %dimension_descriptor, ptr %357, i32 0, i32 0
+  %359 = load i64, ptr %358, align 8
+  %360 = getelementptr %dimension_descriptor, ptr %357, i32 0, i32 1
+  %361 = load i64, ptr %360, align 8
+  %362 = sext i32 %353 to i64
+  %363 = sub i64 %362, %359
+  %364 = add i64 %359, %361
+  %365 = sub i64 %364, 1
+  %366 = icmp slt i64 %362, %359
+  %367 = icmp sgt i64 %362, %365
+  %368 = or i1 %366, %367
+  br i1 %368, label %then27, label %ifcont28
 
 then27:                                           ; preds = %loop.body26
-  %374 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %375 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %376 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %375, i32 0, i32 0
-  %377 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %376, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @13, i32 0, i32 0), i8** %377, align 8
-  %378 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %376, i32 0, i32 1
-  store i32 5, i32* %378, align 4
-  %379 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %376, i32 0, i32 2
-  store i32 8, i32* %379, align 4
-  %380 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %376, i32 0, i32 3
-  store i32 5, i32* %380, align 4
-  %381 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %376, i32 0, i32 4
-  store i32 14, i32* %381, align 4
-  %382 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @14, i32 0, i32 0))
-  %383 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %374, i32 0, i32 0
-  %384 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %375, i32 0, i32 0
-  %385 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 0, i32 2
-  %386 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 0, i32 0
-  store i1 true, i1* %386, align 1
-  %387 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 0, i32 1
-  store i8* %382, i8** %387, align 8
-  store { i8*, i32, i32, i32, i32 }* %384, { i8*, i32, i32, i32, i32 }** %385, align 8
-  %388 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %383, i32 0, i32 3
-  store i32 1, i32* %388, align 4
-  %389 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %374, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %389, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([36 x i8], [36 x i8]* @12, i32 0, i32 0), i64 %367, i32 1, i64 %364, i64 %370)
+  %369 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %370 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %371 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %370, i32 0, i32 0
+  %372 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %371, i32 0, i32 0
+  store ptr @13, ptr %372, align 8
+  %373 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %371, i32 0, i32 1
+  store i32 5, ptr %373, align 4
+  %374 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %371, i32 0, i32 2
+  store i32 8, ptr %374, align 4
+  %375 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %371, i32 0, i32 3
+  store i32 5, ptr %375, align 4
+  %376 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %371, i32 0, i32 4
+  store i32 14, ptr %376, align 4
+  %377 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @14)
+  %378 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %369, i32 0, i32 0
+  %379 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %370, i32 0, i32 0
+  %380 = getelementptr { i1, ptr, ptr, i32 }, ptr %378, i32 0, i32 2
+  %381 = getelementptr { i1, ptr, ptr, i32 }, ptr %378, i32 0, i32 0
+  store i1 true, ptr %381, align 1
+  %382 = getelementptr { i1, ptr, ptr, i32 }, ptr %378, i32 0, i32 1
+  store ptr %377, ptr %382, align 8
+  store ptr %379, ptr %380, align 8
+  %383 = getelementptr { i1, ptr, ptr, i32 }, ptr %378, i32 0, i32 3
+  store i32 1, ptr %383, align 4
+  %384 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %369, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %384, i32 1, ptr @15, ptr @12, i64 %362, i32 1, i64 %359, i64 %365)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %loop.body26
-  %390 = getelementptr %dimension_descriptor, %dimension_descriptor* %362, i32 0, i32 2
-  %391 = load i64, i64* %390, align 8
-  %392 = mul i64 %391, %368
-  %393 = add i64 0, %392
-  %394 = getelementptr %array.1, %array.1* %359, i32 0, i32 7
-  %395 = load i64, i64* %394, align 8
-  %396 = add i64 %393, %395
-  %397 = getelementptr %array.1, %array.1* %359, i32 0, i32 0
-  %398 = load double*, double** %397, align 8
-  %399 = getelementptr inbounds double, double* %398, i64 %396
-  %400 = load i32, i32* %__lcompilers_i_0, align 4
-  %401 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %402 = getelementptr %array.1, %array.1* %401, i32 0, i32 8
-  %403 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %402, i32 0, i32 0
-  %404 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %403, i32 0
-  %405 = getelementptr %dimension_descriptor, %dimension_descriptor* %404, i32 0, i32 0
-  %406 = load i64, i64* %405, align 8
-  %407 = getelementptr %dimension_descriptor, %dimension_descriptor* %404, i32 0, i32 1
-  %408 = load i64, i64* %407, align 8
-  %409 = sext i32 %400 to i64
-  %410 = sub i64 %409, %406
-  %411 = add i64 %406, %408
-  %412 = sub i64 %411, 1
-  %413 = icmp slt i64 %409, %406
-  %414 = icmp sgt i64 %409, %412
-  %415 = or i1 %413, %414
-  br i1 %415, label %then29, label %ifcont30
+  %385 = getelementptr %dimension_descriptor, ptr %357, i32 0, i32 2
+  %386 = load i64, ptr %385, align 8
+  %387 = mul i64 %386, %363
+  %388 = add i64 0, %387
+  %389 = getelementptr %array.1, ptr %354, i32 0, i32 7
+  %390 = load i64, ptr %389, align 8
+  %391 = add i64 %388, %390
+  %392 = getelementptr %array.1, ptr %354, i32 0, i32 0
+  %393 = load ptr, ptr %392, align 8
+  %394 = getelementptr inbounds double, ptr %393, i64 %391
+  %395 = load i32, ptr %__lcompilers_i_0, align 4
+  %396 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %397 = getelementptr %array.1, ptr %396, i32 0, i32 8
+  %398 = getelementptr [1 x %dimension_descriptor], ptr %397, i32 0, i32 0
+  %399 = getelementptr inbounds %dimension_descriptor, ptr %398, i32 0
+  %400 = getelementptr %dimension_descriptor, ptr %399, i32 0, i32 0
+  %401 = load i64, ptr %400, align 8
+  %402 = getelementptr %dimension_descriptor, ptr %399, i32 0, i32 1
+  %403 = load i64, ptr %402, align 8
+  %404 = sext i32 %395 to i64
+  %405 = sub i64 %404, %401
+  %406 = add i64 %401, %403
+  %407 = sub i64 %406, 1
+  %408 = icmp slt i64 %404, %401
+  %409 = icmp sgt i64 %404, %407
+  %410 = or i1 %408, %409
+  br i1 %410, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %416 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %417 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %418 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %417, i32 0, i32 0
-  %419 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %418, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @17, i32 0, i32 0), i8** %419, align 8
-  %420 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %418, i32 0, i32 1
-  store i32 5, i32* %420, align 4
-  %421 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %418, i32 0, i32 2
-  store i32 8, i32* %421, align 4
-  %422 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %418, i32 0, i32 3
-  store i32 5, i32* %422, align 4
-  %423 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %418, i32 0, i32 4
-  store i32 14, i32* %423, align 4
-  %424 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @18, i32 0, i32 0))
-  %425 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %416, i32 0, i32 0
-  %426 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %417, i32 0, i32 0
-  %427 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %425, i32 0, i32 2
-  %428 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %425, i32 0, i32 0
-  store i1 true, i1* %428, align 1
-  %429 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %425, i32 0, i32 1
-  store i8* %424, i8** %429, align 8
-  store { i8*, i32, i32, i32, i32 }* %426, { i8*, i32, i32, i32, i32 }** %427, align 8
-  %430 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %425, i32 0, i32 3
-  store i32 1, i32* %430, align 4
-  %431 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %416, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %431, i32 1, i8* getelementptr inbounds ([103 x i8], [103 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([37 x i8], [37 x i8]* @16, i32 0, i32 0), i64 %409, i32 1, i64 %406, i64 %412)
+  %411 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %412 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %413 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %412, i32 0, i32 0
+  %414 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %413, i32 0, i32 0
+  store ptr @17, ptr %414, align 8
+  %415 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %413, i32 0, i32 1
+  store i32 5, ptr %415, align 4
+  %416 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %413, i32 0, i32 2
+  store i32 8, ptr %416, align 4
+  %417 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %413, i32 0, i32 3
+  store i32 5, ptr %417, align 4
+  %418 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %413, i32 0, i32 4
+  store i32 14, ptr %418, align 4
+  %419 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @18)
+  %420 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %411, i32 0, i32 0
+  %421 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %412, i32 0, i32 0
+  %422 = getelementptr { i1, ptr, ptr, i32 }, ptr %420, i32 0, i32 2
+  %423 = getelementptr { i1, ptr, ptr, i32 }, ptr %420, i32 0, i32 0
+  store i1 true, ptr %423, align 1
+  %424 = getelementptr { i1, ptr, ptr, i32 }, ptr %420, i32 0, i32 1
+  store ptr %419, ptr %424, align 8
+  store ptr %421, ptr %422, align 8
+  %425 = getelementptr { i1, ptr, ptr, i32 }, ptr %420, i32 0, i32 3
+  store i32 1, ptr %425, align 4
+  %426 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %411, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %426, i32 1, ptr @19, ptr @16, i64 %404, i32 1, i64 %401, i64 %407)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %432 = getelementptr %dimension_descriptor, %dimension_descriptor* %404, i32 0, i32 2
-  %433 = load i64, i64* %432, align 8
-  %434 = mul i64 %433, %410
-  %435 = add i64 0, %434
-  %436 = getelementptr %array.1, %array.1* %401, i32 0, i32 7
-  %437 = load i64, i64* %436, align 8
-  %438 = add i64 %435, %437
-  %439 = getelementptr %array.1, %array.1* %401, i32 0, i32 0
-  %440 = load double*, double** %439, align 8
-  %441 = getelementptr inbounds double, double* %440, i64 %438
-  %442 = load double, double* %441, align 8
-  store double %442, double* %399, align 8
+  %427 = getelementptr %dimension_descriptor, ptr %399, i32 0, i32 2
+  %428 = load i64, ptr %427, align 8
+  %429 = mul i64 %428, %405
+  %430 = add i64 0, %429
+  %431 = getelementptr %array.1, ptr %396, i32 0, i32 7
+  %432 = load i64, ptr %431, align 8
+  %433 = add i64 %430, %432
+  %434 = getelementptr %array.1, ptr %396, i32 0, i32 0
+  %435 = load ptr, ptr %434, align 8
+  %436 = getelementptr inbounds double, ptr %435, i64 %433
+  %437 = load double, ptr %436, align 8
+  store double %437, ptr %394, align 8
   br label %loop.head25
 
 loop.end31:                                       ; preds = %loop.head25
@@ -723,72 +719,71 @@ else32:                                           ; preds = %merge_allocated22
   br label %ifcont33
 
 ifcont33:                                         ; preds = %else32, %loop.end31
-  %443 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b, align 8
-  %444 = getelementptr %array.1, %array.1* %443, i32 0, i32 8
-  %445 = getelementptr [1 x %dimension_descriptor], [1 x %dimension_descriptor]* %444, i32 0, i32 0
-  %446 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %445, i32 0
-  %447 = getelementptr %dimension_descriptor, %dimension_descriptor* %446, i32 0, i32 0
-  %448 = load i64, i64* %447, align 8
-  %449 = getelementptr %dimension_descriptor, %dimension_descriptor* %446, i32 0, i32 2
-  %450 = load i64, i64* %449, align 8
-  %451 = icmp eq i64 %450, 1
-  %452 = and i1 true, %451
-  %453 = getelementptr %dimension_descriptor, %dimension_descriptor* %446, i32 0, i32 0
-  %454 = load i64, i64* %453, align 8
-  %455 = getelementptr %dimension_descriptor, %dimension_descriptor* %446, i32 0, i32 1
-  %456 = load i64, i64* %455, align 8
-  %457 = add i64 %456, %454
-  %458 = sub i64 %457, 1
-  %459 = sub i64 %458, %448
-  %460 = add i64 %459, 1
-  %461 = mul i64 1, %460
-  %462 = ptrtoint %array.1* %443 to i64
-  %463 = icmp eq i64 %462, 0
-  br i1 %463, label %merge_allocated35, label %check_data34
+  %438 = load ptr, ptr %__libasr_created__subroutine_call_b, align 8
+  %439 = getelementptr %array.1, ptr %438, i32 0, i32 8
+  %440 = getelementptr [1 x %dimension_descriptor], ptr %439, i32 0, i32 0
+  %441 = getelementptr inbounds %dimension_descriptor, ptr %440, i32 0
+  %442 = getelementptr %dimension_descriptor, ptr %441, i32 0, i32 0
+  %443 = load i64, ptr %442, align 8
+  %444 = getelementptr %dimension_descriptor, ptr %441, i32 0, i32 2
+  %445 = load i64, ptr %444, align 8
+  %446 = icmp eq i64 %445, 1
+  %447 = and i1 true, %446
+  %448 = getelementptr %dimension_descriptor, ptr %441, i32 0, i32 0
+  %449 = load i64, ptr %448, align 8
+  %450 = getelementptr %dimension_descriptor, ptr %441, i32 0, i32 1
+  %451 = load i64, ptr %450, align 8
+  %452 = add i64 %451, %449
+  %453 = sub i64 %452, 1
+  %454 = sub i64 %453, %443
+  %455 = add i64 %454, 1
+  %456 = mul i64 1, %455
+  %457 = ptrtoint ptr %438 to i64
+  %458 = icmp eq i64 %457, 0
+  br i1 %458, label %merge_allocated35, label %check_data34
 
 check_data34:                                     ; preds = %ifcont33
-  %464 = getelementptr %array.1, %array.1* %443, i32 0, i32 0
-  %465 = load double*, double** %464, align 8
-  %466 = ptrtoint double* %465 to i64
-  %467 = icmp ne i64 %466, 0
+  %459 = getelementptr %array.1, ptr %438, i32 0, i32 0
+  %460 = load ptr, ptr %459, align 8
+  %461 = ptrtoint ptr %460 to i64
+  %462 = icmp ne i64 %461, 0
   br label %merge_allocated35
 
 merge_allocated35:                                ; preds = %check_data34, %ifcont33
-  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %467, %check_data34 ]
-  %468 = xor i1 %is_allocated36, true
-  %469 = or i1 %452, %468
-  br i1 %469, label %then37, label %else38
+  %is_allocated36 = phi i1 [ false, %ifcont33 ], [ %462, %check_data34 ]
+  %463 = xor i1 %is_allocated36, true
+  %464 = or i1 %447, %463
+  br i1 %464, label %then37, label %else38
 
 then37:                                           ; preds = %merge_allocated35
-  %470 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %471 = getelementptr %array.1, %array.1* %470, i32 0, i32 0
-  store double* null, double** %471, align 8
+  %465 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %466 = getelementptr %array.1, ptr %465, i32 0, i32 0
+  store ptr null, ptr %466, align 8
   br label %ifcont45
 
 else38:                                           ; preds = %merge_allocated35
-  %472 = load %array.1*, %array.1** %__libasr_created__subroutine_call_b1, align 8
-  %473 = ptrtoint %array.1* %472 to i64
-  %474 = icmp eq i64 %473, 0
-  br i1 %474, label %merge_allocated40, label %check_data39
+  %467 = load ptr, ptr %__libasr_created__subroutine_call_b1, align 8
+  %468 = ptrtoint ptr %467 to i64
+  %469 = icmp eq i64 %468, 0
+  br i1 %469, label %merge_allocated40, label %check_data39
 
 check_data39:                                     ; preds = %else38
-  %475 = getelementptr %array.1, %array.1* %472, i32 0, i32 0
-  %476 = load double*, double** %475, align 8
-  %477 = ptrtoint double* %476 to i64
-  %478 = icmp ne i64 %477, 0
+  %470 = getelementptr %array.1, ptr %467, i32 0, i32 0
+  %471 = load ptr, ptr %470, align 8
+  %472 = ptrtoint ptr %471 to i64
+  %473 = icmp ne i64 %472, 0
   br label %merge_allocated40
 
 merge_allocated40:                                ; preds = %check_data39, %else38
-  %is_allocated41 = phi i1 [ false, %else38 ], [ %478, %check_data39 ]
+  %is_allocated41 = phi i1 [ false, %else38 ], [ %473, %check_data39 ]
   br i1 %is_allocated41, label %then42, label %else43
 
 then42:                                           ; preds = %merge_allocated40
-  %479 = getelementptr %array.1, %array.1* %472, i32 0, i32 0
-  %480 = load double*, double** %479, align 8
-  %481 = bitcast double* %480 to i8*
-  call void @_lfortran_free_alloc(i8* %0, i8* %481)
-  %482 = getelementptr %array.1, %array.1* %472, i32 0, i32 0
-  store double* null, double** %482, align 8
+  %474 = getelementptr %array.1, ptr %467, i32 0, i32 0
+  %475 = load ptr, ptr %474, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %475)
+  %476 = getelementptr %array.1, ptr %467, i32 0, i32 0
+  store ptr null, ptr %476, align 8
   br label %ifcont44
 
 else43:                                           ; preds = %merge_allocated40
@@ -810,12 +805,12 @@ FINALIZE_SYMTABLE_a:                              ; preds = %return
   ret void
 }
 
-define void @b(double* %con) {
+define void @b(ptr %con) {
 .entry:
-  %0 = getelementptr inbounds double, double* %con, i64 3
-  store double -4.830000e+00, double* %0, align 8
-  %1 = getelementptr inbounds double, double* %con, i64 2
-  store double 3.140000e+00, double* %1, align 8
+  %0 = getelementptr inbounds double, ptr %con, i64 3
+  store double -4.830000e+00, ptr %0, align 8
+  %1 = getelementptr inbounds double, ptr %con, i64 2
+  store double 3.140000e+00, ptr %1, align 8
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -828,73 +823,73 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
 
-; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly, i8* noalias nocapture readonly, i64, i1 immarg) #1
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %array_bound1 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %__do_loop_end = alloca i32, align 4
   %__libasr_index_0_ = alloca i32, align 4
   %w = alloca [5 x double], align 8
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 5, i32* %array_bound, align 4
+  store i32 5, ptr %array_bound, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %3 = load i32, i32* %array_bound, align 4
-  store i32 %3, i32* %__do_loop_end, align 4
+  %3 = load i32, ptr %array_bound, align 4
+  store i32 %3, ptr %__do_loop_end, align 4
   br i1 true, label %then2, label %else3
 
 then2:                                            ; preds = %ifcont
-  store i32 1, i32* %array_bound1, align 4
+  store i32 1, ptr %array_bound1, align 4
   br label %ifcont4
 
 else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %then2
-  %4 = load i32, i32* %array_bound1, align 4
+  %4 = load i32, ptr %array_bound1, align 4
   %5 = sub i32 %4, 1
-  store i32 %5, i32* %__libasr_index_0_, align 4
+  store i32 %5, ptr %__libasr_index_0_, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont6, %ifcont4
-  %6 = load i32, i32* %__libasr_index_0_, align 4
+  %6 = load i32, ptr %__libasr_index_0_, align 4
   %7 = add i32 %6, 1
-  %8 = load i32, i32* %__do_loop_end, align 4
+  %8 = load i32, ptr %__do_loop_end, align 4
   %9 = icmp sle i32 %7, %8
   br i1 %9, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %10 = load i32, i32* %__libasr_index_0_, align 4
+  %10 = load i32, ptr %__libasr_index_0_, align 4
   %11 = add i32 %10, 1
-  store i32 %11, i32* %__libasr_index_0_, align 4
-  %12 = load i32, i32* %__libasr_index_0_, align 4
+  store i32 %11, ptr %__libasr_index_0_, align 4
+  %12 = load i32, ptr %__libasr_index_0_, align 4
   %13 = sext i32 %12 to i64
   %14 = sub i64 %13, 1
   %15 = mul i64 1, %14
@@ -905,140 +900,140 @@ loop.body:                                        ; preds = %loop.head
   br i1 %19, label %then5, label %ifcont6
 
 then5:                                            ; preds = %loop.body
-  %20 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %21 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %22 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %21, i32 0, i32 0
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %22, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @21, i32 0, i32 0), i8** %23, align 8
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %22, i32 0, i32 1
-  store i32 18, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %22, i32 0, i32 2
-  store i32 1, i32* %25, align 4
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %22, i32 0, i32 3
-  store i32 18, i32* %26, align 4
-  %27 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %22, i32 0, i32 4
-  store i32 1, i32* %27, align 4
-  %28 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @22, i32 0, i32 0))
-  %29 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %20, i32 0, i32 0
-  %30 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %21, i32 0, i32 0
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %29, i32 0, i32 2
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %29, i32 0, i32 0
-  store i1 true, i1* %32, align 1
-  %33 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %29, i32 0, i32 1
-  store i8* %28, i8** %33, align 8
-  store { i8*, i32, i32, i32, i32 }* %30, { i8*, i32, i32, i32, i32 }** %31, align 8
-  %34 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %29, i32 0, i32 3
-  store i32 1, i32* %34, align 4
-  %35 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %20, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %35, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i64 %13, i32 1, i64 1, i64 5)
+  %20 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %21 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %22 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %21, i32 0, i32 0
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %22, i32 0, i32 0
+  store ptr @21, ptr %23, align 8
+  %24 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %22, i32 0, i32 1
+  store i32 18, ptr %24, align 4
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %22, i32 0, i32 2
+  store i32 1, ptr %25, align 4
+  %26 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %22, i32 0, i32 3
+  store i32 18, ptr %26, align 4
+  %27 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %22, i32 0, i32 4
+  store i32 1, ptr %27, align 4
+  %28 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @22)
+  %29 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %20, i32 0, i32 0
+  %30 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %21, i32 0, i32 0
+  %31 = getelementptr { i1, ptr, ptr, i32 }, ptr %29, i32 0, i32 2
+  %32 = getelementptr { i1, ptr, ptr, i32 }, ptr %29, i32 0, i32 0
+  store i1 true, ptr %32, align 1
+  %33 = getelementptr { i1, ptr, ptr, i32 }, ptr %29, i32 0, i32 1
+  store ptr %28, ptr %33, align 8
+  store ptr %30, ptr %31, align 8
+  %34 = getelementptr { i1, ptr, ptr, i32 }, ptr %29, i32 0, i32 3
+  store i32 1, ptr %34, align 4
+  %35 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %20, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %35, i32 1, ptr @23, ptr @20, i64 %13, i32 1, i64 1, i64 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont6:                                          ; preds = %loop.body
-  %36 = getelementptr [5 x double], [5 x double]* %w, i32 0, i64 %16
-  store double 1.390000e+00, double* %36, align 8
+  %36 = getelementptr [5 x double], ptr %w, i32 0, i64 %16
+  store double 1.390000e+00, ptr %36, align 8
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then7, label %ifcont8
 
 then7:                                            ; preds = %loop.end
-  %37 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %38 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %39 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %40 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @25, i32 0, i32 0), i8** %40, align 8
-  %41 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 1
-  store i32 19, i32* %41, align 4
-  %42 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 2
-  store i32 8, i32* %42, align 4
-  %43 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 3
-  store i32 19, i32* %43, align 4
-  %44 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %39, i32 0, i32 4
-  store i32 8, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @26, i32 0, i32 0))
-  %46 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  %47 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %38, i32 0, i32 0
-  %48 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 2
-  %49 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 0
-  store i1 true, i1* %49, align 1
-  %50 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 1
-  store i8* %45, i8** %50, align 8
-  store { i8*, i32, i32, i32, i32 }* %47, { i8*, i32, i32, i32, i32 }** %48, align 8
-  %51 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %46, i32 0, i32 3
-  store i32 1, i32* %51, align 4
-  %52 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %37, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %52, i32 1, i8* getelementptr inbounds ([143 x i8], [143 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 5, i32 1, i32 1, i32 5)
+  %37 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %38 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %39 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %38, i32 0, i32 0
+  %40 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 0
+  store ptr @25, ptr %40, align 8
+  %41 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 1
+  store i32 19, ptr %41, align 4
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 2
+  store i32 8, ptr %42, align 4
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 3
+  store i32 19, ptr %43, align 4
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %39, i32 0, i32 4
+  store i32 8, ptr %44, align 4
+  %45 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @26)
+  %46 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %37, i32 0, i32 0
+  %47 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %38, i32 0, i32 0
+  %48 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 2
+  %49 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 0
+  store i1 true, ptr %49, align 1
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 1
+  store ptr %45, ptr %50, align 8
+  store ptr %47, ptr %48, align 8
+  %51 = getelementptr { i1, ptr, ptr, i32 }, ptr %46, i32 0, i32 3
+  store i32 1, ptr %51, align 4
+  %52 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %37, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %52, i32 1, ptr @27, ptr @24, i32 5, i32 1, i32 1, i32 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont8:                                          ; preds = %loop.end
-  %53 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
-  call void @a(double* %53)
+  %53 = getelementptr [5 x double], ptr %w, i32 0, i32 0
+  call void @a(ptr %53)
   %54 = alloca i64, align 8
-  %55 = getelementptr [5 x double], [5 x double]* %w, i32 0, i32 0
-  %56 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @serialization_info, i32 0, i32 0), i64* %54, i32 1, i32 0, i32 0, i32 0, i32 0, i64 5, double* %55)
-  %57 = load i64, i64* %54, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %56, i8** %58, align 8
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %57, i64* %59, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %61 = load i8*, i8** %60, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %63 = load i64, i64* %62, align 8
+  %55 = getelementptr [5 x double], ptr %w, i32 0, i32 0
+  %56 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %54, i32 1, i32 0, i32 0, i32 0, i32 0, i64 5, ptr %55)
+  %57 = load i64, ptr %54, align 8
+  %58 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %56, ptr %58, align 8
+  %59 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %57, ptr %59, align 8
+  %60 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %61 = load ptr, ptr %60, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %63 = load i64, ptr %62, align 8
   %64 = trunc i64 %63 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %61, i32 %64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
-  %65 = icmp eq i8* %56, null
+  call void @_lfortran_printf(ptr @29, ptr %61, i32 %64, ptr @28, i32 1)
+  %65 = icmp eq ptr %56, null
   br i1 %65, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont8
-  call void @_lfortran_free_alloc(i8* %2, i8* %56)
+  call void @_lfortran_free_alloc(ptr %2, ptr %56)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont8
   br i1 false, label %then9, label %ifcont10
 
 then9:                                            ; preds = %free_done
-  %66 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %67 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %68 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %67, i32 0, i32 0
-  %69 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @31, i32 0, i32 0), i8** %69, align 8
-  %70 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 1
-  store i32 21, i32* %70, align 4
-  %71 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 2
-  store i32 9, i32* %71, align 4
-  %72 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 3
-  store i32 21, i32* %72, align 4
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %68, i32 0, i32 4
-  store i32 12, i32* %73, align 4
-  %74 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @32, i32 0, i32 0))
-  %75 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %66, i32 0, i32 0
-  %76 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %67, i32 0, i32 0
-  %77 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 2
-  %78 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 0
-  store i1 true, i1* %78, align 1
-  %79 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 1
-  store i8* %74, i8** %79, align 8
-  store { i8*, i32, i32, i32, i32 }* %76, { i8*, i32, i32, i32, i32 }** %77, align 8
-  %80 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %75, i32 0, i32 3
-  store i32 1, i32* %80, align 4
-  %81 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %66, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %81, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i64 5, i32 1, i64 1, i64 5)
+  %66 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %67 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %68 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %67, i32 0, i32 0
+  %69 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %68, i32 0, i32 0
+  store ptr @31, ptr %69, align 8
+  %70 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %68, i32 0, i32 1
+  store i32 21, ptr %70, align 4
+  %71 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %68, i32 0, i32 2
+  store i32 9, ptr %71, align 4
+  %72 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %68, i32 0, i32 3
+  store i32 21, ptr %72, align 4
+  %73 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %68, i32 0, i32 4
+  store i32 12, ptr %73, align 4
+  %74 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @32)
+  %75 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %66, i32 0, i32 0
+  %76 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %67, i32 0, i32 0
+  %77 = getelementptr { i1, ptr, ptr, i32 }, ptr %75, i32 0, i32 2
+  %78 = getelementptr { i1, ptr, ptr, i32 }, ptr %75, i32 0, i32 0
+  store i1 true, ptr %78, align 1
+  %79 = getelementptr { i1, ptr, ptr, i32 }, ptr %75, i32 0, i32 1
+  store ptr %74, ptr %79, align 8
+  store ptr %76, ptr %77, align 8
+  %80 = getelementptr { i1, ptr, ptr, i32 }, ptr %75, i32 0, i32 3
+  store i32 1, ptr %80, align 4
+  %81 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %66, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %81, i32 1, ptr @33, ptr @30, i64 5, i32 1, i64 1, i64 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %free_done
-  %82 = getelementptr [5 x double], [5 x double]* %w, i32 0, i64 4
-  %83 = load double, double* %82, align 8
+  %82 = getelementptr [5 x double], ptr %w, i32 0, i64 4
+  %83 = load double, ptr %82, align 8
   %84 = fsub double %83, -4.830000e+00
   %85 = call double @llvm.fabs.f64(double %84)
   %86 = fcmp ogt double %85, 1.000000e-08
   br i1 %86, label %then11, label %else12
 
 then11:                                           ; preds = %ifcont10
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @35, ptr @"ERROR STOP", ptr @34)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont13
@@ -1050,45 +1045,45 @@ ifcont13:                                         ; preds = %else12, %then11
   br i1 false, label %then14, label %ifcont15
 
 then14:                                           ; preds = %ifcont13
-  %87 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %88 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %89 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %88, i32 0, i32 0
-  %90 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 0
-  store i8* getelementptr inbounds ([56 x i8], [56 x i8]* @37, i32 0, i32 0), i8** %90, align 8
-  %91 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 1
-  store i32 22, i32* %91, align 4
-  %92 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 2
-  store i32 9, i32* %92, align 4
-  %93 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 3
-  store i32 22, i32* %93, align 4
-  %94 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %89, i32 0, i32 4
-  store i32 12, i32* %94, align 4
-  %95 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @38, i32 0, i32 0))
-  %96 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %87, i32 0, i32 0
-  %97 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %88, i32 0, i32 0
-  %98 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 2
-  %99 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 0
-  store i1 true, i1* %99, align 1
-  %100 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 1
-  store i8* %95, i8** %100, align 8
-  store { i8*, i32, i32, i32, i32 }* %97, { i8*, i32, i32, i32, i32 }** %98, align 8
-  %101 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %96, i32 0, i32 3
-  store i32 1, i32* %101, align 4
-  %102 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %87, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %102, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i64 4, i32 1, i64 1, i64 5)
+  %87 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %88 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %89 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %88, i32 0, i32 0
+  %90 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %89, i32 0, i32 0
+  store ptr @37, ptr %90, align 8
+  %91 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %89, i32 0, i32 1
+  store i32 22, ptr %91, align 4
+  %92 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %89, i32 0, i32 2
+  store i32 9, ptr %92, align 4
+  %93 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %89, i32 0, i32 3
+  store i32 22, ptr %93, align 4
+  %94 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %89, i32 0, i32 4
+  store i32 12, ptr %94, align 4
+  %95 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @38)
+  %96 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %87, i32 0, i32 0
+  %97 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %88, i32 0, i32 0
+  %98 = getelementptr { i1, ptr, ptr, i32 }, ptr %96, i32 0, i32 2
+  %99 = getelementptr { i1, ptr, ptr, i32 }, ptr %96, i32 0, i32 0
+  store i1 true, ptr %99, align 1
+  %100 = getelementptr { i1, ptr, ptr, i32 }, ptr %96, i32 0, i32 1
+  store ptr %95, ptr %100, align 8
+  store ptr %97, ptr %98, align 8
+  %101 = getelementptr { i1, ptr, ptr, i32 }, ptr %96, i32 0, i32 3
+  store i32 1, ptr %101, align 4
+  %102 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %87, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %102, i32 1, ptr @39, ptr @36, i64 4, i32 1, i64 1, i64 5)
   call void @exit(i32 1)
   unreachable
 
 ifcont15:                                         ; preds = %ifcont13
-  %103 = getelementptr [5 x double], [5 x double]* %w, i32 0, i64 3
-  %104 = load double, double* %103, align 8
+  %103 = getelementptr [5 x double], ptr %w, i32 0, i64 3
+  %104 = load double, ptr %103, align 8
   %105 = fsub double %104, 3.140000e+00
   %106 = call double @llvm.fabs.f64(double %105)
   %107 = fcmp ogt double %106, 1.000000e-10
   br i1 %107, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @41, ptr @"ERROR STOP", ptr @40)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -1107,19 +1102,19 @@ FINALIZE_SYMTABLE_legacy_array_sections_01:       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-; Function Attrs: nounwind readnone speculatable willreturn
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare double @llvm.fabs.f64(double) #2
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
-attributes #1 = { argmemonly nounwind willreturn }
-attributes #2 = { nounwind readnone speculatable willreturn }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "d0a2bdc1c03971ef6a4fc49f3fb741024264e14b995cbae6ff730da5",
+    "stdout_hash": "a048cf3072b18bbedc8892a5375c24d2b5019499fe61ed1cd55ad6c9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -1,40 +1,41 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [8 x i8] c"L32,L32\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
-  store i32 1, i32* %a, align 4
-  store i32 0, i32* %b, align 4
+  store i32 1, ptr %a, align 4
+  store i32 0, ptr %b, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a, i32* %b)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a, ptr %b)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -48,14 +49,14 @@ FINALIZE_SYMTABLE_logical1:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-logical2-94a2259.json
+++ b/tests/reference/llvm-logical2-94a2259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical2-94a2259.stdout",
-    "stdout_hash": "09e8c8ce2adf703ca0837b5e6f859cd99c2838d6bae31d8bed24d6a5",
+    "stdout_hash": "30bc820575a024cfc155af2a4893c41157c6e81fe484481bad747a55",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical2-94a2259.stdout
+++ b/tests/reference/llvm-logical2-94a2259.stdout
@@ -1,39 +1,40 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [26 x i8] c"Line 1 - Condition is true"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data, i32 0, i32 0), i64 26 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 26 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [27 x i8] c"Line 1 - Condition is false"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.1, i32 0, i32 0), i64 27 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 27 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
-  store i32 1, i32* %a, align 4
-  store i32 0, i32* %b, align 4
-  %2 = load i32, i32* %a, align 4
-  %3 = load i32, i32* %b, align 4
+  store i32 1, ptr %a, align 4
+  store i32 0, ptr %b, align 4
+  %2 = load i32, ptr %a, align 4
+  %3 = load i32, ptr %b, align 4
   %4 = and i32 %2, %3
   %5 = icmp ne i32 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %6 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %6, i32 26, ptr @0, i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %7 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %7, i32 27, ptr @2, i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -47,8 +48,8 @@ FINALIZE_SYMTABLE_logical2:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-logical3-4bbf8ea.json
+++ b/tests/reference/llvm-logical3-4bbf8ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical3-4bbf8ea.stdout",
-    "stdout_hash": "51992588f6050e2b97ae924a6fffa0a2e49a9f8f71a97257b468051a",
+    "stdout_hash": "be54a6afa69089552da633797614107ab756562e5c09479fc8ab87d0",
     "stderr": "llvm-logical3-4bbf8ea.stderr",
     "stderr_hash": "d7e28e54d198e14f86c18ab4c4ad128018b9bc6523fb945b05607a57",
     "returncode": 0

--- a/tests/reference/llvm-logical3-4bbf8ea.stdout
+++ b/tests/reference/llvm-logical3-4bbf8ea.stdout
@@ -1,291 +1,292 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [26 x i8] c"Line 1 - Condition is true"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data, i32 0, i32 0), i64 26 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 26 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [27 x i8] c"Line 1 - Condition is false"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.1, i32 0, i32 0), i64 27 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 27 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [26 x i8] c"Line 2 - Condition is true"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.3, i32 0, i32 0), i64 26 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 26 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [27 x i8] c"Line 2 - Condition is false"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.5, i32 0, i32 0), i64 27 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 27 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [28 x i8] c"Line xor - Condition is true"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([28 x i8], [28 x i8]* @string_const_data.7, i32 0, i32 0), i64 28 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 28 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.9 = private constant [29 x i8] c"Line xor - Condition is false"
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([29 x i8], [29 x i8]* @string_const_data.9, i32 0, i32 0), i64 29 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 29 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @18 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.11 = private constant [26 x i8] c"Line 3 - Condition is true"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.11, i32 0, i32 0), i64 26 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 26 }>
 @19 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @20 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.13 = private constant [27 x i8] c"Line 3 - Condition is false"
-@string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.13, i32 0, i32 0), i64 27 }>
+@string_const.14 = private global %string_descriptor <{ ptr @string_const_data.13, i64 27 }>
 @21 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @22 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @23 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @24 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.15 = private constant [26 x i8] c"Line 4 - Condition is true"
-@string_const.16 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.15, i32 0, i32 0), i64 26 }>
+@string_const.16 = private global %string_descriptor <{ ptr @string_const_data.15, i64 26 }>
 @25 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @26 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.17 = private constant [27 x i8] c"Line 4 - Condition is false"
-@string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.17, i32 0, i32 0), i64 27 }>
+@string_const.18 = private global %string_descriptor <{ ptr @string_const_data.17, i64 27 }>
 @27 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @28 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @29 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @30 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.19 = private constant [26 x i8] c"Line 5 - Condition is true"
-@string_const.20 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.19, i32 0, i32 0), i64 26 }>
+@string_const.20 = private global %string_descriptor <{ ptr @string_const_data.19, i64 26 }>
 @31 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @32 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @33 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @34 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.21 = private constant [27 x i8] c"Line 5 - Condition is false"
-@string_const.22 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.21, i32 0, i32 0), i64 27 }>
+@string_const.22 = private global %string_descriptor <{ ptr @string_const_data.21, i64 27 }>
 @35 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @36 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.23 = private constant [26 x i8] c"Line 6 - Condition is true"
-@string_const.24 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.23, i32 0, i32 0), i64 26 }>
+@string_const.24 = private global %string_descriptor <{ ptr @string_const_data.23, i64 26 }>
 @37 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @38 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.25 = private constant [27 x i8] c"Line 6 - Condition is false"
-@string_const.26 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.25, i32 0, i32 0), i64 27 }>
+@string_const.26 = private global %string_descriptor <{ ptr @string_const_data.25, i64 27 }>
 @39 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @40 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @41 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @42 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.27 = private constant [26 x i8] c"Line 7 - Condition is true"
-@string_const.28 = private global %string_descriptor <{ i8* getelementptr inbounds ([26 x i8], [26 x i8]* @string_const_data.27, i32 0, i32 0), i64 26 }>
+@string_const.28 = private global %string_descriptor <{ ptr @string_const_data.27, i64 26 }>
 @43 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @44 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.29 = private constant [27 x i8] c"Line 7 - Condition is false"
-@string_const.30 = private global %string_descriptor <{ i8* getelementptr inbounds ([27 x i8], [27 x i8]* @string_const_data.29, i32 0, i32 0), i64 27 }>
+@string_const.30 = private global %string_descriptor <{ ptr @string_const_data.29, i64 27 }>
 @45 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @46 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @47 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @48 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.31 = private constant [30 x i8] c"Line 8 xor - Condition is true"
-@string_const.32 = private global %string_descriptor <{ i8* getelementptr inbounds ([30 x i8], [30 x i8]* @string_const_data.31, i32 0, i32 0), i64 30 }>
+@string_const.32 = private global %string_descriptor <{ ptr @string_const_data.31, i64 30 }>
 @49 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @50 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @51 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @52 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.33 = private constant [31 x i8] c"Line 8 xor - Condition is false"
-@string_const.34 = private global %string_descriptor <{ i8* getelementptr inbounds ([31 x i8], [31 x i8]* @string_const_data.33, i32 0, i32 0), i64 31 }>
+@string_const.34 = private global %string_descriptor <{ ptr @string_const_data.33, i64 31 }>
 @53 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
-  store i32 1, i32* %a, align 4
-  store i32 0, i32* %b, align 4
-  %2 = load i32, i32* %a, align 4
-  %3 = load i32, i32* %b, align 4
+  store i32 1, ptr %a, align 4
+  store i32 0, ptr %b, align 4
+  %2 = load i32, ptr %a, align 4
+  %3 = load i32, ptr %b, align 4
   %4 = and i32 %2, %3
   %5 = icmp ne i32 %4, 0
   br i1 %5, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  %6 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %6, i32 26, ptr @0, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %7 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @5, ptr %7, i32 27, ptr @4, i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %8 = load i32, i32* %a, align 4
-  %9 = load i32, i32* %b, align 4
+  %8 = load i32, ptr %a, align 4
+  %9 = load i32, ptr %b, align 4
   %10 = or i32 %8, %9
   %11 = icmp ne i32 %10, 0
   br i1 %11, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  %12 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %12 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @7, ptr %12, i32 26, ptr @6, i32 1)
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %13, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  %13 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @9, ptr %13, i32 27, ptr @8, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %14 = load i32, i32* %a, align 4
-  %15 = load i32, i32* %b, align 4
+  %14 = load i32, ptr %a, align 4
+  %15 = load i32, ptr %b, align 4
   %16 = xor i32 %14, %15
   %17 = icmp ne i32 %16, 0
   br i1 %17, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %18, i32 28, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  %18 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @13, ptr %18, i32 28, ptr @12, i32 1)
   br label %ifcont6
 
 else5:                                            ; preds = %ifcont3
-  %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %19, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  %19 = load ptr, ptr @string_const.10, align 8
+  call void @_lfortran_printf(ptr @15, ptr %19, i32 29, ptr @14, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  store i32 0, i32* %a, align 4
-  store i32 1, i32* %b, align 4
-  %20 = load i32, i32* %a, align 4
-  %21 = load i32, i32* %b, align 4
+  store i32 0, ptr %a, align 4
+  store i32 1, ptr %b, align 4
+  %20 = load i32, ptr %a, align 4
+  %21 = load i32, ptr %b, align 4
   %22 = and i32 %20, %21
   %23 = xor i32 %22, 1
   %24 = icmp ne i32 %23, 0
   br i1 %24, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  %25 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %25, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  %25 = load ptr, ptr @string_const.12, align 8
+  call void @_lfortran_printf(ptr @19, ptr %25, i32 26, ptr @18, i32 1)
   br label %ifcont9
 
 else8:                                            ; preds = %ifcont6
-  %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %26, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  %26 = load ptr, ptr @string_const.14, align 8
+  call void @_lfortran_printf(ptr @21, ptr %26, i32 27, ptr @20, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @23, ptr @"ERROR STOP", ptr @22)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %27 = load i32, i32* %b, align 4
-  %28 = load i32, i32* %a, align 4
+  %27 = load i32, ptr %b, align 4
+  %28 = load i32, ptr %a, align 4
   %29 = xor i32 %27, %28
   %30 = icmp ne i32 %29, 0
   br i1 %30, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %31, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  %31 = load ptr, ptr @string_const.16, align 8
+  call void @_lfortran_printf(ptr @25, ptr %31, i32 26, ptr @24, i32 1)
   br label %ifcont12
 
 else11:                                           ; preds = %ifcont9
-  %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %32, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  %32 = load ptr, ptr @string_const.18, align 8
+  call void @_lfortran_printf(ptr @27, ptr %32, i32 27, ptr @26, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @29, ptr @"ERROR STOP", ptr @28)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %33 = load i32, i32* %b, align 4
-  %34 = load i32, i32* %a, align 4
+  %33 = load i32, ptr %b, align 4
+  %34 = load i32, ptr %a, align 4
   %35 = xor i32 %33, %34
   %36 = xor i32 %35, 1
   %37 = icmp ne i32 %36, 0
   br i1 %37, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %38, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
+  %38 = load ptr, ptr @string_const.20, align 8
+  call void @_lfortran_printf(ptr @31, ptr %38, i32 26, ptr @30, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @33, ptr @"ERROR STOP", ptr @32)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
 
 else14:                                           ; preds = %ifcont12
-  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %39, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  %39 = load ptr, ptr @string_const.22, align 8
+  call void @_lfortran_printf(ptr @35, ptr %39, i32 27, ptr @34, i32 1)
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  store i32 1, i32* %a, align 4
-  store i32 1, i32* %b, align 4
-  %40 = load i32, i32* %a, align 4
-  %41 = load i32, i32* %b, align 4
+  store i32 1, ptr %a, align 4
+  store i32 1, ptr %b, align 4
+  %40 = load i32, ptr %a, align 4
+  %41 = load i32, ptr %b, align 4
   %42 = and i32 %40, %41
   %43 = icmp ne i32 %42, 0
   br i1 %43, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  %44 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %44, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
+  %44 = load ptr, ptr @string_const.24, align 8
+  call void @_lfortran_printf(ptr @37, ptr %44, i32 26, ptr @36, i32 1)
   br label %ifcont18
 
 else17:                                           ; preds = %ifcont15
-  %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %45, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  %45 = load ptr, ptr @string_const.26, align 8
+  call void @_lfortran_printf(ptr @39, ptr %45, i32 27, ptr @38, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @41, ptr @"ERROR STOP", ptr @40)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %46 = load i32, i32* %a, align 4
-  %47 = load i32, i32* %b, align 4
+  %46 = load i32, ptr %a, align 4
+  %47 = load i32, ptr %b, align 4
   %48 = or i32 %46, %47
   %49 = icmp ne i32 %48, 0
   br i1 %49, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  %50 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %50, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  %50 = load ptr, ptr @string_const.28, align 8
+  call void @_lfortran_printf(ptr @43, ptr %50, i32 26, ptr @42, i32 1)
   br label %ifcont21
 
 else20:                                           ; preds = %ifcont18
-  %51 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.30, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %51, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
+  %51 = load ptr, ptr @string_const.30, align 8
+  call void @_lfortran_printf(ptr @45, ptr %51, i32 27, ptr @44, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @47, ptr @"ERROR STOP", ptr @46)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %52 = load i32, i32* %a, align 4
-  %53 = load i32, i32* %b, align 4
+  %52 = load i32, ptr %a, align 4
+  %53 = load i32, ptr %b, align 4
   %54 = xor i32 %52, %53
   %55 = icmp ne i32 %54, 0
   br i1 %55, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  %56 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.32, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %56, i32 30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
+  %56 = load ptr, ptr @string_const.32, align 8
+  call void @_lfortran_printf(ptr @49, ptr %56, i32 30, ptr @48, i32 1)
+  call void (ptr, ...) @_lcompilers_print_error(ptr @51, ptr @"ERROR STOP", ptr @50)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
 
 else23:                                           ; preds = %ifcont21
-  %57 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.34, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* %57, i32 31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1)
+  %57 = load ptr, ptr @string_const.34, align 8
+  call void @_lfortran_printf(ptr @53, ptr %57, i32 31, ptr @52, i32 1)
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
@@ -299,11 +300,11 @@ FINALIZE_SYMTABLE_logical3:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "9e730c767c7f4fc34113e53abef510521ba89f79afa835a1b0699bfa",
+    "stdout_hash": "e5239b84565dd5b8d26fd929d840672ca3ea744676ad568eace9fcfb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -1,42 +1,43 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"L32,L32,L32\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %a = alloca i32, align 4
   %b = alloca i32, align 4
   %c = alloca i32, align 4
-  store i32 1, i32* %a, align 4
-  store i32 1, i32* %b, align 4
-  store i32 0, i32* %c, align 4
+  store i32 1, ptr %a, align 4
+  store i32 1, ptr %b, align 4
+  store i32 0, ptr %c, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a, i32* %b, i32* %c)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a, ptr %b, ptr %c)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -50,14 +51,14 @@ FINALIZE_SYMTABLE_logical4:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-mangle_underscore_external_01-c26c50a.json
+++ b/tests/reference/llvm-mangle_underscore_external_01-c26c50a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-mangle_underscore_external_01-c26c50a.stdout",
-    "stdout_hash": "b81de9dc74370a243ca68f4acc5d0eea3d7f4404b9cf481e5cb05f59",
+    "stdout_hash": "6e43d0e78fa2de6f5b3fd3492094ec0b7de1306a09de926856c8e053",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-mangle_underscore_external_01-c26c50a.stdout
+++ b/tests/reference/llvm-mangle_underscore_external_01-c26c50a.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @foo_()
   br label %return
 
@@ -18,6 +19,6 @@ FINALIZE_SYMTABLE_mangle_underscore_external_01:  ; preds = %return
 
 declare void @foo_()
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.json
+++ b/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-module_struct_global_separate_compilation_01-043bc7f.stdout",
-    "stdout_hash": "3312f21b19cb099a6045658030b4bdfaef3d2d6169a25cb520da9567",
+    "stdout_hash": "ff159e1fc19315d8f6fd3f99371f9c082304f40be9abb2d1d7c496b1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.stdout
+++ b/tests/reference/llvm-module_struct_global_separate_compilation_01-043bc7f.stdout
@@ -1,15 +1,16 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 %module_struct_global_separate_compilation_01.t.3 = type { i32 }
 
 @__module_module_struct_global_separate_compilation_01_targets = global %module_struct_global_separate_compilation_01.t.3 zeroinitializer
 
-define void @__module_module_struct_global_separate_compilation_01_set_targets(i32* %v) {
+define void @__module_module_struct_global_separate_compilation_01_set_targets(ptr %v) {
 .entry:
-  %0 = load i32, i32* %v, align 4
-  store i32 %0, i32* getelementptr inbounds (%module_struct_global_separate_compilation_01.t.3, %module_struct_global_separate_compilation_01.t.3* @__module_module_struct_global_separate_compilation_01_targets, i32 0, i32 0), align 4
+  %0 = load i32, ptr %v, align 4
+  store i32 %0, ptr @__module_module_struct_global_separate_compilation_01_targets, align 4
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-modules_01-1b129c3.json
+++ b/tests/reference/llvm-modules_01-1b129c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_01-1b129c3.stdout",
-    "stdout_hash": "7bdd8efae069739778feb85d65790478673d26231b9109f2b1a5ca61",
+    "stdout_hash": "639d904d138e70ba1b810fb2eb6f33b1b24a66d8e1f476cd5f8d7c72",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_01-1b129c3.stdout
+++ b/tests/reference/llvm-modules_01-1b129c3.stdout
@@ -1,18 +1,19 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @__module_modules_01_a_b() {
 .entry:
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %0, i32 3, ptr @0, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -22,11 +23,11 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @__module_modules_01_a_b()
   br label %return
 
@@ -38,6 +39,6 @@ FINALIZE_SYMTABLE_modules_01:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "ec5c9e7b0e7118ce4db9231b8ae99b6178b83add3e4d9cfb2fb7c89b",
+    "stdout_hash": "62284fdbc82b8023267566f1a6aac51b555bd4a7c34cd4042e588eea",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -1,12 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -15,47 +16,47 @@ target datalayout = "..."
 define i32 @__module_modules_06_a_b() {
 .entry:
   %r = alloca i32, align 4
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  store i32 5, i32* %r, align 4
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %0, i32 3, ptr @0, i32 1)
+  store i32 5, ptr %r, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_b
 
 FINALIZE_SYMTABLE_b:                              ; preds = %return
-  %1 = load i32, i32* %r, align 4
+  %1 = load i32, ptr %r, align 4
   ret i32 %1
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %3 = call i32 @__module_modules_06_a_b()
-  store i32 %3, i32* %i, align 4
+  store i32 %3, ptr %i, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @3, ptr %10, i32 %13, ptr @2, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -69,12 +70,12 @@ FINALIZE_SYMTABLE_modules_06:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "1da1c65c78dfcc912998868f650c67401887ccb6f5b2b9d058e3be5b",
+    "stdout_hash": "76effb0cdf4d6a4da81397808eb19583a35cd43bcaa383cc76551959",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -1,44 +1,45 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module_modules_11_module11_i = global i32 1
 @__module_modules_11_module11_j = global i32 2
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data = private constant [4 x i8] c"i = "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"j = "
-@string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
+@string_const.3 = private global %string_descriptor <{ ptr @string_const_data.2, i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @__module_modules_11_module11_access_internally() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* @__module_modules_11_module11_i)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr @__module_modules_11_module11_i)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -51,37 +52,37 @@ FINALIZE_SYMTABLE_access_internally:              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* @__module_modules_11_module11_j)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.3, ptr @__module_modules_11_module11_j)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @3, ptr %9, i32 %12, ptr @2, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -96,6 +97,6 @@ FINALIZE_SYMTABLE_access_externally:              ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "34910404e9c193d158d695c0da043e1815c747512e40f3de8886eb3d",
+    "stdout_hash": "dfdb661abaac638668f335465c9c7e2d4ba55c35961d5ab3cf5b0dd3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -12,57 +13,57 @@ define i32 @__module_module_13_f1() {
 .entry:
   %f1 = alloca i32, align 4
   %0 = call i32 @__module_module_13_f2()
-  store i32 %0, i32* %f1, align 4
+  store i32 %0, ptr %f1, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f1
 
 FINALIZE_SYMTABLE_f1:                             ; preds = %return
-  %1 = load i32, i32* %f1, align 4
+  %1 = load i32, ptr %f1, align 4
   ret i32 %1
 }
 
 define i32 @__module_module_13_f2() {
 .entry:
   %f2 = alloca i32, align 4
-  store i32 5, i32* %f2, align 4
+  store i32 5, ptr %f2, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f2
 
 FINALIZE_SYMTABLE_f2:                             ; preds = %return
-  %0 = load i32, i32* %f2, align 4
+  %0 = load i32, ptr %f2, align 4
   ret i32 %0
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %f = alloca i32, align 4
   %3 = call i32 @__module_module_13_f1()
-  store i32 %3, i32* %f, align 4
+  store i32 %3, ptr %f, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %f)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %f)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @1, ptr %10, i32 %13, ptr @0, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -76,14 +77,14 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-modules_36-53c9a79.json
+++ b/tests/reference/llvm-modules_36-53c9a79.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_36-53c9a79.stdout",
-    "stdout_hash": "e0dc21f81a7b6b11c114cda899443d50385b8b1d8850ff80c0897941",
+    "stdout_hash": "9dc3b463f0798cb06d0f03159fb68ca8eb0efed3e41e5f4aaf5720f7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_36-53c9a79.stdout
+++ b/tests/reference/llvm-modules_36-53c9a79.stdout
@@ -1,12 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%modules_36_fpm_main_01.fpm_run_settings.4_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_run_settings.4* }>
+%string_descriptor = type <{ ptr, i64 }>
+%modules_36_fpm_main_01.fpm_run_settings.4_class = type <{ ptr, ptr }>
 %modules_36_fpm_main_01.fpm_run_settings.4 = type { %modules_36_fpm_main_01.fpm_build_settings.3, %string_descriptor, %string_descriptor, %string_descriptor, i32 }
 %modules_36_fpm_main_01.fpm_build_settings.3 = type { i32 }
-%modules_36_fpm_main_01.fpm_build_settings.3_class = type <{ i32 (...)**, %modules_36_fpm_main_01.fpm_build_settings.3* }>
+%modules_36_fpm_main_01.fpm_build_settings.3_class = type <{ ptr, ptr }>
 
 @0 = private unnamed_addr constant [47 x i8] c"__libasr_created__intrinsic_array_function_Any\00", align 1
 @1 = private unnamed_addr constant [42 x i8] c"tests/../integration_tests/modules_36.f90\00", align 1
@@ -27,46 +28,46 @@ target datalayout = "..."
 @16 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @17 = private unnamed_addr constant [143 x i8] c"Runtime error: Array shape mismatch in subroutine '%s'\0A\0ATried to match size %d of dimension %d of argument number %d, but expected size is %d\0A\00", align 1
 @string_const_data = private constant [0 x i8] zeroinitializer
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([0 x i8], [0 x i8]* @string_const_data, i32 0, i32 0), i64 0 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 0 }>
 @18 = private unnamed_addr constant [5 x i8] c"mask\00", align 1
 @19 = private unnamed_addr constant [42 x i8] c"tests/../integration_tests/modules_36.f90\00", align 1
 @20 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @21 = private unnamed_addr constant [118 x i8] c"Runtime error: Array '%s' index out of bounds. Tried to access index %d of dimension %d, but valid range is %d to %d.\00", align 1
 @_Name_fpm_build_settings = private unnamed_addr constant [19 x i8] c"fpm_build_settings\00", align 1
-@_Type_Info_fpm_build_settings = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([19 x i8], [19 x i8]* @_Name_fpm_build_settings, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
-@_VTable_fpm_build_settings = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_build_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings to i8*), i8* bitcast (void (i8*)* @finalize_StructType__fpm_build_settings_3_of_modules_36_fpm_main_01_for_UPoly to i8*)] }, align 8
+@_Type_Info_fpm_build_settings = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_fpm_build_settings, ptr inttoptr (i64 4 to ptr), ptr null }, align 8
+@_VTable_fpm_build_settings = linkonce_odr unnamed_addr constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr @_Type_Info_fpm_build_settings, ptr @_copy_modules_36_fpm_main_01_fpm_build_settings, ptr @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings, ptr @finalize_StructType__fpm_build_settings_3_of_modules_36_fpm_main_01_for_UPoly] }, align 8
 @_Name_fpm_run_settings = private unnamed_addr constant [17 x i8] c"fpm_run_settings\00", align 1
-@_Type_Info_fpm_run_settings = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([17 x i8], [17 x i8]* @_Name_fpm_run_settings, i32 0, i32 0), i8* inttoptr (i64 56 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_build_settings to i8*) }, align 8
-@_VTable_fpm_run_settings = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_fpm_run_settings to i8*), i8* bitcast (void (i8*, i8*)* @_copy_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8**)* @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings to i8*), i8* bitcast (void (i8*)* @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly to i8*)] }, align 8
+@_Type_Info_fpm_run_settings = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_fpm_run_settings, ptr inttoptr (i64 56 to ptr), ptr @_Type_Info_fpm_build_settings }, align 8
+@_VTable_fpm_run_settings = linkonce_odr unnamed_addr constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr @_Type_Info_fpm_run_settings, ptr @_copy_modules_36_fpm_main_01_fpm_run_settings, ptr @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings, ptr @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly] }, align 8
 
-define i32 @_lcompilers_Any_4_1_0_logical____0(i32* %mask, i32* %__1mask) {
+define i32 @_lcompilers_Any_4_1_0_logical____0(ptr %mask, ptr %__1mask) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %__1_i = alloca i32, align 4
   %__do_loop_end = alloca i32, align 4
   %_lcompilers_Any_4_1_0 = alloca i32, align 4
-  store i32 0, i32* %_lcompilers_Any_4_1_0, align 4
-  %1 = load i32, i32* %__1mask, align 4
+  store i32 0, ptr %_lcompilers_Any_4_1_0, align 4
+  %1 = load i32, ptr %__1mask, align 4
   %2 = add i32 %1, 1
   %3 = sub i32 %2, 1
-  store i32 %3, i32* %__do_loop_end, align 4
-  store i32 0, i32* %__1_i, align 4
+  store i32 %3, ptr %__do_loop_end, align 4
+  store i32 0, ptr %__1_i, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %.entry
-  %4 = load i32, i32* %__1_i, align 4
+  %4 = load i32, ptr %__1_i, align 4
   %5 = add i32 %4, 1
-  %6 = load i32, i32* %__do_loop_end, align 4
+  %6 = load i32, ptr %__do_loop_end, align 4
   %7 = icmp sle i32 %5, %6
   br i1 %7, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %8 = load i32, i32* %__1_i, align 4
+  %8 = load i32, ptr %__1_i, align 4
   %9 = add i32 %8, 1
-  store i32 %9, i32* %__1_i, align 4
-  %10 = load i32, i32* %_lcompilers_Any_4_1_0, align 4
-  %11 = load i32, i32* %__1_i, align 4
-  %12 = load i32, i32* %__1mask, align 4
+  store i32 %9, ptr %__1_i, align 4
+  %10 = load i32, ptr %_lcompilers_Any_4_1_0, align 4
+  %11 = load i32, ptr %__1_i, align 4
+  %12 = load i32, ptr %__1mask, align 4
   %13 = sext i32 %11 to i64
   %14 = sub i64 %13, 1
   %15 = mul i64 1, %14
@@ -80,41 +81,41 @@ loop.body:                                        ; preds = %loop.head
   br i1 %22, label %then, label %ifcont
 
 then:                                             ; preds = %loop.body
-  %23 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %24 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %25 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %24, i32 0, i32 0
-  %26 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @19, i32 0, i32 0), i8** %26, align 8
-  %27 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 1
-  store i32 24, i32* %27, align 4
-  %28 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 2
-  store i32 10, i32* %28, align 4
-  %29 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 3
-  store i32 24, i32* %29, align 4
-  %30 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %25, i32 0, i32 4
-  store i32 24, i32* %30, align 4
-  %31 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @20, i32 0, i32 0))
-  %32 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %23, i32 0, i32 0
-  %33 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %24, i32 0, i32 0
-  %34 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 2
-  %35 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 0
-  store i1 true, i1* %35, align 1
-  %36 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 1
-  store i8* %31, i8** %36, align 8
-  store { i8*, i32, i32, i32, i32 }* %33, { i8*, i32, i32, i32, i32 }** %34, align 8
-  %37 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %32, i32 0, i32 3
-  store i32 1, i32* %37, align 4
-  %38 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %23, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %38, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @18, i32 0, i32 0), i64 %13, i32 1, i64 1, i64 %19)
+  %23 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %24 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %25 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %24, i32 0, i32 0
+  %26 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %25, i32 0, i32 0
+  store ptr @19, ptr %26, align 8
+  %27 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %25, i32 0, i32 1
+  store i32 24, ptr %27, align 4
+  %28 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %25, i32 0, i32 2
+  store i32 10, ptr %28, align 4
+  %29 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %25, i32 0, i32 3
+  store i32 24, ptr %29, align 4
+  %30 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %25, i32 0, i32 4
+  store i32 24, ptr %30, align 4
+  %31 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @20)
+  %32 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %23, i32 0, i32 0
+  %33 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %24, i32 0, i32 0
+  %34 = getelementptr { i1, ptr, ptr, i32 }, ptr %32, i32 0, i32 2
+  %35 = getelementptr { i1, ptr, ptr, i32 }, ptr %32, i32 0, i32 0
+  store i1 true, ptr %35, align 1
+  %36 = getelementptr { i1, ptr, ptr, i32 }, ptr %32, i32 0, i32 1
+  store ptr %31, ptr %36, align 8
+  store ptr %33, ptr %34, align 8
+  %37 = getelementptr { i1, ptr, ptr, i32 }, ptr %32, i32 0, i32 3
+  store i32 1, ptr %37, align 4
+  %38 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %23, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %38, i32 1, ptr @21, ptr @18, i64 %13, i32 1, i64 1, i64 %19)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %loop.body
   %39 = mul i64 1, %17
-  %40 = getelementptr inbounds i32, i32* %mask, i64 %16
-  %41 = load i32, i32* %40, align 4
+  %40 = getelementptr inbounds i32, ptr %mask, i64 %16
+  %41 = load i32, ptr %40, align 4
   %42 = or i32 %10, %41
-  store i32 %42, i32* %_lcompilers_Any_4_1_0, align 4
+  store i32 %42, ptr %_lcompilers_Any_4_1_0, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
@@ -124,17 +125,17 @@ return:                                           ; preds = %loop.end
   br label %FINALIZE_SYMTABLE__lcompilers_Any_4_1_0_logical____0
 
 FINALIZE_SYMTABLE__lcompilers_Any_4_1_0_logical____0: ; preds = %return
-  %43 = load i32, i32* %_lcompilers_Any_4_1_0, align 4
+  %43 = load i32, ptr %_lcompilers_Any_4_1_0, align 4
   ret i32 %43
 }
 
-define void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32* %test) {
+define void @__module_modules_36_fpm_main_01_cmd_run(ptr %settings, ptr %test) {
 .entry:
   %call_arg_value = alloca i32, align 4
   %array_bound14 = alloca i32, align 4
   %array_bound10 = alloca i32, align 4
   %array_bound = alloca i32, align 4
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %array_size1 = alloca i32, align 4
   %array_size = alloca i32, align 4
   %__do_loop_end = alloca i32, align 4
@@ -147,78 +148,78 @@ define void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 2, i32* %array_size, align 4
+  store i32 2, ptr %array_size, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %1 = load i32, i32* %array_size, align 4
+  %1 = load i32, ptr %array_size, align 4
   br i1 true, label %then2, label %else3
 
 then2:                                            ; preds = %ifcont
-  store i32 2, i32* %array_size1, align 4
+  store i32 2, ptr %array_size1, align 4
   br label %ifcont4
 
 else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %then2
-  %2 = load i32, i32* %array_size1, align 4
+  %2 = load i32, ptr %array_size1, align 4
   %3 = icmp ne i32 %2, %1
   br i1 %3, label %then5, label %ifcont6
 
 then5:                                            ; preds = %ifcont4
-  %4 = alloca [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %5 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %6 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %5, i32 0, i32 0
-  %7 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %6, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @1, i32 0, i32 0), i8** %7, align 8
-  %8 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %6, i32 0, i32 1
-  store i32 24, i32* %8, align 4
-  %9 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %6, i32 0, i32 2
-  store i32 14, i32* %9, align 4
-  %10 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %6, i32 0, i32 3
-  store i32 24, i32* %10, align 4
-  %11 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %6, i32 0, i32 4
-  store i32 23, i32* %11, align 4
-  %12 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @2, i32 0, i32 0), i32 %1)
-  %13 = getelementptr inbounds [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %4, i32 0, i32 0
-  %14 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %5, i32 0, i32 0
-  %15 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %13, i32 0, i32 2
-  %16 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %13, i32 0, i32 0
-  store i1 true, i1* %16, align 1
-  %17 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %13, i32 0, i32 1
-  store i8* %12, i8** %17, align 8
-  store { i8*, i32, i32, i32, i32 }* %14, { i8*, i32, i32, i32, i32 }** %15, align 8
-  %18 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %13, i32 0, i32 3
-  store i32 1, i32* %18, align 4
-  %19 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %20 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %21 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @3, i32 0, i32 0), i8** %21, align 8
-  %22 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 1
-  store i32 24, i32* %22, align 4
-  %23 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 2
-  store i32 19, i32* %23, align 4
-  %24 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 3
-  store i32 24, i32* %24, align 4
-  %25 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %20, i32 0, i32 4
-  store i32 23, i32* %25, align 4
-  %26 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @4, i32 0, i32 0), i32 %2)
-  %27 = getelementptr inbounds [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %4, i32 0, i32 1
-  %28 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %19, i32 0, i32 0
-  %29 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 2
-  %30 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 0
-  store i1 true, i1* %30, align 1
-  %31 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 1
-  store i8* %26, i8** %31, align 8
-  store { i8*, i32, i32, i32, i32 }* %28, { i8*, i32, i32, i32, i32 }** %29, align 8
-  %32 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %27, i32 0, i32 3
-  store i32 1, i32* %32, align 4
-  %33 = getelementptr [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [2 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %4, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %33, i32 2, i8* getelementptr inbounds ([127 x i8], [127 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([47 x i8], [47 x i8]* @0, i32 0, i32 0), i32 %1, i32 1, i32 %2, i32 1)
+  %4 = alloca [2 x { i1, ptr, ptr, i32 }], align 8
+  %5 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %6 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %5, i32 0, i32 0
+  %7 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %6, i32 0, i32 0
+  store ptr @1, ptr %7, align 8
+  %8 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %6, i32 0, i32 1
+  store i32 24, ptr %8, align 4
+  %9 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %6, i32 0, i32 2
+  store i32 14, ptr %9, align 4
+  %10 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %6, i32 0, i32 3
+  store i32 24, ptr %10, align 4
+  %11 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %6, i32 0, i32 4
+  store i32 23, ptr %11, align 4
+  %12 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @2, i32 %1)
+  %13 = getelementptr inbounds [2 x { i1, ptr, ptr, i32 }], ptr %4, i32 0, i32 0
+  %14 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %5, i32 0, i32 0
+  %15 = getelementptr { i1, ptr, ptr, i32 }, ptr %13, i32 0, i32 2
+  %16 = getelementptr { i1, ptr, ptr, i32 }, ptr %13, i32 0, i32 0
+  store i1 true, ptr %16, align 1
+  %17 = getelementptr { i1, ptr, ptr, i32 }, ptr %13, i32 0, i32 1
+  store ptr %12, ptr %17, align 8
+  store ptr %14, ptr %15, align 8
+  %18 = getelementptr { i1, ptr, ptr, i32 }, ptr %13, i32 0, i32 3
+  store i32 1, ptr %18, align 4
+  %19 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %20 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %21 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 0
+  store ptr @3, ptr %21, align 8
+  %22 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 1
+  store i32 24, ptr %22, align 4
+  %23 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 2
+  store i32 19, ptr %23, align 4
+  %24 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 3
+  store i32 24, ptr %24, align 4
+  %25 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %20, i32 0, i32 4
+  store i32 23, ptr %25, align 4
+  %26 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @4, i32 %2)
+  %27 = getelementptr inbounds [2 x { i1, ptr, ptr, i32 }], ptr %4, i32 0, i32 1
+  %28 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %19, i32 0, i32 0
+  %29 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 2
+  %30 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 0
+  store i1 true, ptr %30, align 1
+  %31 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 1
+  store ptr %26, ptr %31, align 8
+  store ptr %28, ptr %29, align 8
+  %32 = getelementptr { i1, ptr, ptr, i32 }, ptr %27, i32 0, i32 3
+  store i32 1, ptr %32, align 4
+  %33 = getelementptr [2 x { i1, ptr, ptr, i32 }], ptr %4, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %33, i32 2, ptr @5, ptr @0, i32 %1, i32 1, i32 %2, i32 1)
   call void @exit(i32 1)
   unreachable
 
@@ -226,54 +227,54 @@ ifcont6:                                          ; preds = %ifcont4
   br i1 true, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  store i32 1, i32* %array_bound, align 4
+  store i32 1, ptr %array_bound, align 4
   br label %ifcont9
 
 else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %34 = load i32, i32* %array_bound, align 4
-  store i32 %34, i32* %__libasr_index_0_1, align 4
+  %34 = load i32, ptr %array_bound, align 4
+  store i32 %34, ptr %__libasr_index_0_1, align 4
   br i1 true, label %then11, label %else12
 
 then11:                                           ; preds = %ifcont9
-  store i32 2, i32* %array_bound10, align 4
+  store i32 2, ptr %array_bound10, align 4
   br label %ifcont13
 
 else12:                                           ; preds = %ifcont9
   br label %ifcont13
 
 ifcont13:                                         ; preds = %else12, %then11
-  %35 = load i32, i32* %array_bound10, align 4
-  store i32 %35, i32* %__do_loop_end, align 4
+  %35 = load i32, ptr %array_bound10, align 4
+  store i32 %35, ptr %__do_loop_end, align 4
   br i1 true, label %then15, label %else16
 
 then15:                                           ; preds = %ifcont13
-  store i32 1, i32* %array_bound14, align 4
+  store i32 1, ptr %array_bound14, align 4
   br label %ifcont17
 
 else16:                                           ; preds = %ifcont13
   br label %ifcont17
 
 ifcont17:                                         ; preds = %else16, %then15
-  %36 = load i32, i32* %array_bound14, align 4
+  %36 = load i32, ptr %array_bound14, align 4
   %37 = sub i32 %36, 1
-  store i32 %37, i32* %__libasr_index_0_, align 4
+  store i32 %37, ptr %__libasr_index_0_, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont21, %ifcont17
-  %38 = load i32, i32* %__libasr_index_0_, align 4
+  %38 = load i32, ptr %__libasr_index_0_, align 4
   %39 = add i32 %38, 1
-  %40 = load i32, i32* %__do_loop_end, align 4
+  %40 = load i32, ptr %__do_loop_end, align 4
   %41 = icmp sle i32 %39, %40
   br i1 %41, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %42 = load i32, i32* %__libasr_index_0_, align 4
+  %42 = load i32, ptr %__libasr_index_0_, align 4
   %43 = add i32 %42, 1
-  store i32 %43, i32* %__libasr_index_0_, align 4
-  %44 = load i32, i32* %__libasr_index_0_, align 4
+  store i32 %43, ptr %__libasr_index_0_, align 4
+  %44 = load i32, ptr %__libasr_index_0_, align 4
   %45 = sext i32 %44 to i64
   %46 = sub i64 %45, 1
   %47 = mul i64 1, %46
@@ -284,38 +285,38 @@ loop.body:                                        ; preds = %loop.head
   br i1 %51, label %then18, label %ifcont19
 
 then18:                                           ; preds = %loop.body
-  %52 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %53 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %54 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %53, i32 0, i32 0
-  %55 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %54, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @7, i32 0, i32 0), i8** %55, align 8
-  %56 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %54, i32 0, i32 1
-  store i32 24, i32* %56, align 4
-  %57 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %54, i32 0, i32 2
-  store i32 14, i32* %57, align 4
-  %58 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %54, i32 0, i32 3
-  store i32 24, i32* %58, align 4
-  %59 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %54, i32 0, i32 4
-  store i32 23, i32* %59, align 4
-  %60 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @8, i32 0, i32 0))
-  %61 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %52, i32 0, i32 0
-  %62 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %53, i32 0, i32 0
-  %63 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %61, i32 0, i32 2
-  %64 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %61, i32 0, i32 0
-  store i1 true, i1* %64, align 1
-  %65 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %61, i32 0, i32 1
-  store i8* %60, i8** %65, align 8
-  store { i8*, i32, i32, i32, i32 }* %62, { i8*, i32, i32, i32, i32 }** %63, align 8
-  %66 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %61, i32 0, i32 3
-  store i32 1, i32* %66, align 4
-  %67 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %52, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %67, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([47 x i8], [47 x i8]* @6, i32 0, i32 0), i64 %45, i32 1, i64 1, i64 2)
+  %52 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %53 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %54 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %53, i32 0, i32 0
+  %55 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %54, i32 0, i32 0
+  store ptr @7, ptr %55, align 8
+  %56 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %54, i32 0, i32 1
+  store i32 24, ptr %56, align 4
+  %57 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %54, i32 0, i32 2
+  store i32 14, ptr %57, align 4
+  %58 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %54, i32 0, i32 3
+  store i32 24, ptr %58, align 4
+  %59 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %54, i32 0, i32 4
+  store i32 23, ptr %59, align 4
+  %60 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @8)
+  %61 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %52, i32 0, i32 0
+  %62 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %53, i32 0, i32 0
+  %63 = getelementptr { i1, ptr, ptr, i32 }, ptr %61, i32 0, i32 2
+  %64 = getelementptr { i1, ptr, ptr, i32 }, ptr %61, i32 0, i32 0
+  store i1 true, ptr %64, align 1
+  %65 = getelementptr { i1, ptr, ptr, i32 }, ptr %61, i32 0, i32 1
+  store ptr %60, ptr %65, align 8
+  store ptr %62, ptr %63, align 8
+  %66 = getelementptr { i1, ptr, ptr, i32 }, ptr %61, i32 0, i32 3
+  store i32 1, ptr %66, align 4
+  %67 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %52, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %67, i32 1, ptr @9, ptr @6, i64 %45, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont19:                                         ; preds = %loop.body
-  %68 = getelementptr [2 x i32], [2 x i32]* %__libasr_created__intrinsic_array_function_Any, i32 0, i64 %48
-  %69 = load i32, i32* %__libasr_index_0_1, align 4
+  %68 = getelementptr [2 x i32], ptr %__libasr_created__intrinsic_array_function_Any, i32 0, i64 %48
+  %69 = load i32, ptr %__libasr_index_0_1, align 4
   %70 = sext i32 %69 to i64
   %71 = sub i64 %70, 1
   %72 = mul i64 1, %71
@@ -326,105 +327,105 @@ ifcont19:                                         ; preds = %loop.body
   br i1 %76, label %then20, label %ifcont21
 
 then20:                                           ; preds = %ifcont19
-  %77 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %78 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %79 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %78, i32 0, i32 0
-  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %79, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @11, i32 0, i32 0), i8** %80, align 8
-  %81 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %79, i32 0, i32 1
-  store i32 24, i32* %81, align 4
-  %82 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %79, i32 0, i32 2
-  store i32 19, i32* %82, align 4
-  %83 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %79, i32 0, i32 3
-  store i32 24, i32* %83, align 4
-  %84 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %79, i32 0, i32 4
-  store i32 23, i32* %84, align 4
-  %85 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @12, i32 0, i32 0))
-  %86 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %77, i32 0, i32 0
-  %87 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %78, i32 0, i32 0
-  %88 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %86, i32 0, i32 2
-  %89 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %86, i32 0, i32 0
-  store i1 true, i1* %89, align 1
-  %90 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %86, i32 0, i32 1
-  store i8* %85, i8** %90, align 8
-  store { i8*, i32, i32, i32, i32 }* %87, { i8*, i32, i32, i32, i32 }** %88, align 8
-  %91 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %86, i32 0, i32 3
-  store i32 1, i32* %91, align 4
-  %92 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %77, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %92, i32 1, i8* getelementptr inbounds ([118 x i8], [118 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([6 x i8], [6 x i8]* @10, i32 0, i32 0), i64 %70, i32 1, i64 1, i64 2)
+  %77 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %78 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %79 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %78, i32 0, i32 0
+  %80 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 0
+  store ptr @11, ptr %80, align 8
+  %81 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 1
+  store i32 24, ptr %81, align 4
+  %82 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 2
+  store i32 19, ptr %82, align 4
+  %83 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 3
+  store i32 24, ptr %83, align 4
+  %84 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %79, i32 0, i32 4
+  store i32 23, ptr %84, align 4
+  %85 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @12)
+  %86 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %77, i32 0, i32 0
+  %87 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %78, i32 0, i32 0
+  %88 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 2
+  %89 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 0
+  store i1 true, ptr %89, align 1
+  %90 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 1
+  store ptr %85, ptr %90, align 8
+  store ptr %87, ptr %88, align 8
+  %91 = getelementptr { i1, ptr, ptr, i32 }, ptr %86, i32 0, i32 3
+  store i32 1, ptr %91, align 4
+  %92 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %77, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %92, i32 1, ptr @13, ptr @10, i64 %70, i32 1, i64 1, i64 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont21:                                         ; preds = %ifcont19
-  %93 = getelementptr [2 x i32], [2 x i32]* %found, i32 0, i64 %73
-  %94 = load i32, i32* %93, align 4
+  %93 = getelementptr [2 x i32], ptr %found, i32 0, i64 %73
+  %94 = load i32, ptr %93, align 4
   %95 = xor i32 %94, 1
-  store i32 %95, i32* %68, align 4
-  %96 = load i32, i32* %__libasr_index_0_1, align 4
+  store i32 %95, ptr %68, align 4
+  %96 = load i32, ptr %__libasr_index_0_1, align 4
   %97 = add i32 %96, 1
-  store i32 %97, i32* %__libasr_index_0_1, align 4
+  store i32 %97, ptr %__libasr_index_0_1, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
   br i1 false, label %then22, label %ifcont23
 
 then22:                                           ; preds = %loop.end
-  %98 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %99 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %100 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %99, i32 0, i32 0
-  %101 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 0
-  store i8* getelementptr inbounds ([42 x i8], [42 x i8]* @15, i32 0, i32 0), i8** %101, align 8
-  %102 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 1
-  store i32 24, i32* %102, align 4
-  %103 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 2
-  store i32 14, i32* %103, align 4
-  %104 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 3
-  store i32 24, i32* %104, align 4
-  %105 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %100, i32 0, i32 4
-  store i32 23, i32* %105, align 4
-  %106 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %0, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @16, i32 0, i32 0))
-  %107 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %98, i32 0, i32 0
-  %108 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %99, i32 0, i32 0
-  %109 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 2
-  %110 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 0
-  store i1 true, i1* %110, align 1
-  %111 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 1
-  store i8* %106, i8** %111, align 8
-  store { i8*, i32, i32, i32, i32 }* %108, { i8*, i32, i32, i32, i32 }** %109, align 8
-  %112 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %107, i32 0, i32 3
-  store i32 1, i32* %112, align 4
-  %113 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %98, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %0, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %113, i32 1, i8* getelementptr inbounds ([143 x i8], [143 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([35 x i8], [35 x i8]* @14, i32 0, i32 0), i32 2, i32 1, i32 1, i32 2)
+  %98 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %99 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %100 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %99, i32 0, i32 0
+  %101 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 0
+  store ptr @15, ptr %101, align 8
+  %102 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 1
+  store i32 24, ptr %102, align 4
+  %103 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 2
+  store i32 14, ptr %103, align 4
+  %104 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 3
+  store i32 24, ptr %104, align 4
+  %105 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %100, i32 0, i32 4
+  store i32 23, ptr %105, align 4
+  %106 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %0, ptr @16)
+  %107 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %98, i32 0, i32 0
+  %108 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %99, i32 0, i32 0
+  %109 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 2
+  %110 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 0
+  store i1 true, ptr %110, align 1
+  %111 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 1
+  store ptr %106, ptr %111, align 8
+  store ptr %108, ptr %109, align 8
+  %112 = getelementptr { i1, ptr, ptr, i32 }, ptr %107, i32 0, i32 3
+  store i32 1, ptr %112, align 4
+  %113 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %98, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %0, ptr %113, i32 1, ptr @17, ptr @14, i32 2, i32 1, i32 1, i32 2)
   call void @exit(i32 1)
   unreachable
 
 ifcont23:                                         ; preds = %loop.end
-  %114 = getelementptr [2 x i32], [2 x i32]* %__libasr_created__intrinsic_array_function_Any, i32 0, i32 0
-  store i32 2, i32* %call_arg_value, align 4
-  %115 = call i32 @_lcompilers_Any_4_1_0_logical____0(i32* %114, i32* %call_arg_value)
-  store i32 %115, i32* %__libasr_created__intrinsic_array_function_Any1, align 4
-  %116 = load i32, i32* %__libasr_created__intrinsic_array_function_Any1, align 4
-  %117 = load i32, i32* %toomany, align 4
-  %118 = load i32, i32* %test, align 4
+  %114 = getelementptr [2 x i32], ptr %__libasr_created__intrinsic_array_function_Any, i32 0, i32 0
+  store i32 2, ptr %call_arg_value, align 4
+  %115 = call i32 @_lcompilers_Any_4_1_0_logical____0(ptr %114, ptr %call_arg_value)
+  store i32 %115, ptr %__libasr_created__intrinsic_array_function_Any1, align 4
+  %116 = load i32, ptr %__libasr_created__intrinsic_array_function_Any1, align 4
+  %117 = load i32, ptr %toomany, align 4
+  %118 = load i32, ptr %test, align 4
   %119 = xor i32 %118, 1
   %120 = and i32 %117, %119
-  %121 = load i32, i32* %toomany, align 4
-  %122 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32 0, i32 1
-  %123 = load %modules_36_fpm_main_01.fpm_run_settings.4*, %modules_36_fpm_main_01.fpm_run_settings.4** %122, align 8
-  %124 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %123, i32 0, i32 3
-  %125 = getelementptr %string_descriptor, %string_descriptor* %124, i32 0, i32 0
-  %126 = load i8*, i8** %125, align 8
-  %127 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %128 = call i32 @str_compare(i8* %126, i64 6, i8* %127, i64 0)
+  %121 = load i32, ptr %toomany, align 4
+  %122 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, ptr %settings, i32 0, i32 1
+  %123 = load ptr, ptr %122, align 8
+  %124 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %123, i32 0, i32 3
+  %125 = getelementptr %string_descriptor, ptr %124, i32 0, i32 0
+  %126 = load ptr, ptr %125, align 8
+  %127 = load ptr, ptr @string_const, align 8
+  %128 = call i32 @str_compare(ptr %126, i64 6, ptr %127, i64 0)
   %129 = icmp ne i32 %128, 0
   %130 = zext i1 %129 to i32
   %131 = and i32 %121, %130
   %132 = or i32 %120, %131
-  %133 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %settings, i32 0, i32 1
-  %134 = load %modules_36_fpm_main_01.fpm_run_settings.4*, %modules_36_fpm_main_01.fpm_run_settings.4** %133, align 8
-  %135 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %134, i32 0, i32 0
-  %136 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %135, i32 0, i32 0
-  %137 = load i32, i32* %136, align 4
+  %133 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, ptr %settings, i32 0, i32 1
+  %134 = load ptr, ptr %133, align 8
+  %135 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %134, i32 0, i32 0
+  %136 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %135, i32 0, i32 0
+  %137 = load i32, ptr %136, align 4
   %138 = xor i32 %137, 1
   %139 = and i32 %132, %138
   %140 = or i32 %116, %139
@@ -447,56 +448,56 @@ FINALIZE_SYMTABLE_cmd_run:                        ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i32 @str_compare(i8*, i64, i8*, i64)
+declare i32 @str_compare(ptr, i64, ptr, i64)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
   %2 = alloca %modules_36_fpm_main_01.fpm_run_settings.4_class, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %settings = alloca %modules_36_fpm_main_01.fpm_run_settings.4, align 8
-  %3 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 2
-  store %string_descriptor zeroinitializer, %string_descriptor* %3, align 1
-  %4 = getelementptr %string_descriptor, %string_descriptor* %3, i32 0, i32 1
-  store i64 4, i64* %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %3, i32 0, i32 0
-  %6 = call i8* @_lfortran_get_default_allocator()
-  %7 = call i8* @_lfortran_malloc_alloc(i8* %6, i64 4)
-  store i8* %7, i8** %5, align 8
-  %8 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 4
-  %9 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %9, align 1
-  %10 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 1
-  store i64 5, i64* %10, align 8
-  %11 = call i8* @_lfortran_get_default_allocator()
-  %12 = call i8* @_lfortran_malloc_alloc(i8* %11, i64 10)
-  %13 = getelementptr %string_descriptor, %string_descriptor* %9, i32 0, i32 0
-  store i8* %12, i8** %13, align 8
-  %14 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 3
-  store %string_descriptor zeroinitializer, %string_descriptor* %14, align 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 1
-  store i64 6, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %14, i32 0, i32 0
-  %17 = call i8* @_lfortran_get_default_allocator()
-  %18 = call i8* @_lfortran_malloc_alloc(i8* %17, i64 6)
-  store i8* %18, i8** %16, align 8
-  %19 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %settings, i32 0, i32 0
-  %20 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %19, i32 0, i32 0
-  store i32 0, i32* %20, align 4
-  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32 0, i32 0
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %21, align 8
-  %22 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32 0, i32 1
-  store %modules_36_fpm_main_01.fpm_run_settings.4* %settings, %modules_36_fpm_main_01.fpm_run_settings.4** %22, align 8
-  store i32 1, i32* %call_arg_value, align 4
-  call void @__module_modules_36_fpm_main_01_cmd_run(%modules_36_fpm_main_01.fpm_run_settings.4_class* %2, i32* %call_arg_value)
+  %3 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %settings, i32 0, i32 2
+  store %string_descriptor zeroinitializer, ptr %3, align 1
+  %4 = getelementptr %string_descriptor, ptr %3, i32 0, i32 1
+  store i64 4, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %3, i32 0, i32 0
+  %6 = call ptr @_lfortran_get_default_allocator()
+  %7 = call ptr @_lfortran_malloc_alloc(ptr %6, i64 4)
+  store ptr %7, ptr %5, align 8
+  %8 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %settings, i32 0, i32 4
+  %9 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %settings, i32 0, i32 1
+  store %string_descriptor zeroinitializer, ptr %9, align 1
+  %10 = getelementptr %string_descriptor, ptr %9, i32 0, i32 1
+  store i64 5, ptr %10, align 8
+  %11 = call ptr @_lfortran_get_default_allocator()
+  %12 = call ptr @_lfortran_malloc_alloc(ptr %11, i64 10)
+  %13 = getelementptr %string_descriptor, ptr %9, i32 0, i32 0
+  store ptr %12, ptr %13, align 8
+  %14 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %settings, i32 0, i32 3
+  store %string_descriptor zeroinitializer, ptr %14, align 1
+  %15 = getelementptr %string_descriptor, ptr %14, i32 0, i32 1
+  store i64 6, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %14, i32 0, i32 0
+  %17 = call ptr @_lfortran_get_default_allocator()
+  %18 = call ptr @_lfortran_malloc_alloc(ptr %17, i64 6)
+  store ptr %18, ptr %16, align 8
+  %19 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %settings, i32 0, i32 0
+  %20 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %19, i32 0, i32 0
+  store i32 0, ptr %20, align 4
+  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, ptr %2, i32 0, i32 0
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_VTable_fpm_run_settings, i32 0, i32 0, i32 2), ptr %21, align 8
+  %22 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, ptr %2, i32 0, i32 1
+  store ptr %settings, ptr %22, align 8
+  store i32 1, ptr %call_arg_value, align 4
+  call void @__module_modules_36_fpm_main_01_cmd_run(ptr %2, ptr %call_arg_value)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -506,26 +507,24 @@ FINALIZE_SYMTABLE_modules_36:                     ; preds = %return
   br label %Finalize_Variable_settings
 
 Finalize_Variable_settings:                       ; preds = %FINALIZE_SYMTABLE_modules_36
-  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %settings)
+  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(ptr %settings)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_build_settings(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_build_settings(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings.3*
-  %3 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_build_settings.3*
-  %4 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %2, i32 0, i32 0
-  %5 = load i32, i32* %4, align 4
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %3, i32 0, i32 0
+  %2 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %0, i32 0, i32 0
+  %3 = load i32, ptr %2, align 4
+  %4 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %1, i32 0, i32 0
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store i32 %5, i32* %6, align 4
+  store i32 %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
@@ -535,114 +534,108 @@ ifcont:                                           ; preds = %else, %then
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings(i8** %0) {
+define linkonce_odr void @_allocate_struct_modules_36_fpm_main_01_fpm_build_settings(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_build_settings.3_class*
-  %5 = bitcast %modules_36_fpm_main_01.fpm_build_settings.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_build_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3_class, %modules_36_fpm_main_01.fpm_build_settings.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_build_settings.3*
-  store %modules_36_fpm_main_01.fpm_build_settings.3* %9, %modules_36_fpm_main_01.fpm_build_settings.3** %6, align 8
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %9, i32 0, i32 0
-  store i32 0, i32* %10, align 4
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_VTable_fpm_build_settings, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %6, i32 0, i32 0
+  store i32 0, ptr %7, align 4
   ret void
 }
 
-define internal void @finalize_StructType__fpm_build_settings_3_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__fpm_build_settings_3_of_modules_36_fpm_main_01_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_build_settings.3*
   ret void
 }
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_run_settings(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_modules_36_fpm_main_01_fpm_run_settings(ptr %0, ptr %1) {
 entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
-  %3 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings.4*
-  %4 = bitcast i8* %1 to %modules_36_fpm_main_01.fpm_run_settings.4*
-  %5 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 1
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 1
+  %2 = call ptr @_lfortran_get_default_allocator()
+  %3 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 1
+  %4 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %1, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  %7 = getelementptr %string_descriptor, %string_descriptor* %6, i32 0, i32 0
-  %8 = getelementptr %string_descriptor, %string_descriptor* %6, i32 0, i32 1
-  %9 = getelementptr %string_descriptor, %string_descriptor* %5, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  store i64 5, i64* %8, align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %7, i64* %8, i8 1, i8 0, i8* %10, i64 5, i32 1)
+  %5 = getelementptr %string_descriptor, ptr %4, i32 0, i32 0
+  %6 = getelementptr %string_descriptor, ptr %4, i32 0, i32 1
+  %7 = getelementptr %string_descriptor, ptr %3, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  store i64 5, ptr %6, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %5, ptr %6, i8 1, i8 0, ptr %8, i64 5, i32 1)
   br label %ifcont
 
 else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 2
-  %12 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 2
+  %9 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 2
+  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %1, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  %13 = getelementptr %string_descriptor, %string_descriptor* %12, i32 0, i32 0
-  %14 = getelementptr %string_descriptor, %string_descriptor* %12, i32 0, i32 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %11, i32 0, i32 0
-  %16 = load i8*, i8** %15, align 8
-  store i64 4, i64* %14, align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %13, i64* %14, i8 1, i8 0, i8* %16, i64 4, i32 1)
+  %11 = getelementptr %string_descriptor, ptr %10, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, ptr %10, i32 0, i32 1
+  %13 = getelementptr %string_descriptor, ptr %9, i32 0, i32 0
+  %14 = load ptr, ptr %13, align 8
+  store i64 4, ptr %12, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %11, ptr %12, i8 1, i8 0, ptr %14, i64 4, i32 1)
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %17 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 3
-  %18 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 3
+  %15 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 3
+  %16 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %1, i32 0, i32 3
   br i1 true, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  %19 = getelementptr %string_descriptor, %string_descriptor* %18, i32 0, i32 0
-  %20 = getelementptr %string_descriptor, %string_descriptor* %18, i32 0, i32 1
-  %21 = getelementptr %string_descriptor, %string_descriptor* %17, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  store i64 6, i64* %20, align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %19, i64* %20, i8 1, i8 0, i8* %22, i64 6, i32 1)
+  %17 = getelementptr %string_descriptor, ptr %16, i32 0, i32 0
+  %18 = getelementptr %string_descriptor, ptr %16, i32 0, i32 1
+  %19 = getelementptr %string_descriptor, ptr %15, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  store i64 6, ptr %18, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %17, ptr %18, i8 1, i8 0, ptr %20, i64 6, i32 1)
   br label %ifcont6
 
 else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %23 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 4
-  %24 = load i32, i32* %23, align 4
-  %25 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 4
+  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 4
+  %22 = load i32, ptr %21, align 4
+  %23 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %1, i32 0, i32 4
   br i1 true, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  store i32 %24, i32* %25, align 4
+  store i32 %22, ptr %23, align 4
   br label %ifcont9
 
 else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %3, i32 0, i32 0
-  %27 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %4, i32 0, i32 0
-  %28 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %26, i32 0, i32 0
-  %29 = load i32, i32* %28, align 4
-  %30 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %27, i32 0, i32 0
+  %24 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 0
+  %25 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %1, i32 0, i32 0
+  %26 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %24, i32 0, i32 0
+  %27 = load i32, ptr %26, align 4
+  %28 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %25, i32 0, i32 0
   br i1 true, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  store i32 %29, i32* %30, align 4
+  store i32 %27, ptr %28, align 4
   br label %ifcont12
 
 else11:                                           ; preds = %ifcont9
@@ -652,71 +645,67 @@ ifcont12:                                         ; preds = %else11, %then10
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings(i8** %0) {
+define linkonce_odr void @_allocate_struct_modules_36_fpm_main_01_fpm_run_settings(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %modules_36_fpm_main_01.fpm_run_settings.4_class*
-  %5 = bitcast %modules_36_fpm_main_01.fpm_run_settings.4_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_fpm_run_settings, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, %modules_36_fpm_main_01.fpm_run_settings.4_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 56)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 56, i1 false)
-  %9 = bitcast i8* %8 to %modules_36_fpm_main_01.fpm_run_settings.4*
-  store %modules_36_fpm_main_01.fpm_run_settings.4* %9, %modules_36_fpm_main_01.fpm_run_settings.4** %6, align 8
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 2
-  store %string_descriptor zeroinitializer, %string_descriptor* %10, align 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 1
-  store i64 4, i64* %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 0
-  %13 = call i8* @_lfortran_get_default_allocator()
-  %14 = call i8* @_lfortran_malloc_alloc(i8* %13, i64 4)
-  store i8* %14, i8** %12, align 8
-  %15 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 4
-  %16 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %16, align 1
-  %17 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 1
-  store i64 5, i64* %17, align 8
-  %18 = call i8* @_lfortran_get_default_allocator()
-  %19 = call i8* @_lfortran_malloc_alloc(i8* %18, i64 10)
-  %20 = getelementptr %string_descriptor, %string_descriptor* %16, i32 0, i32 0
-  store i8* %19, i8** %20, align 8
-  %21 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 3
-  store %string_descriptor zeroinitializer, %string_descriptor* %21, align 1
-  %22 = getelementptr %string_descriptor, %string_descriptor* %21, i32 0, i32 1
-  store i64 6, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %21, i32 0, i32 0
-  %24 = call i8* @_lfortran_get_default_allocator()
-  %25 = call i8* @_lfortran_malloc_alloc(i8* %24, i64 6)
-  store i8* %25, i8** %23, align 8
-  %26 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %9, i32 0, i32 0
-  %27 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, %modules_36_fpm_main_01.fpm_build_settings.3* %26, i32 0, i32 0
-  store i32 0, i32* %27, align 4
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_VTable_fpm_run_settings, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 56)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 56, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %6, i32 0, i32 2
+  store %string_descriptor zeroinitializer, ptr %7, align 1
+  %8 = getelementptr %string_descriptor, ptr %7, i32 0, i32 1
+  store i64 4, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %7, i32 0, i32 0
+  %10 = call ptr @_lfortran_get_default_allocator()
+  %11 = call ptr @_lfortran_malloc_alloc(ptr %10, i64 4)
+  store ptr %11, ptr %9, align 8
+  %12 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %6, i32 0, i32 4
+  %13 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %6, i32 0, i32 1
+  store %string_descriptor zeroinitializer, ptr %13, align 1
+  %14 = getelementptr %string_descriptor, ptr %13, i32 0, i32 1
+  store i64 5, ptr %14, align 8
+  %15 = call ptr @_lfortran_get_default_allocator()
+  %16 = call ptr @_lfortran_malloc_alloc(ptr %15, i64 10)
+  %17 = getelementptr %string_descriptor, ptr %13, i32 0, i32 0
+  store ptr %16, ptr %17, align 8
+  %18 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %6, i32 0, i32 3
+  store %string_descriptor zeroinitializer, ptr %18, align 1
+  %19 = getelementptr %string_descriptor, ptr %18, i32 0, i32 1
+  store i64 6, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %18, i32 0, i32 0
+  %21 = call ptr @_lfortran_get_default_allocator()
+  %22 = call ptr @_lfortran_malloc_alloc(ptr %21, i64 6)
+  store ptr %22, ptr %20, align 8
+  %23 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %6, i32 0, i32 0
+  %24 = getelementptr %modules_36_fpm_main_01.fpm_build_settings.3, ptr %23, i32 0, i32 0
+  store i32 0, ptr %24, align 4
   ret void
 }
 
-define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %modules_36_fpm_main_01.fpm_run_settings.4*
-  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %1)
+  call void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(ptr %0)
   ret void
 }
 
-define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(%modules_36_fpm_main_01.fpm_run_settings.4* %0) {
+define internal void @finalize_StructType__fpm_run_settings_4_of_modules_36_fpm_main_01(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
+  %1 = call ptr @_lfortran_get_default_allocator()
   br label %"Finalize_struct_fpm_run_settings's_name_member"
 
 "Finalize_struct_fpm_run_settings's_name_member": ; preds = %entry
-  %2 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %2, i32 0, i32 0
-  %4 = load i8*, i8** %3, align 8
-  call void @_lfortran_free_alloc(i8* %1, i8* %4)
-  %5 = ptrtoint %string_descriptor* %2 to i64
+  %2 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 1
+  %3 = getelementptr %string_descriptor, ptr %2, i32 0, i32 0
+  %4 = load ptr, ptr %3, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %4)
+  %5 = ptrtoint ptr %2 to i64
   %6 = icmp ne i64 %5, 0
   br i1 %6, label %then, label %else
 
@@ -730,24 +719,24 @@ ifcont:                                           ; preds = %else, %then
   br label %"Finalize_struct_fpm_run_settings's_args_member"
 
 "Finalize_struct_fpm_run_settings's_args_member": ; preds = %ifcont
-  %7 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 2
-  %8 = getelementptr %string_descriptor, %string_descriptor* %7, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  call void @_lfortran_free_alloc(i8* %1, i8* %9)
+  %7 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 2
+  %8 = getelementptr %string_descriptor, ptr %7, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %9)
   br label %"Finalize_struct_fpm_run_settings's_runner_member"
 
 "Finalize_struct_fpm_run_settings's_runner_member": ; preds = %"Finalize_struct_fpm_run_settings's_args_member"
-  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, %modules_36_fpm_main_01.fpm_run_settings.4* %0, i32 0, i32 3
-  %11 = getelementptr %string_descriptor, %string_descriptor* %10, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  call void @_lfortran_free_alloc(i8* %1, i8* %12)
+  %10 = getelementptr %modules_36_fpm_main_01.fpm_run_settings.4, ptr %0, i32 0, i32 3
+  %11 = getelementptr %string_descriptor, ptr %10, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %12)
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "e861d6924e569c02e76513df234cf56daa5ab7da4f44f216c8ba57c1",
+    "stdout_hash": "2860d285c36f15372113da08198011d89dda764c62e238c0222f3986",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -1,61 +1,62 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"d()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [3 x i8] c"b()"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.1, i32 0, i32 0), i64 3 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 3 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define i32 @__module_nested_01_a_b() {
 .entry:
   %b = alloca i32, align 4
   %e = alloca i32, align 4
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %0 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %0, i32 3, ptr @2, i32 1)
   %1 = call i32 @b.__module_nested_01_a_d()
-  store i32 %1, i32* %e, align 4
-  store i32 0, i32* %b, align 4
+  store i32 %1, ptr %e, align 4
+  store i32 0, ptr %b, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_b
 
 FINALIZE_SYMTABLE_b:                              ; preds = %return
-  %2 = load i32, i32* %b, align 4
+  %2 = load i32, ptr %b, align 4
   ret i32 %2
 }
 
 define i32 @b.__module_nested_01_a_d() {
 .entry:
   %d = alloca i32, align 4
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  store i32 1, i32* %d, align 4
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %0, i32 3, ptr @0, i32 1)
+  store i32 1, ptr %d, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_d
 
 FINALIZE_SYMTABLE_d:                              ; preds = %return
-  %1 = load i32, i32* %d, align 4
+  %1 = load i32, ptr %d, align 4
   ret i32 %1
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %c = alloca i32, align 4
   %2 = call i32 @__module_nested_01_a_b()
-  store i32 %2, i32* %c, align 4
+  store i32 %2, ptr %c, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -66,6 +67,6 @@ FINALIZE_SYMTABLE_nested_01:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "8ed77d065ae8eff53ca5498af477f8ebe41609362434d7ce1e668639",
+    "stdout_hash": "348da55acd263b8aded7fe3c3f7e7074a97a1a275f6ea68a37f9596d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -1,21 +1,22 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @__module_nested_02_a_b() {
 .entry:
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @3, ptr %0, i32 3, ptr @2, i32 1)
   call void @b.__module_nested_02_a_c()
   br label %return
 
@@ -29,27 +30,27 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
 define void @b.__module_nested_02_a_c() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
   %2 = alloca i32, align 4
-  store i32 5, i32* %2, align 4
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %2)
-  %4 = load i64, i64* %1, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  store i32 5, ptr %2, align 4
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %2)
+  %4 = load i64, ptr %1, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -62,17 +63,17 @@ FINALIZE_SYMTABLE_c:                              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @__module_nested_02_a_b()
   br label %return
 
@@ -84,6 +85,6 @@ FINALIZE_SYMTABLE_nested_02:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "eca11ccd1c7f628d09fcda6fbc8ae87c1e36098840cc7b78f277d448",
+    "stdout_hash": "1a14507ce37c6d042621718259ce4a9b7e10d09483736468fae4cf77",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__b__x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -13,20 +14,20 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @__module_nested_03_a_b() {
 .entry:
   %x = alloca float, align 4
-  store float 6.000000e+00, float* %x, align 4
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %1 = load float, float* %x, align 4
-  store float %1, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  store float 6.000000e+00, ptr %x, align 4
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @5, ptr %0, i32 3, ptr @4, i32 1)
+  %1 = load float, ptr %x, align 4
+  store float %1, ptr @__module___lcompilers_created__nested_context__b__x, align 4
   call void @b.__module_nested_03_a_c()
-  %2 = load float, float* @__module___lcompilers_created__nested_context__b__x, align 4
-  store float %2, float* %x, align 4
+  %2 = load float, ptr @__module___lcompilers_created__nested_context__b__x, align 4
+  store float %2, ptr %x, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -40,48 +41,48 @@ define void @b.__module_nested_03_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
   %2 = alloca i32, align 4
-  store i32 5, i32* %2, align 4
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %2)
-  %4 = load i64, i64* %1, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  store i32 5, ptr %2, align 4
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %2)
+  %4 = load i64, ptr %1, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
-  %15 = load i64, i64* %13, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %15, i64* %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %21 = load i64, i64* %20, align 8
+  %14 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %13, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__x)
+  %15 = load i64, ptr %13, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %19 = load ptr, ptr %18, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %21 = load i64, ptr %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
+  call void @_lfortran_printf(ptr @3, ptr %19, i32 %22, ptr @2, i32 1)
+  %23 = icmp eq ptr %14, null
   br i1 %23, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %14)
+  call void @_lfortran_free_alloc(ptr %0, ptr %14)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -94,17 +95,17 @@ FINALIZE_SYMTABLE_c:                              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @__module_nested_03_a_b()
   br label %return
 
@@ -116,6 +117,6 @@ FINALIZE_SYMTABLE_nested_03:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "0d472c8777be37de9b86abc5deef93dffbd3fd26864ba241474eafca",
+    "stdout_hash": "e888c9ee0136656ae267aca0546392fc7e7cfec09ac52aa9c4530bee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__b__y = global i32 0
 @__module___lcompilers_created__nested_context__b__yy = global float 0.000000e+00
@@ -17,139 +18,139 @@ target datalayout = "..."
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_nested_04_a_b(i32* %x) {
+define i32 @__module_nested_04_a_b(ptr %x) {
 .entry:
   %call_arg_value = alloca i32, align 4
   %b = alloca i32, align 4
   %y = alloca i32, align 4
   %yy = alloca float, align 4
-  store float 0x401A666660000000, float* %yy, align 4
-  %0 = load i32, i32* %x, align 4
-  store i32 %0, i32* %y, align 4
-  %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %2 = load i32, i32* %y, align 4
-  store i32 %2, i32* @__module___lcompilers_created__nested_context__b__y, align 4
-  %3 = load float, float* %yy, align 4
-  store float %3, float* @__module___lcompilers_created__nested_context__b__yy, align 4
-  store i32 6, i32* %call_arg_value, align 4
-  %4 = call i32 @b.__module_nested_04_a_c(i32* %call_arg_value)
-  store i32 %4, i32* %b, align 4
-  %5 = load i32, i32* @__module___lcompilers_created__nested_context__b__y, align 4
-  store i32 %5, i32* %y, align 4
-  %6 = load float, float* @__module___lcompilers_created__nested_context__b__yy, align 4
-  store float %6, float* %yy, align 4
+  store float 0x401A666660000000, ptr %yy, align 4
+  %0 = load i32, ptr %x, align 4
+  store i32 %0, ptr %y, align 4
+  %1 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @7, ptr %1, i32 3, ptr @6, i32 1)
+  %2 = load i32, ptr %y, align 4
+  store i32 %2, ptr @__module___lcompilers_created__nested_context__b__y, align 4
+  %3 = load float, ptr %yy, align 4
+  store float %3, ptr @__module___lcompilers_created__nested_context__b__yy, align 4
+  store i32 6, ptr %call_arg_value, align 4
+  %4 = call i32 @b.__module_nested_04_a_c(ptr %call_arg_value)
+  store i32 %4, ptr %b, align 4
+  %5 = load i32, ptr @__module___lcompilers_created__nested_context__b__y, align 4
+  store i32 %5, ptr %y, align 4
+  %6 = load float, ptr @__module___lcompilers_created__nested_context__b__yy, align 4
+  store float %6, ptr %yy, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_b
 
 FINALIZE_SYMTABLE_b:                              ; preds = %return
-  %7 = load i32, i32* %b, align 4
+  %7 = load i32, ptr %b, align 4
   ret i32 %7
 }
 
-define i32 @b.__module_nested_04_a_c(i32* %z) {
+define i32 @b.__module_nested_04_a_c(ptr %z) {
 .entry:
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %c = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %z)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %z)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__y)
-  %14 = load i64, i64* %12, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %14, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
+  %13 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %12, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__y)
+  %14 = load i64, ptr %12, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %18 = load ptr, ptr %17, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, ptr %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
+  call void @_lfortran_printf(ptr @3, ptr %18, i32 %21, ptr @2, i32 1)
+  %22 = icmp eq ptr %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %13)
+  call void @_lfortran_free_alloc(ptr %0, ptr %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %23 = alloca i64, align 8
-  %24 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %23, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__yy)
-  %25 = load i64, i64* %23, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %24, i8** %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %25, i64* %27, align 8
-  %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %29 = load i8*, i8** %28, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %31 = load i64, i64* %30, align 8
+  %24 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.2, ptr %23, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__yy)
+  %25 = load i64, ptr %23, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %24, ptr %26, align 8
+  %27 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %25, ptr %27, align 8
+  %28 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %29 = load ptr, ptr %28, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %31 = load i64, ptr %30, align 8
   %32 = trunc i64 %31 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %33 = icmp eq i8* %24, null
+  call void @_lfortran_printf(ptr @5, ptr %29, i32 %32, ptr @4, i32 1)
+  %33 = icmp eq ptr %24, null
   br i1 %33, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %0, i8* %24)
+  call void @_lfortran_free_alloc(ptr %0, ptr %24)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %34 = load i32, i32* %z, align 4
-  store i32 %34, i32* %c, align 4
+  %34 = load i32, ptr %z, align 4
+  store i32 %34, ptr %c, align 4
   br label %return
 
 return:                                           ; preds = %free_done6
   br label %FINALIZE_SYMTABLE_c
 
 FINALIZE_SYMTABLE_c:                              ; preds = %return
-  %35 = load i32, i32* %c, align 4
+  %35 = load i32, ptr %c, align 4
   ret i32 %35
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %test = alloca i32, align 4
-  store i32 5, i32* %call_arg_value, align 4
-  %2 = call i32 @__module_nested_04_a_b(i32* %call_arg_value)
-  store i32 %2, i32* %test, align 4
+  store i32 5, ptr %call_arg_value, align 4
+  %2 = call i32 @__module_nested_04_a_b(ptr %call_arg_value)
+  store i32 %2, ptr %test, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -160,6 +161,6 @@ FINALIZE_SYMTABLE_nested_04:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "214fddad051e18f16d0549cf236b7bb194c302a4e64796824bc806d1",
+    "stdout_hash": "446f7b439025f1c1016828a5e155d083129480ca40cf869dca912459",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__b__x = global i32 0
 @__module___lcompilers_created__nested_context__b__y = global float 0.000000e+00
@@ -31,101 +32,101 @@ define void @__module_nested_05_a_b() {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %x = alloca i32, align 4
   %y = alloca float, align 4
-  store i32 6, i32* %x, align 4
-  store float 5.500000e+00, float* %y, align 4
+  store i32 6, ptr %x, align 4
+  store float 5.500000e+00, ptr %y, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %x)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.2, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @5, ptr %7, i32 %10, ptr @4, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* %y)
-  %14 = load i64, i64* %12, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %14, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
+  %13 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.3, ptr %12, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %y)
+  %14 = load i64, ptr %12, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %18 = load ptr, ptr %17, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, ptr %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
+  call void @_lfortran_printf(ptr @7, ptr %18, i32 %21, ptr @6, i32 1)
+  %22 = icmp eq ptr %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %13)
+  call void @_lfortran_free_alloc(ptr %0, ptr %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %23 = load i32, i32* %x, align 4
-  store i32 %23, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  %24 = load float, float* %y, align 4
-  store float %24, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  %23 = load i32, ptr %x, align 4
+  store i32 %23, ptr @__module___lcompilers_created__nested_context__b__x, align 4
+  %24 = load float, ptr %y, align 4
+  store float %24, ptr @__module___lcompilers_created__nested_context__b__y, align 4
   call void @b.__module_nested_05_a_c()
-  %25 = load i32, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  store i32 %25, i32* %x, align 4
-  %26 = load float, float* @__module___lcompilers_created__nested_context__b__y, align 4
-  store float %26, float* %y, align 4
+  %25 = load i32, ptr @__module___lcompilers_created__nested_context__b__x, align 4
+  store i32 %25, ptr %x, align 4
+  %26 = load float, ptr @__module___lcompilers_created__nested_context__b__y, align 4
+  store float %26, ptr %y, align 4
   %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.4, i32 0, i32 0), i64* %27, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %x)
-  %29 = load i64, i64* %27, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %29, i64* %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %35 = load i64, i64* %34, align 8
+  %28 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.4, ptr %27, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %29 = load i64, ptr %27, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %28, ptr %30, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %33 = load ptr, ptr %32, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %35 = load i64, ptr %34, align 8
   %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %37 = icmp eq i8* %28, null
+  call void @_lfortran_printf(ptr @9, ptr %33, i32 %36, ptr @8, i32 1)
+  %37 = icmp eq ptr %28, null
   br i1 %37, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %0, i8* %28)
+  call void @_lfortran_free_alloc(ptr %0, ptr %28)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   %38 = alloca i64, align 8
-  %39 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.5, i32 0, i32 0), i64* %38, i32 0, i32 0, i32 0, i32 0, i32 0, float* %y)
-  %40 = load i64, i64* %38, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %39, i8** %41, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %40, i64* %42, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %44 = load i8*, i8** %43, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %46 = load i64, i64* %45, align 8
+  %39 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.5, ptr %38, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %y)
+  %40 = load i64, ptr %38, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %39, ptr %41, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %40, ptr %42, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %44 = load ptr, ptr %43, align 8
+  %45 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %46 = load i64, ptr %45, align 8
   %47 = trunc i64 %46 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %44, i32 %47, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %48 = icmp eq i8* %39, null
+  call void @_lfortran_printf(ptr @11, ptr %44, i32 %47, ptr @10, i32 1)
+  %48 = icmp eq ptr %39, null
   br i1 %48, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %0, i8* %39)
+  call void @_lfortran_free_alloc(ptr %0, ptr %39)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
@@ -142,51 +143,51 @@ define void @b.__module_nested_05_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__b__x)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__x)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %12 = alloca i64, align 8
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %12, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__y)
-  %14 = load i64, i64* %12, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %14, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
+  %13 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %12, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__y)
+  %14 = load i64, ptr %12, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %18 = load ptr, ptr %17, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %20 = load i64, ptr %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
+  call void @_lfortran_printf(ptr @3, ptr %18, i32 %21, ptr @2, i32 1)
+  %22 = icmp eq ptr %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %13)
+  call void @_lfortran_free_alloc(ptr %0, ptr %13)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  store i32 4, i32* @__module___lcompilers_created__nested_context__b__x, align 4
-  store float 3.500000e+00, float* @__module___lcompilers_created__nested_context__b__y, align 4
+  store i32 4, ptr @__module___lcompilers_created__nested_context__b__x, align 4
+  store float 3.500000e+00, ptr @__module___lcompilers_created__nested_context__b__y, align 4
   br label %return
 
 return:                                           ; preds = %free_done3
@@ -196,17 +197,17 @@ FINALIZE_SYMTABLE_c:                              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @__module_nested_05_a_b()
   br label %return
 
@@ -218,6 +219,6 @@ FINALIZE_SYMTABLE_nested_05:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "c4afe3527c18e0af0c9f276cc0fe8a9d477864773ec222c8217fd6f6",
+    "stdout_hash": "6571326a73d3a13880532e2f1548e498ee2ba749cdddb19ecfba50da",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__b__x = global float 0.000000e+00
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -13,18 +14,18 @@ target datalayout = "..."
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [3 x i8] c"b()"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data, i32 0, i32 0), i64 3 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 3 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_nested_06_a_b(float* %x) {
+define void @__module_nested_06_a_b(ptr %x) {
 .entry:
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %1 = load float, float* %x, align 4
-  store float %1, float* @__module___lcompilers_created__nested_context__b__x, align 4
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @5, ptr %0, i32 3, ptr @4, i32 1)
+  %1 = load float, ptr %x, align 4
+  store float %1, ptr @__module___lcompilers_created__nested_context__b__x, align 4
   call void @b.__module_nested_06_a_c()
-  %2 = load float, float* @__module___lcompilers_created__nested_context__b__x, align 4
-  store float %2, float* %x, align 4
+  %2 = load float, ptr @__module___lcompilers_created__nested_context__b__x, align 4
+  store float %2, ptr %x, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -38,48 +39,48 @@ define void @b.__module_nested_06_a_c() {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
   %2 = alloca i32, align 4
-  store i32 5, i32* %2, align 4
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %2)
-  %4 = load i64, i64* %1, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  store i32 5, ptr %2, align 4
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %2)
+  %4 = load i64, ptr %1, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %13 = alloca i64, align 8
-  %14 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %13, i32 0, i32 0, i32 0, i32 0, i32 0, float* @__module___lcompilers_created__nested_context__b__x)
-  %15 = load i64, i64* %13, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %14, i8** %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %15, i64* %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %19 = load i8*, i8** %18, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %21 = load i64, i64* %20, align 8
+  %14 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %13, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__b__x)
+  %15 = load i64, ptr %13, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %19 = load ptr, ptr %18, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %21 = load i64, ptr %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %23 = icmp eq i8* %14, null
+  call void @_lfortran_printf(ptr @3, ptr %19, i32 %22, ptr @2, i32 1)
+  %23 = icmp eq ptr %14, null
   br i1 %23, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %14)
+  call void @_lfortran_free_alloc(ptr %0, ptr %14)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -92,20 +93,20 @@ FINALIZE_SYMTABLE_c:                              ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value = alloca float, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store float 6.000000e+00, float* %call_arg_value, align 4
-  call void @__module_nested_06_a_b(float* %call_arg_value)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store float 6.000000e+00, ptr %call_arg_value, align 4
+  call void @__module_nested_06_a_b(ptr %call_arg_value)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -116,6 +117,6 @@ FINALIZE_SYMTABLE_nested_06:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nullify_01-810c9d3.json
+++ b/tests/reference/llvm-nullify_01-810c9d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_01-810c9d3.stdout",
-    "stdout_hash": "41f61980362bc0970b2722586c3f9455bb780f49c030cbaad70c177a",
+    "stdout_hash": "976719999de609fe63e8c10b5008b1ab5a3eef680f3cd853037bfe47",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_01-810c9d3.stdout
+++ b/tests/reference/llvm-nullify_01-810c9d3.stdout
@@ -1,21 +1,22 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %p1 = alloca i32*, align 8
-  store i32* null, i32** %p1, align 8
-  %p2 = alloca i32*, align 8
-  store i32* null, i32** %p2, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %p1 = alloca ptr, align 8
+  store ptr null, ptr %p1, align 8
+  %p2 = alloca ptr, align 8
+  store ptr null, ptr %p2, align 8
   %t1 = alloca i32, align 4
-  store i32* %t1, i32** %p1, align 8
-  store i32* %t1, i32** %p2, align 8
-  %2 = load i32*, i32** %p1, align 8
-  store i32 1, i32* %2, align 4
-  store i32* null, i32** %p1, align 8
-  store i32* null, i32** %p2, align 8
+  store ptr %t1, ptr %p1, align 8
+  store ptr %t1, ptr %p2, align 8
+  %2 = load ptr, ptr %p1, align 8
+  store i32 1, ptr %2, align 4
+  store ptr null, ptr %p1, align 8
+  store ptr null, ptr %p2, align 8
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,6 +27,6 @@ FINALIZE_SYMTABLE_nullify_01:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-nullify_02-3c7ee61.json
+++ b/tests/reference/llvm-nullify_02-3c7ee61.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nullify_02-3c7ee61.stdout",
-    "stdout_hash": "959785ce821d576c3d9dca04193993ccbd089dfc97b1a907d770b500",
+    "stdout_hash": "7e4a46730482bdcf6780742b8f666f8d75ae4d1fcb175229e3655e8b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nullify_02-3c7ee61.stdout
+++ b/tests/reference/llvm-nullify_02-3c7ee61.stdout
@@ -1,24 +1,25 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %p1 = alloca float*, align 8
-  store float* null, float** %p1, align 8
-  %p2 = alloca i32*, align 8
-  store i32* null, i32** %p2, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %p1 = alloca ptr, align 8
+  store ptr null, ptr %p1, align 8
+  %p2 = alloca ptr, align 8
+  store ptr null, ptr %p2, align 8
   %t1 = alloca float, align 4
   %t2 = alloca i32, align 4
-  store float* %t1, float** %p1, align 8
-  %2 = load float*, float** %p1, align 8
-  store float 1.000000e+00, float* %2, align 4
-  store i32* %t2, i32** %p2, align 8
-  %3 = load i32*, i32** %p2, align 8
-  store i32 2, i32* %3, align 4
-  store float* null, float** %p1, align 8
-  store i32* null, i32** %p2, align 8
+  store ptr %t1, ptr %p1, align 8
+  %2 = load ptr, ptr %p1, align 8
+  store float 1.000000e+00, ptr %2, align 4
+  store ptr %t2, ptr %p2, align 8
+  %3 = load ptr, ptr %p2, align 8
+  store i32 2, ptr %3, align 4
+  store ptr null, ptr %p1, align 8
+  store ptr null, ptr %p2, align 8
   br label %return
 
 return:                                           ; preds = %.entry
@@ -29,6 +30,6 @@ FINALIZE_SYMTABLE_nullify_02:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "ff3c78f3c1639b0a0d775c2ea732d6b53a99a8884a166c75e264c7e4",
+    "stdout_hash": "64870f4ee3e2f3f9a7c370b0ff82eb6c29a427dae974f45e030d644b",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -1,78 +1,79 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data = private constant [4 x i8] c"T*T:"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"T*F:"
-@string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
+@string_const.3 = private global %string_descriptor <{ ptr @string_const_data.2, i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.4 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.5 = private constant [4 x i8] c"F*T:"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 4 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.7 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.8 = private constant [4 x i8] c"F*F:"
-@string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.8, i32 0, i32 0), i64 4 }>
+@string_const.9 = private global %string_descriptor <{ ptr @string_const_data.8, i64 4 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.10 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data.11 = private constant [4 x i8] c"T+T:"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.11, i32 0, i32 0), i64 4 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 4 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.13 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data.14 = private constant [4 x i8] c"T+F:"
-@string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.14, i32 0, i32 0), i64 4 }>
+@string_const.15 = private global %string_descriptor <{ ptr @string_const_data.14, i64 4 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.16 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data.17 = private constant [4 x i8] c"F+T:"
-@string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.17, i32 0, i32 0), i64 4 }>
+@string_const.18 = private global %string_descriptor <{ ptr @string_const_data.17, i64 4 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.19 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data.20 = private constant [4 x i8] c"F+F:"
-@string_const.21 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.20, i32 0, i32 0), i64 4 }>
+@string_const.21 = private global %string_descriptor <{ ptr @string_const_data.20, i64 4 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %log1, i32* %log2) {
+define i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(ptr %log1, ptr %log2) {
 .entry:
   %bin_add = alloca i32, align 4
-  %0 = load i32, i32* %log1, align 4
-  %1 = load i32, i32* %log2, align 4
+  %0 = load i32, ptr %log1, align 4
+  %1 = load i32, ptr %log2, align 4
   %2 = and i32 %0, %1
   %3 = icmp ne i32 %2, 0
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 2, i32* %bin_add, align 4
+  store i32 2, ptr %bin_add, align 4
   br label %ifcont3
 
 else:                                             ; preds = %.entry
-  %4 = load i32, i32* %log1, align 4
+  %4 = load i32, ptr %log1, align 4
   %5 = xor i32 %4, 1
-  %6 = load i32, i32* %log2, align 4
+  %6 = load i32, ptr %log2, align 4
   %7 = xor i32 %6, 1
   %8 = and i32 %5, %7
   %9 = icmp ne i32 %8, 0
   br i1 %9, label %then1, label %else2
 
 then1:                                            ; preds = %else
-  store i32 0, i32* %bin_add, align 4
+  store i32 0, ptr %bin_add, align 4
   br label %ifcont
 
 else2:                                            ; preds = %else
-  store i32 1, i32* %bin_add, align 4
+  store i32 1, ptr %bin_add, align 4
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
@@ -85,28 +86,28 @@ return:                                           ; preds = %ifcont3
   br label %FINALIZE_SYMTABLE_bin_add
 
 FINALIZE_SYMTABLE_bin_add:                        ; preds = %return
-  %10 = load i32, i32* %bin_add, align 4
+  %10 = load i32, ptr %bin_add, align 4
   ret i32 %10
 }
 
-define i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %log1, i32* %log2) {
+define i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(ptr %log1, ptr %log2) {
 .entry:
   %logical_and = alloca i32, align 4
-  %0 = load i32, i32* %log1, align 4
-  %1 = load i32, i32* %log2, align 4
+  %0 = load i32, ptr %log1, align 4
+  %1 = load i32, ptr %log2, align 4
   %2 = and i32 %0, %1
-  store i32 %2, i32* %logical_and, align 4
+  store i32 %2, ptr %logical_and, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_logical_and
 
 FINALIZE_SYMTABLE_logical_and:                    ; preds = %return
-  %3 = load i32, i32* %logical_and, align 4
+  %3 = load i32, ptr %logical_and, align 4
   ret i32 %3
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
@@ -116,201 +117,201 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %f = alloca i32, align 4
-  store i32 0, i32* %f, align 4
+  store i32 0, ptr %f, align 4
   %t = alloca i32, align 4
-  store i32 1, i32* %t, align 4
+  store i32 1, ptr %t, align 4
   %3 = alloca i64, align 8
-  %4 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %t, i32* %t)
+  %4 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(ptr %t, ptr %t)
   %5 = alloca i32, align 4
-  store i32 %4, i32* %5, align 4
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
-  %7 = load i64, i64* %3, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  store i32 %4, ptr %5, align 4
+  %6 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %5)
+  %7 = load i64, ptr %3, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %11 = load ptr, ptr %10, align 8
+  %12 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
+  call void @_lfortran_printf(ptr @1, ptr %11, i32 %14, ptr @0, i32 1)
+  %15 = icmp eq ptr %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %6)
+  call void @_lfortran_free_alloc(ptr %2, ptr %6)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %16 = alloca i64, align 8
-  %17 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %t, i32* %f)
+  %17 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(ptr %t, ptr %f)
   %18 = alloca i32, align 4
-  store i32 %17, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
-  %20 = load i64, i64* %16, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %19, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %20, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %26 = load i64, i64* %25, align 8
+  store i32 %17, ptr %18, align 4
+  %19 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %16, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.3, ptr %18)
+  %20 = load i64, ptr %16, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %20, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %26 = load i64, ptr %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %28 = icmp eq i8* %19, null
+  call void @_lfortran_printf(ptr @3, ptr %24, i32 %27, ptr @2, i32 1)
+  %28 = icmp eq ptr %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %19)
+  call void @_lfortran_free_alloc(ptr %2, ptr %19)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %29 = alloca i64, align 8
-  %30 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %f, i32* %t)
+  %30 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(ptr %f, ptr %t)
   %31 = alloca i32, align 4
-  store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
-  %33 = load i64, i64* %29, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %33, i64* %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %39 = load i64, i64* %38, align 8
+  store i32 %30, ptr %31, align 4
+  %32 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %29, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.6, ptr %31)
+  %33 = load i64, ptr %29, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %32, ptr %34, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %33, ptr %35, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %37 = load ptr, ptr %36, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %39 = load i64, ptr %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
+  call void @_lfortran_printf(ptr @5, ptr %37, i32 %40, ptr @4, i32 1)
+  %41 = icmp eq ptr %32, null
   br i1 %41, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %32)
+  call void @_lfortran_free_alloc(ptr %2, ptr %32)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   %42 = alloca i64, align 8
-  %43 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %f, i32* %f)
+  %43 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(ptr %f, ptr %f)
   %44 = alloca i32, align 4
-  store i32 %43, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
-  %46 = load i64, i64* %42, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %45, i8** %47, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %46, i64* %48, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %50 = load i8*, i8** %49, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %52 = load i64, i64* %51, align 8
+  store i32 %43, ptr %44, align 4
+  %45 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.7, ptr %42, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.9, ptr %44)
+  %46 = load i64, ptr %42, align 8
+  %47 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %45, ptr %47, align 8
+  %48 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %46, ptr %48, align 8
+  %49 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %50 = load ptr, ptr %49, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %52 = load i64, ptr %51, align 8
   %53 = trunc i64 %52 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %54 = icmp eq i8* %45, null
+  call void @_lfortran_printf(ptr @7, ptr %50, i32 %53, ptr @6, i32 1)
+  %54 = icmp eq ptr %45, null
   br i1 %54, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %45)
+  call void @_lfortran_free_alloc(ptr %2, ptr %45)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
   %55 = alloca i64, align 8
-  %56 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %t, i32* %t)
+  %56 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(ptr %t, ptr %t)
   %57 = alloca i32, align 4
-  store i32 %56, i32* %57, align 4
-  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
-  %59 = load i64, i64* %55, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %58, i8** %60, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %59, i64* %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %63 = load i8*, i8** %62, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %65 = load i64, i64* %64, align 8
+  store i32 %56, ptr %57, align 4
+  %58 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.10, ptr %55, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.12, ptr %57)
+  %59 = load i64, ptr %55, align 8
+  %60 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %58, ptr %60, align 8
+  %61 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %59, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %63 = load ptr, ptr %62, align 8
+  %64 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %65 = load i64, ptr %64, align 8
   %66 = trunc i64 %65 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %67 = icmp eq i8* %58, null
+  call void @_lfortran_printf(ptr @9, ptr %63, i32 %66, ptr @8, i32 1)
+  %67 = icmp eq ptr %58, null
   br i1 %67, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free_alloc(i8* %2, i8* %58)
+  call void @_lfortran_free_alloc(ptr %2, ptr %58)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
   %68 = alloca i64, align 8
-  %69 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %t, i32* %f)
+  %69 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(ptr %t, ptr %f)
   %70 = alloca i32, align 4
-  store i32 %69, i32* %70, align 4
-  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
-  %72 = load i64, i64* %68, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %71, i8** %73, align 8
-  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %72, i64* %74, align 8
-  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %76 = load i8*, i8** %75, align 8
-  %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %78 = load i64, i64* %77, align 8
+  store i32 %69, ptr %70, align 4
+  %71 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.13, ptr %68, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.15, ptr %70)
+  %72 = load i64, ptr %68, align 8
+  %73 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %71, ptr %73, align 8
+  %74 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %72, ptr %74, align 8
+  %75 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %76 = load ptr, ptr %75, align 8
+  %77 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %78 = load i64, ptr %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %80 = icmp eq i8* %71, null
+  call void @_lfortran_printf(ptr @11, ptr %76, i32 %79, ptr @10, i32 1)
+  %80 = icmp eq ptr %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free_alloc(i8* %2, i8* %71)
+  call void @_lfortran_free_alloc(ptr %2, ptr %71)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
   %81 = alloca i64, align 8
-  %82 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %f, i32* %t)
+  %82 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(ptr %f, ptr %t)
   %83 = alloca i32, align 4
-  store i32 %82, i32* %83, align 4
-  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
-  %85 = load i64, i64* %81, align 8
-  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %84, i8** %86, align 8
-  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %85, i64* %87, align 8
-  %88 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %89 = load i8*, i8** %88, align 8
-  %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %91 = load i64, i64* %90, align 8
+  store i32 %82, ptr %83, align 4
+  %84 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.16, ptr %81, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.18, ptr %83)
+  %85 = load i64, ptr %81, align 8
+  %86 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %84, ptr %86, align 8
+  %87 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %85, ptr %87, align 8
+  %88 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %89 = load ptr, ptr %88, align 8
+  %90 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %91 = load i64, ptr %90, align 8
   %92 = trunc i64 %91 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %93 = icmp eq i8* %84, null
+  call void @_lfortran_printf(ptr @13, ptr %89, i32 %92, ptr @12, i32 1)
+  %93 = icmp eq ptr %84, null
   br i1 %93, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free_alloc(i8* %2, i8* %84)
+  call void @_lfortran_free_alloc(ptr %2, ptr %84)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
   %94 = alloca i64, align 8
-  %95 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %f, i32* %f)
+  %95 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(ptr %f, ptr %f)
   %96 = alloca i32, align 4
-  store i32 %95, i32* %96, align 4
-  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
-  %98 = load i64, i64* %94, align 8
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %97, i8** %99, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %98, i64* %100, align 8
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %102 = load i8*, i8** %101, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %104 = load i64, i64* %103, align 8
+  store i32 %95, ptr %96, align 4
+  %97 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.19, ptr %94, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.21, ptr %96)
+  %98 = load i64, ptr %94, align 8
+  %99 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  store ptr %97, ptr %99, align 8
+  %100 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  store i64 %98, ptr %100, align 8
+  %101 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  %102 = load ptr, ptr %101, align 8
+  %103 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  %104 = load i64, ptr %103, align 8
   %105 = trunc i64 %104 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %106 = icmp eq i8* %97, null
+  call void @_lfortran_printf(ptr @15, ptr %102, i32 %105, ptr @14, i32 1)
+  %106 = icmp eq ptr %97, null
   br i1 %106, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %free_done18
-  call void @_lfortran_free_alloc(i8* %2, i8* %97)
+  call void @_lfortran_free_alloc(ptr %2, ptr %97)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
@@ -324,14 +325,14 @@ FINALIZE_SYMTABLE_operator_overloading_01:        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "0690f1aeaee036054b51aeffa394de8a5e49124bf7985e881da61633",
+    "stdout_hash": "1e4b6b8831cacc0987ced9574b8e59f03acfda07da15f93f531b8640",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -1,26 +1,27 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-5,L32\00", align 1
 @string_const_data = private constant [5 x i8] c"tf=0:"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data, i32 0, i32 0), i64 5 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 5 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-5,L32\00", align 1
 @string_const_data.2 = private constant [5 x i8] c"tf=1:"
-@string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.2, i32 0, i32 0), i64 5 }>
+@string_const.3 = private global %string_descriptor <{ ptr @string_const_data.2, i64 5 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_overload_assignment_m_logical_gets_integer(i32* %tf, i32* %i) {
+define void @__module_overload_assignment_m_logical_gets_integer(ptr %tf, ptr %i) {
 .entry:
-  %0 = load i32, i32* %i, align 4
+  %0 = load i32, ptr %i, align 4
   %1 = icmp eq i32 %0, 0
   %2 = zext i1 %1 to i32
-  store i32 %2, i32* %tf, align 4
+  store i32 %2, ptr %tf, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -30,57 +31,57 @@ FINALIZE_SYMTABLE_logical_gets_integer:           ; preds = %return
   ret void
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %tf = alloca i32, align 4
-  store i32 0, i32* %call_arg_value, align 4
-  call void @__module_overload_assignment_m_logical_gets_integer(i32* %tf, i32* %call_arg_value)
+  store i32 0, ptr %call_arg_value, align 4
+  call void @__module_overload_assignment_m_logical_gets_integer(ptr %tf, ptr %call_arg_value)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %tf)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %tf)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i32 1, i32* %call_arg_value, align 4
-  call void @__module_overload_assignment_m_logical_gets_integer(i32* %tf, i32* %call_arg_value)
+  store i32 1, ptr %call_arg_value, align 4
+  call void @__module_overload_assignment_m_logical_gets_integer(ptr %tf, ptr %call_arg_value)
   %14 = alloca i64, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %tf)
-  %16 = load i64, i64* %14, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %15, i8** %17, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %16, i64* %18, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %15 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %14, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.3, ptr %tf)
+  %16 = load i64, ptr %14, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %15, ptr %17, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %16, ptr %18, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %24 = icmp eq i8* %15, null
+  call void @_lfortran_printf(ptr @3, ptr %20, i32 %23, ptr @2, i32 1)
+  %24 = icmp eq ptr %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  call void @_lfortran_free_alloc(ptr %2, ptr %15)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -94,14 +95,14 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "e49ea24acbbe3c5549c7b610b53425a27592f520ea6950adbcd8db47",
+    "stdout_hash": "104a6ff8aa618bd58312f1fb43d7bb7d6a07c739850022cac275a47d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -1,55 +1,56 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data = private constant [4 x i8] c"T>T:"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"T>F:"
-@string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
+@string_const.3 = private global %string_descriptor <{ ptr @string_const_data.2, i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.4 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.5 = private constant [4 x i8] c"F>T:"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 4 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.7 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.8 = private constant [4 x i8] c"F>F:"
-@string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.8, i32 0, i32 0), i64 4 }>
+@string_const.9 = private global %string_descriptor <{ ptr @string_const_data.8, i64 4 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.10 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.11 = private constant [4 x i8] c"T<T:"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.11, i32 0, i32 0), i64 4 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 4 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.13 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.14 = private constant [4 x i8] c"T<F:"
-@string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.14, i32 0, i32 0), i64 4 }>
+@string_const.15 = private global %string_descriptor <{ ptr @string_const_data.14, i64 4 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.16 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.17 = private constant [4 x i8] c"F<T:"
-@string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.17, i32 0, i32 0), i64 4 }>
+@string_const.18 = private global %string_descriptor <{ ptr @string_const_data.17, i64 4 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.19 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
 @string_const_data.20 = private constant [4 x i8] c"F<F:"
-@string_const.21 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.20, i32 0, i32 0), i64 4 }>
+@string_const.21 = private global %string_descriptor <{ ptr @string_const_data.20, i64 4 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %log1, i32* %log2) {
+define i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(ptr %log1, ptr %log2) {
 .entry:
   %greater_than_inverse = alloca i32, align 4
-  %0 = load i32, i32* %log1, align 4
-  %1 = load i32, i32* %log2, align 4
+  %0 = load i32, ptr %log1, align 4
+  %1 = load i32, ptr %log2, align 4
   %2 = and i32 1, %1
   %3 = xor i32 %0, %2
   %4 = xor i32 %3, 1
@@ -59,11 +60,11 @@ define i32 @__module_operator_overloading_01_overload_comp_m_greater_than_invers
   br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 1, i32* %greater_than_inverse, align 4
+  store i32 1, ptr %greater_than_inverse, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  store i32 0, i32* %greater_than_inverse, align 4
+  store i32 0, ptr %greater_than_inverse, align 4
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -73,15 +74,15 @@ return:                                           ; preds = %ifcont
   br label %FINALIZE_SYMTABLE_greater_than_inverse
 
 FINALIZE_SYMTABLE_greater_than_inverse:           ; preds = %return
-  %8 = load i32, i32* %greater_than_inverse, align 4
+  %8 = load i32, ptr %greater_than_inverse, align 4
   ret i32 %8
 }
 
-define i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %log1, i32* %log2) {
+define i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(ptr %log1, ptr %log2) {
 .entry:
   %less_than_inverse = alloca i32, align 4
-  %0 = load i32, i32* %log1, align 4
-  %1 = load i32, i32* %log2, align 4
+  %0 = load i32, ptr %log1, align 4
+  %1 = load i32, ptr %log2, align 4
   %2 = and i32 0, %1
   %3 = xor i32 %0, %2
   %4 = xor i32 %3, 1
@@ -91,11 +92,11 @@ define i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i
   br i1 %7, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 1, i32* %less_than_inverse, align 4
+  store i32 1, ptr %less_than_inverse, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  store i32 0, i32* %less_than_inverse, align 4
+  store i32 0, ptr %less_than_inverse, align 4
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -105,11 +106,11 @@ return:                                           ; preds = %ifcont
   br label %FINALIZE_SYMTABLE_less_than_inverse
 
 FINALIZE_SYMTABLE_less_than_inverse:              ; preds = %return
-  %8 = load i32, i32* %less_than_inverse, align 4
+  %8 = load i32, ptr %less_than_inverse, align 4
   ret i32 %8
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc19 = alloca %string_descriptor, align 8
   %stringFormat_desc16 = alloca %string_descriptor, align 8
@@ -119,201 +120,201 @@ define i32 @main(i32 %0, i8** %1) {
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %f = alloca i32, align 4
-  store i32 0, i32* %f, align 4
+  store i32 0, ptr %f, align 4
   %t = alloca i32, align 4
-  store i32 1, i32* %t, align 4
+  store i32 1, ptr %t, align 4
   %3 = alloca i64, align 8
-  %4 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %t, i32* %t)
+  %4 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(ptr %t, ptr %t)
   %5 = alloca i32, align 4
-  store i32 %4, i32* %5, align 4
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
-  %7 = load i64, i64* %3, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  store i32 %4, ptr %5, align 4
+  %6 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %5)
+  %7 = load i64, ptr %3, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %11 = load ptr, ptr %10, align 8
+  %12 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
+  call void @_lfortran_printf(ptr @1, ptr %11, i32 %14, ptr @0, i32 1)
+  %15 = icmp eq ptr %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %6)
+  call void @_lfortran_free_alloc(ptr %2, ptr %6)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %16 = alloca i64, align 8
-  %17 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %t, i32* %f)
+  %17 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(ptr %t, ptr %f)
   %18 = alloca i32, align 4
-  store i32 %17, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
-  %20 = load i64, i64* %16, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %19, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %20, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %26 = load i64, i64* %25, align 8
+  store i32 %17, ptr %18, align 4
+  %19 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %16, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.3, ptr %18)
+  %20 = load i64, ptr %16, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %20, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %26 = load i64, ptr %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %28 = icmp eq i8* %19, null
+  call void @_lfortran_printf(ptr @3, ptr %24, i32 %27, ptr @2, i32 1)
+  %28 = icmp eq ptr %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %19)
+  call void @_lfortran_free_alloc(ptr %2, ptr %19)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
   %29 = alloca i64, align 8
-  %30 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %f, i32* %t)
+  %30 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(ptr %f, ptr %t)
   %31 = alloca i32, align 4
-  store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
-  %33 = load i64, i64* %29, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %32, i8** %34, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %33, i64* %35, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %37 = load i8*, i8** %36, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %39 = load i64, i64* %38, align 8
+  store i32 %30, ptr %31, align 4
+  %32 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.4, ptr %29, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.6, ptr %31)
+  %33 = load i64, ptr %29, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %32, ptr %34, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %33, ptr %35, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %37 = load ptr, ptr %36, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %39 = load i64, ptr %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %41 = icmp eq i8* %32, null
+  call void @_lfortran_printf(ptr @5, ptr %37, i32 %40, ptr @4, i32 1)
+  %41 = icmp eq ptr %32, null
   br i1 %41, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %32)
+  call void @_lfortran_free_alloc(ptr %2, ptr %32)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
   %42 = alloca i64, align 8
-  %43 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %f, i32* %f)
+  %43 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(ptr %f, ptr %f)
   %44 = alloca i32, align 4
-  store i32 %43, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
-  %46 = load i64, i64* %42, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %45, i8** %47, align 8
-  %48 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %46, i64* %48, align 8
-  %49 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %50 = load i8*, i8** %49, align 8
-  %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %52 = load i64, i64* %51, align 8
+  store i32 %43, ptr %44, align 4
+  %45 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.7, ptr %42, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.9, ptr %44)
+  %46 = load i64, ptr %42, align 8
+  %47 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %45, ptr %47, align 8
+  %48 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %46, ptr %48, align 8
+  %49 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %50 = load ptr, ptr %49, align 8
+  %51 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %52 = load i64, ptr %51, align 8
   %53 = trunc i64 %52 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %54 = icmp eq i8* %45, null
+  call void @_lfortran_printf(ptr @7, ptr %50, i32 %53, ptr @6, i32 1)
+  %54 = icmp eq ptr %45, null
   br i1 %54, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %45)
+  call void @_lfortran_free_alloc(ptr %2, ptr %45)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
   %55 = alloca i64, align 8
-  %56 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %t, i32* %t)
+  %56 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(ptr %t, ptr %t)
   %57 = alloca i32, align 4
-  store i32 %56, i32* %57, align 4
-  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
-  %59 = load i64, i64* %55, align 8
-  %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %58, i8** %60, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %59, i64* %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %63 = load i8*, i8** %62, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %65 = load i64, i64* %64, align 8
+  store i32 %56, ptr %57, align 4
+  %58 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.10, ptr %55, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.12, ptr %57)
+  %59 = load i64, ptr %55, align 8
+  %60 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %58, ptr %60, align 8
+  %61 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %59, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %63 = load ptr, ptr %62, align 8
+  %64 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %65 = load i64, ptr %64, align 8
   %66 = trunc i64 %65 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %67 = icmp eq i8* %58, null
+  call void @_lfortran_printf(ptr @9, ptr %63, i32 %66, ptr @8, i32 1)
+  %67 = icmp eq ptr %58, null
   br i1 %67, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %free_done9
-  call void @_lfortran_free_alloc(i8* %2, i8* %58)
+  call void @_lfortran_free_alloc(ptr %2, ptr %58)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %free_done9
   %68 = alloca i64, align 8
-  %69 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %t, i32* %f)
+  %69 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(ptr %t, ptr %f)
   %70 = alloca i32, align 4
-  store i32 %69, i32* %70, align 4
-  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
-  %72 = load i64, i64* %68, align 8
-  %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %71, i8** %73, align 8
-  %74 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %72, i64* %74, align 8
-  %75 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %76 = load i8*, i8** %75, align 8
-  %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %78 = load i64, i64* %77, align 8
+  store i32 %69, ptr %70, align 4
+  %71 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.13, ptr %68, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.15, ptr %70)
+  %72 = load i64, ptr %68, align 8
+  %73 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %71, ptr %73, align 8
+  %74 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %72, ptr %74, align 8
+  %75 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %76 = load ptr, ptr %75, align 8
+  %77 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %78 = load i64, ptr %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %80 = icmp eq i8* %71, null
+  call void @_lfortran_printf(ptr @11, ptr %76, i32 %79, ptr @10, i32 1)
+  %80 = icmp eq ptr %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %free_done12
-  call void @_lfortran_free_alloc(i8* %2, i8* %71)
+  call void @_lfortran_free_alloc(ptr %2, ptr %71)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %free_done12
   %81 = alloca i64, align 8
-  %82 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %f, i32* %t)
+  %82 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(ptr %f, ptr %t)
   %83 = alloca i32, align 4
-  store i32 %82, i32* %83, align 4
-  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
-  %85 = load i64, i64* %81, align 8
-  %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  store i8* %84, i8** %86, align 8
-  %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  store i64 %85, i64* %87, align 8
-  %88 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
-  %89 = load i8*, i8** %88, align 8
-  %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
-  %91 = load i64, i64* %90, align 8
+  store i32 %82, ptr %83, align 4
+  %84 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.16, ptr %81, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.18, ptr %83)
+  %85 = load i64, ptr %81, align 8
+  %86 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  store ptr %84, ptr %86, align 8
+  %87 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  store i64 %85, ptr %87, align 8
+  %88 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 0
+  %89 = load ptr, ptr %88, align 8
+  %90 = getelementptr %string_descriptor, ptr %stringFormat_desc16, i32 0, i32 1
+  %91 = load i64, ptr %90, align 8
   %92 = trunc i64 %91 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %93 = icmp eq i8* %84, null
+  call void @_lfortran_printf(ptr @13, ptr %89, i32 %92, ptr @12, i32 1)
+  %93 = icmp eq ptr %84, null
   br i1 %93, label %free_done18, label %free_nonnull17
 
 free_nonnull17:                                   ; preds = %free_done15
-  call void @_lfortran_free_alloc(i8* %2, i8* %84)
+  call void @_lfortran_free_alloc(ptr %2, ptr %84)
   br label %free_done18
 
 free_done18:                                      ; preds = %free_nonnull17, %free_done15
   %94 = alloca i64, align 8
-  %95 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %f, i32* %f)
+  %95 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(ptr %f, ptr %f)
   %96 = alloca i32, align 4
-  store i32 %95, i32* %96, align 4
-  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
-  %98 = load i64, i64* %94, align 8
-  %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %97, i8** %99, align 8
-  %100 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %98, i64* %100, align 8
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %102 = load i8*, i8** %101, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %104 = load i64, i64* %103, align 8
+  store i32 %95, ptr %96, align 4
+  %97 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.19, ptr %94, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.21, ptr %96)
+  %98 = load i64, ptr %94, align 8
+  %99 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  store ptr %97, ptr %99, align 8
+  %100 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  store i64 %98, ptr %100, align 8
+  %101 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  %102 = load ptr, ptr %101, align 8
+  %103 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  %104 = load i64, ptr %103, align 8
   %105 = trunc i64 %104 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
-  %106 = icmp eq i8* %97, null
+  call void @_lfortran_printf(ptr @15, ptr %102, i32 %105, ptr @14, i32 1)
+  %106 = icmp eq ptr %97, null
   br i1 %106, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %free_done18
-  call void @_lfortran_free_alloc(i8* %2, i8* %97)
+  call void @_lfortran_free_alloc(ptr %2, ptr %97)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %free_done18
@@ -327,14 +328,14 @@ FINALIZE_SYMTABLE_operator_overloading_01:        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "bca6cea51335c5187634d6e542f0a229bad230ee8efda6c99b9b1591",
+    "stdout_hash": "d5271bf6bb0c54ab206412095d2c1a576eede8dbbf59c0b29a838571",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [15 x i8] c"I4,I4,I4,I4,I4\00", align 1
@@ -12,82 +13,82 @@ target datalayout = "..."
 @serialization_info.1 = private unnamed_addr constant [15 x i8] c"I4,I4,I4,I4,I4\00", align 1
 @4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %lfortran_iomsg = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
-  store i64 0, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 1)
-  store i8* %6, i8** %4, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %lfortran_iomsg, align 1
+  %3 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 1
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 1)
+  store ptr %6, ptr %4, align 8
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
+  store i32 25, ptr %x, align 4
   %7 = alloca i64, align 8
   %8 = alloca i32, align 4
-  store i32 1, i32* %8, align 4
+  store i32 1, ptr %8, align 4
   %9 = alloca i32, align 4
-  store i32 3, i32* %9, align 4
-  %10 = load i32, i32* %x, align 4
+  store i32 3, ptr %9, align 4
+  %10 = load i32, ptr %x, align 4
   %11 = add i32 25, %10
   %12 = alloca i32, align 4
-  store i32 %11, i32* %12, align 4
-  %13 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %7, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %x, i32* %8, i32* %9, i32* %x, i32* %12)
-  %14 = load i64, i64* %7, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %13, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %14, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %18 = load i8*, i8** %17, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
+  store i32 %11, ptr %12, align 4
+  %13 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %7, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x, ptr %8, ptr %9, ptr %x, ptr %12)
+  %14 = load i64, ptr %7, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %14, ptr %16, align 8
+  %17 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %18 = load ptr, ptr %17, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %20 = load i64, ptr %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %22 = icmp eq i8* %13, null
+  call void @_lfortran_printf(ptr @1, ptr %18, i32 %21, ptr @0, i32 1)
+  %22 = icmp eq ptr %13, null
   br i1 %22, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %13)
+  call void @_lfortran_free_alloc(ptr %2, ptr %13)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %23 = alloca i32*, align 8
-  store i32* null, i32** %23, align 8
-  %24 = load i32*, i32** %23, align 8
+  %23 = alloca ptr, align 8
+  store ptr null, ptr %23, align 8
+  %24 = load ptr, ptr %23, align 8
   %25 = call i32 @_lfortran_get_decimal_mode(i32 6)
   %26 = call i32 @_lfortran_get_sign_mode(i32 6)
   %27 = call i32 @_lfortran_get_round_mode(i32 6)
   %28 = alloca i64, align 8
   %29 = alloca i32, align 4
-  store i32 1, i32* %29, align 4
+  store i32 1, ptr %29, align 4
   %30 = alloca i32, align 4
-  store i32 3, i32* %30, align 4
-  %31 = load i32, i32* %x, align 4
+  store i32 3, ptr %30, align 4
+  %31 = load i32, ptr %x, align 4
   %32 = add i32 25, %31
   %33 = alloca i32, align 4
-  store i32 %32, i32* %33, align 4
-  %34 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %28, i32 0, i32 0, i32 %25, i32 %26, i32 %27, i32* %x, i32* %29, i32* %30, i32* %x, i32* %33)
-  %35 = load i64, i64* %28, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %34, i8** %36, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %35, i64* %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %39 = load i8*, i8** %38, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %41 = load i64, i64* %40, align 8
-  call void (i32, i32*, i8*, i64, ...) @_lfortran_file_write(i32 6, i32* %24, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i64 4, i8* %39, i64 %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i64 1)
-  %42 = icmp eq i8* %34, null
+  store i32 %32, ptr %33, align 4
+  %34 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %28, i32 0, i32 0, i32 %25, i32 %26, i32 %27, ptr %x, ptr %29, ptr %30, ptr %x, ptr %33)
+  %35 = load i64, ptr %28, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %34, ptr %36, align 8
+  %37 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %35, ptr %37, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %39 = load ptr, ptr %38, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %41 = load i64, ptr %40, align 8
+  call void (i32, ptr, ptr, i64, ...) @_lfortran_file_write(i32 6, ptr %24, ptr @4, i64 4, ptr %39, i64 %41, ptr @3, i64 1)
+  %42 = icmp eq ptr %34, null
   br i1 %42, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %34)
+  call void @_lfortran_free_alloc(ptr %2, ptr %34)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -100,24 +101,24 @@ FINALIZE_SYMTABLE_print_01:                       ; preds = %return
   br label %Finalize_Variable_lfortran_iomsg
 
 Finalize_Variable_lfortran_iomsg:                 ; preds = %FINALIZE_SYMTABLE_print_01
-  %43 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %44 = load i8*, i8** %43, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %44)
+  %43 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %44 = load ptr, ptr %43, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %44)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare i32 @_lfortran_get_decimal_mode(i32)
 
@@ -125,6 +126,6 @@ declare i32 @_lfortran_get_sign_mode(i32)
 
 declare i32 @_lfortran_get_round_mode(i32)
 
-declare void @_lfortran_file_write(i32, i32*, i8*, i64, ...)
+declare void @_lfortran_file_write(i32, ptr, ptr, i64, ...)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "b890f45e1f991f70324ab531ea19d85370f161fc04d44a7ca2b4b813",
+    "stdout_hash": "7a726561bb8c3727e5cb26920fb2b911dbe75d67eb08d60c4e5dff1a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -11,57 +12,57 @@ target datalayout = "..."
 @serialization_info.1 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
-  store i32 5, i32* %i, align 4
+  store i32 5, ptr %i, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
   %14 = alloca i64, align 8
-  %15 = load i32, i32* %i, align 4
+  %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
   %17 = alloca i32, align 4
-  store i32 %16, i32* %17, align 4
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %17)
-  %19 = load i64, i64* %14, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  store i32 %16, ptr %17, align 4
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %14, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %17)
+  %19 = load i64, ptr %14, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %18)
+  call void @_lfortran_free_alloc(ptr %2, ptr %18)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -75,14 +76,14 @@ FINALIZE_SYMTABLE_program1:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "e2d568e0f8a1cc19cdd5c43b3d2af449e27176f2ae13ace6d4618644",
+    "stdout_hash": "0df35c9ce3ed803af9f1495556135e30b4dbca3b0fc2add12b83c3e7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -1,63 +1,64 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__closuretest__z = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %z = alloca i32, align 4
-  store i32 0, i32* %z, align 4
+  store i32 0, ptr %z, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %free_done, %.entry
-  %3 = load i32, i32* %z, align 4
+  %3 = load i32, ptr %z, align 4
   %4 = add i32 %3, 1
   %5 = icmp sle i32 %4, 10
   br i1 %5, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %6 = load i32, i32* %z, align 4
+  %6 = load i32, ptr %z, align 4
   %7 = add i32 %6, 1
-  store i32 %7, i32* %z, align 4
-  %8 = load i32, i32* %z, align 4
-  store i32 %8, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
+  store i32 %7, ptr %z, align 4
+  %8 = load i32, ptr %z, align 4
+  store i32 %8, ptr @__module___lcompilers_created__nested_context__closuretest__z, align 4
   %9 = alloca i64, align 8
-  store i32 1, i32* %call_arg_value, align 4
-  %10 = call i32 @apply(i32 (i32*)* @add_z, i32* %call_arg_value)
+  store i32 1, ptr %call_arg_value, align 4
+  %10 = call i32 @apply(ptr @add_z, ptr %call_arg_value)
   %11 = alloca i32, align 4
-  store i32 %10, i32* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %9, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %11)
-  %13 = load i64, i64* %9, align 8
-  %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %12, i8** %14, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %13, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %19 = load i64, i64* %18, align 8
+  store i32 %10, ptr %11, align 4
+  %12 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %9, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %11)
+  %13 = load i64, ptr %9, align 8
+  %14 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %12, ptr %14, align 8
+  %15 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %13, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  %18 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %19 = load i64, ptr %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %21 = icmp eq i8* %12, null
+  call void @_lfortran_printf(ptr @1, ptr %17, i32 %20, ptr @0, i32 1)
+  %21 = icmp eq ptr %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %loop.body
-  call void @_lfortran_free_alloc(i8* %2, i8* %12)
+  call void @_lfortran_free_alloc(ptr %2, ptr %12)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %loop.body
-  %22 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
-  store i32 %22, i32* %z, align 4
+  %22 = load i32, ptr @__module___lcompilers_created__nested_context__closuretest__z, align 4
+  store i32 %22, ptr %z, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
@@ -71,48 +72,48 @@ FINALIZE_SYMTABLE_closuretest:                    ; preds = %return
   ret i32 0
 }
 
-define i32 @add_z(i32* %x) {
+define i32 @add_z(ptr %x) {
 .entry:
   %y = alloca i32, align 4
-  %0 = load i32, i32* %x, align 4
-  %1 = load i32, i32* @__module___lcompilers_created__nested_context__closuretest__z, align 4
+  %0 = load i32, ptr %x, align 4
+  %1 = load i32, ptr @__module___lcompilers_created__nested_context__closuretest__z, align 4
   %2 = add i32 %0, %1
-  store i32 %2, i32* %y, align 4
+  store i32 %2, ptr %y, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_add_z
 
 FINALIZE_SYMTABLE_add_z:                          ; preds = %return
-  %3 = load i32, i32* %y, align 4
+  %3 = load i32, ptr %y, align 4
   ret i32 %3
 }
 
-define i32 @apply(i32 (i32*)* %fun, i32* %x) {
+define i32 @apply(ptr %fun, ptr %x) {
 .entry:
   %y = alloca i32, align 4
-  %0 = call i32 %fun(i32* %x)
-  store i32 %0, i32* %y, align 4
+  %0 = call i32 %fun(ptr %x)
+  store i32 %0, ptr %y, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_apply
 
 FINALIZE_SYMTABLE_apply:                          ; preds = %return
-  %1 = load i32, i32* %y, align 4
+  %1 = load i32, ptr %y, align 4
   ret i32 %1
 }
 
-declare i32 @fun(i32*)
+declare i32 @fun(ptr)
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-program_cmake_01-caf8f48.json
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_cmake_01-caf8f48.stdout",
-    "stdout_hash": "68da5f40052eada8ecf691dd18194540d300a0a1c2220dc74faccd0b",
+    "stdout_hash": "5a941949c30492546c35b955b9cf88a599e95da6c76a48259d15ac5c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_cmake_01-caf8f48.stdout
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.stdout
@@ -1,19 +1,20 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [5 x i8] c"Hello"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data, i32 0, i32 0), i64 5 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 5 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %2 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %2, i32 5, ptr @0, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -24,8 +25,8 @@ FINALIZE_SYMTABLE_testfortran:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-read_83-d6544e3.json
+++ b/tests/reference/llvm-read_83-d6544e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-read_83-d6544e3.stdout",
-    "stdout_hash": "47f9f2d340cb680fc3a9822dbaedf41c20dee9bc6854d05764f0d4a8",
+    "stdout_hash": "463efb8e37b1aa320741d7442c1535a6b4ce4685b7ef7db3bb36b64b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-read_83-d6544e3.stdout
+++ b/tests/reference/llvm-read_83-d6544e3.stdout
@@ -1,62 +1,63 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
 @string_const_data = private constant [1 x i8] c" "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data, i32 0, i32 0), i64 1 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 1 }>
 @string_const_data.1 = private constant [12 x i8] c"--empty-read"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data.1, i32 0, i32 0), i64 12 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 12 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [58 x i8] c"Starting empty read. All input to stdin will be discarded."
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([58 x i8], [58 x i8]* @string_const_data.3, i32 0, i32 0), i64 58 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 58 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
 @3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [92 x i8] c"Empty read 1 completed successfully. Starting empty read 2 with unit=5 (stdin), fmt='(I10)'."
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([92 x i8], [92 x i8]* @string_const_data.5, i32 0, i32 0), i64 92 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 92 }>
 @4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @5 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [78 x i8] c"Empty read 2 completed successfully. Starting empty read 3 with unit=*, fmt=*."
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([78 x i8], [78 x i8]* @string_const_data.7, i32 0, i32 0), i64 78 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 78 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
 @9 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.9 = private constant [77 x i8] c"Empty read 3 completed successfully. Starting empty read 4 with format label."
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([77 x i8], [77 x i8]* @string_const_data.9, i32 0, i32 0), i64 77 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 77 }>
 @10 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @11 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.11 = private constant [93 x i8] c"Empty read 4 completed successfully. Starting empty read 5 with unit passed through variable."
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([93 x i8], [93 x i8]* @string_const_data.11, i32 0, i32 0), i64 93 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 93 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [4 x i8] c"yes\00", align 1
 @15 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.13 = private constant [77 x i8] c"Empty read 5 completed successfully. All empty reads completed without error."
-@string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([77 x i8], [77 x i8]* @string_const_data.13, i32 0, i32 0), i64 77 }>
+@string_const.14 = private global %string_descriptor <{ ptr @string_const_data.13, i64 77 }>
 @16 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @_lcompilers_get_command_argument_(i32* %number, %string_descriptor* %value) {
+define void @_lcompilers_get_command_argument_(ptr %number, ptr %value) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %command_argument_holder = alloca %string_descriptor, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %command_argument_holder, align 1
+  store %string_descriptor zeroinitializer, ptr %command_argument_holder, align 1
   %length_to_allocate = alloca i32, align 4
-  store i32 0, i32* %length_to_allocate, align 4
-  %1 = load i32, i32* %number, align 4
+  store i32 0, ptr %length_to_allocate, align 4
+  %1 = load i32, ptr %number, align 4
   %2 = call i32 @_lfortran_get_command_argument_length(i32 %1)
-  store i32 %2, i32* %length_to_allocate, align 4
-  %3 = load i32, i32* %length_to_allocate, align 4
-  %4 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
-  %5 = load i8*, i8** %4, align 8
-  %6 = icmp ne i8* %5, null
+  store i32 %2, ptr %length_to_allocate, align 4
+  %3 = load i32, ptr %length_to_allocate, align 4
+  %4 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  %6 = icmp ne ptr %5, null
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @__Wrong_allocation)
   call void @exit(i32 1)
   br label %ifcont
 
@@ -64,27 +65,27 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
+  %7 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
   %8 = sext i32 %3 to i64
-  %9 = call i8* @_lfortran_get_default_allocator()
-  %10 = call i8* @_lfortran_string_malloc_alloc(i8* %9, i64 %8)
-  store i8* %10, i8** %7, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 1
+  %9 = call ptr @_lfortran_get_default_allocator()
+  %10 = call ptr @_lfortran_string_malloc_alloc(ptr %9, i64 %8)
+  store ptr %10, ptr %7, align 8
+  %11 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 1
   %12 = sext i32 %3 to i64
-  store i64 %12, i64* %11, align 8
-  %13 = load i32, i32* %number, align 4
-  %14 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
-  %15 = load i8*, i8** %14, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
-  %17 = load i8*, i8** %16, align 8
-  call void @_lfortran_get_command_argument_value(i32 %13, i8* %17)
-  %18 = getelementptr %string_descriptor, %string_descriptor* %value, i32 0, i32 0
-  %19 = getelementptr %string_descriptor, %string_descriptor* %value, i32 0, i32 1
-  %20 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
-  %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 1
-  %23 = load i64, i64* %22, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %18, i64* %19, i8 0, i8 0, i8* %21, i64 %23, i32 1)
+  store i64 %12, ptr %11, align 8
+  %13 = load i32, ptr %number, align 4
+  %14 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
+  %15 = load ptr, ptr %14, align 8
+  %16 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
+  %17 = load ptr, ptr %16, align 8
+  call void @_lfortran_get_command_argument_value(i32 %13, ptr %17)
+  %18 = getelementptr %string_descriptor, ptr %value, i32 0, i32 0
+  %19 = getelementptr %string_descriptor, ptr %value, i32 0, i32 1
+  %20 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
+  %21 = load ptr, ptr %20, align 8
+  %22 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 1
+  %23 = load i64, ptr %22, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %18, ptr %19, i8 0, i8 0, ptr %21, i64 %23, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -94,25 +95,25 @@ FINALIZE_SYMTABLE__lcompilers_get_command_argument_: ; preds = %return
   br label %Finalize_Variable_command_argument_holder
 
 Finalize_Variable_command_argument_holder:        ; preds = %FINALIZE_SYMTABLE__lcompilers_get_command_argument_
-  %24 = getelementptr %string_descriptor, %string_descriptor* %command_argument_holder, i32 0, i32 0
-  %25 = load i8*, i8** %24, align 8
-  call void @_lfortran_free_alloc(i8* %0, i8* %25)
+  %24 = getelementptr %string_descriptor, ptr %command_argument_holder, i32 0, i32 0
+  %25 = load ptr, ptr %24, align 8
+  call void @_lfortran_free_alloc(ptr %0, ptr %25)
   ret void
 }
 
 declare i32 @_lfortran_get_command_argument_length(i32)
 
-declare void @_lfortran_get_command_argument_value(i32, i8*)
+declare void @_lfortran_get_command_argument_value(i32, ptr)
 
-define i32 @_lcompilers_len_trim_str(%string_descriptor* %str) {
+define i32 @_lcompilers_len_trim_str(ptr %str) {
 .entry:
   %StringItem = alloca %string_descriptor, align 8
   %result = alloca i32, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %1 = load i64, i64* %0, align 8
+  %0 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %1 = load i64, ptr %0, align 8
   %2 = trunc i64 %1 to i32
-  store i32 %2, i32* %result, align 4
-  %3 = load i32, i32* %result, align 4
+  store i32 %2, ptr %result, align 4
+  %3 = load i32, ptr %result, align 4
   %4 = icmp ne i32 %3, 0
   br i1 %4, label %then, label %else2
 
@@ -120,29 +121,29 @@ then:                                             ; preds = %.entry
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont, %then
-  %5 = load i32, i32* %result, align 4
-  %6 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
+  %5 = load i32, ptr %result, align 4
+  %6 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
   %8 = sext i32 %5 to i64
   %9 = sub i64 %8, 1
-  %10 = getelementptr i8, i8* %7, i64 %9
-  %11 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  store i8* %10, i8** %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
-  store i64 1, i64* %12, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %16 = load i8, i8* %14, align 1
-  %17 = load i8, i8* %15, align 1
+  %10 = getelementptr i8, ptr %7, i64 %9
+  %11 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 0
+  store ptr %10, ptr %11, align 8
+  %12 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 1
+  store i64 1, ptr %12, align 8
+  %13 = getelementptr %string_descriptor, ptr %StringItem, i32 0, i32 0
+  %14 = load ptr, ptr %13, align 8
+  %15 = load ptr, ptr @string_const, align 8
+  %16 = load i8, ptr %14, align 1
+  %17 = load i8, ptr %15, align 1
   %18 = icmp eq i8 %16, %17
   br i1 %18, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %19 = load i32, i32* %result, align 4
+  %19 = load i32, ptr %result, align 4
   %20 = sub i32 %19, 1
-  store i32 %20, i32* %result, align 4
-  %21 = load i32, i32* %result, align 4
+  store i32 %20, ptr %result, align 4
+  %21 = load i32, ptr %result, align 4
   %22 = icmp eq i32 %21, 0
   br i1 %22, label %then1, label %else
 
@@ -171,34 +172,34 @@ return:                                           ; preds = %ifcont3
   br label %FINALIZE_SYMTABLE__lcompilers_len_trim_str
 
 FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
-  %23 = load i32, i32* %result, align 4
+  %23 = load i32, ptr %result, align 4
   ret i32 %23
 }
 
-define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
+define void @_lcompilers_trim_str(ptr %str, ptr %result) {
 .entry:
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %StrSlice_StrView = alloca %string_descriptor, align 8
-  %1 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %str)
+  %1 = call i32 @_lcompilers_len_trim_str(ptr %str)
   %2 = sext i32 %1 to i64
   %3 = sub i64 %2, 1
   %4 = add i64 %3, 1
   %5 = icmp slt i64 %4, 0
   %6 = select i1 %5, i64 0, i64 %4
-  %7 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %StrSliceGEP = getelementptr i8, i8* %8, i64 0
-  %9 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %6, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 0
-  %12 = getelementptr %string_descriptor, %string_descriptor* %result, i32 0, i32 1
-  %13 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %16 = load i64, i64* %15, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %11, i64* %12, i8 0, i8 0, i8* %14, i64 %16, i32 1)
+  %7 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %StrSliceGEP = getelementptr i8, ptr %8, i64 0
+  %9 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 %6, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %result, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, ptr %result, i32 0, i32 1
+  %13 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %14 = load ptr, ptr %13, align 8
+  %15 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %11, ptr %12, i8 0, i8 0, ptr %14, i64 %16, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -208,50 +209,50 @@ FINALIZE_SYMTABLE__lcompilers_trim_str:           ; preds = %return
   ret void
 }
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_string_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_string_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value = alloca i32, align 4
   %empty_read = alloca %string_descriptor, align 8
   %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %empty_read, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 1
-  store i64 32, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 32)
-  store i8* %6, i8** %4, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__0_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %empty_read, align 1
+  %3 = getelementptr %string_descriptor, ptr %empty_read, i32 0, i32 1
+  store i64 32, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %empty_read, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 32)
+  store ptr %6, ptr %4, align 8
   %unit_num = alloca i32, align 4
-  store i32 1, i32* %call_arg_value, align 4
-  call void @_lcompilers_get_command_argument_(i32* %call_arg_value, %string_descriptor* %empty_read)
-  %7 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %8 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %9 = load i8*, i8** %7, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %9)
-  store i8* null, i8** %7, align 8
-  store i64 0, i64* %8, align 8
-  %10 = call i32 @_lcompilers_len_trim_str(%string_descriptor* %empty_read)
-  %11 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = icmp ne i8* %12, null
+  store i32 1, ptr %call_arg_value, align 4
+  call void @_lcompilers_get_command_argument_(ptr %call_arg_value, ptr %empty_read)
+  %7 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %8 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %9 = load ptr, ptr %7, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %9)
+  store ptr null, ptr %7, align 8
+  store i64 0, ptr %8, align 8
+  %10 = call i32 @_lcompilers_len_trim_str(ptr %empty_read)
+  %11 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = icmp ne ptr %12, null
   br i1 %13, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @__Wrong_allocation)
   call void @exit(i32 1)
   br label %ifcont
 
@@ -259,64 +260,64 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %14 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %14 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
   %15 = sext i32 %10 to i64
-  %16 = call i8* @_lfortran_get_default_allocator()
-  %17 = call i8* @_lfortran_string_malloc_alloc(i8* %16, i64 %15)
-  store i8* %17, i8** %14, align 8
-  %18 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %16 = call ptr @_lfortran_get_default_allocator()
+  %17 = call ptr @_lfortran_string_malloc_alloc(ptr %16, i64 %15)
+  store ptr %17, ptr %14, align 8
+  %18 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
   %19 = sext i32 %10 to i64
-  store i64 %19, i64* %18, align 8
-  call void @_lcompilers_trim_str(%string_descriptor* %empty_read, %string_descriptor* %__libasr__created__var__0_return_slot)
-  %20 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %21 = load i8*, i8** %20, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %23 = load i64, i64* %22, align 8
-  %24 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  %25 = call i32 @str_compare(i8* %21, i64 %23, i8* %24, i64 12)
+  store i64 %19, ptr %18, align 8
+  call void @_lcompilers_trim_str(ptr %empty_read, ptr %__libasr__created__var__0_return_slot)
+  %20 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %21 = load ptr, ptr %20, align 8
+  %22 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %23 = load i64, ptr %22, align 8
+  %24 = load ptr, ptr @string_const.2, align 8
+  %25 = call i32 @str_compare(ptr %21, i64 %23, ptr %24, i64 12)
   %26 = icmp eq i32 %25, 0
   br i1 %26, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %27 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @1, ptr %27, i32 58, ptr @0, i32 1)
   %28 = alloca i32, align 4
-  store i32 0, i32* %28, align 4
+  store i32 0, ptr %28, align 4
   %29 = alloca i32, align 4
-  call void @_lfortran_empty_read(i32 -2, i32* %28, i32 1)
-  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %30, i32 92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
+  call void @_lfortran_empty_read(i32 -2, ptr %28, i32 1)
+  %30 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @4, ptr %30, i32 92, ptr @3, i32 1)
   %31 = alloca i32, align 4
-  store i32 0, i32* %31, align 4
+  store i32 0, ptr %31, align 4
   %32 = alloca i32, align 4
-  call void @_lfortran_empty_read(i32 -2, i32* %31, i32 1)
-  %33 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_empty_read(i32 -2, ptr %31, i32 1)
+  %33 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @7, ptr %33, i32 78, ptr @6, i32 1)
   %34 = alloca i32, align 4
-  store i32 0, i32* %34, align 4
+  store i32 0, ptr %34, align 4
   %35 = alloca i32, align 4
-  call void @_lfortran_empty_read(i32 -2, i32* %34, i32 1)
-  %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %36, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 1)
+  call void @_lfortran_empty_read(i32 -2, ptr %34, i32 1)
+  %36 = load ptr, ptr @string_const.10, align 8
+  call void @_lfortran_printf(ptr @10, ptr %36, i32 77, ptr @9, i32 1)
   br label %goto_target
 
 goto_target:                                      ; preds = %then1
   %37 = alloca i32, align 4
-  store i32 0, i32* %37, align 4
+  store i32 0, ptr %37, align 4
   %38 = alloca i32, align 4
-  call void @_lfortran_empty_read(i32 -2, i32* %37, i32 1)
-  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 93, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  store i32 5, i32* %unit_num, align 4
-  %40 = load i32, i32* %unit_num, align 4
+  call void @_lfortran_empty_read(i32 -2, ptr %37, i32 1)
+  %39 = load ptr, ptr @string_const.12, align 8
+  call void @_lfortran_printf(ptr @13, ptr %39, i32 93, ptr @12, i32 1)
+  store i32 5, ptr %unit_num, align 4
+  %40 = load i32, ptr %unit_num, align 4
   %41 = icmp eq i32 %40, 5
   %42 = select i1 %41, i32 -2, i32 %40
   %43 = alloca i32, align 4
-  store i32 0, i32* %43, align 4
+  store i32 0, ptr %43, align 4
   %44 = alloca i32, align 4
-  call void @_lfortran_empty_read(i32 %42, i32* %43, i32 1)
-  %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i8* %45, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0), i32 1)
+  call void @_lfortran_empty_read(i32 %42, ptr %43, i32 1)
+  %45 = load ptr, ptr @string_const.14, align 8
+  call void @_lfortran_printf(ptr @16, ptr %45, i32 77, ptr @15, i32 1)
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
@@ -332,27 +333,27 @@ FINALIZE_SYMTABLE_read_83:                        ; preds = %return
   br label %Finalize_Variable___libasr__created__var__0_return_slot
 
 Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_read_83
-  %46 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %47 = load i8*, i8** %46, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %47)
+  %46 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %47 = load ptr, ptr %46, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %47)
   br label %Finalize_Variable_empty_read
 
 Finalize_Variable_empty_read:                     ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
-  %48 = getelementptr %string_descriptor, %string_descriptor* %empty_read, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %49)
+  %48 = getelementptr %string_descriptor, ptr %empty_read, i32 0, i32 0
+  %49 = load ptr, ptr %48, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %49)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i32 @str_compare(i8*, i64, i8*, i64)
+declare i32 @str_compare(ptr, i64, ptr, i64)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_empty_read(i32, i32*, i32)
+declare void @_lfortran_empty_read(i32, ptr, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "4bb7f5b8d1af1e7d61aa4c5b021977f25eaf14af5b4f226c1a82d3ce",
+    "stdout_hash": "6c0383a8216d9e70d47b45221365f7805a2cce6822aad3887459dac9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -1,42 +1,43 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [9 x i8] c"R4,R8,R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %v = alloca double, align 8
   %x = alloca float, align 4
   %zero = alloca float, align 4
-  store float 0.000000e+00, float* %zero, align 4
-  store double 0x3FF0CCCCC0000000, double* %v, align 8
-  store float 0x3FF0CCCCC0000000, float* %x, align 4
+  store float 0.000000e+00, ptr %zero, align 4
+  store double 0x3FF0CCCCC0000000, ptr %v, align 8
+  store float 0x3FF0CCCCC0000000, ptr %x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %x, double* %v, float* %zero)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x, ptr %v, ptr %zero)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -50,14 +51,14 @@ FINALIZE_SYMTABLE_real_dp_01:                     ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "9723af18f23ec688a910302da5f76f73278111e445554b94d923f396",
+    "stdout_hash": "4e53347d542af2580998ddc8fdca1b6cc33c6208fac1e950c89c1ac8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @real_dp_param.u = internal global float 0x3FF0CCCCC0000000
 @real_dp_param.v = internal global double 0x3FF0CCCCC0000000
@@ -11,33 +12,33 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [9 x i8] c"R4,R8,R8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %prec1 = alloca i32, align 4
-  store i32 4, i32* %prec1, align 4
+  store i32 4, ptr %prec1, align 4
   %prec2 = alloca i32, align 4
-  store i32 8, i32* %prec2, align 4
+  store i32 8, ptr %prec2, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* @real_dp_param.u, double* @real_dp_param.v, double* @real_dp_param.zero)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @real_dp_param.u, ptr @real_dp_param.v, ptr @real_dp_param.zero)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -51,14 +52,14 @@ FINALIZE_SYMTABLE_real_dp_param:                  ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "fd992af00b868fe3898498f26fab3fda05aa9776db227cf15cc46ca4",
+    "stdout_hash": "0259e4941f46bcc54d4776b95185c4d4c8bab49b528a8cbb895e36fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__sub1__x = global i32 0
 @__module_recursion_01_n = global i32 0
@@ -13,49 +14,49 @@ target datalayout = "..."
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
 @string_const_data = private constant [4 x i8] c"x = "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module_recursion_01_sub1(i32* %x) {
+define void @__module_recursion_01_sub1(ptr %x) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load i32, i32* %x, align 4
-  %2 = load i32, i32* @__module_recursion_01_n, align 4
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load i32, ptr %x, align 4
+  %2 = load i32, ptr @__module_recursion_01_n, align 4
   %3 = icmp slt i32 %1, %2
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %4 = load i32, i32* %x, align 4
+  %4 = load i32, ptr %x, align 4
   %5 = add i32 %4, 1
-  store i32 %5, i32* %x, align 4
+  store i32 %5, ptr %x, align 4
   %6 = alloca i64, align 8
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
-  %8 = load i64, i64* %6, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %7, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %8, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %14 = load i64, i64* %13, align 8
+  %7 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %6, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %x)
+  %8 = load i64, ptr %6, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %16 = icmp eq i8* %7, null
+  call void @_lfortran_printf(ptr @3, ptr %12, i32 %15, ptr @2, i32 1)
+  %16 = icmp eq ptr %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %then
-  call void @_lfortran_free_alloc(i8* %0, i8* %7)
+  call void @_lfortran_free_alloc(ptr %0, ptr %7)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %then
-  %17 = load i32, i32* %x, align 4
-  store i32 %17, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %17 = load i32, ptr %x, align 4
+  store i32 %17, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
   call void @sub1.__module_recursion_01_sub2()
-  %18 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %18, i32* %x, align 4
-  call void @__module_recursion_01_sub1(i32* %x)
+  %18 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %18, ptr %x, align 4
+  call void @__module_recursion_01_sub1(ptr %x)
   br label %ifcont
 
 else:                                             ; preds = %.entry
@@ -74,32 +75,32 @@ FINALIZE_SYMTABLE_sub1:                           ; preds = %return
 define void @sub1.__module_recursion_01_sub2() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
-  %1 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %0 = call ptr @_lfortran_get_default_allocator()
+  %1 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
   %2 = add i32 %1, 1
-  store i32 %2, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %2, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* @__module___lcompilers_created__nested_context__sub1__x)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @__module___lcompilers_created__nested_context__sub1__x)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %4)
+  call void @_lfortran_free_alloc(ptr %0, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  call void @__module_recursion_01_sub1(i32* @__module___lcompilers_created__nested_context__sub1__x)
+  call void @__module_recursion_01_sub1(ptr @__module___lcompilers_created__nested_context__sub1__x)
   br label %return
 
 return:                                           ; preds = %free_done
@@ -109,19 +110,19 @@ FINALIZE_SYMTABLE_sub2:                           ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store i32 10, i32* @__module_recursion_01_n, align 4
-  call void @__module_recursion_01_sub1(i32* @__module_recursion_01_x)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store i32 10, ptr @__module_recursion_01_n, align 4
+  call void @__module_recursion_01_sub1(ptr @__module_recursion_01_x)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -132,6 +133,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "9232fab42cb620824631803cac16762b2cddf28d140333101ce1e435",
+    "stdout_hash": "ecd42e1924cc9bab5ccd691fd6d2031cf2ae0b24fe62f80e8579cbb2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -1,93 +1,94 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data, i32 0, i32 0), i64 7 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 7 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-6,I4\00", align 1
 @string_const_data.2 = private constant [6 x i8] c"after:"
-@string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([6 x i8], [6 x i8]* @string_const_data.2, i32 0, i32 0), i64 6 }>
+@string_const.3 = private global %string_descriptor <{ ptr @string_const_data.2, i64 6 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.4 = private unnamed_addr constant [12 x i8] c"S-DESC-9,I4\00", align 1
 @string_const_data.5 = private constant [9 x i8] c"x in getx"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([9 x i8], [9 x i8]* @string_const_data.5, i32 0, i32 0), i64 9 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 9 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [7 x i8] c"in sub1"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.7, i32 0, i32 0), i64 7 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 7 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.9 = private unnamed_addr constant [12 x i8] c"S-DESC-3,I4\00", align 1
 @string_const_data.10 = private constant [3 x i8] c"r ="
-@string_const.11 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.10, i32 0, i32 0), i64 3 }>
+@string_const.11 = private global %string_descriptor <{ ptr @string_const_data.10, i64 3 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
+define i32 @__module_recursion_02_solver(ptr %f, ptr %iter) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
   %1 = call i32 %f()
-  store i32 %1, i32* %f_val, align 4
+  store i32 %1, ptr %f_val, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
-  %4 = load i64, i64* %2, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %2, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %f_val)
+  %4 = load i64, ptr %2, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i32 2, i32* %call_arg_value, align 4
-  %13 = load i32, i32* %iter, align 4
+  store i32 2, ptr %call_arg_value, align 4
+  %13 = load i32, ptr %iter, align 4
   %14 = sub i32 %13, 1
-  store i32 %14, i32* %call_arg_value1, align 4
-  %15 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %15, i32* %solver, align 4
+  store i32 %14, ptr %call_arg_value1, align 4
+  %15 = call i32 @__module_recursion_02_sub1(ptr %call_arg_value, ptr %call_arg_value1)
+  store i32 %15, ptr %solver, align 4
   %16 = call i32 %f()
-  store i32 %16, i32* %f_val, align 4
+  store i32 %16, ptr %f_val, align 4
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.1, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.3, ptr %f_val)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done4, label %free_nonnull3
 
 free_nonnull3:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %18)
+  call void @_lfortran_free_alloc(ptr %0, ptr %18)
   br label %free_done4
 
 free_done4:                                       ; preds = %free_nonnull3, %free_done
@@ -97,27 +98,27 @@ return:                                           ; preds = %free_done4
   br label %FINALIZE_SYMTABLE_solver
 
 FINALIZE_SYMTABLE_solver:                         ; preds = %return
-  %28 = load i32, i32* %solver, align 4
+  %28 = load i32, ptr %solver, align 4
   ret i32 %28
 }
 
 declare i32 @f()
 
-define i32 @__module_recursion_02_sub1(i32* %y, i32* %iter) {
+define i32 @__module_recursion_02_sub1(ptr %y, ptr %iter) {
 .entry:
   %sub1 = alloca i32, align 4
   %tmp = alloca i32, align 4
   %x = alloca i32, align 4
-  %0 = load i32, i32* %y, align 4
-  store i32 %0, i32* %x, align 4
-  %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %2 = load i32, i32* %iter, align 4
+  %0 = load i32, ptr %y, align 4
+  store i32 %0, ptr %x, align 4
+  %1 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @7, ptr %1, i32 7, ptr @6, i32 1)
+  %2 = load i32, ptr %iter, align 4
   %3 = icmp eq i32 %2, 1
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 1, i32* %sub1, align 4
+  store i32 1, ptr %sub1, align 4
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -127,104 +128,104 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
-  %4 = load i32, i32* %x, align 4
-  store i32 %4, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %4 = load i32, ptr %x, align 4
+  store i32 %4, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
   %5 = call i32 @sub1.__module_recursion_02_getx()
-  store i32 %5, i32* %tmp, align 4
-  %6 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %6, i32* %x, align 4
-  %7 = load i32, i32* %x, align 4
-  store i32 %7, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  %8 = call i32 @__module_recursion_02_solver(i32 ()* @sub1.__module_recursion_02_getx, i32* %iter)
-  store i32 %8, i32* %sub1, align 4
-  %9 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %9, i32* %x, align 4
+  store i32 %5, ptr %tmp, align 4
+  %6 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %6, ptr %x, align 4
+  %7 = load i32, ptr %x, align 4
+  store i32 %7, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %8 = call i32 @__module_recursion_02_solver(ptr @sub1.__module_recursion_02_getx, ptr %iter)
+  store i32 %8, ptr %sub1, align 4
+  %9 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %9, ptr %x, align 4
   br label %return
 
 return:                                           ; preds = %ifcont, %then
   br label %FINALIZE_SYMTABLE_sub1
 
 FINALIZE_SYMTABLE_sub1:                           ; preds = %return
-  %10 = load i32, i32* %sub1, align 4
+  %10 = load i32, ptr %sub1, align 4
   ret i32 %10
 }
 
 define i32 @sub1.__module_recursion_02_getx() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__sub1__x)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.4, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.6, ptr @__module___lcompilers_created__nested_context__sub1__x)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @5, ptr %7, i32 %10, ptr @4, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %12, i32* %getx, align 4
+  %12 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %12, ptr %getx, align 4
   br label %return
 
 return:                                           ; preds = %free_done
   br label %FINALIZE_SYMTABLE_getx
 
 FINALIZE_SYMTABLE_getx:                           ; preds = %return
-  %13 = load i32, i32* %getx, align 4
+  %13 = load i32, ptr %getx, align 4
   ret i32 %13
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %r = alloca i32, align 4
-  store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value1, align 4
-  %3 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %3, i32* %r, align 4
+  store i32 3, ptr %call_arg_value, align 4
+  store i32 3, ptr %call_arg_value1, align 4
+  %3 = call i32 @__module_recursion_02_sub1(ptr %call_arg_value, ptr %call_arg_value1)
+  store i32 %3, ptr %r, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.9, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.11, ptr %r)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @9, ptr %10, i32 %13, ptr @8, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -238,6 +239,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "508319cf165bb4d7fab359538ba157367a6ea3c12486bc061140eb1d",
+    "stdout_hash": "06a78c1d19515959378e672ae514df79f9621bb28a5536d14086a915",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -1,93 +1,94 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__module___lcompilers_created__nested_context__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data, i32 0, i32 0), i64 7 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 7 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.2 = private unnamed_addr constant [12 x i8] c"S-DESC-6,I4\00", align 1
 @string_const_data.3 = private constant [6 x i8] c"after:"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([6 x i8], [6 x i8]* @string_const_data.3, i32 0, i32 0), i64 6 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 6 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.5 = private unnamed_addr constant [12 x i8] c"S-DESC-9,I4\00", align 1
 @string_const_data.6 = private constant [9 x i8] c"x in getx"
-@string_const.7 = private global %string_descriptor <{ i8* getelementptr inbounds ([9 x i8], [9 x i8]* @string_const_data.6, i32 0, i32 0), i64 9 }>
+@string_const.7 = private global %string_descriptor <{ ptr @string_const_data.6, i64 9 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.8 = private constant [7 x i8] c"in sub1"
-@string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.8, i32 0, i32 0), i64 7 }>
+@string_const.9 = private global %string_descriptor <{ ptr @string_const_data.8, i64 7 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.10 = private unnamed_addr constant [12 x i8] c"S-DESC-3,I4\00", align 1
 @string_const_data.11 = private constant [3 x i8] c"r ="
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.11, i32 0, i32 0), i64 3 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 3 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
+define i32 @__module_recursion_03_solver(ptr %f, ptr %iter) {
 .entry:
   %stringFormat_desc2 = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %f_val = alloca i32, align 4
   %solver = alloca i32, align 4
   %1 = call i32 %f()
-  store i32 %1, i32* %f_val, align 4
+  store i32 %1, ptr %f_val, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
-  %4 = load i64, i64* %2, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %3, i8** %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %4, i64* %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %10 = load i64, i64* %9, align 8
+  %3 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %2, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %f_val)
+  %4 = load i64, ptr %2, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %10 = load i64, ptr %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %12 = icmp eq i8* %3, null
+  call void @_lfortran_printf(ptr @1, ptr %8, i32 %11, ptr @0, i32 1)
+  %12 = icmp eq ptr %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %3)
+  call void @_lfortran_free_alloc(ptr %0, ptr %3)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i32 2, i32* %call_arg_value, align 4
-  %13 = load i32, i32* %iter, align 4
+  store i32 2, ptr %call_arg_value, align 4
+  %13 = load i32, ptr %iter, align 4
   %14 = sub i32 %13, 1
-  store i32 %14, i32* %call_arg_value1, align 4
-  %15 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %15, i32* %solver, align 4
+  store i32 %14, ptr %call_arg_value1, align 4
+  %15 = call i32 @__module_recursion_03_sub1(ptr %call_arg_value, ptr %call_arg_value1)
+  store i32 %15, ptr %solver, align 4
   %16 = call i32 %f()
-  store i32 %16, i32* %f_val, align 4
+  store i32 %16, ptr %f_val, align 4
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
-  %19 = load i64, i64* %17, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  store i8* %18, i8** %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
-  %23 = load i8*, i8** %22, align 8
-  %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
-  %25 = load i64, i64* %24, align 8
+  %18 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.2, ptr %17, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.4, ptr %f_val)
+  %19 = load i64, ptr %17, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  store i64 %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 0
+  %23 = load ptr, ptr %22, align 8
+  %24 = getelementptr %string_descriptor, ptr %stringFormat_desc2, i32 0, i32 1
+  %25 = load i64, ptr %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %27 = icmp eq i8* %18, null
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 %26, ptr @2, i32 1)
+  %27 = icmp eq ptr %18, null
   br i1 %27, label %free_done4, label %free_nonnull3
 
 free_nonnull3:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %0, i8* %18)
+  call void @_lfortran_free_alloc(ptr %0, ptr %18)
   br label %free_done4
 
 free_done4:                                       ; preds = %free_nonnull3, %free_done
@@ -97,44 +98,44 @@ return:                                           ; preds = %free_done4
   br label %FINALIZE_SYMTABLE_solver
 
 FINALIZE_SYMTABLE_solver:                         ; preds = %return
-  %28 = load i32, i32* %solver, align 4
+  %28 = load i32, ptr %solver, align 4
   ret i32 %28
 }
 
 declare i32 @f()
 
-define i32 @__module_recursion_03_solver_caller(i32 ()* %f, i32* %iter) {
+define i32 @__module_recursion_03_solver_caller(ptr %f, ptr %iter) {
 .entry:
   %solver_caller = alloca i32, align 4
-  %0 = call i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter)
-  store i32 %0, i32* %solver_caller, align 4
+  %0 = call i32 @__module_recursion_03_solver(ptr %f, ptr %iter)
+  store i32 %0, ptr %solver_caller, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_solver_caller
 
 FINALIZE_SYMTABLE_solver_caller:                  ; preds = %return
-  %1 = load i32, i32* %solver_caller, align 4
+  %1 = load i32, ptr %solver_caller, align 4
   ret i32 %1
 }
 
 declare i32 @f.1()
 
-define i32 @__module_recursion_03_sub1(i32* %y, i32* %iter) {
+define i32 @__module_recursion_03_sub1(ptr %y, ptr %iter) {
 .entry:
   %sub1 = alloca i32, align 4
   %tmp = alloca i32, align 4
   %x = alloca i32, align 4
-  %0 = load i32, i32* %y, align 4
-  store i32 %0, i32* %x, align 4
-  %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.9, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %2 = load i32, i32* %iter, align 4
+  %0 = load i32, ptr %y, align 4
+  store i32 %0, ptr %x, align 4
+  %1 = load ptr, ptr @string_const.9, align 8
+  call void @_lfortran_printf(ptr @7, ptr %1, i32 7, ptr @6, i32 1)
+  %2 = load i32, ptr %iter, align 4
   %3 = icmp eq i32 %2, 1
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 1, i32* %sub1, align 4
+  store i32 1, ptr %sub1, align 4
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -144,104 +145,104 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
-  %4 = load i32, i32* %x, align 4
-  store i32 %4, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %4 = load i32, ptr %x, align 4
+  store i32 %4, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
   %5 = call i32 @sub1.__module_recursion_03_getx()
-  store i32 %5, i32* %tmp, align 4
-  %6 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %6, i32* %x, align 4
-  %7 = load i32, i32* %x, align 4
-  store i32 %7, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  %8 = call i32 @__module_recursion_03_solver_caller(i32 ()* @sub1.__module_recursion_03_getx, i32* %iter)
-  store i32 %8, i32* %sub1, align 4
-  %9 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %9, i32* %x, align 4
+  store i32 %5, ptr %tmp, align 4
+  %6 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %6, ptr %x, align 4
+  %7 = load i32, ptr %x, align 4
+  store i32 %7, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  %8 = call i32 @__module_recursion_03_solver_caller(ptr @sub1.__module_recursion_03_getx, ptr %iter)
+  store i32 %8, ptr %sub1, align 4
+  %9 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %9, ptr %x, align 4
   br label %return
 
 return:                                           ; preds = %ifcont, %then
   br label %FINALIZE_SYMTABLE_sub1
 
 FINALIZE_SYMTABLE_sub1:                           ; preds = %return
-  %10 = load i32, i32* %sub1, align 4
+  %10 = load i32, ptr %sub1, align 4
   ret i32 %10
 }
 
 define i32 @sub1.__module_recursion_03_getx() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__sub1__x)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info.5, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.7, ptr @__module___lcompilers_created__nested_context__sub1__x)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @5, ptr %7, i32 %10, ptr @4, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %12 = load i32, i32* @__module___lcompilers_created__nested_context__sub1__x, align 4
-  store i32 %12, i32* %getx, align 4
+  %12 = load i32, ptr @__module___lcompilers_created__nested_context__sub1__x, align 4
+  store i32 %12, ptr %getx, align 4
   br label %return
 
 return:                                           ; preds = %free_done
   br label %FINALIZE_SYMTABLE_getx
 
 FINALIZE_SYMTABLE_getx:                           ; preds = %return
-  %13 = load i32, i32* %getx, align 4
+  %13 = load i32, ptr %getx, align 4
   ret i32 %13
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %r = alloca i32, align 4
-  store i32 3, i32* %call_arg_value, align 4
-  store i32 3, i32* %call_arg_value1, align 4
-  %3 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
-  store i32 %3, i32* %r, align 4
+  store i32 3, ptr %call_arg_value, align 4
+  store i32 3, ptr %call_arg_value1, align 4
+  %3 = call i32 @__module_recursion_03_sub1(ptr %call_arg_value, ptr %call_arg_value1)
+  store i32 %3, ptr %r, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.10, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.12, ptr %r)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @9, ptr %10, i32 %13, ptr @8, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -255,6 +256,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "e9961a7d4a2f26118382139e90818d37716291e7becd252c96ff264b",
+    "stdout_hash": "d444d324ef13870ab51eb8ae60ffe13868959203dd016202984aefce",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -1,30 +1,31 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [12 x i8] c"early return"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 12 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [13 x i8] c"normal return"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.1, i32 0, i32 0), i64 13 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 13 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [12 x i8] c"main1 called"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data.3, i32 0, i32 0), i64 12 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 12 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %main_out = alloca i32, align 4
   %2 = call i32 @main1()
-  store i32 %2, i32* %main_out, align 4
-  %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  store i32 %2, ptr %main_out, align 4
+  %3 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %3, i32 12, ptr @4, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -39,16 +40,16 @@ define i32 @main1() {
 .entry:
   %i = alloca i32, align 4
   %main1 = alloca i32, align 4
-  store i32 10, i32* %i, align 4
-  %0 = load i32, i32* %i, align 4
+  store i32 10, ptr %i, align 4
+  %0 = load i32, ptr %i, align 4
   %1 = icmp sgt i32 %0, 5
   br i1 %1, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %2 = load i32, i32* %i, align 4
-  store i32 %2, i32* %main1, align 4
-  %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %2 = load i32, ptr %i, align 4
+  store i32 %2, ptr %main1, align 4
+  %3 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %3, i32 12, ptr @0, i32 1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -58,22 +59,22 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
-  %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %5 = load i32, i32* %i, align 4
-  store i32 %5, i32* %main1, align 4
+  %4 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %4, i32 13, ptr @2, i32 1)
+  %5 = load i32, ptr %i, align 4
+  store i32 %5, ptr %main1, align 4
   br label %return
 
 return:                                           ; preds = %ifcont, %then
   br label %FINALIZE_SYMTABLE_main1
 
 FINALIZE_SYMTABLE_main1:                          ; preds = %return
-  %6 = load i32, i32* %main1, align 4
+  %6 = load i32, ptr %main1, align 4
   ret i32 %6
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "ccb974cc5e56c7d89d77ef0505cc0d06421601827f05c5c43be3829f",
+    "stdout_hash": "66c04f87836892c575d99123a4e65d7690b7e0a0c4d9e2669d80f466",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -1,12 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [9 x i8] c"calling b"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([9 x i8], [9 x i8]* @string_const_data, i32 0, i32 0), i64 9 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 9 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
@@ -21,33 +22,33 @@ target datalayout = "..."
 @serialization_info.3 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @__module_many_returns_b(i32* %a) {
+define i32 @__module_many_returns_b(ptr %a) {
 .entry:
   %b = alloca i32, align 4
   %e = alloca i32, align 4
-  %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %1 = call i32 @b.__module_many_returns_d(i32* %a)
-  store i32 %1, i32* %b, align 4
+  %0 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %0, i32 9, ptr @0, i32 1)
+  %1 = call i32 @b.__module_many_returns_d(ptr %a)
+  store i32 %1, ptr %b, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_b
 
 FINALIZE_SYMTABLE_b:                              ; preds = %return
-  %2 = load i32, i32* %b, align 4
+  %2 = load i32, ptr %b, align 4
   ret i32 %2
 }
 
-define i32 @b.__module_many_returns_d(i32* %i) {
+define i32 @b.__module_many_returns_d(ptr %i) {
 .entry:
   %d = alloca i32, align 4
-  %0 = load i32, i32* %i, align 4
+  %0 = load i32, ptr %i, align 4
   %1 = icmp eq i32 %0, 1
   br i1 %1, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 1, i32* %d, align 4
+  store i32 1, ptr %d, align 4
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -57,12 +58,12 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, ptr %i, align 4
   %3 = icmp eq i32 %2, 2
   br i1 %3, label %then1, label %else3
 
 then1:                                            ; preds = %ifcont
-  store i32 2, i32* %d, align 4
+  store i32 2, ptr %d, align 4
   br label %return
 
 unreachable_after_return2:                        ; No predecessors!
@@ -72,12 +73,12 @@ else3:                                            ; preds = %ifcont
   br label %ifcont4
 
 ifcont4:                                          ; preds = %else3, %unreachable_after_return2
-  %4 = load i32, i32* %i, align 4
+  %4 = load i32, ptr %i, align 4
   %5 = icmp eq i32 %4, 3
   br i1 %5, label %then5, label %else7
 
 then5:                                            ; preds = %ifcont4
-  store i32 3, i32* %d, align 4
+  store i32 3, ptr %d, align 4
   br label %return
 
 unreachable_after_return6:                        ; No predecessors!
@@ -87,122 +88,122 @@ else7:                                            ; preds = %ifcont4
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %unreachable_after_return6
-  store i32 999, i32* %d, align 4
+  store i32 999, ptr %d, align 4
   br label %return
 
 return:                                           ; preds = %ifcont8, %then5, %then1, %then
   br label %FINALIZE_SYMTABLE_d
 
 FINALIZE_SYMTABLE_d:                              ; preds = %return
-  %6 = load i32, i32* %d, align 4
+  %6 = load i32, ptr %d, align 4
   ret i32 %6
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc7 = alloca %string_descriptor, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %call_arg_value = alloca i32, align 4
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %c = alloca i32, align 4
-  store i32 1, i32* %call_arg_value, align 4
-  %3 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %3, i32* %c, align 4
+  store i32 1, ptr %call_arg_value, align 4
+  %3 = call i32 @__module_many_returns_b(ptr %call_arg_value)
+  store i32 %3, ptr %c, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %c)
-  %6 = load i64, i64* %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %5, i8** %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %6, i64* %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %12 = load i64, i64* %11, align 8
+  %5 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %4, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %c)
+  %6 = load i64, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %14 = icmp eq i8* %5, null
+  call void @_lfortran_printf(ptr @3, ptr %10, i32 %13, ptr @2, i32 1)
+  %14 = icmp eq ptr %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %5)
+  call void @_lfortran_free_alloc(ptr %2, ptr %5)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  store i32 2, i32* %call_arg_value, align 4
-  %15 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %15, i32* %c, align 4
+  store i32 2, ptr %call_arg_value, align 4
+  %15 = call i32 @__module_many_returns_b(ptr %call_arg_value)
+  store i32 %15, ptr %c, align 4
   %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %c)
-  %18 = load i64, i64* %16, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %18, i64* %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %24 = load i64, i64* %23, align 8
+  %17 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %16, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %c)
+  %18 = load i64, ptr %16, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %17, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %22 = load ptr, ptr %21, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %24 = load i64, ptr %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
+  call void @_lfortran_printf(ptr @5, ptr %22, i32 %25, ptr @4, i32 1)
+  %26 = icmp eq ptr %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %17)
+  call void @_lfortran_free_alloc(ptr %2, ptr %17)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  store i32 3, i32* %call_arg_value, align 4
-  %27 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %27, i32* %c, align 4
+  store i32 3, ptr %call_arg_value, align 4
+  %27 = call i32 @__module_many_returns_b(ptr %call_arg_value)
+  store i32 %27, ptr %c, align 4
   %28 = alloca i64, align 8
-  %29 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %28, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %c)
-  %30 = load i64, i64* %28, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %29, i8** %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %30, i64* %32, align 8
-  %33 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %36 = load i64, i64* %35, align 8
+  %29 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %28, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %c)
+  %30 = load i64, ptr %28, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %30, ptr %32, align 8
+  %33 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  %35 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %38 = icmp eq i8* %29, null
+  call void @_lfortran_printf(ptr @7, ptr %34, i32 %37, ptr @6, i32 1)
+  %38 = icmp eq ptr %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %29)
+  call void @_lfortran_free_alloc(ptr %2, ptr %29)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  store i32 4, i32* %call_arg_value, align 4
-  %39 = call i32 @__module_many_returns_b(i32* %call_arg_value)
-  store i32 %39, i32* %c, align 4
+  store i32 4, ptr %call_arg_value, align 4
+  %39 = call i32 @__module_many_returns_b(ptr %call_arg_value)
+  store i32 %39, ptr %c, align 4
   %40 = alloca i64, align 8
-  %41 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %40, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %c)
-  %42 = load i64, i64* %40, align 8
-  %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  store i8* %41, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  store i64 %42, i64* %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
+  %41 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %40, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %c)
+  %42 = load i64, ptr %40, align 8
+  %43 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  store ptr %41, ptr %43, align 8
+  %44 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  store i64 %42, ptr %44, align 8
+  %45 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 0
+  %46 = load ptr, ptr %45, align 8
+  %47 = getelementptr %string_descriptor, ptr %stringFormat_desc7, i32 0, i32 1
+  %48 = load i64, ptr %47, align 8
   %49 = trunc i64 %48 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %50 = icmp eq i8* %41, null
+  call void @_lfortran_printf(ptr @9, ptr %46, i32 %49, ptr @8, i32 1)
+  %50 = icmp eq ptr %41, null
   br i1 %50, label %free_done9, label %free_nonnull8
 
 free_nonnull8:                                    ; preds = %free_done6
-  call void @_lfortran_free_alloc(i8* %2, i8* %41)
+  call void @_lfortran_free_alloc(ptr %2, ptr %41)
   br label %free_done9
 
 free_done9:                                       ; preds = %free_nonnull8, %free_done6
@@ -216,12 +217,12 @@ FINALIZE_SYMTABLE_returns:                        ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "43e95fe72656d8993d3ed7ef431b5b4b9e74ba65da00a4bae440aaee",
+    "stdout_hash": "31008d2d1a9e175155c96009cba04e77ed709cff0436d4f87aac4f32",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -1,29 +1,30 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [12 x i8] c"early return"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 12 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [13 x i8] c"normal return"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.1, i32 0, i32 0), i64 13 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 13 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @main.main_out = internal global i32 999
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [12 x i8] c"main1 called"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data.3, i32 0, i32 0), i64 12 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 12 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  call void @main1(i32* @main.main_out)
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  call void @main1(ptr @main.main_out)
+  %2 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %2, i32 12, ptr @4, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -34,19 +35,19 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-define void @main1(i32* %out_var) {
+define void @main1(ptr %out_var) {
 .entry:
   %i = alloca i32, align 4
-  store i32 10, i32* %i, align 4
-  %0 = load i32, i32* %i, align 4
+  store i32 10, ptr %i, align 4
+  %0 = load i32, ptr %i, align 4
   %1 = icmp sgt i32 %0, 5
   br i1 %1, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %2 = load i32, i32* %i, align 4
-  store i32 %2, i32* %out_var, align 4
-  %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %2 = load i32, ptr %i, align 4
+  store i32 %2, ptr %out_var, align 4
+  %3 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %3, i32 12, ptr @0, i32 1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -56,10 +57,10 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
-  %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %5 = load i32, i32* %i, align 4
-  store i32 %5, i32* %out_var, align 4
+  %4 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %4, i32 13, ptr @2, i32 1)
+  %5 = load i32, ptr %i, align 4
+  store i32 %5, ptr %out_var, align 4
   br label %return
 
 return:                                           ; preds = %ifcont, %then
@@ -69,8 +70,8 @@ FINALIZE_SYMTABLE_main1:                          ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_05-b1ab26b.json
+++ b/tests/reference/llvm-return_05-b1ab26b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_05-b1ab26b.stdout",
-    "stdout_hash": "a3c0e131e2e7ebcf54a6c96b0d26f76ccbd2978344290e974d147b54",
+    "stdout_hash": "3c054e33f96ef266bc96bc61ef08c0710d4784afc2eab87ab5b0155e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_05-b1ab26b.stdout
+++ b/tests/reference/llvm-return_05-b1ab26b.stdout
@@ -1,12 +1,13 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [11 x i8] c"Hello world"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data, i32 0, i32 0), i64 11 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 11 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
 define void @f() {
@@ -20,14 +21,14 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
   ret void
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
-  %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %2 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %2, i32 11, ptr @0, i32 1)
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -38,8 +39,8 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-return_06-ec98b0b.json
+++ b/tests/reference/llvm-return_06-ec98b0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_06-ec98b0b.stdout",
-    "stdout_hash": "2ac0b608df3a61128ee62d7fce3a0023d8c2f4225bc08208383f1fa3",
+    "stdout_hash": "ba7961af2a0add72d05205d09bfb4ab0c6a927597f3bc21661d6552a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_06-ec98b0b.stdout
+++ b/tests/reference/llvm-return_06-ec98b0b.stdout
@@ -1,10 +1,11 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -18,6 +19,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "ec17e120d06afc299ab09e2bd16c3f51dbb5200b3493915a04afe5b6",
+    "stdout_hash": "c80eed55c0095a5bf3c084fb19010e9ed686368cb2623501b2ec508d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -1,31 +1,32 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%select_type_13_module.shape.3_class = type <{ i32 (...)**, %select_type_13_module.shape.3* }>
-%select_type_13_module.shape.3 = type {}
-%string_descriptor = type <{ i8*, i64 }>
-%select_type_13_module.circle.5_class = type <{ i32 (...)**, %select_type_13_module.circle.5* }>
+%string_descriptor = type <{ ptr, i64 }>
+%select_type_13_module.circle.5_class = type <{ ptr, ptr }>
 %select_type_13_module.circle.5 = type { %select_type_13_module.shape.3, float }
-%select_type_13_module.rectangle.6_class = type <{ i32 (...)**, %select_type_13_module.rectangle.6* }>
+%select_type_13_module.shape.3 = type {}
+%select_type_13_module.rectangle.6_class = type <{ ptr, ptr }>
 %select_type_13_module.rectangle.6 = type { %select_type_13_module.shape.3, float, float }
+%select_type_13_module.shape.3_class = type <{ ptr, ptr }>
 
 @_Name_shape = private unnamed_addr constant [6 x i8] c"shape\00", align 1
-@_Type_Info_shape = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @_Name_shape, i32 0, i32 0), i8* null, i8* null }, align 8
-@_VTable_shape = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_shape to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_shape to i8*), i8* bitcast (void (i8*)* @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly to i8*), i8* null] }, align 8
+@_Type_Info_shape = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_shape, ptr null, ptr null }, align 8
+@_VTable_shape = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_shape, ptr @_copy_select_type_13_module_shape, ptr @_allocate_struct_select_type_13_module_shape, ptr @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly, ptr null] }, align 8
 @_Name_circle = private unnamed_addr constant [7 x i8] c"circle\00", align 1
-@_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.circle.5_class*)* @__module_select_type_13_module_circle_area to i8*)] }, align 8
+@_Type_Info_circle = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_circle, ptr inttoptr (i64 4 to ptr), ptr @_Type_Info_shape }, align 8
+@_VTable_circle = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_circle, ptr @_copy_select_type_13_module_circle, ptr @_allocate_struct_select_type_13_module_circle, ptr @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly, ptr @__module_select_type_13_module_circle_area] }, align 8
 @_Name_rectangle = private unnamed_addr constant [10 x i8] c"rectangle\00", align 1
-@_Type_Info_rectangle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([10 x i8], [10 x i8]* @_Name_rectangle, i32 0, i32 0), i8* inttoptr (i64 8 to i8*), i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_shape to i8*) }, align 8
-@_VTable_rectangle = linkonce_odr unnamed_addr constant { [6 x i8*] } { [6 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_select_type_13_module_rectangle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly to i8*), i8* bitcast (float (%select_type_13_module.rectangle.6_class*)* @__module_select_type_13_module_rectangle_area to i8*)] }, align 8
+@_Type_Info_rectangle = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr @_Name_rectangle, ptr inttoptr (i64 8 to ptr), ptr @_Type_Info_shape }, align 8
+@_VTable_rectangle = linkonce_odr unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_Type_Info_rectangle, ptr @_copy_select_type_13_module_rectangle, ptr @_allocate_struct_select_type_13_module_rectangle, ptr @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly, ptr @__module_select_type_13_module_rectangle_area] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [20 x i8] c"Matched as rectangle"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* @string_const_data, i32 0, i32 0), i64 20 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 20 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [17 x i8] c"Matched as circle"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.1, i32 0, i32 0), i64 17 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 17 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [3 x i8] c"s1\00", align 1
 @5 = private unnamed_addr constant [46 x i8] c"tests/../integration_tests/select_type_13.f90\00", align 1
@@ -47,15 +48,15 @@ target datalayout = "..."
 @19 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @20 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [16 x i8] c"Matched as shape"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([16 x i8], [16 x i8]* @string_const_data.3, i32 0, i32 0), i64 16 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 16 }>
 @21 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @22 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [17 x i8] c"Matched as circle"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.5, i32 0, i32 0), i64 17 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 17 }>
 @23 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @24 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.7 = private constant [20 x i8] c"Matched as rectangle"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([20 x i8], [20 x i8]* @string_const_data.7, i32 0, i32 0), i64 20 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 20 }>
 @25 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @26 = private unnamed_addr constant [3 x i8] c"s2\00", align 1
 @27 = private unnamed_addr constant [46 x i8] c"tests/../integration_tests/select_type_13.f90\00", align 1
@@ -90,320 +91,309 @@ target datalayout = "..."
 @55 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @56 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.10 = private constant [16 x i8] c"Matched as shape"
-@string_const.11 = private global %string_descriptor <{ i8* getelementptr inbounds ([16 x i8], [16 x i8]* @string_const_data.10, i32 0, i32 0), i64 16 }>
+@string_const.11 = private global %string_descriptor <{ ptr @string_const_data.10, i64 16 }>
 @57 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define float @__module_select_type_13_module_circle_area(%select_type_13_module.circle.5_class* %this) {
+define float @__module_select_type_13_module_circle_area(ptr %this) {
 .entry:
   %circle_area = alloca float, align 4
-  %0 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %this, i32 0, i32 1
-  %1 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %0, align 8
-  %2 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %1, i32 0, i32 1
-  %3 = load float, float* %2, align 4
+  %0 = getelementptr %select_type_13_module.circle.5_class, ptr %this, i32 0, i32 1
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %select_type_13_module.circle.5, ptr %1, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
   %4 = fmul float 0x400921FA00000000, %3
-  %5 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %this, i32 0, i32 1
-  %6 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %5, align 8
-  %7 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %6, i32 0, i32 1
-  %8 = load float, float* %7, align 4
+  %5 = getelementptr %select_type_13_module.circle.5_class, ptr %this, i32 0, i32 1
+  %6 = load ptr, ptr %5, align 8
+  %7 = getelementptr %select_type_13_module.circle.5, ptr %6, i32 0, i32 1
+  %8 = load float, ptr %7, align 4
   %9 = fmul float %4, %8
-  store float %9, float* %circle_area, align 4
+  store float %9, ptr %circle_area, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_circle_area
 
 FINALIZE_SYMTABLE_circle_area:                    ; preds = %return
-  %10 = load float, float* %circle_area, align 4
+  %10 = load float, ptr %circle_area, align 4
   ret float %10
 }
 
-define float @__module_select_type_13_module_rectangle_area(%select_type_13_module.rectangle.6_class* %this) {
+define float @__module_select_type_13_module_rectangle_area(ptr %this) {
 .entry:
   %rectangle_area = alloca float, align 4
-  %0 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %this, i32 0, i32 1
-  %1 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %0, align 8
-  %2 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %1, i32 0, i32 1
-  %3 = load float, float* %2, align 4
-  %4 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %this, i32 0, i32 1
-  %5 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %4, align 8
-  %6 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %5, i32 0, i32 2
-  %7 = load float, float* %6, align 4
+  %0 = getelementptr %select_type_13_module.rectangle.6_class, ptr %this, i32 0, i32 1
+  %1 = load ptr, ptr %0, align 8
+  %2 = getelementptr %select_type_13_module.rectangle.6, ptr %1, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %select_type_13_module.rectangle.6_class, ptr %this, i32 0, i32 1
+  %5 = load ptr, ptr %4, align 8
+  %6 = getelementptr %select_type_13_module.rectangle.6, ptr %5, i32 0, i32 2
+  %7 = load float, ptr %6, align 4
   %8 = fmul float %3, %7
-  store float %8, float* %rectangle_area, align 4
+  store float %8, ptr %rectangle_area, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_rectangle_area
 
 FINALIZE_SYMTABLE_rectangle_area:                 ; preds = %return
-  %9 = load float, float* %rectangle_area, align 4
+  %9 = load float, ptr %rectangle_area, align 4
   ret float %9
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc35 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %s1 = alloca %select_type_13_module.shape.3_class*, align 8
-  store %select_type_13_module.shape.3_class* null, %select_type_13_module.shape.3_class** %s1, align 8
-  %s2 = alloca %select_type_13_module.shape.3_class*, align 8
-  store %select_type_13_module.shape.3_class* null, %select_type_13_module.shape.3_class** %s2, align 8
-  %3 = call i8* @_lfortran_get_default_allocator()
-  %4 = call i8* @_lfortran_malloc_alloc(i8* %3, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %4, i8 0, i32 4, i1 false)
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 16, i1 false)
-  %7 = bitcast i8* %6 to %select_type_13_module.shape.3_class*
-  store %select_type_13_module.shape.3_class* %7, %select_type_13_module.shape.3_class** %s1, align 8
-  %8 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %9 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %8, i32 0, i32 1
-  %10 = bitcast i8* %4 to %select_type_13_module.shape.3*
-  store %select_type_13_module.shape.3* %10, %select_type_13_module.shape.3** %9, align 8
-  %11 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %9, align 8
-  %12 = bitcast %select_type_13_module.shape.3* %11 to %select_type_13_module.circle.5*
-  %13 = bitcast %select_type_13_module.shape.3_class* %7 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %13, align 8
-  %14 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %12, i32 0, i32 1
-  %15 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %12, i32 0, i32 0
-  %16 = alloca i1, align 1
-  %17 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %18 = ptrtoint %select_type_13_module.shape.3_class* %17 to i64
-  %19 = icmp eq i64 %18, 0
-  br i1 %19, label %then1, label %else
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %s1 = alloca %select_type_13_module.shape.3_class, align 8
+  store ptr null, ptr %s1, align 8
+  %s2 = alloca %select_type_13_module.shape.3_class, align 8
+  store ptr null, ptr %s2, align 8
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 4)
+  call void @llvm.memset.p0.i32(ptr %4, i8 0, i32 4, i1 false)
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 16)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 16, i1 false)
+  store ptr %6, ptr %s1, align 8
+  %7 = load ptr, ptr %s1, align 8
+  %8 = getelementptr %select_type_13_module.shape.3_class, ptr %7, i32 0, i32 1
+  store ptr %4, ptr %8, align 8
+  %9 = load ptr, ptr %8, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %6, align 8
+  %10 = getelementptr %select_type_13_module.circle.5, ptr %9, i32 0, i32 1
+  %11 = getelementptr %select_type_13_module.circle.5, ptr %9, i32 0, i32 0
+  %12 = alloca i1, align 1
+  %13 = load ptr, ptr %s1, align 8
+  %14 = ptrtoint ptr %13 to i64
+  %15 = icmp eq i64 %14, 0
+  br i1 %15, label %then1, label %else
 
 then:                                             ; preds = %ifcont
   br label %"~select_type_block_.start"
 
 then1:                                            ; preds = %.entry
-  %20 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %20, align 8
-  %21 = bitcast i32 (...)*** %20 to i8*
-  %22 = call i8* @__lfortran_dynamic_cast(i8* %21, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %23 = icmp ne i8* %22, null
-  store i1 %23, i1* %16, align 1
+  %16 = alloca ptr, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_shape, i32 0, i32 0, i32 2), ptr %16, align 8
+  %17 = call ptr @__lfortran_dynamic_cast(ptr %16, ptr @_Type_Info_rectangle, i1 false)
+  %18 = icmp ne ptr %17, null
+  store i1 %18, ptr %12, align 1
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %24 = bitcast %select_type_13_module.shape.3_class* %17 to i8*
-  %25 = call i8* @__lfortran_dynamic_cast(i8* %24, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %26 = icmp ne i8* %25, null
-  store i1 %26, i1* %16, align 1
+  %19 = call ptr @__lfortran_dynamic_cast(ptr %13, ptr @_Type_Info_rectangle, i1 false)
+  %20 = icmp ne ptr %19, null
+  store i1 %20, ptr %12, align 1
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then1
-  %27 = load i1, i1* %16, align 1
-  br i1 %27, label %then, label %else2
+  %21 = load i1, ptr %12, align 1
+  br i1 %21, label %then, label %else2
 
 "~select_type_block_.start":                      ; preds = %then
-  %28 = call i8* @llvm.stacksave()
-  %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %29, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %22 = call ptr @llvm.stacksave.p0()
+  %23 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %23, i32 20, ptr @0, i32 1)
   br label %"~select_type_block_.end"
 
 "~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_"
 
 "FINALIZE_SYMTABLE_~select_type_block_":          ; preds = %"~select_type_block_.end"
-  call void @llvm.stackrestore(i8* %28)
+  call void @llvm.stackrestore.p0(ptr %22)
   br label %ifcont17
 
 else2:                                            ; preds = %ifcont
-  %30 = alloca i1, align 1
-  %31 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %32 = ptrtoint %select_type_13_module.shape.3_class* %31 to i64
-  %33 = icmp eq i64 %32, 0
-  br i1 %33, label %then4, label %else5
+  %24 = alloca i1, align 1
+  %25 = load ptr, ptr %s1, align 8
+  %26 = ptrtoint ptr %25 to i64
+  %27 = icmp eq i64 %26, 0
+  br i1 %27, label %then4, label %else5
 
 then3:                                            ; preds = %ifcont6
   br label %"~select_type_block_1.start"
 
 then4:                                            ; preds = %else2
-  %34 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %34, align 8
-  %35 = bitcast i32 (...)*** %34 to i8*
-  %36 = call i8* @__lfortran_dynamic_cast(i8* %35, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %37 = icmp ne i8* %36, null
-  store i1 %37, i1* %30, align 1
+  %28 = alloca ptr, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_shape, i32 0, i32 0, i32 2), ptr %28, align 8
+  %29 = call ptr @__lfortran_dynamic_cast(ptr %28, ptr @_Type_Info_circle, i1 false)
+  %30 = icmp ne ptr %29, null
+  store i1 %30, ptr %24, align 1
   br label %ifcont6
 
 else5:                                            ; preds = %else2
-  %38 = bitcast %select_type_13_module.shape.3_class* %31 to i8*
-  %39 = call i8* @__lfortran_dynamic_cast(i8* %38, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %40 = icmp ne i8* %39, null
-  store i1 %40, i1* %30, align 1
+  %31 = call ptr @__lfortran_dynamic_cast(ptr %25, ptr @_Type_Info_circle, i1 false)
+  %32 = icmp ne ptr %31, null
+  store i1 %32, ptr %24, align 1
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %41 = load i1, i1* %30, align 1
-  br i1 %41, label %then3, label %else16
+  %33 = load i1, ptr %24, align 1
+  br i1 %33, label %then3, label %else16
 
 "~select_type_block_1.start":                     ; preds = %then3
-  %42 = call i8* @llvm.stacksave()
-  %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %44 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
-  %45 = ptrtoint %select_type_13_module.shape.3_class** %44 to i64
-  %46 = icmp eq i64 %45, 0
-  br i1 %46, label %then7, label %ifcont8
+  %34 = call ptr @llvm.stacksave.p0()
+  %35 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %35, i32 17, ptr @2, i32 1)
+  %36 = load ptr, ptr %s1, align 8
+  %37 = ptrtoint ptr %36 to i64
+  %38 = icmp eq i64 %37, 0
+  br i1 %38, label %then7, label %ifcont8
 
 then7:                                            ; preds = %"~select_type_block_1.start"
-  %47 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %48 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %49 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %48, i32 0, i32 0
-  %50 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %49, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @5, i32 0, i32 0), i8** %50, align 8
-  %51 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %49, i32 0, i32 1
-  store i32 56, i32* %51, align 4
-  %52 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %49, i32 0, i32 2
-  store i32 7, i32* %52, align 4
-  %53 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %49, i32 0, i32 3
-  store i32 56, i32* %53, align 4
-  %54 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %49, i32 0, i32 4
-  store i32 10, i32* %54, align 4
-  %55 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @6, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
-  %56 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %47, i32 0, i32 0
-  %57 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %48, i32 0, i32 0
-  %58 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %56, i32 0, i32 2
-  %59 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %56, i32 0, i32 0
-  store i1 true, i1* %59, align 1
-  %60 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %56, i32 0, i32 1
-  store i8* %55, i8** %60, align 8
-  store { i8*, i32, i32, i32, i32 }* %57, { i8*, i32, i32, i32, i32 }** %58, align 8
-  %61 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %56, i32 0, i32 3
-  store i32 1, i32* %61, align 4
-  %62 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %47, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %62, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
+  %39 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %40 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %41 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %40, i32 0, i32 0
+  %42 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 0
+  store ptr @5, ptr %42, align 8
+  %43 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 1
+  store i32 56, ptr %43, align 4
+  %44 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 2
+  store i32 7, ptr %44, align 4
+  %45 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 3
+  store i32 56, ptr %45, align 4
+  %46 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %41, i32 0, i32 4
+  store i32 10, ptr %46, align 4
+  %47 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6, ptr @4)
+  %48 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %39, i32 0, i32 0
+  %49 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %40, i32 0, i32 0
+  %50 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 2
+  %51 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 0
+  store i1 true, ptr %51, align 1
+  %52 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 1
+  store ptr %47, ptr %52, align 8
+  store ptr %49, ptr %50, align 8
+  %53 = getelementptr { i1, ptr, ptr, i32 }, ptr %48, i32 0, i32 3
+  store i32 1, ptr %53, align 4
+  %54 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %39, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %54, i32 1, ptr @7, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont8:                                          ; preds = %"~select_type_block_1.start"
-  %63 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %64 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %63, align 1
-  %65 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %66 = bitcast %select_type_13_module.shape.3_class* %65 to %select_type_13_module.circle.5_class*
-  %67 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %66, i32 0, i32 1
-  %68 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %67, align 8
-  %69 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %68, i32 0, i32 1
-  store float 1.000000e+01, float* %69, align 4
-  %70 = alloca i64, align 8
-  %71 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
-  %72 = ptrtoint %select_type_13_module.shape.3_class** %71 to i64
-  %73 = icmp eq i64 %72, 0
-  br i1 %73, label %then9, label %ifcont10
+  %55 = load ptr, ptr %s1, align 8
+  %56 = load %select_type_13_module.shape.3_class, ptr %55, align 1
+  %57 = load ptr, ptr %s1, align 8
+  %58 = getelementptr %select_type_13_module.circle.5_class, ptr %57, i32 0, i32 1
+  %59 = load ptr, ptr %58, align 8
+  %60 = getelementptr %select_type_13_module.circle.5, ptr %59, i32 0, i32 1
+  store float 1.000000e+01, ptr %60, align 4
+  %61 = alloca i64, align 8
+  %62 = load ptr, ptr %s1, align 8
+  %63 = ptrtoint ptr %62 to i64
+  %64 = icmp eq i64 %63, 0
+  br i1 %64, label %then9, label %ifcont10
 
 then9:                                            ; preds = %ifcont8
-  %74 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %75 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %76 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %77 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @10, i32 0, i32 0), i8** %77, align 8
-  %78 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 1
-  store i32 57, i32* %78, align 4
-  %79 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 2
-  store i32 16, i32* %79, align 4
-  %80 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 3
-  store i32 57, i32* %80, align 4
-  %81 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %76, i32 0, i32 4
-  store i32 19, i32* %81, align 4
-  %82 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
-  %83 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  %84 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %75, i32 0, i32 0
-  %85 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 2
-  %86 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 0
-  store i1 true, i1* %86, align 1
-  %87 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 1
-  store i8* %82, i8** %87, align 8
-  store { i8*, i32, i32, i32, i32 }* %84, { i8*, i32, i32, i32, i32 }** %85, align 8
-  %88 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 0, i32 3
-  store i32 1, i32* %88, align 4
-  %89 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %74, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %89, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @12, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
+  %65 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %66 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %67 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %66, i32 0, i32 0
+  %68 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 0
+  store ptr @10, ptr %68, align 8
+  %69 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 1
+  store i32 57, ptr %69, align 4
+  %70 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 2
+  store i32 16, ptr %70, align 4
+  %71 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 3
+  store i32 57, ptr %71, align 4
+  %72 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %67, i32 0, i32 4
+  store i32 19, ptr %72, align 4
+  %73 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @11, ptr @9)
+  %74 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %65, i32 0, i32 0
+  %75 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %66, i32 0, i32 0
+  %76 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 2
+  %77 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 0
+  store i1 true, ptr %77, align 1
+  %78 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 1
+  store ptr %73, ptr %78, align 8
+  store ptr %75, ptr %76, align 8
+  %79 = getelementptr { i1, ptr, ptr, i32 }, ptr %74, i32 0, i32 3
+  store i32 1, ptr %79, align 4
+  %80 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %65, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %80, i32 1, ptr @12, ptr @9)
   call void @exit(i32 1)
   unreachable
 
 ifcont10:                                         ; preds = %ifcont8
-  %90 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %91 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %90, align 1
-  %92 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %93 = bitcast %select_type_13_module.shape.3_class* %92 to %select_type_13_module.circle.5_class*
-  %94 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %93, i32 0, i32 1
-  %95 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %94, align 8
-  %96 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %95, i32 0, i32 1
-  %97 = load float, float* %96, align 4
-  %98 = alloca float, align 4
-  store float %97, float* %98, align 4
-  %99 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %70, i32 0, i32 0, i32 0, i32 0, i32 0, float* %98)
-  %100 = load i64, i64* %70, align 8
-  %101 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %99, i8** %101, align 8
-  %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %100, i64* %102, align 8
-  %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %104 = load i8*, i8** %103, align 8
-  %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %106 = load i64, i64* %105, align 8
-  %107 = trunc i64 %106 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %104, i32 %107, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
-  %108 = icmp eq i8* %99, null
-  br i1 %108, label %free_done, label %free_nonnull
+  %81 = load ptr, ptr %s1, align 8
+  %82 = load %select_type_13_module.shape.3_class, ptr %81, align 1
+  %83 = load ptr, ptr %s1, align 8
+  %84 = getelementptr %select_type_13_module.circle.5_class, ptr %83, i32 0, i32 1
+  %85 = load ptr, ptr %84, align 8
+  %86 = getelementptr %select_type_13_module.circle.5, ptr %85, i32 0, i32 1
+  %87 = load float, ptr %86, align 4
+  %88 = alloca float, align 4
+  store float %87, ptr %88, align 4
+  %89 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %61, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %88)
+  %90 = load i64, ptr %61, align 8
+  %91 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %89, ptr %91, align 8
+  %92 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %90, ptr %92, align 8
+  %93 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %94 = load ptr, ptr %93, align 8
+  %95 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %96 = load i64, ptr %95, align 8
+  %97 = trunc i64 %96 to i32
+  call void @_lfortran_printf(ptr @13, ptr %94, i32 %97, ptr @8, i32 1)
+  %98 = icmp eq ptr %89, null
+  br i1 %98, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont10
-  call void @_lfortran_free_alloc(i8* %2, i8* %99)
+  call void @_lfortran_free_alloc(ptr %2, ptr %89)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont10
-  %109 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
-  %110 = ptrtoint %select_type_13_module.shape.3_class** %109 to i64
-  %111 = icmp eq i64 %110, 0
-  br i1 %111, label %then11, label %ifcont12
+  %99 = load ptr, ptr %s1, align 8
+  %100 = ptrtoint ptr %99 to i64
+  %101 = icmp eq i64 %100, 0
+  br i1 %101, label %then11, label %ifcont12
 
 then11:                                           ; preds = %free_done
-  %112 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %113 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %114 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %113, i32 0, i32 0
-  %115 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %114, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @15, i32 0, i32 0), i8** %115, align 8
-  %116 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %114, i32 0, i32 1
-  store i32 58, i32* %116, align 4
-  %117 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %114, i32 0, i32 2
-  store i32 11, i32* %117, align 4
-  %118 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %114, i32 0, i32 3
-  store i32 58, i32* %118, align 4
-  %119 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %114, i32 0, i32 4
-  store i32 14, i32* %119, align 4
-  %120 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @16, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
-  %121 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %112, i32 0, i32 0
-  %122 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %113, i32 0, i32 0
-  %123 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 0, i32 2
-  %124 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 0, i32 0
-  store i1 true, i1* %124, align 1
-  %125 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 0, i32 1
-  store i8* %120, i8** %125, align 8
-  store { i8*, i32, i32, i32, i32 }* %122, { i8*, i32, i32, i32, i32 }** %123, align 8
-  %126 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %121, i32 0, i32 3
-  store i32 1, i32* %126, align 4
-  %127 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %112, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %127, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @14, i32 0, i32 0))
+  %102 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %103 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %104 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %103, i32 0, i32 0
+  %105 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 0
+  store ptr @15, ptr %105, align 8
+  %106 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 1
+  store i32 58, ptr %106, align 4
+  %107 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 2
+  store i32 11, ptr %107, align 4
+  %108 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 3
+  store i32 58, ptr %108, align 4
+  %109 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %104, i32 0, i32 4
+  store i32 14, ptr %109, align 4
+  %110 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @16, ptr @14)
+  %111 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %102, i32 0, i32 0
+  %112 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %103, i32 0, i32 0
+  %113 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 2
+  %114 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 0
+  store i1 true, ptr %114, align 1
+  %115 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 1
+  store ptr %110, ptr %115, align 8
+  store ptr %112, ptr %113, align 8
+  %116 = getelementptr { i1, ptr, ptr, i32 }, ptr %111, i32 0, i32 3
+  store i32 1, ptr %116, align 4
+  %117 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %102, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %117, i32 1, ptr @17, ptr @14)
   call void @exit(i32 1)
   unreachable
 
 ifcont12:                                         ; preds = %free_done
-  %128 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %129 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %128, align 1
-  %130 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  %131 = bitcast %select_type_13_module.shape.3_class* %130 to %select_type_13_module.circle.5_class*
-  %132 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %131, i32 0, i32 1
-  %133 = load %select_type_13_module.circle.5*, %select_type_13_module.circle.5** %132, align 8
-  %134 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %133, i32 0, i32 1
-  %135 = load float, float* %134, align 4
-  %136 = fcmp une float %135, 1.000000e+01
-  br i1 %136, label %then13, label %else14
+  %118 = load ptr, ptr %s1, align 8
+  %119 = load %select_type_13_module.shape.3_class, ptr %118, align 1
+  %120 = load ptr, ptr %s1, align 8
+  %121 = getelementptr %select_type_13_module.circle.5_class, ptr %120, i32 0, i32 1
+  %122 = load ptr, ptr %121, align 8
+  %123 = getelementptr %select_type_13_module.circle.5, ptr %122, i32 0, i32 1
+  %124 = load float, ptr %123, align 4
+  %125 = fcmp une float %124, 1.000000e+01
+  br i1 %125, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @19, ptr @"ERROR STOP", ptr @18)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -418,371 +408,358 @@ ifcont15:                                         ; preds = %else14, %then13
   br label %"FINALIZE_SYMTABLE_~select_type_block_1"
 
 "FINALIZE_SYMTABLE_~select_type_block_1":         ; preds = %"~select_type_block_1.end"
-  call void @llvm.stackrestore(i8* %42)
+  call void @llvm.stackrestore.p0(ptr %34)
   br label %ifcont17
 
 else16:                                           ; preds = %ifcont6
   br label %"~select_type_block_2.start"
 
 "~select_type_block_2.start":                     ; preds = %else16
-  %137 = call i8* @llvm.stacksave()
-  %138 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %138, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  %126 = call ptr @llvm.stacksave.p0()
+  %127 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @21, ptr %127, i32 16, ptr @20, i32 1)
   br label %"~select_type_block_2.end"
 
 "~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_2"
 
 "FINALIZE_SYMTABLE_~select_type_block_2":         ; preds = %"~select_type_block_2.end"
-  call void @llvm.stackrestore(i8* %137)
+  call void @llvm.stackrestore.p0(ptr %126)
   br label %ifcont17
 
 ifcont17:                                         ; preds = %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
-  %139 = call i8* @_lfortran_get_default_allocator()
-  %140 = call i8* @_lfortran_malloc_alloc(i8* %139, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %140, i8 0, i32 8, i1 false)
-  %141 = call i8* @_lfortran_get_default_allocator()
-  %142 = call i8* @_lfortran_malloc_alloc(i8* %141, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %142, i8 0, i32 16, i1 false)
-  %143 = bitcast i8* %142 to %select_type_13_module.shape.3_class*
-  store %select_type_13_module.shape.3_class* %143, %select_type_13_module.shape.3_class** %s2, align 8
-  %144 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %145 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %144, i32 0, i32 1
-  %146 = bitcast i8* %140 to %select_type_13_module.shape.3*
-  store %select_type_13_module.shape.3* %146, %select_type_13_module.shape.3** %145, align 8
-  %147 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %145, align 8
-  %148 = bitcast %select_type_13_module.shape.3* %147 to %select_type_13_module.rectangle.6*
-  %149 = bitcast %select_type_13_module.shape.3_class* %143 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %149, align 8
-  %150 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 1
-  %151 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 2
-  %152 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %148, i32 0, i32 0
-  %153 = alloca i1, align 1
-  %154 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %155 = ptrtoint %select_type_13_module.shape.3_class* %154 to i64
-  %156 = icmp eq i64 %155, 0
-  br i1 %156, label %then19, label %else20
+  %128 = call ptr @_lfortran_get_default_allocator()
+  %129 = call ptr @_lfortran_malloc_alloc(ptr %128, i64 8)
+  call void @llvm.memset.p0.i32(ptr %129, i8 0, i32 8, i1 false)
+  %130 = call ptr @_lfortran_get_default_allocator()
+  %131 = call ptr @_lfortran_malloc_alloc(ptr %130, i64 16)
+  call void @llvm.memset.p0.i32(ptr %131, i8 0, i32 16, i1 false)
+  store ptr %131, ptr %s2, align 8
+  %132 = load ptr, ptr %s2, align 8
+  %133 = getelementptr %select_type_13_module.shape.3_class, ptr %132, i32 0, i32 1
+  store ptr %129, ptr %133, align 8
+  %134 = load ptr, ptr %133, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_rectangle, i32 0, i32 0, i32 2), ptr %131, align 8
+  %135 = getelementptr %select_type_13_module.rectangle.6, ptr %134, i32 0, i32 1
+  %136 = getelementptr %select_type_13_module.rectangle.6, ptr %134, i32 0, i32 2
+  %137 = getelementptr %select_type_13_module.rectangle.6, ptr %134, i32 0, i32 0
+  %138 = alloca i1, align 1
+  %139 = load ptr, ptr %s2, align 8
+  %140 = ptrtoint ptr %139 to i64
+  %141 = icmp eq i64 %140, 0
+  br i1 %141, label %then19, label %else20
 
 then18:                                           ; preds = %ifcont21
   br label %"~select_type_block_3.start"
 
 then19:                                           ; preds = %ifcont17
-  %157 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %157, align 8
-  %158 = bitcast i32 (...)*** %157 to i8*
-  %159 = call i8* @__lfortran_dynamic_cast(i8* %158, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %160 = icmp ne i8* %159, null
-  store i1 %160, i1* %153, align 1
+  %142 = alloca ptr, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_shape, i32 0, i32 0, i32 2), ptr %142, align 8
+  %143 = call ptr @__lfortran_dynamic_cast(ptr %142, ptr @_Type_Info_circle, i1 false)
+  %144 = icmp ne ptr %143, null
+  store i1 %144, ptr %138, align 1
   br label %ifcont21
 
 else20:                                           ; preds = %ifcont17
-  %161 = bitcast %select_type_13_module.shape.3_class* %154 to i8*
-  %162 = call i8* @__lfortran_dynamic_cast(i8* %161, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i1 false)
-  %163 = icmp ne i8* %162, null
-  store i1 %163, i1* %153, align 1
+  %145 = call ptr @__lfortran_dynamic_cast(ptr %139, ptr @_Type_Info_circle, i1 false)
+  %146 = icmp ne ptr %145, null
+  store i1 %146, ptr %138, align 1
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %164 = load i1, i1* %153, align 1
-  br i1 %164, label %then18, label %else22
+  %147 = load i1, ptr %138, align 1
+  br i1 %147, label %then18, label %else22
 
 "~select_type_block_3.start":                     ; preds = %then18
-  %165 = call i8* @llvm.stacksave()
-  %166 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %166, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  %148 = call ptr @llvm.stacksave.p0()
+  %149 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @23, ptr %149, i32 17, ptr @22, i32 1)
   br label %"~select_type_block_3.end"
 
 "~select_type_block_3.end":                       ; preds = %"~select_type_block_3.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_3"
 
 "FINALIZE_SYMTABLE_~select_type_block_3":         ; preds = %"~select_type_block_3.end"
-  call void @llvm.stackrestore(i8* %165)
+  call void @llvm.stackrestore.p0(ptr %148)
   br label %ifcont49
 
 else22:                                           ; preds = %ifcont21
-  %167 = alloca i1, align 1
-  %168 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %169 = ptrtoint %select_type_13_module.shape.3_class* %168 to i64
-  %170 = icmp eq i64 %169, 0
-  br i1 %170, label %then24, label %else25
+  %150 = alloca i1, align 1
+  %151 = load ptr, ptr %s2, align 8
+  %152 = ptrtoint ptr %151 to i64
+  %153 = icmp eq i64 %152, 0
+  br i1 %153, label %then24, label %else25
 
 then23:                                           ; preds = %ifcont26
   br label %"~select_type_block_4.start"
 
 then24:                                           ; preds = %else22
-  %171 = alloca i32 (...)**, align 8
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %171, align 8
-  %172 = bitcast i32 (...)*** %171 to i8*
-  %173 = call i8* @__lfortran_dynamic_cast(i8* %172, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %174 = icmp ne i8* %173, null
-  store i1 %174, i1* %167, align 1
+  %154 = alloca ptr, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_shape, i32 0, i32 0, i32 2), ptr %154, align 8
+  %155 = call ptr @__lfortran_dynamic_cast(ptr %154, ptr @_Type_Info_rectangle, i1 false)
+  %156 = icmp ne ptr %155, null
+  store i1 %156, ptr %150, align 1
   br label %ifcont26
 
 else25:                                           ; preds = %else22
-  %175 = bitcast %select_type_13_module.shape.3_class* %168 to i8*
-  %176 = call i8* @__lfortran_dynamic_cast(i8* %175, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_rectangle to i8*), i1 false)
-  %177 = icmp ne i8* %176, null
-  store i1 %177, i1* %167, align 1
+  %157 = call ptr @__lfortran_dynamic_cast(ptr %151, ptr @_Type_Info_rectangle, i1 false)
+  %158 = icmp ne ptr %157, null
+  store i1 %158, ptr %150, align 1
   br label %ifcont26
 
 ifcont26:                                         ; preds = %else25, %then24
-  %178 = load i1, i1* %167, align 1
-  br i1 %178, label %then23, label %else48
+  %159 = load i1, ptr %150, align 1
+  br i1 %159, label %then23, label %else48
 
 "~select_type_block_4.start":                     ; preds = %then23
-  %179 = call i8* @llvm.stacksave()
-  %180 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %180, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
-  %181 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %182 = ptrtoint %select_type_13_module.shape.3_class** %181 to i64
-  %183 = icmp eq i64 %182, 0
-  br i1 %183, label %then27, label %ifcont28
+  %160 = call ptr @llvm.stacksave.p0()
+  %161 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_printf(ptr @25, ptr %161, i32 20, ptr @24, i32 1)
+  %162 = load ptr, ptr %s2, align 8
+  %163 = ptrtoint ptr %162 to i64
+  %164 = icmp eq i64 %163, 0
+  br i1 %164, label %then27, label %ifcont28
 
 then27:                                           ; preds = %"~select_type_block_4.start"
-  %184 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %185 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %186 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %185, i32 0, i32 0
-  %187 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @27, i32 0, i32 0), i8** %187, align 8
-  %188 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 1
-  store i32 72, i32* %188, align 4
-  %189 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 2
-  store i32 7, i32* %189, align 4
-  %190 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 3
-  store i32 72, i32* %190, align 4
-  %191 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %186, i32 0, i32 4
-  store i32 10, i32* %191, align 4
-  %192 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @28, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
-  %193 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %184, i32 0, i32 0
-  %194 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %185, i32 0, i32 0
-  %195 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 2
-  %196 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 0
-  store i1 true, i1* %196, align 1
-  %197 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 1
-  store i8* %192, i8** %197, align 8
-  store { i8*, i32, i32, i32, i32 }* %194, { i8*, i32, i32, i32, i32 }** %195, align 8
-  %198 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %193, i32 0, i32 3
-  store i32 1, i32* %198, align 4
-  %199 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %184, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %199, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @26, i32 0, i32 0))
+  %165 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %166 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %167 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %166, i32 0, i32 0
+  %168 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 0
+  store ptr @27, ptr %168, align 8
+  %169 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 1
+  store i32 72, ptr %169, align 4
+  %170 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 2
+  store i32 7, ptr %170, align 4
+  %171 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 3
+  store i32 72, ptr %171, align 4
+  %172 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %167, i32 0, i32 4
+  store i32 10, ptr %172, align 4
+  %173 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @28, ptr @26)
+  %174 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %165, i32 0, i32 0
+  %175 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %166, i32 0, i32 0
+  %176 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 2
+  %177 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 0
+  store i1 true, ptr %177, align 1
+  %178 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 1
+  store ptr %173, ptr %178, align 8
+  store ptr %175, ptr %176, align 8
+  %179 = getelementptr { i1, ptr, ptr, i32 }, ptr %174, i32 0, i32 3
+  store i32 1, ptr %179, align 4
+  %180 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %165, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %180, i32 1, ptr @29, ptr @26)
   call void @exit(i32 1)
   unreachable
 
 ifcont28:                                         ; preds = %"~select_type_block_4.start"
-  %200 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %201 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %200, align 1
-  %202 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %203 = bitcast %select_type_13_module.shape.3_class* %202 to %select_type_13_module.rectangle.6_class*
-  %204 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %203, i32 0, i32 1
-  %205 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %204, align 8
-  %206 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %205, i32 0, i32 1
-  store float 5.000000e+00, float* %206, align 4
-  %207 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %208 = ptrtoint %select_type_13_module.shape.3_class** %207 to i64
-  %209 = icmp eq i64 %208, 0
-  br i1 %209, label %then29, label %ifcont30
+  %181 = load ptr, ptr %s2, align 8
+  %182 = load %select_type_13_module.shape.3_class, ptr %181, align 1
+  %183 = load ptr, ptr %s2, align 8
+  %184 = getelementptr %select_type_13_module.rectangle.6_class, ptr %183, i32 0, i32 1
+  %185 = load ptr, ptr %184, align 8
+  %186 = getelementptr %select_type_13_module.rectangle.6, ptr %185, i32 0, i32 1
+  store float 5.000000e+00, ptr %186, align 4
+  %187 = load ptr, ptr %s2, align 8
+  %188 = ptrtoint ptr %187 to i64
+  %189 = icmp eq i64 %188, 0
+  br i1 %189, label %then29, label %ifcont30
 
 then29:                                           ; preds = %ifcont28
-  %210 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %211 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %212 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %211, i32 0, i32 0
-  %213 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %212, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @31, i32 0, i32 0), i8** %213, align 8
-  %214 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %212, i32 0, i32 1
-  store i32 73, i32* %214, align 4
-  %215 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %212, i32 0, i32 2
-  store i32 7, i32* %215, align 4
-  %216 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %212, i32 0, i32 3
-  store i32 73, i32* %216, align 4
-  %217 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %212, i32 0, i32 4
-  store i32 10, i32* %217, align 4
-  %218 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @32, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
-  %219 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %210, i32 0, i32 0
-  %220 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %211, i32 0, i32 0
-  %221 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %219, i32 0, i32 2
-  %222 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %219, i32 0, i32 0
-  store i1 true, i1* %222, align 1
-  %223 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %219, i32 0, i32 1
-  store i8* %218, i8** %223, align 8
-  store { i8*, i32, i32, i32, i32 }* %220, { i8*, i32, i32, i32, i32 }** %221, align 8
-  %224 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %219, i32 0, i32 3
-  store i32 1, i32* %224, align 4
-  %225 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %210, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %225, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @30, i32 0, i32 0))
+  %190 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %191 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %192 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %191, i32 0, i32 0
+  %193 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 0
+  store ptr @31, ptr %193, align 8
+  %194 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 1
+  store i32 73, ptr %194, align 4
+  %195 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 2
+  store i32 7, ptr %195, align 4
+  %196 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 3
+  store i32 73, ptr %196, align 4
+  %197 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %192, i32 0, i32 4
+  store i32 10, ptr %197, align 4
+  %198 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @32, ptr @30)
+  %199 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %190, i32 0, i32 0
+  %200 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %191, i32 0, i32 0
+  %201 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 2
+  %202 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 0
+  store i1 true, ptr %202, align 1
+  %203 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 1
+  store ptr %198, ptr %203, align 8
+  store ptr %200, ptr %201, align 8
+  %204 = getelementptr { i1, ptr, ptr, i32 }, ptr %199, i32 0, i32 3
+  store i32 1, ptr %204, align 4
+  %205 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %190, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %205, i32 1, ptr @33, ptr @30)
   call void @exit(i32 1)
   unreachable
 
 ifcont30:                                         ; preds = %ifcont28
-  %226 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %227 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %226, align 1
-  %228 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %229 = bitcast %select_type_13_module.shape.3_class* %228 to %select_type_13_module.rectangle.6_class*
-  %230 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %229, i32 0, i32 1
-  %231 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %230, align 8
-  %232 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %231, i32 0, i32 2
-  store float 4.000000e+00, float* %232, align 4
-  %233 = alloca i64, align 8
-  %234 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %235 = ptrtoint %select_type_13_module.shape.3_class** %234 to i64
-  %236 = icmp eq i64 %235, 0
-  br i1 %236, label %then31, label %ifcont32
+  %206 = load ptr, ptr %s2, align 8
+  %207 = load %select_type_13_module.shape.3_class, ptr %206, align 1
+  %208 = load ptr, ptr %s2, align 8
+  %209 = getelementptr %select_type_13_module.rectangle.6_class, ptr %208, i32 0, i32 1
+  %210 = load ptr, ptr %209, align 8
+  %211 = getelementptr %select_type_13_module.rectangle.6, ptr %210, i32 0, i32 2
+  store float 4.000000e+00, ptr %211, align 4
+  %212 = alloca i64, align 8
+  %213 = load ptr, ptr %s2, align 8
+  %214 = ptrtoint ptr %213 to i64
+  %215 = icmp eq i64 %214, 0
+  br i1 %215, label %then31, label %ifcont32
 
 then31:                                           ; preds = %ifcont30
-  %237 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %238 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %239 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %238, i32 0, i32 0
-  %240 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @36, i32 0, i32 0), i8** %240, align 8
-  %241 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 1
-  store i32 74, i32* %241, align 4
-  %242 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 2
-  store i32 16, i32* %242, align 4
-  %243 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 3
-  store i32 74, i32* %243, align 4
-  %244 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %239, i32 0, i32 4
-  store i32 19, i32* %244, align 4
-  %245 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @35, i32 0, i32 0))
-  %246 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %237, i32 0, i32 0
-  %247 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %238, i32 0, i32 0
-  %248 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 2
-  %249 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 0
-  store i1 true, i1* %249, align 1
-  %250 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 1
-  store i8* %245, i8** %250, align 8
-  store { i8*, i32, i32, i32, i32 }* %247, { i8*, i32, i32, i32, i32 }** %248, align 8
-  %251 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %246, i32 0, i32 3
-  store i32 1, i32* %251, align 4
-  %252 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %237, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %252, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @38, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @35, i32 0, i32 0))
+  %216 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %217 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %218 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %217, i32 0, i32 0
+  %219 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %218, i32 0, i32 0
+  store ptr @36, ptr %219, align 8
+  %220 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %218, i32 0, i32 1
+  store i32 74, ptr %220, align 4
+  %221 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %218, i32 0, i32 2
+  store i32 16, ptr %221, align 4
+  %222 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %218, i32 0, i32 3
+  store i32 74, ptr %222, align 4
+  %223 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %218, i32 0, i32 4
+  store i32 19, ptr %223, align 4
+  %224 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @37, ptr @35)
+  %225 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %216, i32 0, i32 0
+  %226 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %217, i32 0, i32 0
+  %227 = getelementptr { i1, ptr, ptr, i32 }, ptr %225, i32 0, i32 2
+  %228 = getelementptr { i1, ptr, ptr, i32 }, ptr %225, i32 0, i32 0
+  store i1 true, ptr %228, align 1
+  %229 = getelementptr { i1, ptr, ptr, i32 }, ptr %225, i32 0, i32 1
+  store ptr %224, ptr %229, align 8
+  store ptr %226, ptr %227, align 8
+  %230 = getelementptr { i1, ptr, ptr, i32 }, ptr %225, i32 0, i32 3
+  store i32 1, ptr %230, align 4
+  %231 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %216, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %231, i32 1, ptr @38, ptr @35)
   call void @exit(i32 1)
   unreachable
 
 ifcont32:                                         ; preds = %ifcont30
-  %253 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %254 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %253, align 1
-  %255 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %256 = bitcast %select_type_13_module.shape.3_class* %255 to %select_type_13_module.rectangle.6_class*
-  %257 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %256, i32 0, i32 1
-  %258 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %257, align 8
-  %259 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %258, i32 0, i32 1
-  %260 = load float, float* %259, align 4
-  %261 = alloca float, align 4
-  store float %260, float* %261, align 4
-  %262 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %263 = ptrtoint %select_type_13_module.shape.3_class** %262 to i64
-  %264 = icmp eq i64 %263, 0
-  br i1 %264, label %then33, label %ifcont34
+  %232 = load ptr, ptr %s2, align 8
+  %233 = load %select_type_13_module.shape.3_class, ptr %232, align 1
+  %234 = load ptr, ptr %s2, align 8
+  %235 = getelementptr %select_type_13_module.rectangle.6_class, ptr %234, i32 0, i32 1
+  %236 = load ptr, ptr %235, align 8
+  %237 = getelementptr %select_type_13_module.rectangle.6, ptr %236, i32 0, i32 1
+  %238 = load float, ptr %237, align 4
+  %239 = alloca float, align 4
+  store float %238, ptr %239, align 4
+  %240 = load ptr, ptr %s2, align 8
+  %241 = ptrtoint ptr %240 to i64
+  %242 = icmp eq i64 %241, 0
+  br i1 %242, label %then33, label %ifcont34
 
 then33:                                           ; preds = %ifcont32
-  %265 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %266 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %267 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %266, i32 0, i32 0
-  %268 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @40, i32 0, i32 0), i8** %268, align 8
-  %269 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 1
-  store i32 74, i32* %269, align 4
-  %270 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 2
-  store i32 22, i32* %270, align 4
-  %271 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 3
-  store i32 74, i32* %271, align 4
-  %272 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %267, i32 0, i32 4
-  store i32 25, i32* %272, align 4
-  %273 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @39, i32 0, i32 0))
-  %274 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %265, i32 0, i32 0
-  %275 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %266, i32 0, i32 0
-  %276 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 2
-  %277 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 0
-  store i1 true, i1* %277, align 1
-  %278 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 1
-  store i8* %273, i8** %278, align 8
-  store { i8*, i32, i32, i32, i32 }* %275, { i8*, i32, i32, i32, i32 }** %276, align 8
-  %279 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %274, i32 0, i32 3
-  store i32 1, i32* %279, align 4
-  %280 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %265, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %280, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @42, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @39, i32 0, i32 0))
+  %243 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %244 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %245 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %244, i32 0, i32 0
+  %246 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 0
+  store ptr @40, ptr %246, align 8
+  %247 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 1
+  store i32 74, ptr %247, align 4
+  %248 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 2
+  store i32 22, ptr %248, align 4
+  %249 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 3
+  store i32 74, ptr %249, align 4
+  %250 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %245, i32 0, i32 4
+  store i32 25, ptr %250, align 4
+  %251 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @41, ptr @39)
+  %252 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %243, i32 0, i32 0
+  %253 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %244, i32 0, i32 0
+  %254 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 2
+  %255 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 0
+  store i1 true, ptr %255, align 1
+  %256 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 1
+  store ptr %251, ptr %256, align 8
+  store ptr %253, ptr %254, align 8
+  %257 = getelementptr { i1, ptr, ptr, i32 }, ptr %252, i32 0, i32 3
+  store i32 1, ptr %257, align 4
+  %258 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %243, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %258, i32 1, ptr @42, ptr @39)
   call void @exit(i32 1)
   unreachable
 
 ifcont34:                                         ; preds = %ifcont32
-  %281 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %282 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %281, align 1
-  %283 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %284 = bitcast %select_type_13_module.shape.3_class* %283 to %select_type_13_module.rectangle.6_class*
-  %285 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %284, i32 0, i32 1
-  %286 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %285, align 8
-  %287 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %286, i32 0, i32 2
-  %288 = load float, float* %287, align 4
-  %289 = alloca float, align 4
-  store float %288, float* %289, align 4
-  %290 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.9, i32 0, i32 0), i64* %233, i32 0, i32 0, i32 0, i32 0, i32 0, float* %261, float* %289)
-  %291 = load i64, i64* %233, align 8
-  %292 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 0
-  store i8* %290, i8** %292, align 8
-  %293 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 1
-  store i64 %291, i64* %293, align 8
-  %294 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 0
-  %295 = load i8*, i8** %294, align 8
-  %296 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 1
-  %297 = load i64, i64* %296, align 8
-  %298 = trunc i64 %297 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %295, i32 %298, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
-  %299 = icmp eq i8* %290, null
-  br i1 %299, label %free_done37, label %free_nonnull36
+  %259 = load ptr, ptr %s2, align 8
+  %260 = load %select_type_13_module.shape.3_class, ptr %259, align 1
+  %261 = load ptr, ptr %s2, align 8
+  %262 = getelementptr %select_type_13_module.rectangle.6_class, ptr %261, i32 0, i32 1
+  %263 = load ptr, ptr %262, align 8
+  %264 = getelementptr %select_type_13_module.rectangle.6, ptr %263, i32 0, i32 2
+  %265 = load float, ptr %264, align 4
+  %266 = alloca float, align 4
+  store float %265, ptr %266, align 4
+  %267 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.9, ptr %212, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %239, ptr %266)
+  %268 = load i64, ptr %212, align 8
+  %269 = getelementptr %string_descriptor, ptr %stringFormat_desc35, i32 0, i32 0
+  store ptr %267, ptr %269, align 8
+  %270 = getelementptr %string_descriptor, ptr %stringFormat_desc35, i32 0, i32 1
+  store i64 %268, ptr %270, align 8
+  %271 = getelementptr %string_descriptor, ptr %stringFormat_desc35, i32 0, i32 0
+  %272 = load ptr, ptr %271, align 8
+  %273 = getelementptr %string_descriptor, ptr %stringFormat_desc35, i32 0, i32 1
+  %274 = load i64, ptr %273, align 8
+  %275 = trunc i64 %274 to i32
+  call void @_lfortran_printf(ptr @43, ptr %272, i32 %275, ptr @34, i32 1)
+  %276 = icmp eq ptr %267, null
+  br i1 %276, label %free_done37, label %free_nonnull36
 
 free_nonnull36:                                   ; preds = %ifcont34
-  call void @_lfortran_free_alloc(i8* %2, i8* %290)
+  call void @_lfortran_free_alloc(ptr %2, ptr %267)
   br label %free_done37
 
 free_done37:                                      ; preds = %free_nonnull36, %ifcont34
-  %300 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %301 = ptrtoint %select_type_13_module.shape.3_class** %300 to i64
-  %302 = icmp eq i64 %301, 0
-  br i1 %302, label %then38, label %ifcont39
+  %277 = load ptr, ptr %s2, align 8
+  %278 = ptrtoint ptr %277 to i64
+  %279 = icmp eq i64 %278, 0
+  br i1 %279, label %then38, label %ifcont39
 
 then38:                                           ; preds = %free_done37
-  %303 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %304 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %305 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %304, i32 0, i32 0
-  %306 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %305, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @45, i32 0, i32 0), i8** %306, align 8
-  %307 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %305, i32 0, i32 1
-  store i32 75, i32* %307, align 4
-  %308 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %305, i32 0, i32 2
-  store i32 11, i32* %308, align 4
-  %309 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %305, i32 0, i32 3
-  store i32 75, i32* %309, align 4
-  %310 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %305, i32 0, i32 4
-  store i32 14, i32* %310, align 4
-  %311 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @46, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @44, i32 0, i32 0))
-  %312 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %303, i32 0, i32 0
-  %313 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %304, i32 0, i32 0
-  %314 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %312, i32 0, i32 2
-  %315 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %312, i32 0, i32 0
-  store i1 true, i1* %315, align 1
-  %316 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %312, i32 0, i32 1
-  store i8* %311, i8** %316, align 8
-  store { i8*, i32, i32, i32, i32 }* %313, { i8*, i32, i32, i32, i32 }** %314, align 8
-  %317 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %312, i32 0, i32 3
-  store i32 1, i32* %317, align 4
-  %318 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %303, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %318, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @44, i32 0, i32 0))
+  %280 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %281 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %282 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %281, i32 0, i32 0
+  %283 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %282, i32 0, i32 0
+  store ptr @45, ptr %283, align 8
+  %284 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %282, i32 0, i32 1
+  store i32 75, ptr %284, align 4
+  %285 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %282, i32 0, i32 2
+  store i32 11, ptr %285, align 4
+  %286 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %282, i32 0, i32 3
+  store i32 75, ptr %286, align 4
+  %287 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %282, i32 0, i32 4
+  store i32 14, ptr %287, align 4
+  %288 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @46, ptr @44)
+  %289 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %280, i32 0, i32 0
+  %290 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %281, i32 0, i32 0
+  %291 = getelementptr { i1, ptr, ptr, i32 }, ptr %289, i32 0, i32 2
+  %292 = getelementptr { i1, ptr, ptr, i32 }, ptr %289, i32 0, i32 0
+  store i1 true, ptr %292, align 1
+  %293 = getelementptr { i1, ptr, ptr, i32 }, ptr %289, i32 0, i32 1
+  store ptr %288, ptr %293, align 8
+  store ptr %290, ptr %291, align 8
+  %294 = getelementptr { i1, ptr, ptr, i32 }, ptr %289, i32 0, i32 3
+  store i32 1, ptr %294, align 4
+  %295 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %280, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %295, i32 1, ptr @47, ptr @44)
   call void @exit(i32 1)
   unreachable
 
 ifcont39:                                         ; preds = %free_done37
-  %319 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %320 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %319, align 1
-  %321 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %322 = bitcast %select_type_13_module.shape.3_class* %321 to %select_type_13_module.rectangle.6_class*
-  %323 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %322, i32 0, i32 1
-  %324 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %323, align 8
-  %325 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %324, i32 0, i32 1
-  %326 = load float, float* %325, align 4
-  %327 = fcmp une float %326, 5.000000e+00
-  br i1 %327, label %then40, label %else41
+  %296 = load ptr, ptr %s2, align 8
+  %297 = load %select_type_13_module.shape.3_class, ptr %296, align 1
+  %298 = load ptr, ptr %s2, align 8
+  %299 = getelementptr %select_type_13_module.rectangle.6_class, ptr %298, i32 0, i32 1
+  %300 = load ptr, ptr %299, align 8
+  %301 = getelementptr %select_type_13_module.rectangle.6, ptr %300, i32 0, i32 1
+  %302 = load float, ptr %301, align 4
+  %303 = fcmp une float %302, 5.000000e+00
+  br i1 %303, label %then40, label %else41
 
 then40:                                           ; preds = %ifcont39
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @49, ptr @"ERROR STOP", ptr @48)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -791,55 +768,54 @@ else41:                                           ; preds = %ifcont39
   br label %ifcont42
 
 ifcont42:                                         ; preds = %else41, %then40
-  %328 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
-  %329 = ptrtoint %select_type_13_module.shape.3_class** %328 to i64
-  %330 = icmp eq i64 %329, 0
-  br i1 %330, label %then43, label %ifcont44
+  %304 = load ptr, ptr %s2, align 8
+  %305 = ptrtoint ptr %304 to i64
+  %306 = icmp eq i64 %305, 0
+  br i1 %306, label %then43, label %ifcont44
 
 then43:                                           ; preds = %ifcont42
-  %331 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %332 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %333 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %332, i32 0, i32 0
-  %334 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 0
-  store i8* getelementptr inbounds ([46 x i8], [46 x i8]* @51, i32 0, i32 0), i8** %334, align 8
-  %335 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 1
-  store i32 76, i32* %335, align 4
-  %336 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 2
-  store i32 11, i32* %336, align 4
-  %337 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 3
-  store i32 76, i32* %337, align 4
-  %338 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %333, i32 0, i32 4
-  store i32 14, i32* %338, align 4
-  %339 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @52, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @50, i32 0, i32 0))
-  %340 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %331, i32 0, i32 0
-  %341 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %332, i32 0, i32 0
-  %342 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 2
-  %343 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 0
-  store i1 true, i1* %343, align 1
-  %344 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 1
-  store i8* %339, i8** %344, align 8
-  store { i8*, i32, i32, i32, i32 }* %341, { i8*, i32, i32, i32, i32 }** %342, align 8
-  %345 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %340, i32 0, i32 3
-  store i32 1, i32* %345, align 4
-  %346 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %331, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %346, i32 1, i8* getelementptr inbounds ([52 x i8], [52 x i8]* @53, i32 0, i32 0), i8* getelementptr inbounds ([3 x i8], [3 x i8]* @50, i32 0, i32 0))
+  %307 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %308 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %309 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %308, i32 0, i32 0
+  %310 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %309, i32 0, i32 0
+  store ptr @51, ptr %310, align 8
+  %311 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %309, i32 0, i32 1
+  store i32 76, ptr %311, align 4
+  %312 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %309, i32 0, i32 2
+  store i32 11, ptr %312, align 4
+  %313 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %309, i32 0, i32 3
+  store i32 76, ptr %313, align 4
+  %314 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %309, i32 0, i32 4
+  store i32 14, ptr %314, align 4
+  %315 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @52, ptr @50)
+  %316 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %307, i32 0, i32 0
+  %317 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %308, i32 0, i32 0
+  %318 = getelementptr { i1, ptr, ptr, i32 }, ptr %316, i32 0, i32 2
+  %319 = getelementptr { i1, ptr, ptr, i32 }, ptr %316, i32 0, i32 0
+  store i1 true, ptr %319, align 1
+  %320 = getelementptr { i1, ptr, ptr, i32 }, ptr %316, i32 0, i32 1
+  store ptr %315, ptr %320, align 8
+  store ptr %317, ptr %318, align 8
+  %321 = getelementptr { i1, ptr, ptr, i32 }, ptr %316, i32 0, i32 3
+  store i32 1, ptr %321, align 4
+  %322 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %307, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %322, i32 1, ptr @53, ptr @50)
   call void @exit(i32 1)
   unreachable
 
 ifcont44:                                         ; preds = %ifcont42
-  %347 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %348 = load %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %347, align 1
-  %349 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  %350 = bitcast %select_type_13_module.shape.3_class* %349 to %select_type_13_module.rectangle.6_class*
-  %351 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %350, i32 0, i32 1
-  %352 = load %select_type_13_module.rectangle.6*, %select_type_13_module.rectangle.6** %351, align 8
-  %353 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %352, i32 0, i32 2
-  %354 = load float, float* %353, align 4
-  %355 = fcmp une float %354, 4.000000e+00
-  br i1 %355, label %then45, label %else46
+  %323 = load ptr, ptr %s2, align 8
+  %324 = load %select_type_13_module.shape.3_class, ptr %323, align 1
+  %325 = load ptr, ptr %s2, align 8
+  %326 = getelementptr %select_type_13_module.rectangle.6_class, ptr %325, i32 0, i32 1
+  %327 = load ptr, ptr %326, align 8
+  %328 = getelementptr %select_type_13_module.rectangle.6, ptr %327, i32 0, i32 2
+  %329 = load float, ptr %328, align 4
+  %330 = fcmp une float %329, 4.000000e+00
+  br i1 %330, label %then45, label %else46
 
 then45:                                           ; preds = %ifcont44
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @55, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @54, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @55, ptr @"ERROR STOP", ptr @54)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont47
@@ -854,23 +830,23 @@ ifcont47:                                         ; preds = %else46, %then45
   br label %"FINALIZE_SYMTABLE_~select_type_block_4"
 
 "FINALIZE_SYMTABLE_~select_type_block_4":         ; preds = %"~select_type_block_4.end"
-  call void @llvm.stackrestore(i8* %179)
+  call void @llvm.stackrestore.p0(ptr %160)
   br label %ifcont49
 
 else48:                                           ; preds = %ifcont26
   br label %"~select_type_block_5.start"
 
 "~select_type_block_5.start":                     ; preds = %else48
-  %356 = call i8* @llvm.stacksave()
-  %357 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.11, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @57, i32 0, i32 0), i8* %357, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
+  %331 = call ptr @llvm.stacksave.p0()
+  %332 = load ptr, ptr @string_const.11, align 8
+  call void @_lfortran_printf(ptr @57, ptr %332, i32 16, ptr @56, i32 1)
   br label %"~select_type_block_5.end"
 
 "~select_type_block_5.end":                       ; preds = %"~select_type_block_5.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_5"
 
 "FINALIZE_SYMTABLE_~select_type_block_5":         ; preds = %"~select_type_block_5.end"
-  call void @llvm.stackrestore(i8* %356)
+  call void @llvm.stackrestore.p0(ptr %331)
   br label %ifcont49
 
 ifcont49:                                         ; preds = %"FINALIZE_SYMTABLE_~select_type_block_5", %"FINALIZE_SYMTABLE_~select_type_block_4", %"FINALIZE_SYMTABLE_~select_type_block_3"
@@ -883,218 +859,198 @@ FINALIZE_SYMTABLE_select_type_13:                 ; preds = %return
   br label %Finalize_Variable_s1
 
 Finalize_Variable_s1:                             ; preds = %FINALIZE_SYMTABLE_select_type_13
-  %358 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s1, align 8
-  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %358)
+  %333 = load ptr, ptr %s1, align 8
+  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(ptr %333)
   br label %Finalize_Variable_s2
 
 Finalize_Variable_s2:                             ; preds = %Finalize_Variable_s1
-  %359 = load %select_type_13_module.shape.3_class*, %select_type_13_module.shape.3_class** %s2, align 8
-  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %359)
+  %334 = load ptr, ptr %s2, align 8
+  call void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(ptr %334)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-define linkonce_odr void @_copy_select_type_13_module_shape(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_select_type_13_module_shape(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.shape.3*
-  %3 = bitcast i8* %1 to %select_type_13_module.shape.3*
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_select_type_13_module_shape(i8** %0) {
+define linkonce_odr void @_allocate_struct_select_type_13_module_shape(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.shape.3_class*
-  %5 = bitcast %select_type_13_module.shape.3_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_shape, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 0)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 0, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.shape.3*
-  store %select_type_13_module.shape.3* %9, %select_type_13_module.shape.3** %6, align 8
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_shape, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %select_type_13_module.shape.3_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 0)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 0, i1 false)
+  store ptr %6, ptr %4, align 8
   ret void
 }
 
-define internal void @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__shape_3_of_select_type_13_module_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.shape.3*
   ret void
 }
 
-define linkonce_odr void @_copy_select_type_13_module_circle(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_select_type_13_module_circle(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.circle.5*
-  %3 = bitcast i8* %1 to %select_type_13_module.circle.5*
-  %4 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %2, i32 0, i32 1
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %3, i32 0, i32 1
+  %2 = getelementptr %select_type_13_module.circle.5, ptr %0, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %select_type_13_module.circle.5, ptr %1, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %2, i32 0, i32 0
-  %8 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %3, i32 0, i32 0
+  %5 = getelementptr %select_type_13_module.circle.5, ptr %0, i32 0, i32 0
+  %6 = getelementptr %select_type_13_module.circle.5, ptr %1, i32 0, i32 0
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_select_type_13_module_circle(i8** %0) {
+define linkonce_odr void @_allocate_struct_select_type_13_module_circle(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.circle.5_class*
-  %5 = bitcast %select_type_13_module.circle.5_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_circle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.circle.5_class, %select_type_13_module.circle.5_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 4)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 4, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.circle.5*
-  store %select_type_13_module.circle.5* %9, %select_type_13_module.circle.5** %6, align 8
-  %10 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %9, i32 0, i32 1
-  %11 = getelementptr %select_type_13_module.circle.5, %select_type_13_module.circle.5* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_circle, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %select_type_13_module.circle.5_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 4)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 4, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %select_type_13_module.circle.5, ptr %6, i32 0, i32 1
+  %8 = getelementptr %select_type_13_module.circle.5, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__circle_5_of_select_type_13_module_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.circle.5*
   ret void
 }
 
-define linkonce_odr void @_copy_select_type_13_module_rectangle(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_select_type_13_module_rectangle(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to %select_type_13_module.rectangle.6*
-  %3 = bitcast i8* %1 to %select_type_13_module.rectangle.6*
-  %4 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 1
-  %5 = load float, float* %4, align 4
-  %6 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 1
+  %2 = getelementptr %select_type_13_module.rectangle.6, ptr %0, i32 0, i32 1
+  %3 = load float, ptr %2, align 4
+  %4 = getelementptr %select_type_13_module.rectangle.6, ptr %1, i32 0, i32 1
   br i1 true, label %then, label %else
 
 then:                                             ; preds = %entry
-  store float %5, float* %6, align 4
+  store float %3, ptr %4, align 4
   br label %ifcont
 
 else:                                             ; preds = %entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 2
-  %8 = load float, float* %7, align 4
-  %9 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 2
+  %5 = getelementptr %select_type_13_module.rectangle.6, ptr %0, i32 0, i32 2
+  %6 = load float, ptr %5, align 4
+  %7 = getelementptr %select_type_13_module.rectangle.6, ptr %1, i32 0, i32 2
   br i1 true, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  store float %8, float* %9, align 4
+  store float %6, ptr %7, align 4
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %10 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %2, i32 0, i32 0
-  %11 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %3, i32 0, i32 0
+  %8 = getelementptr %select_type_13_module.rectangle.6, ptr %0, i32 0, i32 0
+  %9 = getelementptr %select_type_13_module.rectangle.6, ptr %1, i32 0, i32 0
   ret void
 }
 
-define linkonce_odr void @_allocate_struct_select_type_13_module_rectangle(i8** %0) {
+define linkonce_odr void @_allocate_struct_select_type_13_module_rectangle(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = load i8*, i8** %0, align 8
-  %4 = bitcast i8* %3 to %select_type_13_module.rectangle.6_class*
-  %5 = bitcast %select_type_13_module.rectangle.6_class* %4 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [6 x i8*] }, { [6 x i8*] }* @_VTable_rectangle, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %5, align 8
-  %6 = getelementptr %select_type_13_module.rectangle.6_class, %select_type_13_module.rectangle.6_class* %4, i32 0, i32 1
-  %7 = call i8* @_lfortran_get_default_allocator()
-  %8 = call i8* @_lfortran_malloc_alloc(i8* %7, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %8, i8 0, i32 8, i1 false)
-  %9 = bitcast i8* %8 to %select_type_13_module.rectangle.6*
-  store %select_type_13_module.rectangle.6* %9, %select_type_13_module.rectangle.6** %6, align 8
-  %10 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 1
-  %11 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 2
-  %12 = getelementptr %select_type_13_module.rectangle.6, %select_type_13_module.rectangle.6* %9, i32 0, i32 0
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  %3 = load ptr, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [6 x ptr] }, ptr @_VTable_rectangle, i32 0, i32 0, i32 2), ptr %3, align 8
+  %4 = getelementptr %select_type_13_module.rectangle.6_class, ptr %3, i32 0, i32 1
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 8)
+  call void @llvm.memset.p0.i32(ptr %6, i8 0, i32 8, i1 false)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %select_type_13_module.rectangle.6, ptr %6, i32 0, i32 1
+  %8 = getelementptr %select_type_13_module.rectangle.6, ptr %6, i32 0, i32 2
+  %9 = getelementptr %select_type_13_module.rectangle.6, ptr %6, i32 0, i32 0
   ret void
 }
 
-define internal void @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly(i8* %0) {
+define internal void @finalize_StructType__rectangle_6_of_select_type_13_module_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to %select_type_13_module.rectangle.6*
   ret void
 }
 
-declare i8* @__lfortran_dynamic_cast(i8*, i8*, i1)
+declare ptr @__lfortran_dynamic_cast(ptr, ptr, i1)
 
-; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #1
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare ptr @llvm.stacksave.p0() #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #1
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare void @llvm.stackrestore.p0(ptr) #1
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-define internal void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0) {
+define internal void @finalize_allocatable__StructType_Class__shape_3_of_select_type_13_module(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %select_type_13_module.shape.3_class* %0, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = icmp ne ptr %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  call void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0)
-  %3 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 1
-  %4 = load %select_type_13_module.shape.3*, %select_type_13_module.shape.3** %3, align 8
-  %5 = icmp ne %select_type_13_module.shape.3* %4, null
+  call void @finalize_StructType_Class__shape_3_of_select_type_13_module(ptr %0)
+  %3 = getelementptr %select_type_13_module.shape.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %4, null
   br i1 %5, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  %6 = bitcast %select_type_13_module.shape.3* %4 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %6)
+  call void @_lfortran_free_alloc(ptr %1, ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then1
-  %7 = bitcast %select_type_13_module.shape.3_class* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %7)
+  call void @_lfortran_free_alloc(ptr %1, ptr %0)
   br label %is_allocated.ifcont3
 
 is_allocated.else2:                               ; preds = %entry
@@ -1104,25 +1060,23 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-define internal void @finalize_StructType_Class__shape_3_of_select_type_13_module(%select_type_13_module.shape.3_class* %0) {
+define internal void @finalize_StructType_Class__shape_3_of_select_type_13_module(ptr %0) {
 entry:
-  %1 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 0
-  %2 = load i32 (...)**, i32 (...)*** %1, align 8
-  %3 = getelementptr %select_type_13_module.shape.3_class, %select_type_13_module.shape.3_class* %0, i32 0, i32 1
-  %4 = load %select_type_13_module.shape.3**, %select_type_13_module.shape.3** %3, align 8
-  %5 = bitcast %select_type_13_module.shape.3** %4 to i8*
-  %6 = icmp ne i32 (...)** %2, null
-  br i1 %6, label %is_allocated.then, label %is_allocated.else2
+  %1 = getelementptr %select_type_13_module.shape.3_class, ptr %0, i32 0, i32 0
+  %2 = load ptr, ptr %1, align 8
+  %3 = getelementptr %select_type_13_module.shape.3_class, ptr %0, i32 0, i32 1
+  %4 = load ptr, ptr %3, align 8
+  %5 = icmp ne ptr %2, null
+  br i1 %5, label %is_allocated.then, label %is_allocated.else2
 
 is_allocated.then:                                ; preds = %entry
-  %7 = getelementptr inbounds i32 (...)*, i32 (...)** %2, i32 2
-  %8 = load i8*, i32 (...)** %7, align 8
-  %9 = bitcast i8* %8 to void (i8*)*
-  %10 = icmp ne i8* %5, null
-  br i1 %10, label %is_allocated.then1, label %is_allocated.else
+  %6 = getelementptr inbounds ptr, ptr %2, i32 2
+  %7 = load ptr, ptr %6, align 8
+  %8 = icmp ne ptr %4, null
+  br i1 %8, label %is_allocated.then1, label %is_allocated.else
 
 is_allocated.then1:                               ; preds = %is_allocated.then
-  call void %9(i8* %5)
+  call void %7(ptr %4)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %is_allocated.then
@@ -1138,5 +1092,5 @@ is_allocated.ifcont3:                             ; preds = %is_allocated.else2,
   ret void
 }
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
-attributes #1 = { nounwind }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nosync nounwind willreturn }

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "c50727f98c1e334ffd1e50c3a8d805c734c6e1417a517e98e7a18901",
+    "stdout_hash": "977f078576d14ea82ddb011bfb7e8a571916437a5de868e9dbbab540",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -1,38 +1,39 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R8\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca double, align 8
-  store double 0x3FEFEB7A9B2C6D8B, double* %x, align 8
+  store double 0x3FEFEB7A9B2C6D8B, ptr %x, align 8
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, double* %x)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %x)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -46,14 +47,14 @@ FINALIZE_SYMTABLE_sin_03:                         ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-stop-866225f.json
+++ b/tests/reference/llvm-stop-866225f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-stop-866225f.stdout",
-    "stdout_hash": "5340c3f795eefcdf8912f06d0a5d9b64640a4a2d4b36862478d7b9cc",
+    "stdout_hash": "51564f69ef219ba0ed6138f631b7dfeb4622a4ef82fef46bb7d0fabc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-stop-866225f.stdout
+++ b/tests/reference/llvm-stop-866225f.stdout
@@ -1,22 +1,23 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @STOP = private unnamed_addr constant [5 x i8] c"STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %x = alloca i32, align 4
-  store i32 25, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  store i32 25, ptr %x, align 4
+  %2 = load i32, ptr %x, align 4
   %3 = icmp eq i32 %2, 25
   br i1 %3, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([5 x i8], [5 x i8]* @STOP, i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @STOP, ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 0)
   br label %ifcont
@@ -35,9 +36,9 @@ FINALIZE_SYMTABLE_stop:                           ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "ef565379c291259557abd75e1d70bbb69f5fce45f416d03cd7c670f0",
+    "stdout_hash": "c88495d0a22d56c6fcd98617936c4540aa3d097943ebfaa811777e02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -1,43 +1,44 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @my_name_data = private global [7 x i8] c"Dominic"
-@my_name = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @my_name_data, i32 0, i32 0), i64 7 }>
+@my_name = private global %string_descriptor <{ ptr @my_name_data, i64 7 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [19 x i8] c"S-DESC-11,S-DESC-7\00", align 1
 @string_const_data = private constant [11 x i8] c"My name is "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data, i32 0, i32 0), i64 11 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 11 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %3 = alloca i64, align 8
-  %4 = load %string_descriptor, %string_descriptor* @my_name, align 1
+  %4 = load %string_descriptor, ptr @my_name, align 1
   %5 = alloca %string_descriptor, align 8
-  store %string_descriptor %4, %string_descriptor* %5, align 1
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, %string_descriptor* %5)
-  %7 = load i64, i64* %3, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  store %string_descriptor %4, ptr %5, align 1
+  %6 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const, ptr %5)
+  %7 = load i64, ptr %3, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %11 = load ptr, ptr %10, align 8
+  %12 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
+  call void @_lfortran_printf(ptr @1, ptr %11, i32 %14, ptr @0, i32 1)
+  %15 = icmp eq ptr %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %6)
+  call void @_lfortran_free_alloc(ptr %2, ptr %6)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -51,14 +52,14 @@ FINALIZE_SYMTABLE_print_01:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "e29e488f2a412c845036e395fa46229fe5f6f377def3887f570e195f",
+    "stdout_hash": "678ec00f95f39060fb3fbd0e5c54765521665674d30ef3ede6b3d900",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -1,111 +1,112 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @string_const_data = private constant [4 x i8] c"Mr. "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 4 }>
 @string_const_data.1 = private constant [6 x i8] c"Rowan "
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([6 x i8], [6 x i8]* @string_const_data.1, i32 0, i32 0), i64 6 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 6 }>
 @string_const_data.3 = private constant [8 x i8] c"Atkinson"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.3, i32 0, i32 0), i64 8 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 8 }>
 @string_const_data.5 = private constant [25 x i8] c"A big hello from Mr. Bean"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([25 x i8], [25 x i8]* @string_const_data.5, i32 0, i32 0), i64 25 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 25 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [38 x i8] c"S-DESC-8,S-DESC-6,S-DESC-15,S-DESC-15\00", align 1
 @string_const_data.7 = private constant [8 x i8] c"Here is "
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.7, i32 0, i32 0), i64 8 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %title = alloca %string_descriptor, align 8
   %surname = alloca %string_descriptor, align 8
   %greetings = alloca %string_descriptor, align 8
   %firstname = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %firstname, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
-  store i64 15, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 15)
-  store i8* %6, i8** %4, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %greetings, align 1
-  %7 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
-  store i64 25, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %9 = call i8* @_lfortran_get_default_allocator()
-  %10 = call i8* @_lfortran_malloc_alloc(i8* %9, i64 25)
-  store i8* %10, i8** %8, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %surname, align 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
-  store i64 15, i64* %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
-  %13 = call i8* @_lfortran_get_default_allocator()
-  %14 = call i8* @_lfortran_malloc_alloc(i8* %13, i64 15)
-  store i8* %14, i8** %12, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %title, align 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  store i64 6, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %17 = call i8* @_lfortran_get_default_allocator()
-  %18 = call i8* @_lfortran_malloc_alloc(i8* %17, i64 6)
-  store i8* %18, i8** %16, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %20 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  %21 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %19, i64* %20, i8 0, i8 0, i8* %21, i64 4, i32 1)
-  %22 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
-  %23 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 1
-  %24 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %22, i64* %23, i8 0, i8 0, i8* %24, i64 6, i32 1)
-  %25 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
-  %26 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 1
-  %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %25, i64* %26, i8 0, i8 0, i8* %27, i64 8, i32 1)
-  %28 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %29 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 1
-  %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %28, i64* %29, i8 0, i8 0, i8* %30, i64 25, i32 1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %firstname, align 1
+  %3 = getelementptr %string_descriptor, ptr %firstname, i32 0, i32 1
+  store i64 15, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %firstname, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 15)
+  store ptr %6, ptr %4, align 8
+  store %string_descriptor zeroinitializer, ptr %greetings, align 1
+  %7 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 1
+  store i64 25, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 0
+  %9 = call ptr @_lfortran_get_default_allocator()
+  %10 = call ptr @_lfortran_malloc_alloc(ptr %9, i64 25)
+  store ptr %10, ptr %8, align 8
+  store %string_descriptor zeroinitializer, ptr %surname, align 1
+  %11 = getelementptr %string_descriptor, ptr %surname, i32 0, i32 1
+  store i64 15, ptr %11, align 8
+  %12 = getelementptr %string_descriptor, ptr %surname, i32 0, i32 0
+  %13 = call ptr @_lfortran_get_default_allocator()
+  %14 = call ptr @_lfortran_malloc_alloc(ptr %13, i64 15)
+  store ptr %14, ptr %12, align 8
+  store %string_descriptor zeroinitializer, ptr %title, align 1
+  %15 = getelementptr %string_descriptor, ptr %title, i32 0, i32 1
+  store i64 6, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %17 = call ptr @_lfortran_get_default_allocator()
+  %18 = call ptr @_lfortran_malloc_alloc(ptr %17, i64 6)
+  store ptr %18, ptr %16, align 8
+  %19 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, ptr %title, i32 0, i32 1
+  %21 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %19, ptr %20, i8 0, i8 0, ptr %21, i64 4, i32 1)
+  %22 = getelementptr %string_descriptor, ptr %firstname, i32 0, i32 0
+  %23 = getelementptr %string_descriptor, ptr %firstname, i32 0, i32 1
+  %24 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %22, ptr %23, i8 0, i8 0, ptr %24, i64 6, i32 1)
+  %25 = getelementptr %string_descriptor, ptr %surname, i32 0, i32 0
+  %26 = getelementptr %string_descriptor, ptr %surname, i32 0, i32 1
+  %27 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %25, ptr %26, i8 0, i8 0, ptr %27, i64 8, i32 1)
+  %28 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 0
+  %29 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 1
+  %30 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %28, ptr %29, i8 0, i8 0, ptr %30, i64 25, i32 1)
   %31 = alloca i64, align 8
-  %32 = load %string_descriptor, %string_descriptor* %title, align 1
+  %32 = load %string_descriptor, ptr %title, align 1
   %33 = alloca %string_descriptor, align 8
-  store %string_descriptor %32, %string_descriptor* %33, align 1
-  %34 = load %string_descriptor, %string_descriptor* %firstname, align 1
+  store %string_descriptor %32, ptr %33, align 1
+  %34 = load %string_descriptor, ptr %firstname, align 1
   %35 = alloca %string_descriptor, align 8
-  store %string_descriptor %34, %string_descriptor* %35, align 1
-  %36 = load %string_descriptor, %string_descriptor* %surname, align 1
+  store %string_descriptor %34, ptr %35, align 1
+  %36 = load %string_descriptor, ptr %surname, align 1
   %37 = alloca %string_descriptor, align 8
-  store %string_descriptor %36, %string_descriptor* %37, align 1
-  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([38 x i8], [38 x i8]* @serialization_info, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %33, %string_descriptor* %35, %string_descriptor* %37)
-  %39 = load i64, i64* %31, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %38, i8** %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %39, i64* %41, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %43 = load i8*, i8** %42, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %45 = load i64, i64* %44, align 8
+  store %string_descriptor %36, ptr %37, align 1
+  %38 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %31, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.8, ptr %33, ptr %35, ptr %37)
+  %39 = load i64, ptr %31, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %39, ptr %41, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %43 = load ptr, ptr %42, align 8
+  %44 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %45 = load i64, ptr %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %47 = icmp eq i8* %38, null
+  call void @_lfortran_printf(ptr @1, ptr %43, i32 %46, ptr @0, i32 1)
+  %47 = icmp eq ptr %38, null
   br i1 %47, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %38)
+  call void @_lfortran_free_alloc(ptr %2, ptr %38)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %48 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %49, i32 25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %48 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 0
+  %49 = load ptr, ptr %48, align 8
+  call void @_lfortran_printf(ptr @3, ptr %49, i32 25, ptr @2, i32 1)
   br label %return
 
 return:                                           ; preds = %free_done
@@ -115,43 +116,43 @@ FINALIZE_SYMTABLE_string_02:                      ; preds = %return
   br label %Finalize_Variable_firstname
 
 Finalize_Variable_firstname:                      ; preds = %FINALIZE_SYMTABLE_string_02
-  %50 = getelementptr %string_descriptor, %string_descriptor* %firstname, i32 0, i32 0
-  %51 = load i8*, i8** %50, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %51)
+  %50 = getelementptr %string_descriptor, ptr %firstname, i32 0, i32 0
+  %51 = load ptr, ptr %50, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %51)
   br label %Finalize_Variable_greetings
 
 Finalize_Variable_greetings:                      ; preds = %Finalize_Variable_firstname
-  %52 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
-  %53 = load i8*, i8** %52, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %53)
+  %52 = getelementptr %string_descriptor, ptr %greetings, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %53)
   br label %Finalize_Variable_surname
 
 Finalize_Variable_surname:                        ; preds = %Finalize_Variable_greetings
-  %54 = getelementptr %string_descriptor, %string_descriptor* %surname, i32 0, i32 0
-  %55 = load i8*, i8** %54, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %55)
+  %54 = getelementptr %string_descriptor, ptr %surname, i32 0, i32 0
+  %55 = load ptr, ptr %54, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %55)
   br label %Finalize_Variable_title
 
 Finalize_Variable_title:                          ; preds = %Finalize_Variable_surname
-  %56 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %57 = load i8*, i8** %56, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %57)
+  %56 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %57 = load ptr, ptr %56, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %57)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "a35884a9d02713f3221183ee155eedacf29970c0b241d35773b05995",
+    "stdout_hash": "5d904291de824ba33d95f22de9971dae1421b99167b1c1ea43291203",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -1,20 +1,21 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @__Wrong_allocation = private unnamed_addr constant [51 x i8] c"Attempting to allocate already allocated variable!\00", align 1
 @string_const_data = private constant [8 x i8] c"learned "
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data, i32 0, i32 0), i64 8 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 8 }>
 @string_const_data.1 = private constant [5 x i8] c"from "
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.1, i32 0, i32 0), i64 5 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 5 }>
 @string_const_data.3 = private constant [4 x i8] c"the "
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.3, i32 0, i32 0), i64 4 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 4 }>
 @string_const_data.5 = private constant [4 x i8] c"best"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 4 }>
 @string_const_data.7 = private constant [5 x i8] c"I've "
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.7, i32 0, i32 0), i64 5 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 5 }>
 @0 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
 @1 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/string_03.f90\00", align 1
 @2 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
@@ -32,25 +33,25 @@ target datalayout = "..."
 @14 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @15 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
 @string_const_data.9 = private constant [1 x i8] c"."
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.9, i32 0, i32 0), i64 1 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 1 }>
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @_lcompilers_stringconcat(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
+define void @_lcompilers_stringconcat(ptr %s1, ptr %s2, ptr %s1_len, ptr %s2_len, ptr %concat_result) {
 .entry:
   %StrSlice_StrView2 = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %StrSlice_StrView = alloca %string_descriptor, align 8
-  %1 = load i32, i32* %s1_len, align 4
-  %2 = load i32, i32* %s2_len, align 4
+  %1 = load i32, ptr %s1_len, align 4
+  %2 = load i32, ptr %s2_len, align 4
   %3 = add i32 %1, %2
-  %4 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %5 = load i8*, i8** %4, align 8
-  %6 = icmp ne i8* %5, null
+  %4 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  %6 = icmp ne ptr %5, null
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([51 x i8], [51 x i8]* @__Wrong_allocation, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @__Wrong_allocation)
   call void @exit(i32 1)
   br label %ifcont
 
@@ -58,38 +59,38 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %7 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 0
   %8 = sext i32 %3 to i64
-  %9 = call i8* @_lfortran_get_default_allocator()
-  %10 = call i8* @_lfortran_string_malloc_alloc(i8* %9, i64 %8)
-  store i8* %10, i8** %7, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %9 = call ptr @_lfortran_get_default_allocator()
+  %10 = call ptr @_lfortran_string_malloc_alloc(ptr %9, i64 %8)
+  store ptr %10, ptr %7, align 8
+  %11 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 1
   %12 = sext i32 %3 to i64
-  store i64 %12, i64* %11, align 8
-  %13 = load i32, i32* %s1_len, align 4
+  store i64 %12, ptr %11, align 8
+  %13 = load i32, ptr %s1_len, align 4
   %14 = sext i32 %13 to i64
   %15 = sub i64 %14, 1
   %16 = add i64 %15, 1
   %17 = icmp slt i64 %16, 0
   %18 = select i1 %17, i64 0, i64 %16
-  %19 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %StrSliceGEP = getelementptr i8, i8* %20, i64 0
-  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %18, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %24 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %25 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 0
-  %26 = load i8*, i8** %25, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 1
-  %28 = load i64, i64* %27, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %23, i64* %24, i8 0, i8 0, i8* %26, i64 %28, i32 1)
-  %29 = load i32, i32* %s1_len, align 4
+  %19 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 0
+  %20 = load ptr, ptr %19, align 8
+  %StrSliceGEP = getelementptr i8, ptr %20, i64 0
+  %21 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 %18, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %24 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %25 = getelementptr %string_descriptor, ptr %s1, i32 0, i32 0
+  %26 = load ptr, ptr %25, align 8
+  %27 = getelementptr %string_descriptor, ptr %s1, i32 0, i32 1
+  %28 = load i64, ptr %27, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %23, ptr %24, i8 0, i8 0, ptr %26, i64 %28, i32 1)
+  %29 = load i32, ptr %s1_len, align 4
   %30 = add i32 %29, 1
-  %31 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
-  %32 = load i64, i64* %31, align 8
+  %31 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 1
+  %32 = load i64, ptr %31, align 8
   %33 = trunc i64 %32 to i32
   %34 = sext i32 %30 to i64
   %35 = sext i32 %33 to i64
@@ -97,22 +98,22 @@ ifcont:                                           ; preds = %else, %then
   %37 = add i64 %36, 1
   %38 = icmp slt i64 %37, 0
   %39 = select i1 %38, i64 0, i64 %37
-  %40 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
+  %40 = getelementptr %string_descriptor, ptr %concat_result, i32 0, i32 0
+  %41 = load ptr, ptr %40, align 8
   %42 = sext i32 %30 to i64
   %43 = sub i64 %42, 1
-  %StrSliceGEP1 = getelementptr i8, i8* %41, i64 %43
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  store i8* %StrSliceGEP1, i8** %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  store i64 %39, i64* %45, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  %48 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 1
-  %51 = load i64, i64* %50, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %46, i64* %47, i8 0, i8 0, i8* %49, i64 %51, i32 1)
+  %StrSliceGEP1 = getelementptr i8, ptr %41, i64 %43
+  %44 = getelementptr %string_descriptor, ptr %StrSlice_StrView2, i32 0, i32 0
+  store ptr %StrSliceGEP1, ptr %44, align 8
+  %45 = getelementptr %string_descriptor, ptr %StrSlice_StrView2, i32 0, i32 1
+  store i64 %39, ptr %45, align 8
+  %46 = getelementptr %string_descriptor, ptr %StrSlice_StrView2, i32 0, i32 0
+  %47 = getelementptr %string_descriptor, ptr %StrSlice_StrView2, i32 0, i32 1
+  %48 = getelementptr %string_descriptor, ptr %s2, i32 0, i32 0
+  %49 = load ptr, ptr %48, align 8
+  %50 = getelementptr %string_descriptor, ptr %s2, i32 0, i32 1
+  %51 = load i64, ptr %50, align 8
+  call void @_lfortran_strcpy_alloc(ptr %0, ptr %46, ptr %47, i8 0, i8 0, ptr %49, i64 %51, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont
@@ -122,21 +123,21 @@ FINALIZE_SYMTABLE__lcompilers_stringconcat:       ; preds = %return
   ret void
 }
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @exit(i32)
 
-declare i8* @_lfortran_string_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_string_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %verb = alloca %string_descriptor, align 8
   %title = alloca %string_descriptor, align 8
   %posit = alloca %string_descriptor, align 8
@@ -147,266 +148,266 @@ define i32 @main(i32 %0, i8** %1) {
   %__libasr__created__var__2_return_slot = alloca %string_descriptor, align 8
   %__libasr__created__var__1_return_slot = alloca %string_descriptor, align 8
   %__libasr__created__var__0_return_slot = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__1_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__2_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__3_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %__libasr__created__var__4_return_slot, align 1
-  store %string_descriptor zeroinitializer, %string_descriptor* %combined, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 1
-  store i64 29, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 29)
-  store i8* %6, i8** %4, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %last_name, align 1
-  %7 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 1
-  store i64 7, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
-  %9 = call i8* @_lfortran_get_default_allocator()
-  %10 = call i8* @_lfortran_malloc_alloc(i8* %9, i64 7)
-  store i8* %10, i8** %8, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %posit, align 1
-  %11 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 1
-  store i64 5, i64* %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
-  %13 = call i8* @_lfortran_get_default_allocator()
-  %14 = call i8* @_lfortran_malloc_alloc(i8* %13, i64 5)
-  store i8* %14, i8** %12, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %title, align 1
-  %15 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  store i64 4, i64* %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %17 = call i8* @_lfortran_get_default_allocator()
-  %18 = call i8* @_lfortran_malloc_alloc(i8* %17, i64 4)
-  store i8* %18, i8** %16, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %verb, align 1
-  %19 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 1
-  store i64 8, i64* %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
-  %21 = call i8* @_lfortran_get_default_allocator()
-  %22 = call i8* @_lfortran_malloc_alloc(i8* %21, i64 8)
-  store i8* %22, i8** %20, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
-  %24 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 1
-  %25 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %23, i64* %24, i8 0, i8 0, i8* %25, i64 8, i32 1)
-  %26 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
-  %27 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 1
-  %28 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %26, i64* %27, i8 0, i8 0, i8* %28, i64 5, i32 1)
-  %29 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %30 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 1
-  %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %29, i64* %30, i8 0, i8 0, i8* %31, i64 4, i32 1)
-  %32 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
-  %33 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 1
-  %34 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %32, i64* %33, i8 0, i8 0, i8* %34, i64 4, i32 1)
-  %35 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %36 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 1
-  %37 = load i8*, i8** %35, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %37)
-  store i8* null, i8** %35, align 8
-  store i64 0, i64* %36, align 8
-  store i32 5, i32* %call_arg_value, align 4
-  store i32 8, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* @string_const.8, %string_descriptor* %verb, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__0_return_slot)
-  %38 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %39 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
-  %40 = load i8*, i8** %38, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %40)
-  store i8* null, i8** %38, align 8
-  store i64 0, i64* %39, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %42 = load i8*, i8** %41, align 8
-  %43 = ptrtoint i8* %42 to i64
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__0_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__1_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__2_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__3_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %__libasr__created__var__4_return_slot, align 1
+  store %string_descriptor zeroinitializer, ptr %combined, align 1
+  %3 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 1
+  store i64 29, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 29)
+  store ptr %6, ptr %4, align 8
+  store %string_descriptor zeroinitializer, ptr %last_name, align 1
+  %7 = getelementptr %string_descriptor, ptr %last_name, i32 0, i32 1
+  store i64 7, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %last_name, i32 0, i32 0
+  %9 = call ptr @_lfortran_get_default_allocator()
+  %10 = call ptr @_lfortran_malloc_alloc(ptr %9, i64 7)
+  store ptr %10, ptr %8, align 8
+  store %string_descriptor zeroinitializer, ptr %posit, align 1
+  %11 = getelementptr %string_descriptor, ptr %posit, i32 0, i32 1
+  store i64 5, ptr %11, align 8
+  %12 = getelementptr %string_descriptor, ptr %posit, i32 0, i32 0
+  %13 = call ptr @_lfortran_get_default_allocator()
+  %14 = call ptr @_lfortran_malloc_alloc(ptr %13, i64 5)
+  store ptr %14, ptr %12, align 8
+  store %string_descriptor zeroinitializer, ptr %title, align 1
+  %15 = getelementptr %string_descriptor, ptr %title, i32 0, i32 1
+  store i64 4, ptr %15, align 8
+  %16 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %17 = call ptr @_lfortran_get_default_allocator()
+  %18 = call ptr @_lfortran_malloc_alloc(ptr %17, i64 4)
+  store ptr %18, ptr %16, align 8
+  store %string_descriptor zeroinitializer, ptr %verb, align 1
+  %19 = getelementptr %string_descriptor, ptr %verb, i32 0, i32 1
+  store i64 8, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %verb, i32 0, i32 0
+  %21 = call ptr @_lfortran_get_default_allocator()
+  %22 = call ptr @_lfortran_malloc_alloc(ptr %21, i64 8)
+  store ptr %22, ptr %20, align 8
+  %23 = getelementptr %string_descriptor, ptr %verb, i32 0, i32 0
+  %24 = getelementptr %string_descriptor, ptr %verb, i32 0, i32 1
+  %25 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %23, ptr %24, i8 0, i8 0, ptr %25, i64 8, i32 1)
+  %26 = getelementptr %string_descriptor, ptr %posit, i32 0, i32 0
+  %27 = getelementptr %string_descriptor, ptr %posit, i32 0, i32 1
+  %28 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %26, ptr %27, i8 0, i8 0, ptr %28, i64 5, i32 1)
+  %29 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %30 = getelementptr %string_descriptor, ptr %title, i32 0, i32 1
+  %31 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %29, ptr %30, i8 0, i8 0, ptr %31, i64 4, i32 1)
+  %32 = getelementptr %string_descriptor, ptr %last_name, i32 0, i32 0
+  %33 = getelementptr %string_descriptor, ptr %last_name, i32 0, i32 1
+  %34 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %32, ptr %33, i8 0, i8 0, ptr %34, i64 4, i32 1)
+  %35 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %36 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 1
+  %37 = load ptr, ptr %35, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %37)
+  store ptr null, ptr %35, align 8
+  store i64 0, ptr %36, align 8
+  store i32 5, ptr %call_arg_value, align 4
+  store i32 8, ptr %call_arg_value1, align 4
+  call void @_lcompilers_stringconcat(ptr @string_const.8, ptr %verb, ptr %call_arg_value, ptr %call_arg_value1, ptr %__libasr__created__var__0_return_slot)
+  %38 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %39 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 1
+  %40 = load ptr, ptr %38, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %40)
+  store ptr null, ptr %38, align 8
+  store i64 0, ptr %39, align 8
+  %41 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = ptrtoint ptr %42 to i64
   %44 = icmp eq i64 %43, 0
   br i1 %44, label %then, label %ifcont
 
 then:                                             ; preds = %.entry
-  %45 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %46 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %47 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %46, i32 0, i32 0
-  %48 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %47, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @1, i32 0, i32 0), i8** %48, align 8
-  %49 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %47, i32 0, i32 1
-  store i32 21, i32* %49, align 4
-  %50 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %47, i32 0, i32 2
-  store i32 12, i32* %50, align 4
-  %51 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %47, i32 0, i32 3
-  store i32 21, i32* %51, align 4
-  %52 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %47, i32 0, i32 4
-  store i32 22, i32* %52, align 4
-  %53 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @2, i32 0, i32 0))
-  %54 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %45, i32 0, i32 0
-  %55 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %46, i32 0, i32 0
-  %56 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 0, i32 2
-  %57 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 0, i32 0
-  store i1 true, i1* %57, align 1
-  %58 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 0, i32 1
-  store i8* %53, i8** %58, align 8
-  store { i8*, i32, i32, i32, i32 }* %55, { i8*, i32, i32, i32, i32 }** %56, align 8
-  %59 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 0, i32 3
-  store i32 1, i32* %59, align 4
-  %60 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %45, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %60, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @0, i32 0, i32 0))
+  %45 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %46 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %47 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %46, i32 0, i32 0
+  %48 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %47, i32 0, i32 0
+  store ptr @1, ptr %48, align 8
+  %49 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %47, i32 0, i32 1
+  store i32 21, ptr %49, align 4
+  %50 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %47, i32 0, i32 2
+  store i32 12, ptr %50, align 4
+  %51 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %47, i32 0, i32 3
+  store i32 21, ptr %51, align 4
+  %52 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %47, i32 0, i32 4
+  store i32 22, ptr %52, align 4
+  %53 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @2)
+  %54 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %45, i32 0, i32 0
+  %55 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %46, i32 0, i32 0
+  %56 = getelementptr { i1, ptr, ptr, i32 }, ptr %54, i32 0, i32 2
+  %57 = getelementptr { i1, ptr, ptr, i32 }, ptr %54, i32 0, i32 0
+  store i1 true, ptr %57, align 1
+  %58 = getelementptr { i1, ptr, ptr, i32 }, ptr %54, i32 0, i32 1
+  store ptr %53, ptr %58, align 8
+  store ptr %55, ptr %56, align 8
+  %59 = getelementptr { i1, ptr, ptr, i32 }, ptr %54, i32 0, i32 3
+  store i32 1, ptr %59, align 4
+  %60 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %45, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %60, i32 1, ptr @3, i32 1, ptr @0)
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %.entry
-  store i32 13, i32* %call_arg_value, align 4
-  store i32 5, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__0_return_slot, %string_descriptor* %posit, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__1_return_slot)
-  %61 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %62 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
-  %63 = load i8*, i8** %61, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %63)
-  store i8* null, i8** %61, align 8
-  store i64 0, i64* %62, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %65 = load i8*, i8** %64, align 8
-  %66 = ptrtoint i8* %65 to i64
+  store i32 13, ptr %call_arg_value, align 4
+  store i32 5, ptr %call_arg_value1, align 4
+  call void @_lcompilers_stringconcat(ptr %__libasr__created__var__0_return_slot, ptr %posit, ptr %call_arg_value, ptr %call_arg_value1, ptr %__libasr__created__var__1_return_slot)
+  %61 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %62 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 1
+  %63 = load ptr, ptr %61, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %63)
+  store ptr null, ptr %61, align 8
+  store i64 0, ptr %62, align 8
+  %64 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %65 = load ptr, ptr %64, align 8
+  %66 = ptrtoint ptr %65 to i64
   %67 = icmp eq i64 %66, 0
   br i1 %67, label %then2, label %ifcont3
 
 then2:                                            ; preds = %ifcont
-  %68 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %69 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %70 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %69, i32 0, i32 0
-  %71 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %70, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @5, i32 0, i32 0), i8** %71, align 8
-  %72 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %70, i32 0, i32 1
-  store i32 21, i32* %72, align 4
-  %73 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %70, i32 0, i32 2
-  store i32 12, i32* %73, align 4
-  %74 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %70, i32 0, i32 3
-  store i32 21, i32* %74, align 4
-  %75 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %70, i32 0, i32 4
-  store i32 29, i32* %75, align 4
-  %76 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0))
-  %77 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %68, i32 0, i32 0
-  %78 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %69, i32 0, i32 0
-  %79 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 0, i32 2
-  %80 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 0, i32 0
-  store i1 true, i1* %80, align 1
-  %81 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 0, i32 1
-  store i8* %76, i8** %81, align 8
-  store { i8*, i32, i32, i32, i32 }* %78, { i8*, i32, i32, i32, i32 }** %79, align 8
-  %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 0, i32 3
-  store i32 1, i32* %82, align 4
-  %83 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %68, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @7, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @4, i32 0, i32 0))
+  %68 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %69 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %70 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %69, i32 0, i32 0
+  %71 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 0
+  store ptr @5, ptr %71, align 8
+  %72 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 1
+  store i32 21, ptr %72, align 4
+  %73 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 2
+  store i32 12, ptr %73, align 4
+  %74 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 3
+  store i32 21, ptr %74, align 4
+  %75 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %70, i32 0, i32 4
+  store i32 29, ptr %75, align 4
+  %76 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @6)
+  %77 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %68, i32 0, i32 0
+  %78 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %69, i32 0, i32 0
+  %79 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 2
+  %80 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 0
+  store i1 true, ptr %80, align 1
+  %81 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 1
+  store ptr %76, ptr %81, align 8
+  store ptr %78, ptr %79, align 8
+  %82 = getelementptr { i1, ptr, ptr, i32 }, ptr %77, i32 0, i32 3
+  store i32 1, ptr %82, align 4
+  %83 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %68, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %83, i32 1, ptr @7, i32 1, ptr @4)
   call void @exit(i32 1)
   unreachable
 
 ifcont3:                                          ; preds = %ifcont
-  store i32 18, i32* %call_arg_value, align 4
-  store i32 4, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__1_return_slot, %string_descriptor* %title, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__2_return_slot)
-  %84 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %85 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
-  %86 = load i8*, i8** %84, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %86)
-  store i8* null, i8** %84, align 8
-  store i64 0, i64* %85, align 8
-  %87 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %88 = load i8*, i8** %87, align 8
-  %89 = ptrtoint i8* %88 to i64
+  store i32 18, ptr %call_arg_value, align 4
+  store i32 4, ptr %call_arg_value1, align 4
+  call void @_lcompilers_stringconcat(ptr %__libasr__created__var__1_return_slot, ptr %title, ptr %call_arg_value, ptr %call_arg_value1, ptr %__libasr__created__var__2_return_slot)
+  %84 = getelementptr %string_descriptor, ptr %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %85 = getelementptr %string_descriptor, ptr %__libasr__created__var__3_return_slot, i32 0, i32 1
+  %86 = load ptr, ptr %84, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %86)
+  store ptr null, ptr %84, align 8
+  store i64 0, ptr %85, align 8
+  %87 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %88 = load ptr, ptr %87, align 8
+  %89 = ptrtoint ptr %88 to i64
   %90 = icmp eq i64 %89, 0
   br i1 %90, label %then4, label %ifcont5
 
 then4:                                            ; preds = %ifcont3
-  %91 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %92 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %93 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %92, i32 0, i32 0
-  %94 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @9, i32 0, i32 0), i8** %94, align 8
-  %95 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 1
-  store i32 21, i32* %95, align 4
-  %96 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 2
-  store i32 12, i32* %96, align 4
-  %97 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 3
-  store i32 21, i32* %97, align 4
-  %98 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %93, i32 0, i32 4
-  store i32 36, i32* %98, align 4
-  %99 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @10, i32 0, i32 0))
-  %100 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %91, i32 0, i32 0
-  %101 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %92, i32 0, i32 0
-  %102 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 2
-  %103 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 0
-  store i1 true, i1* %103, align 1
-  %104 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 1
-  store i8* %99, i8** %104, align 8
-  store { i8*, i32, i32, i32, i32 }* %101, { i8*, i32, i32, i32, i32 }** %102, align 8
-  %105 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 3
-  store i32 1, i32* %105, align 4
-  %106 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %91, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @11, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @8, i32 0, i32 0))
+  %91 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %92 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %93 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %92, i32 0, i32 0
+  %94 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %93, i32 0, i32 0
+  store ptr @9, ptr %94, align 8
+  %95 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %93, i32 0, i32 1
+  store i32 21, ptr %95, align 4
+  %96 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %93, i32 0, i32 2
+  store i32 12, ptr %96, align 4
+  %97 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %93, i32 0, i32 3
+  store i32 21, ptr %97, align 4
+  %98 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %93, i32 0, i32 4
+  store i32 36, ptr %98, align 4
+  %99 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @10)
+  %100 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %91, i32 0, i32 0
+  %101 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %92, i32 0, i32 0
+  %102 = getelementptr { i1, ptr, ptr, i32 }, ptr %100, i32 0, i32 2
+  %103 = getelementptr { i1, ptr, ptr, i32 }, ptr %100, i32 0, i32 0
+  store i1 true, ptr %103, align 1
+  %104 = getelementptr { i1, ptr, ptr, i32 }, ptr %100, i32 0, i32 1
+  store ptr %99, ptr %104, align 8
+  store ptr %101, ptr %102, align 8
+  %105 = getelementptr { i1, ptr, ptr, i32 }, ptr %100, i32 0, i32 3
+  store i32 1, ptr %105, align 4
+  %106 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %91, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %106, i32 1, ptr @11, i32 1, ptr @8)
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %ifcont3
-  store i32 22, i32* %call_arg_value, align 4
-  store i32 7, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__2_return_slot, %string_descriptor* %last_name, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__3_return_slot)
-  %107 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %108 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  %109 = load i8*, i8** %107, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %109)
-  store i8* null, i8** %107, align 8
-  store i64 0, i64* %108, align 8
-  %110 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %111 = load i8*, i8** %110, align 8
-  %112 = ptrtoint i8* %111 to i64
+  store i32 22, ptr %call_arg_value, align 4
+  store i32 7, ptr %call_arg_value1, align 4
+  call void @_lcompilers_stringconcat(ptr %__libasr__created__var__2_return_slot, ptr %last_name, ptr %call_arg_value, ptr %call_arg_value1, ptr %__libasr__created__var__3_return_slot)
+  %107 = getelementptr %string_descriptor, ptr %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %108 = getelementptr %string_descriptor, ptr %__libasr__created__var__4_return_slot, i32 0, i32 1
+  %109 = load ptr, ptr %107, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %109)
+  store ptr null, ptr %107, align 8
+  store i64 0, ptr %108, align 8
+  %110 = getelementptr %string_descriptor, ptr %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %111 = load ptr, ptr %110, align 8
+  %112 = ptrtoint ptr %111 to i64
   %113 = icmp eq i64 %112, 0
   br i1 %113, label %then6, label %ifcont7
 
 then6:                                            ; preds = %ifcont5
-  %114 = alloca [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], align 8
-  %115 = alloca [1 x { i8*, i32, i32, i32, i32 }], align 8
-  %116 = getelementptr inbounds [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %115, i32 0, i32 0
-  %117 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %116, i32 0, i32 0
-  store i8* getelementptr inbounds ([41 x i8], [41 x i8]* @13, i32 0, i32 0), i8** %117, align 8
-  %118 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %116, i32 0, i32 1
-  store i32 21, i32* %118, align 4
-  %119 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %116, i32 0, i32 2
-  store i32 12, i32* %119, align 4
-  %120 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %116, i32 0, i32 3
-  store i32 21, i32* %120, align 4
-  %121 = getelementptr { i8*, i32, i32, i32, i32 }, { i8*, i32, i32, i32, i32 }* %116, i32 0, i32 4
-  store i32 47, i32* %121, align 4
-  %122 = call i8* (i8*, i8*, ...) @_lcompilers_snprintf_alloc(i8* %2, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @14, i32 0, i32 0))
-  %123 = getelementptr inbounds [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %114, i32 0, i32 0
-  %124 = getelementptr [1 x { i8*, i32, i32, i32, i32 }], [1 x { i8*, i32, i32, i32, i32 }]* %115, i32 0, i32 0
-  %125 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 0, i32 2
-  %126 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 0, i32 0
-  store i1 true, i1* %126, align 1
-  %127 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 0, i32 1
-  store i8* %122, i8** %127, align 8
-  store { i8*, i32, i32, i32, i32 }* %124, { i8*, i32, i32, i32, i32 }** %125, align 8
-  %128 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 0, i32 3
-  store i32 1, i32* %128, align 4
-  %129 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %114, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %129, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @15, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @12, i32 0, i32 0))
+  %114 = alloca [1 x { i1, ptr, ptr, i32 }], align 8
+  %115 = alloca [1 x { ptr, i32, i32, i32, i32 }], align 8
+  %116 = getelementptr inbounds [1 x { ptr, i32, i32, i32, i32 }], ptr %115, i32 0, i32 0
+  %117 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %116, i32 0, i32 0
+  store ptr @13, ptr %117, align 8
+  %118 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %116, i32 0, i32 1
+  store i32 21, ptr %118, align 4
+  %119 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %116, i32 0, i32 2
+  store i32 12, ptr %119, align 4
+  %120 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %116, i32 0, i32 3
+  store i32 21, ptr %120, align 4
+  %121 = getelementptr { ptr, i32, i32, i32, i32 }, ptr %116, i32 0, i32 4
+  store i32 47, ptr %121, align 4
+  %122 = call ptr (ptr, ptr, ...) @_lcompilers_snprintf_alloc(ptr %2, ptr @14)
+  %123 = getelementptr inbounds [1 x { i1, ptr, ptr, i32 }], ptr %114, i32 0, i32 0
+  %124 = getelementptr [1 x { ptr, i32, i32, i32, i32 }], ptr %115, i32 0, i32 0
+  %125 = getelementptr { i1, ptr, ptr, i32 }, ptr %123, i32 0, i32 2
+  %126 = getelementptr { i1, ptr, ptr, i32 }, ptr %123, i32 0, i32 0
+  store i1 true, ptr %126, align 1
+  %127 = getelementptr { i1, ptr, ptr, i32 }, ptr %123, i32 0, i32 1
+  store ptr %122, ptr %127, align 8
+  store ptr %124, ptr %125, align 8
+  %128 = getelementptr { i1, ptr, ptr, i32 }, ptr %123, i32 0, i32 3
+  store i32 1, ptr %128, align 4
+  %129 = getelementptr [1 x { i1, ptr, ptr, i32 }], ptr %114, i32 0, i32 0
+  call void (ptr, ptr, i32, ptr, ...) @_lcompilers_runtime_error(ptr %2, ptr %129, i32 1, ptr @15, i32 1, ptr @12)
   call void @exit(i32 1)
   unreachable
 
 ifcont7:                                          ; preds = %ifcont5
-  store i32 29, i32* %call_arg_value, align 4
-  store i32 1, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__3_return_slot, %string_descriptor* @string_const.10, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__4_return_slot)
-  %130 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %131 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 1
-  %132 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %133 = load i8*, i8** %132, align 8
-  %134 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
-  %135 = load i64, i64* %134, align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %130, i64* %131, i8 0, i8 0, i8* %133, i64 %135, i32 1)
-  %136 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %137 = load i8*, i8** %136, align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %137, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
+  store i32 29, ptr %call_arg_value, align 4
+  store i32 1, ptr %call_arg_value1, align 4
+  call void @_lcompilers_stringconcat(ptr %__libasr__created__var__3_return_slot, ptr @string_const.10, ptr %call_arg_value, ptr %call_arg_value1, ptr %__libasr__created__var__4_return_slot)
+  %130 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 0
+  %131 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 1
+  %132 = getelementptr %string_descriptor, ptr %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %133 = load ptr, ptr %132, align 8
+  %134 = getelementptr %string_descriptor, ptr %__libasr__created__var__4_return_slot, i32 0, i32 1
+  %135 = load i64, ptr %134, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %130, ptr %131, i8 0, i8 0, ptr %133, i64 %135, i32 1)
+  %136 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 0
+  %137 = load ptr, ptr %136, align 8
+  call void @_lfortran_printf(ptr @17, ptr %137, i32 29, ptr @16, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont7
@@ -416,77 +417,77 @@ FINALIZE_SYMTABLE_string_03:                      ; preds = %return
   br label %Finalize_Variable___libasr__created__var__0_return_slot
 
 Finalize_Variable___libasr__created__var__0_return_slot: ; preds = %FINALIZE_SYMTABLE_string_03
-  %138 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, i32 0, i32 0
-  %139 = load i8*, i8** %138, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %139)
+  %138 = getelementptr %string_descriptor, ptr %__libasr__created__var__0_return_slot, i32 0, i32 0
+  %139 = load ptr, ptr %138, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %139)
   br label %Finalize_Variable___libasr__created__var__1_return_slot
 
 Finalize_Variable___libasr__created__var__1_return_slot: ; preds = %Finalize_Variable___libasr__created__var__0_return_slot
-  %140 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
-  %141 = load i8*, i8** %140, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %141)
+  %140 = getelementptr %string_descriptor, ptr %__libasr__created__var__1_return_slot, i32 0, i32 0
+  %141 = load ptr, ptr %140, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %141)
   br label %Finalize_Variable___libasr__created__var__2_return_slot
 
 Finalize_Variable___libasr__created__var__2_return_slot: ; preds = %Finalize_Variable___libasr__created__var__1_return_slot
-  %142 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
-  %143 = load i8*, i8** %142, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %143)
+  %142 = getelementptr %string_descriptor, ptr %__libasr__created__var__2_return_slot, i32 0, i32 0
+  %143 = load ptr, ptr %142, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %143)
   br label %Finalize_Variable___libasr__created__var__3_return_slot
 
 Finalize_Variable___libasr__created__var__3_return_slot: ; preds = %Finalize_Variable___libasr__created__var__2_return_slot
-  %144 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
-  %145 = load i8*, i8** %144, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %145)
+  %144 = getelementptr %string_descriptor, ptr %__libasr__created__var__3_return_slot, i32 0, i32 0
+  %145 = load ptr, ptr %144, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %145)
   br label %Finalize_Variable___libasr__created__var__4_return_slot
 
 Finalize_Variable___libasr__created__var__4_return_slot: ; preds = %Finalize_Variable___libasr__created__var__3_return_slot
-  %146 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
-  %147 = load i8*, i8** %146, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %147)
+  %146 = getelementptr %string_descriptor, ptr %__libasr__created__var__4_return_slot, i32 0, i32 0
+  %147 = load ptr, ptr %146, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %147)
   br label %Finalize_Variable_combined
 
 Finalize_Variable_combined:                       ; preds = %Finalize_Variable___libasr__created__var__4_return_slot
-  %148 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
-  %149 = load i8*, i8** %148, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %149)
+  %148 = getelementptr %string_descriptor, ptr %combined, i32 0, i32 0
+  %149 = load ptr, ptr %148, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %149)
   br label %Finalize_Variable_last_name
 
 Finalize_Variable_last_name:                      ; preds = %Finalize_Variable_combined
-  %150 = getelementptr %string_descriptor, %string_descriptor* %last_name, i32 0, i32 0
-  %151 = load i8*, i8** %150, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %151)
+  %150 = getelementptr %string_descriptor, ptr %last_name, i32 0, i32 0
+  %151 = load ptr, ptr %150, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %151)
   br label %Finalize_Variable_posit
 
 Finalize_Variable_posit:                          ; preds = %Finalize_Variable_last_name
-  %152 = getelementptr %string_descriptor, %string_descriptor* %posit, i32 0, i32 0
-  %153 = load i8*, i8** %152, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %153)
+  %152 = getelementptr %string_descriptor, ptr %posit, i32 0, i32 0
+  %153 = load ptr, ptr %152, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %153)
   br label %Finalize_Variable_title
 
 Finalize_Variable_title:                          ; preds = %Finalize_Variable_posit
-  %154 = getelementptr %string_descriptor, %string_descriptor* %title, i32 0, i32 0
-  %155 = load i8*, i8** %154, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %155)
+  %154 = getelementptr %string_descriptor, ptr %title, i32 0, i32 0
+  %155 = load ptr, ptr %154, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %155)
   br label %Finalize_Variable_verb
 
 Finalize_Variable_verb:                           ; preds = %Finalize_Variable_title
-  %156 = getelementptr %string_descriptor, %string_descriptor* %verb, i32 0, i32 0
-  %157 = load i8*, i8** %156, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %157)
+  %156 = getelementptr %string_descriptor, ptr %verb, i32 0, i32 0
+  %157 = load ptr, ptr %156, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %157)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
+declare ptr @_lcompilers_snprintf_alloc(ptr, ptr, ...)
 
-declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
+declare void @_lcompilers_runtime_error(ptr, ptr, i32, ptr, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "d7eda03c22b4031ef3be6ee191782a625a9ce2fec593e9232699e468",
+    "stdout_hash": "c10ae4396479903be489793f2f7392b0c0396bb0b47193f383e50b49",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -1,223 +1,224 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @c_data = private global [2 x i8] c"BC"
-@c = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @c_data, i32 0, i32 0), i64 2 }>
+@c = private global %string_descriptor <{ ptr @c_data, i64 2 }>
 @string_const_data = private constant [1 x i8] c"A"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data, i32 0, i32 0), i64 1 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 1 }>
 @string_const_data.1 = private constant [1 x i8] c"Z"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.1, i32 0, i32 0), i64 1 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 1 }>
 @string_const_data.3 = private constant [1 x i8] c"a"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.3, i32 0, i32 0), i64 1 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 1 }>
 @string_const_data.5 = private constant [1 x i8] c"z"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.5, i32 0, i32 0), i64 1 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 1 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [4 x i8] c"L32\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.7 = private constant [2 x i8] c"@a"
-@string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data.7, i32 0, i32 0), i64 2 }>
+@string_const.8 = private global %string_descriptor <{ ptr @string_const_data.7, i64 2 }>
 @string_const_data.9 = private constant [1 x i8] c"A"
-@string_const.10 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.9, i32 0, i32 0), i64 1 }>
+@string_const.10 = private global %string_descriptor <{ ptr @string_const_data.9, i64 1 }>
 @string_const_data.11 = private constant [1 x i8] c"Z"
-@string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.11, i32 0, i32 0), i64 1 }>
+@string_const.12 = private global %string_descriptor <{ ptr @string_const_data.11, i64 1 }>
 @string_const_data.13 = private constant [1 x i8] c"a"
-@string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.13, i32 0, i32 0), i64 1 }>
+@string_const.14 = private global %string_descriptor <{ ptr @string_const_data.13, i64 1 }>
 @string_const_data.15 = private constant [1 x i8] c"z"
-@string_const.16 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.15, i32 0, i32 0), i64 1 }>
+@string_const.16 = private global %string_descriptor <{ ptr @string_const_data.15, i64 1 }>
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.17 = private unnamed_addr constant [4 x i8] c"L32\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.18 = private constant [2 x i8] c"a@"
-@string_const.19 = private global %string_descriptor <{ i8* getelementptr inbounds ([2 x i8], [2 x i8]* @string_const_data.18, i32 0, i32 0), i64 2 }>
+@string_const.19 = private global %string_descriptor <{ ptr @string_const_data.18, i64 2 }>
 @string_const_data.20 = private constant [1 x i8] c"A"
-@string_const.21 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.20, i32 0, i32 0), i64 1 }>
+@string_const.21 = private global %string_descriptor <{ ptr @string_const_data.20, i64 1 }>
 @string_const_data.22 = private constant [1 x i8] c"Z"
-@string_const.23 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.22, i32 0, i32 0), i64 1 }>
+@string_const.23 = private global %string_descriptor <{ ptr @string_const_data.22, i64 1 }>
 @string_const_data.24 = private constant [1 x i8] c"a"
-@string_const.25 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.24, i32 0, i32 0), i64 1 }>
+@string_const.25 = private global %string_descriptor <{ ptr @string_const_data.24, i64 1 }>
 @string_const_data.26 = private constant [1 x i8] c"z"
-@string_const.27 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.26, i32 0, i32 0), i64 1 }>
+@string_const.27 = private global %string_descriptor <{ ptr @string_const_data.26, i64 1 }>
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info.28 = private unnamed_addr constant [4 x i8] c"L32\00", align 1
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.29 = private constant [3 x i8] c"sbs"
-@string_const.30 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.29, i32 0, i32 0), i64 3 }>
+@string_const.30 = private global %string_descriptor <{ ptr @string_const_data.29, i64 3 }>
 @string_const_data.31 = private constant [3 x i8] c"sbs"
-@string_const.32 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.31, i32 0, i32 0), i64 3 }>
+@string_const.32 = private global %string_descriptor <{ ptr @string_const_data.31, i64 3 }>
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %StrSlice_StrView = alloca %string_descriptor, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %num = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %is_alpha = alloca i32, align 4
-  store %string_descriptor zeroinitializer, %string_descriptor* %num, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 1
-  store i64 3, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 3)
-  store i8* %6, i8** %4, align 8
-  %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %9 = call i32 @str_compare(i8* %7, i64 2, i8* %8, i64 1)
+  store %string_descriptor zeroinitializer, ptr %num, align 1
+  %3 = getelementptr %string_descriptor, ptr %num, i32 0, i32 1
+  store i64 3, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %num, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 3)
+  store ptr %6, ptr %4, align 8
+  %7 = load ptr, ptr @c, align 8
+  %8 = load ptr, ptr @string_const, align 8
+  %9 = call i32 @str_compare(ptr %7, i64 2, ptr %8, i64 1)
   %10 = icmp sge i32 %9, 0
-  %11 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %12 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  %13 = call i32 @str_compare(i8* %11, i64 2, i8* %12, i64 1)
+  %11 = load ptr, ptr @c, align 8
+  %12 = load ptr, ptr @string_const.2, align 8
+  %13 = call i32 @str_compare(ptr %11, i64 2, ptr %12, i64 1)
   %14 = icmp sle i32 %13, 0
   %15 = and i1 %10, %14
-  %16 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  %18 = call i32 @str_compare(i8* %16, i64 2, i8* %17, i64 1)
+  %16 = load ptr, ptr @c, align 8
+  %17 = load ptr, ptr @string_const.4, align 8
+  %18 = call i32 @str_compare(ptr %16, i64 2, ptr %17, i64 1)
   %19 = icmp sge i32 %18, 0
-  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %21 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  %22 = call i32 @str_compare(i8* %20, i64 2, i8* %21, i64 1)
+  %20 = load ptr, ptr @c, align 8
+  %21 = load ptr, ptr @string_const.6, align 8
+  %22 = call i32 @str_compare(ptr %20, i64 2, ptr %21, i64 1)
   %23 = icmp sle i32 %22, 0
   %24 = and i1 %19, %23
   %25 = or i1 %15, %24
   %26 = zext i1 %25 to i32
-  store i32 %26, i32* %is_alpha, align 4
+  store i32 %26, ptr %is_alpha, align 4
   %27 = alloca i64, align 8
-  %28 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @serialization_info, i32 0, i32 0), i64* %27, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %is_alpha)
-  %29 = load i64, i64* %27, align 8
-  %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %28, i8** %30, align 8
-  %31 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %29, i64* %31, align 8
-  %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %33 = load i8*, i8** %32, align 8
-  %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %35 = load i64, i64* %34, align 8
+  %28 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %27, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %is_alpha)
+  %29 = load i64, ptr %27, align 8
+  %30 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %28, ptr %30, align 8
+  %31 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %29, ptr %31, align 8
+  %32 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %33 = load ptr, ptr %32, align 8
+  %34 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %35 = load i64, ptr %34, align 8
   %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %37 = icmp eq i8* %28, null
+  call void @_lfortran_printf(ptr @1, ptr %33, i32 %36, ptr @0, i32 1)
+  %37 = icmp eq ptr %28, null
   br i1 %37, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %28)
+  call void @_lfortran_free_alloc(ptr %2, ptr %28)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %38, i64 2, i32 1)
-  %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %40 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  %41 = call i32 @str_compare(i8* %39, i64 2, i8* %40, i64 1)
+  %38 = load ptr, ptr @string_const.8, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr @c, ptr getelementptr (%string_descriptor, ptr @c, i32 0, i32 1), i8 0, i8 0, ptr %38, i64 2, i32 1)
+  %39 = load ptr, ptr @c, align 8
+  %40 = load ptr, ptr @string_const.10, align 8
+  %41 = call i32 @str_compare(ptr %39, i64 2, ptr %40, i64 1)
   %42 = icmp sge i32 %41, 0
-  %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %44 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  %45 = call i32 @str_compare(i8* %43, i64 2, i8* %44, i64 1)
+  %43 = load ptr, ptr @c, align 8
+  %44 = load ptr, ptr @string_const.12, align 8
+  %45 = call i32 @str_compare(ptr %43, i64 2, ptr %44, i64 1)
   %46 = icmp sle i32 %45, 0
   %47 = and i1 %42, %46
-  %48 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %49 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  %50 = call i32 @str_compare(i8* %48, i64 2, i8* %49, i64 1)
+  %48 = load ptr, ptr @c, align 8
+  %49 = load ptr, ptr @string_const.14, align 8
+  %50 = call i32 @str_compare(ptr %48, i64 2, ptr %49, i64 1)
   %51 = icmp sge i32 %50, 0
-  %52 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %53 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  %54 = call i32 @str_compare(i8* %52, i64 2, i8* %53, i64 1)
+  %52 = load ptr, ptr @c, align 8
+  %53 = load ptr, ptr @string_const.16, align 8
+  %54 = call i32 @str_compare(ptr %52, i64 2, ptr %53, i64 1)
   %55 = icmp sle i32 %54, 0
   %56 = and i1 %51, %55
   %57 = or i1 %47, %56
   %58 = zext i1 %57 to i32
-  store i32 %58, i32* %is_alpha, align 4
+  store i32 %58, ptr %is_alpha, align 4
   %59 = alloca i64, align 8
-  %60 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @serialization_info.17, i32 0, i32 0), i64* %59, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %is_alpha)
-  %61 = load i64, i64* %59, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %60, i8** %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %61, i64* %63, align 8
-  %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %65 = load i8*, i8** %64, align 8
-  %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %67 = load i64, i64* %66, align 8
+  %60 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.17, ptr %59, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %is_alpha)
+  %61 = load i64, ptr %59, align 8
+  %62 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %60, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %61, ptr %63, align 8
+  %64 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %65 = load ptr, ptr %64, align 8
+  %66 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %67 = load i64, ptr %66, align 8
   %68 = trunc i64 %67 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %69 = icmp eq i8* %60, null
+  call void @_lfortran_printf(ptr @3, ptr %65, i32 %68, ptr @2, i32 1)
+  %69 = icmp eq ptr %60, null
   br i1 %69, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %60)
+  call void @_lfortran_free_alloc(ptr %2, ptr %60)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
-  %70 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.19, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 1), i8 0, i8 0, i8* %70, i64 2, i32 1)
-  %71 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %72 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.21, i32 0, i32 0), align 8
-  %73 = call i32 @str_compare(i8* %71, i64 2, i8* %72, i64 1)
+  %70 = load ptr, ptr @string_const.19, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr @c, ptr getelementptr (%string_descriptor, ptr @c, i32 0, i32 1), i8 0, i8 0, ptr %70, i64 2, i32 1)
+  %71 = load ptr, ptr @c, align 8
+  %72 = load ptr, ptr @string_const.21, align 8
+  %73 = call i32 @str_compare(ptr %71, i64 2, ptr %72, i64 1)
   %74 = icmp sge i32 %73, 0
-  %75 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %76 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.23, i32 0, i32 0), align 8
-  %77 = call i32 @str_compare(i8* %75, i64 2, i8* %76, i64 1)
+  %75 = load ptr, ptr @c, align 8
+  %76 = load ptr, ptr @string_const.23, align 8
+  %77 = call i32 @str_compare(ptr %75, i64 2, ptr %76, i64 1)
   %78 = icmp sle i32 %77, 0
   %79 = and i1 %74, %78
-  %80 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %81 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.25, i32 0, i32 0), align 8
-  %82 = call i32 @str_compare(i8* %80, i64 2, i8* %81, i64 1)
+  %80 = load ptr, ptr @c, align 8
+  %81 = load ptr, ptr @string_const.25, align 8
+  %82 = call i32 @str_compare(ptr %80, i64 2, ptr %81, i64 1)
   %83 = icmp sge i32 %82, 0
-  %84 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @c, i32 0, i32 0), align 8
-  %85 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.27, i32 0, i32 0), align 8
-  %86 = call i32 @str_compare(i8* %84, i64 2, i8* %85, i64 1)
+  %84 = load ptr, ptr @c, align 8
+  %85 = load ptr, ptr @string_const.27, align 8
+  %86 = call i32 @str_compare(ptr %84, i64 2, ptr %85, i64 1)
   %87 = icmp sle i32 %86, 0
   %88 = and i1 %83, %87
   %89 = or i1 %79, %88
   %90 = zext i1 %89 to i32
-  store i32 %90, i32* %is_alpha, align 4
+  store i32 %90, ptr %is_alpha, align 4
   %91 = alloca i64, align 8
-  %92 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @serialization_info.28, i32 0, i32 0), i64* %91, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %is_alpha)
-  %93 = load i64, i64* %91, align 8
-  %94 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %92, i8** %94, align 8
-  %95 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %93, i64* %95, align 8
-  %96 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %97 = load i8*, i8** %96, align 8
-  %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %99 = load i64, i64* %98, align 8
+  %92 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.28, ptr %91, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %is_alpha)
+  %93 = load i64, ptr %91, align 8
+  %94 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %92, ptr %94, align 8
+  %95 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %93, ptr %95, align 8
+  %96 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %97 = load ptr, ptr %96, align 8
+  %98 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %99 = load i64, ptr %98, align 8
   %100 = trunc i64 %99 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %97, i32 %100, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
-  %101 = icmp eq i8* %92, null
+  call void @_lfortran_printf(ptr @5, ptr %97, i32 %100, ptr @4, i32 1)
+  %101 = icmp eq ptr %92, null
   br i1 %101, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %free_done3
-  call void @_lfortran_free_alloc(i8* %2, i8* %92)
+  call void @_lfortran_free_alloc(ptr %2, ptr %92)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %free_done3
-  %102 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
-  %103 = load i8*, i8** %102, align 8
-  %StrSliceGEP = getelementptr i8, i8* %103, i64 0
-  %104 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %104, align 8
-  %105 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 3, i64* %105, align 8
-  %106 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %107 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %108 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.30, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %106, i64* %107, i8 0, i8 0, i8* %108, i64 3, i32 1)
-  %109 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
-  %110 = load i8*, i8** %109, align 8
-  %111 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.32, i32 0, i32 0), align 8
-  %112 = call i32 @str_compare(i8* %110, i64 3, i8* %111, i64 3)
+  %102 = getelementptr %string_descriptor, ptr %num, i32 0, i32 0
+  %103 = load ptr, ptr %102, align 8
+  %StrSliceGEP = getelementptr i8, ptr %103, i64 0
+  %104 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %104, align 8
+  %105 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 3, ptr %105, align 8
+  %106 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %107 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %108 = load ptr, ptr @string_const.30, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %106, ptr %107, i8 0, i8 0, ptr %108, i64 3, i32 1)
+  %109 = getelementptr %string_descriptor, ptr %num, i32 0, i32 0
+  %110 = load ptr, ptr %109, align 8
+  %111 = load ptr, ptr @string_const.32, align 8
+  %112 = call i32 @str_compare(ptr %110, i64 3, ptr %111, i64 3)
   %113 = icmp ne i32 %112, 0
   br i1 %113, label %then, label %else
 
 then:                                             ; preds = %free_done6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -235,30 +236,30 @@ FINALIZE_SYMTABLE_string_10:                      ; preds = %return
   br label %Finalize_Variable_num
 
 Finalize_Variable_num:                            ; preds = %FINALIZE_SYMTABLE_string_10
-  %114 = getelementptr %string_descriptor, %string_descriptor* %num, i32 0, i32 0
-  %115 = load i8*, i8** %114, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %115)
+  %114 = getelementptr %string_descriptor, ptr %num, i32 0, i32 0
+  %115 = load ptr, ptr %114, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %115)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare i32 @str_compare(i8*, i64, i8*, i64)
+declare i32 @str_compare(ptr, i64, ptr, i64)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "2ef42d973a53bdb53be49e9d010bd271b8a78d3703992d11b5573ba4",
+    "stdout_hash": "96a79baf50bbc719f1edb20c2706736e1b7d7b1ebb19daaf5d30703a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -1,24 +1,25 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @string_const_data = private constant [14 x i8] c"This is a test"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([14 x i8], [14 x i8]* @string_const_data, i32 0, i32 0), i64 14 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 14 }>
 @string_const_data.1 = private constant [4 x i8] c"test"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.1, i32 0, i32 0), i64 4 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 4 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [17 x i8] c"test is not found"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.3, i32 0, i32 0), i64 17 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 17 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-24,I4\00", align 1
 @string_const_data.5 = private constant [24 x i8] c"test is found at index: "
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([24 x i8], [24 x i8]* @string_const_data.5, i32 0, i32 0), i64 24 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 24 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @_lcompilers_index_str(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
+define i32 @_lcompilers_index_str(ptr %str, ptr %substr, ptr %back, ptr %kind) {
 .entry:
   %StrSlice_StrView4 = alloca %string_descriptor, align 8
   %StrSlice_StrView = alloca %string_descriptor, align 8
@@ -28,20 +29,20 @@ define i32 @_lcompilers_index_str(%string_descriptor* %str, %string_descriptor* 
   %j = alloca i32, align 4
   %k = alloca i32, align 4
   %pos = alloca i32, align 4
-  store i32 0, i32* %_lcompilers_index_str, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %found, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %1 = load i64, i64* %0, align 8
+  store i32 0, ptr %_lcompilers_index_str, align 4
+  store i32 1, ptr %i, align 4
+  store i32 1, ptr %found, align 4
+  %0 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %1 = load i64, ptr %0, align 8
   %2 = trunc i64 %1 to i32
-  %3 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %4 = load i64, i64* %3, align 8
+  %3 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %4 = load i64, ptr %3, align 8
   %5 = trunc i64 %4 to i32
   %6 = icmp slt i32 %2, %5
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 0, i32* %found, align 4
+  store i32 0, ptr %found, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
@@ -51,124 +52,124 @@ ifcont:                                           ; preds = %else, %then
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont10, %ifcont
-  %7 = load i32, i32* %i, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %7 = load i32, ptr %i, align 4
+  %8 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
   %11 = add i32 %10, 1
-  %12 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  %12 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
   %15 = sub i32 %11, %14
   %16 = icmp sle i32 %7, %15
-  %17 = load i32, i32* %found, align 4
+  %17 = load i32, ptr %found, align 4
   %18 = icmp eq i32 %17, 1
   %19 = and i1 %16, %18
   br i1 %19, label %loop.body, label %loop.end11
 
 loop.body:                                        ; preds = %loop.head
-  store i32 0, i32* %k, align 4
-  store i32 1, i32* %j, align 4
+  store i32 0, ptr %k, align 4
+  store i32 1, ptr %j, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %ifcont7, %loop.body
-  %20 = load i32, i32* %j, align 4
-  %21 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %20 = load i32, ptr %j, align 4
+  %21 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
   %24 = icmp sle i32 %20, %23
-  %25 = load i32, i32* %found, align 4
+  %25 = load i32, ptr %found, align 4
   %26 = icmp eq i32 %25, 1
   %27 = and i1 %24, %26
   br i1 %27, label %loop.body2, label %loop.end
 
 loop.body2:                                       ; preds = %loop.head1
-  %28 = load i32, i32* %i, align 4
-  %29 = load i32, i32* %k, align 4
+  %28 = load i32, ptr %i, align 4
+  %29 = load i32, ptr %k, align 4
   %30 = add i32 %28, %29
-  store i32 %30, i32* %pos, align 4
-  %31 = load i32, i32* %pos, align 4
-  %32 = load i32, i32* %pos, align 4
+  store i32 %30, ptr %pos, align 4
+  %31 = load i32, ptr %pos, align 4
+  %32 = load i32, ptr %pos, align 4
   %33 = sext i32 %31 to i64
   %34 = sext i32 %32 to i64
   %35 = sub i64 %34, %33
   %36 = add i64 %35, 1
   %37 = icmp slt i64 %36, 0
   %38 = select i1 %37, i64 0, i64 %36
-  %39 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
+  %39 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %40 = load ptr, ptr %39, align 8
   %41 = sext i32 %31 to i64
   %42 = sub i64 %41, 1
-  %StrSliceGEP = getelementptr i8, i8* %40, i64 %42
-  %43 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %38, i64* %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
-  %49 = load i32, i32* %j, align 4
-  %50 = load i32, i32* %j, align 4
+  %StrSliceGEP = getelementptr i8, ptr %40, i64 %42
+  %43 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %43, align 8
+  %44 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 %38, ptr %44, align 8
+  %45 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %46 = load ptr, ptr %45, align 8
+  %47 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %48 = load i64, ptr %47, align 8
+  %49 = load i32, ptr %j, align 4
+  %50 = load i32, ptr %j, align 4
   %51 = sext i32 %49 to i64
   %52 = sext i32 %50 to i64
   %53 = sub i64 %52, %51
   %54 = add i64 %53, 1
   %55 = icmp slt i64 %54, 0
   %56 = select i1 %55, i64 0, i64 %54
-  %57 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
-  %58 = load i8*, i8** %57, align 8
+  %57 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 0
+  %58 = load ptr, ptr %57, align 8
   %59 = sext i32 %49 to i64
   %60 = sub i64 %59, 1
-  %StrSliceGEP3 = getelementptr i8, i8* %58, i64 %60
-  %61 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  store i8* %StrSliceGEP3, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  store i64 %56, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
-  %67 = call i32 @str_compare(i8* %46, i64 %48, i8* %64, i64 %66)
+  %StrSliceGEP3 = getelementptr i8, ptr %58, i64 %60
+  %61 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 0
+  store ptr %StrSliceGEP3, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 1
+  store i64 %56, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 0
+  %64 = load ptr, ptr %63, align 8
+  %65 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 1
+  %66 = load i64, ptr %65, align 8
+  %67 = call i32 @str_compare(ptr %46, i64 %48, ptr %64, i64 %66)
   %68 = icmp ne i32 %67, 0
   br i1 %68, label %then5, label %else6
 
 then5:                                            ; preds = %loop.body2
-  store i32 0, i32* %found, align 4
+  store i32 0, ptr %found, align 4
   br label %ifcont7
 
 else6:                                            ; preds = %loop.body2
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %69 = load i32, i32* %j, align 4
+  %69 = load i32, ptr %j, align 4
   %70 = add i32 %69, 1
-  store i32 %70, i32* %j, align 4
-  %71 = load i32, i32* %k, align 4
+  store i32 %70, ptr %j, align 4
+  %71 = load i32, ptr %k, align 4
   %72 = add i32 %71, 1
-  store i32 %72, i32* %k, align 4
+  store i32 %72, ptr %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %73 = load i32, i32* %found, align 4
+  %73 = load i32, ptr %found, align 4
   %74 = icmp eq i32 %73, 1
   br i1 %74, label %then8, label %else9
 
 then8:                                            ; preds = %loop.end
-  %75 = load i32, i32* %i, align 4
-  store i32 %75, i32* %_lcompilers_index_str, align 4
-  %76 = load i32, i32* %back, align 4
-  store i32 %76, i32* %found, align 4
+  %75 = load i32, ptr %i, align 4
+  store i32 %75, ptr %_lcompilers_index_str, align 4
+  %76 = load i32, ptr %back, align 4
+  store i32 %76, ptr %found, align 4
   br label %ifcont10
 
 else9:                                            ; preds = %loop.end
-  store i32 1, i32* %found, align 4
+  store i32 1, ptr %found, align 4
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %77 = load i32, i32* %i, align 4
+  %77 = load i32, ptr %i, align 4
   %78 = add i32 %77, 1
-  store i32 %78, i32* %i, align 4
+  store i32 %78, ptr %i, align 4
   br label %loop.head
 
 loop.end11:                                       ; preds = %loop.head
@@ -178,11 +179,11 @@ return:                                           ; preds = %loop.end11
   br label %FINALIZE_SYMTABLE__lcompilers_index_str
 
 FINALIZE_SYMTABLE__lcompilers_index_str:          ; preds = %return
-  %79 = load i32, i32* %_lcompilers_index_str, align 4
+  %79 = load i32, ptr %_lcompilers_index_str, align 4
   ret i32 %79
 }
 
-define i32 @_lcompilers_index_str1(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
+define i32 @_lcompilers_index_str1(ptr %str, ptr %substr, ptr %back, ptr %kind) {
 .entry:
   %StrSlice_StrView4 = alloca %string_descriptor, align 8
   %StrSlice_StrView = alloca %string_descriptor, align 8
@@ -192,20 +193,20 @@ define i32 @_lcompilers_index_str1(%string_descriptor* %str, %string_descriptor*
   %j = alloca i32, align 4
   %k = alloca i32, align 4
   %pos = alloca i32, align 4
-  store i32 0, i32* %_lcompilers_index_str1, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %found, align 4
-  %0 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %1 = load i64, i64* %0, align 8
+  store i32 0, ptr %_lcompilers_index_str1, align 4
+  store i32 1, ptr %i, align 4
+  store i32 1, ptr %found, align 4
+  %0 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %1 = load i64, ptr %0, align 8
   %2 = trunc i64 %1 to i32
-  %3 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %4 = load i64, i64* %3, align 8
+  %3 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %4 = load i64, ptr %3, align 8
   %5 = trunc i64 %4 to i32
   %6 = icmp slt i32 %2, %5
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  store i32 0, i32* %found, align 4
+  store i32 0, ptr %found, align 4
   br label %ifcont
 
 else:                                             ; preds = %.entry
@@ -215,124 +216,124 @@ ifcont:                                           ; preds = %else, %then
   br label %loop.head
 
 loop.head:                                        ; preds = %ifcont10, %ifcont
-  %7 = load i32, i32* %i, align 4
-  %8 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %7 = load i32, ptr %i, align 4
+  %8 = getelementptr %string_descriptor, ptr %str, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
   %11 = add i32 %10, 1
-  %12 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  %12 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
   %15 = sub i32 %11, %14
   %16 = icmp sle i32 %7, %15
-  %17 = load i32, i32* %found, align 4
+  %17 = load i32, ptr %found, align 4
   %18 = icmp eq i32 %17, 1
   %19 = and i1 %16, %18
   br i1 %19, label %loop.body, label %loop.end11
 
 loop.body:                                        ; preds = %loop.head
-  store i32 0, i32* %k, align 4
-  store i32 1, i32* %j, align 4
+  store i32 0, ptr %k, align 4
+  store i32 1, ptr %j, align 4
   br label %loop.head1
 
 loop.head1:                                       ; preds = %ifcont7, %loop.body
-  %20 = load i32, i32* %j, align 4
-  %21 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
+  %20 = load i32, ptr %j, align 4
+  %21 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 1
+  %22 = load i64, ptr %21, align 8
   %23 = trunc i64 %22 to i32
   %24 = icmp sle i32 %20, %23
-  %25 = load i32, i32* %found, align 4
+  %25 = load i32, ptr %found, align 4
   %26 = icmp eq i32 %25, 1
   %27 = and i1 %24, %26
   br i1 %27, label %loop.body2, label %loop.end
 
 loop.body2:                                       ; preds = %loop.head1
-  %28 = load i32, i32* %i, align 4
-  %29 = load i32, i32* %k, align 4
+  %28 = load i32, ptr %i, align 4
+  %29 = load i32, ptr %k, align 4
   %30 = add i32 %28, %29
-  store i32 %30, i32* %pos, align 4
-  %31 = load i32, i32* %pos, align 4
-  %32 = load i32, i32* %pos, align 4
+  store i32 %30, ptr %pos, align 4
+  %31 = load i32, ptr %pos, align 4
+  %32 = load i32, ptr %pos, align 4
   %33 = sext i32 %31 to i64
   %34 = sext i32 %32 to i64
   %35 = sub i64 %34, %33
   %36 = add i64 %35, 1
   %37 = icmp slt i64 %36, 0
   %38 = select i1 %37, i64 0, i64 %36
-  %39 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
-  %40 = load i8*, i8** %39, align 8
+  %39 = getelementptr %string_descriptor, ptr %str, i32 0, i32 0
+  %40 = load ptr, ptr %39, align 8
   %41 = sext i32 %31 to i64
   %42 = sub i64 %41, 1
-  %StrSliceGEP = getelementptr i8, i8* %40, i64 %42
-  %43 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %38, i64* %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
-  %49 = load i32, i32* %j, align 4
-  %50 = load i32, i32* %j, align 4
+  %StrSliceGEP = getelementptr i8, ptr %40, i64 %42
+  %43 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  store ptr %StrSliceGEP, ptr %43, align 8
+  %44 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  store i64 %38, ptr %44, align 8
+  %45 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 0
+  %46 = load ptr, ptr %45, align 8
+  %47 = getelementptr %string_descriptor, ptr %StrSlice_StrView, i32 0, i32 1
+  %48 = load i64, ptr %47, align 8
+  %49 = load i32, ptr %j, align 4
+  %50 = load i32, ptr %j, align 4
   %51 = sext i32 %49 to i64
   %52 = sext i32 %50 to i64
   %53 = sub i64 %52, %51
   %54 = add i64 %53, 1
   %55 = icmp slt i64 %54, 0
   %56 = select i1 %55, i64 0, i64 %54
-  %57 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
-  %58 = load i8*, i8** %57, align 8
+  %57 = getelementptr %string_descriptor, ptr %substr, i32 0, i32 0
+  %58 = load ptr, ptr %57, align 8
   %59 = sext i32 %49 to i64
   %60 = sub i64 %59, 1
-  %StrSliceGEP3 = getelementptr i8, i8* %58, i64 %60
-  %61 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  store i8* %StrSliceGEP3, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  store i64 %56, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
-  %67 = call i32 @str_compare(i8* %46, i64 %48, i8* %64, i64 %66)
+  %StrSliceGEP3 = getelementptr i8, ptr %58, i64 %60
+  %61 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 0
+  store ptr %StrSliceGEP3, ptr %61, align 8
+  %62 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 1
+  store i64 %56, ptr %62, align 8
+  %63 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 0
+  %64 = load ptr, ptr %63, align 8
+  %65 = getelementptr %string_descriptor, ptr %StrSlice_StrView4, i32 0, i32 1
+  %66 = load i64, ptr %65, align 8
+  %67 = call i32 @str_compare(ptr %46, i64 %48, ptr %64, i64 %66)
   %68 = icmp ne i32 %67, 0
   br i1 %68, label %then5, label %else6
 
 then5:                                            ; preds = %loop.body2
-  store i32 0, i32* %found, align 4
+  store i32 0, ptr %found, align 4
   br label %ifcont7
 
 else6:                                            ; preds = %loop.body2
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %69 = load i32, i32* %j, align 4
+  %69 = load i32, ptr %j, align 4
   %70 = add i32 %69, 1
-  store i32 %70, i32* %j, align 4
-  %71 = load i32, i32* %k, align 4
+  store i32 %70, ptr %j, align 4
+  %71 = load i32, ptr %k, align 4
   %72 = add i32 %71, 1
-  store i32 %72, i32* %k, align 4
+  store i32 %72, ptr %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %73 = load i32, i32* %found, align 4
+  %73 = load i32, ptr %found, align 4
   %74 = icmp eq i32 %73, 1
   br i1 %74, label %then8, label %else9
 
 then8:                                            ; preds = %loop.end
-  %75 = load i32, i32* %i, align 4
-  store i32 %75, i32* %_lcompilers_index_str1, align 4
-  %76 = load i32, i32* %back, align 4
-  store i32 %76, i32* %found, align 4
+  %75 = load i32, ptr %i, align 4
+  store i32 %75, ptr %_lcompilers_index_str1, align 4
+  %76 = load i32, ptr %back, align 4
+  store i32 %76, ptr %found, align 4
   br label %ifcont10
 
 else9:                                            ; preds = %loop.end
-  store i32 1, i32* %found, align 4
+  store i32 1, ptr %found, align 4
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %77 = load i32, i32* %i, align 4
+  %77 = load i32, ptr %i, align 4
   %78 = add i32 %77, 1
-  store i32 %78, i32* %i, align 4
+  store i32 %78, ptr %i, align 4
   br label %loop.head
 
 loop.end11:                                       ; preds = %loop.head
@@ -342,78 +343,78 @@ return:                                           ; preds = %loop.end11
   br label %FINALIZE_SYMTABLE__lcompilers_index_str1
 
 FINALIZE_SYMTABLE__lcompilers_index_str1:         ; preds = %return
-  %79 = load i32, i32* %_lcompilers_index_str1, align 4
+  %79 = load i32, ptr %_lcompilers_index_str1, align 4
   ret i32 %79
 }
 
-declare i32 @str_compare(i8*, i64, i8*, i64)
+declare i32 @str_compare(ptr, i64, ptr, i64)
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
   %call_arg_value1 = alloca i32, align 4
   %call_arg_value = alloca i32, align 4
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %teststring = alloca %string_descriptor, align 8
   %mystring = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %mystring, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
-  store i64 30, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 30)
-  store i8* %6, i8** %4, align 8
-  store %string_descriptor zeroinitializer, %string_descriptor* %teststring, align 1
-  %7 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
-  store i64 10, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
-  %9 = call i8* @_lfortran_get_default_allocator()
-  %10 = call i8* @_lfortran_malloc_alloc(i8* %9, i64 10)
-  store i8* %10, i8** %8, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
-  %12 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 1
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %11, i64* %12, i8 0, i8 0, i8* %13, i64 14, i32 1)
-  %14 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
-  %15 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 1
-  %16 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** %14, i64* %15, i8 0, i8 0, i8* %16, i64 4, i32 1)
-  store i32 0, i32* %call_arg_value, align 4
-  store i32 4, i32* %call_arg_value1, align 4
-  %17 = call i32 @_lcompilers_index_str(%string_descriptor* %mystring, %string_descriptor* %teststring, i32* %call_arg_value, i32* %call_arg_value1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %mystring, align 1
+  %3 = getelementptr %string_descriptor, ptr %mystring, i32 0, i32 1
+  store i64 30, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %mystring, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 30)
+  store ptr %6, ptr %4, align 8
+  store %string_descriptor zeroinitializer, ptr %teststring, align 1
+  %7 = getelementptr %string_descriptor, ptr %teststring, i32 0, i32 1
+  store i64 10, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %teststring, i32 0, i32 0
+  %9 = call ptr @_lfortran_get_default_allocator()
+  %10 = call ptr @_lfortran_malloc_alloc(ptr %9, i64 10)
+  store ptr %10, ptr %8, align 8
+  %11 = getelementptr %string_descriptor, ptr %mystring, i32 0, i32 0
+  %12 = getelementptr %string_descriptor, ptr %mystring, i32 0, i32 1
+  %13 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %11, ptr %12, i8 0, i8 0, ptr %13, i64 14, i32 1)
+  %14 = getelementptr %string_descriptor, ptr %teststring, i32 0, i32 0
+  %15 = getelementptr %string_descriptor, ptr %teststring, i32 0, i32 1
+  %16 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr %14, ptr %15, i8 0, i8 0, ptr %16, i64 4, i32 1)
+  store i32 0, ptr %call_arg_value, align 4
+  store i32 4, ptr %call_arg_value1, align 4
+  %17 = call i32 @_lcompilers_index_str(ptr %mystring, ptr %teststring, ptr %call_arg_value, ptr %call_arg_value1)
   %18 = icmp eq i32 %17, 0
   br i1 %18, label %then, label %else
 
 then:                                             ; preds = %.entry
-  %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %19 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @1, ptr %19, i32 17, ptr @0, i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
   %20 = alloca i64, align 8
-  store i32 0, i32* %call_arg_value, align 4
-  store i32 4, i32* %call_arg_value1, align 4
-  %21 = call i32 @_lcompilers_index_str1(%string_descriptor* %mystring, %string_descriptor* %teststring, i32* %call_arg_value, i32* %call_arg_value1)
+  store i32 0, ptr %call_arg_value, align 4
+  store i32 4, ptr %call_arg_value1, align 4
+  %21 = call i32 @_lcompilers_index_str1(ptr %mystring, ptr %teststring, ptr %call_arg_value, ptr %call_arg_value1)
   %22 = alloca i32, align 4
-  store i32 %21, i32* %22, align 4
-  %23 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %20, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %22)
-  %24 = load i64, i64* %20, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %23, i8** %25, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %24, i64* %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %28 = load i8*, i8** %27, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %30 = load i64, i64* %29, align 8
+  store i32 %21, ptr %22, align 4
+  %23 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %20, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @string_const.6, ptr %22)
+  %24 = load i64, ptr %20, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %23, ptr %25, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %24, ptr %26, align 8
+  %27 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %28 = load ptr, ptr %27, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %30 = load i64, ptr %29, align 8
   %31 = trunc i64 %30 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %32 = icmp eq i8* %23, null
+  call void @_lfortran_printf(ptr @3, ptr %28, i32 %31, ptr @2, i32 1)
+  %32 = icmp eq ptr %23, null
   br i1 %32, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %else
-  call void @_lfortran_free_alloc(i8* %2, i8* %23)
+  call void @_lfortran_free_alloc(ptr %2, ptr %23)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %else
@@ -429,31 +430,31 @@ FINALIZE_SYMTABLE_string_11:                      ; preds = %return
   br label %Finalize_Variable_mystring
 
 Finalize_Variable_mystring:                       ; preds = %FINALIZE_SYMTABLE_string_11
-  %33 = getelementptr %string_descriptor, %string_descriptor* %mystring, i32 0, i32 0
-  %34 = load i8*, i8** %33, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %34)
+  %33 = getelementptr %string_descriptor, ptr %mystring, i32 0, i32 0
+  %34 = load ptr, ptr %33, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %34)
   br label %Finalize_Variable_teststring
 
 Finalize_Variable_teststring:                     ; preds = %Finalize_Variable_mystring
-  %35 = getelementptr %string_descriptor, %string_descriptor* %teststring, i32 0, i32 0
-  %36 = load i8*, i8** %35, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %36)
+  %35 = getelementptr %string_descriptor, ptr %teststring, i32 0, i32 0
+  %36 = load ptr, ptr %35, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %36)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "c0374a8fdcf48dc96584c24875b0c4256ad0b9fd5cfa618ff10bf548",
+    "stdout_hash": "f21546dd9f7bf0b2934eb71a2babe7883398e1ecfc367cebd6c963b0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -15,21 +16,21 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [9 x i8] c"I4,I4,I4\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %ia0 = alloca i32, align 4
-  store i32 48, i32* %ia0, align 4
+  store i32 48, ptr %ia0, align 4
   %ia5 = alloca i32, align 4
-  store i32 53, i32* %ia5, align 4
+  store i32 53, ptr %ia5, align 4
   %ia9 = alloca i32, align 4
-  store i32 57, i32* %ia9, align 4
+  store i32 57, ptr %ia9, align 4
   br i1 false, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -41,7 +42,7 @@ ifcont:                                           ; preds = %else, %then
   br i1 false, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -53,7 +54,7 @@ ifcont3:                                          ; preds = %else2, %then1
   br i1 false, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -64,28 +65,28 @@ else5:                                            ; preds = %ifcont3
 ifcont6:                                          ; preds = %else5, %then4
   %3 = alloca i64, align 8
   %4 = alloca i32, align 4
-  store i32 48, i32* %4, align 4
+  store i32 48, ptr %4, align 4
   %5 = alloca i32, align 4
-  store i32 53, i32* %5, align 4
+  store i32 53, ptr %5, align 4
   %6 = alloca i32, align 4
-  store i32 57, i32* %6, align 4
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([9 x i8], [9 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4, i32* %5, i32* %6)
-  %8 = load i64, i64* %3, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %7, i8** %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %8, i64* %10, align 8
-  %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %12 = load i8*, i8** %11, align 8
-  %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %14 = load i64, i64* %13, align 8
+  store i32 57, ptr %6, align 4
+  %7 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %4, ptr %5, ptr %6)
+  %8 = load i64, ptr %3, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %12 = load ptr, ptr %11, align 8
+  %13 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %16 = icmp eq i8* %7, null
+  call void @_lfortran_printf(ptr @7, ptr %12, i32 %15, ptr @6, i32 1)
+  %16 = icmp eq ptr %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont6
-  call void @_lfortran_free_alloc(i8* %2, i8* %7)
+  call void @_lfortran_free_alloc(ptr %2, ptr %7)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont6
@@ -99,18 +100,18 @@ FINALIZE_SYMTABLE_string_13:                      ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-string_54-06ad64c.json
+++ b/tests/reference/llvm-string_54-06ad64c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_54-06ad64c.stdout",
-    "stdout_hash": "ade750df89e7948b2e534bc2b7e77dadd75ef27dc6d16379a5e38c86",
+    "stdout_hash": "fde5197d5a43843b3552c8ee65675d620fc0946e0ce3425ab2473ec7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_54-06ad64c.stdout
+++ b/tests/reference/llvm-string_54-06ad64c.stdout
@@ -1,26 +1,27 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
-define i32 @__module_string_54_mod_double_(i32* %x) {
+define i32 @__module_string_54_mod_double_(ptr %x) {
 .entry:
   %ret = alloca i32, align 4
-  %0 = load i32, i32* %x, align 4
+  %0 = load i32, ptr %x, align 4
   %1 = mul i32 %0, 2
-  store i32 %1, i32* %ret, align 4
+  store i32 %1, ptr %ret, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_double_
 
 FINALIZE_SYMTABLE_double_:                        ; preds = %return
-  %2 = load i32, i32* %ret, align 4
+  %2 = load i32, ptr %ret, align 4
   ret i32 %2
 }
 
-define void @__module_string_54_mod_foo_sub(i32* %x, %string_descriptor* %char) {
+define void @__module_string_54_mod_foo_sub(ptr %x, ptr %char) {
 .entry:
   br label %return
 
@@ -31,21 +32,21 @@ FINALIZE_SYMTABLE_foo_sub:                        ; preds = %return
   ret void
 }
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %char = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %char, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %char, i32 0, i32 1
-  store i64 10, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %char, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 10)
-  store i8* %6, i8** %4, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %char, align 1
+  %3 = getelementptr %string_descriptor, ptr %char, i32 0, i32 1
+  store i64 10, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %char, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 10)
+  store ptr %6, ptr %4, align 8
   %x = alloca i32, align 4
-  store i32 10, i32* %x, align 4
-  call void @__module_string_54_mod_foo_sub(i32* %x, %string_descriptor* %char)
+  store i32 10, ptr %x, align 4
+  call void @__module_string_54_mod_foo_sub(ptr %x, ptr %char)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -55,19 +56,19 @@ FINALIZE_SYMTABLE_string_54:                      ; preds = %return
   br label %Finalize_Variable_char
 
 Finalize_Variable_char:                           ; preds = %FINALIZE_SYMTABLE_string_54
-  %7 = getelementptr %string_descriptor, %string_descriptor* %char, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %8)
+  %7 = getelementptr %string_descriptor, ptr %char, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %8)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-subroutine3-fb7e0b8.json
+++ b/tests/reference/llvm-subroutine3-fb7e0b8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutine3-fb7e0b8.stdout",
-    "stdout_hash": "06b2bdeaaf51a338d727f26ab674bd2aef8ec6df35d42bce23ec8b0a",
+    "stdout_hash": "d3a392f16ebb0a59254befd2e01e2cc97bfbd150bde27fcc942e948a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutine3-fb7e0b8.stdout
+++ b/tests/reference/llvm-subroutine3-fb7e0b8.stdout
@@ -1,17 +1,18 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 define i32 @f() {
 .entry:
   %f = alloca i32, align 4
-  store i32 42, i32* %f, align 4
+  store i32 42, ptr %f, align 4
   br label %return
 
 return:                                           ; preds = %.entry
   br label %FINALIZE_SYMTABLE_f
 
 FINALIZE_SYMTABLE_f:                              ; preds = %return
-  %0 = load i32, i32* %f, align 4
+  %0 = load i32, ptr %f, align 4
   ret i32 %0
 }

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "fa09ec2a09177717110be16b2dcc56cc10348e274ba3f79e8c7750a3",
+    "stdout_hash": "3c1566b0d22222bcefbe86532aafe974a13b2d88249a1d75aa179352",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -36,25 +37,25 @@ target datalayout = "..."
 @24 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @25 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc28 = alloca %string_descriptor, align 8
   %stringFormat_desc19 = alloca %string_descriptor, align 8
   %stringFormat_desc10 = alloca %string_descriptor, align 8
   %call_arg_value = alloca i32, align 4
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %j, align 4
-  %3 = load i32, i32* %j, align 4
+  store i32 1, ptr %i, align 4
+  store i32 1, ptr %j, align 4
+  %3 = load i32, ptr %j, align 4
   %4 = icmp ne i32 %3, 1
   br i1 %4, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -63,34 +64,34 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  call void @f(i32* %i, i32* %j)
+  call void @f(ptr %i, ptr %j)
   %5 = alloca i64, align 8
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %5, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i, i32* %j)
-  %7 = load i64, i64* %5, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %6, i8** %8, align 8
-  %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %7, i64* %9, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %11 = load i8*, i8** %10, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %13 = load i64, i64* %12, align 8
+  %6 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %5, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i, ptr %j)
+  %7 = load i64, ptr %5, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %6, ptr %8, align 8
+  %9 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %7, ptr %9, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %11 = load ptr, ptr %10, align 8
+  %12 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %15 = icmp eq i8* %6, null
+  call void @_lfortran_printf(ptr @3, ptr %11, i32 %14, ptr @2, i32 1)
+  %15 = icmp eq ptr %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %ifcont
-  call void @_lfortran_free_alloc(i8* %2, i8* %6)
+  call void @_lfortran_free_alloc(ptr %2, ptr %6)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %ifcont
-  %16 = load i32, i32* %i, align 4
+  %16 = load i32, ptr %i, align 4
   %17 = icmp ne i32 %16, 1
   br i1 %17, label %then1, label %else2
 
 then1:                                            ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -99,12 +100,12 @@ else2:                                            ; preds = %free_done
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %18 = load i32, i32* %j, align 4
+  %18 = load i32, ptr %j, align 4
   %19 = icmp ne i32 %18, 2
   br i1 %19, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -113,13 +114,13 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  store i32 1, i32* %j, align 4
-  %20 = load i32, i32* %j, align 4
+  store i32 1, ptr %j, align 4
+  %20 = load i32, ptr %j, align 4
   %21 = icmp ne i32 %20, 1
   br i1 %21, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -128,35 +129,35 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  store i32 3, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j)
+  store i32 3, ptr %call_arg_value, align 4
+  call void @f(ptr %call_arg_value, ptr %j)
   %22 = alloca i64, align 8
-  %23 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %22, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %24 = load i64, i64* %22, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  store i8* %23, i8** %25, align 8
-  %26 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  store i64 %24, i64* %26, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
-  %28 = load i8*, i8** %27, align 8
-  %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
-  %30 = load i64, i64* %29, align 8
+  %23 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %22, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %24 = load i64, ptr %22, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  store ptr %23, ptr %25, align 8
+  %26 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  store i64 %24, ptr %26, align 8
+  %27 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 0
+  %28 = load ptr, ptr %27, align 8
+  %29 = getelementptr %string_descriptor, ptr %stringFormat_desc10, i32 0, i32 1
+  %30 = load i64, ptr %29, align 8
   %31 = trunc i64 %30 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
-  %32 = icmp eq i8* %23, null
+  call void @_lfortran_printf(ptr @11, ptr %28, i32 %31, ptr @10, i32 1)
+  %32 = icmp eq ptr %23, null
   br i1 %32, label %free_done12, label %free_nonnull11
 
 free_nonnull11:                                   ; preds = %ifcont9
-  call void @_lfortran_free_alloc(i8* %2, i8* %23)
+  call void @_lfortran_free_alloc(ptr %2, ptr %23)
   br label %free_done12
 
 free_done12:                                      ; preds = %free_nonnull11, %ifcont9
-  %33 = load i32, i32* %j, align 4
+  %33 = load i32, ptr %j, align 4
   %34 = icmp ne i32 %33, 4
   br i1 %34, label %then13, label %else14
 
 then13:                                           ; preds = %free_done12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -165,13 +166,13 @@ else14:                                           ; preds = %free_done12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  store i32 1, i32* %j, align 4
-  %35 = load i32, i32* %j, align 4
+  store i32 1, ptr %j, align 4
+  %35 = load i32, ptr %j, align 4
   %36 = icmp ne i32 %35, 1
   br i1 %36, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -180,35 +181,35 @@ else17:                                           ; preds = %ifcont15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  store i32 3, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j)
+  store i32 3, ptr %call_arg_value, align 4
+  call void @f(ptr %call_arg_value, ptr %j)
   %37 = alloca i64, align 8
-  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.2, i32 0, i32 0), i64* %37, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %39 = load i64, i64* %37, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  store i8* %38, i8** %40, align 8
-  %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  store i64 %39, i64* %41, align 8
-  %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
-  %43 = load i8*, i8** %42, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
-  %45 = load i64, i64* %44, align 8
+  %38 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %37, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %39 = load i64, ptr %37, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  store ptr %38, ptr %40, align 8
+  %41 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  store i64 %39, ptr %41, align 8
+  %42 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 0
+  %43 = load ptr, ptr %42, align 8
+  %44 = getelementptr %string_descriptor, ptr %stringFormat_desc19, i32 0, i32 1
+  %45 = load i64, ptr %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
-  %47 = icmp eq i8* %38, null
+  call void @_lfortran_printf(ptr @17, ptr %43, i32 %46, ptr @16, i32 1)
+  %47 = icmp eq ptr %38, null
   br i1 %47, label %free_done21, label %free_nonnull20
 
 free_nonnull20:                                   ; preds = %ifcont18
-  call void @_lfortran_free_alloc(i8* %2, i8* %38)
+  call void @_lfortran_free_alloc(ptr %2, ptr %38)
   br label %free_done21
 
 free_done21:                                      ; preds = %free_nonnull20, %ifcont18
-  %48 = load i32, i32* %j, align 4
+  %48 = load i32, ptr %j, align 4
   %49 = icmp ne i32 %48, 4
   br i1 %49, label %then22, label %else23
 
 then22:                                           ; preds = %free_done21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @19, ptr @"ERROR STOP", ptr @18)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -217,13 +218,13 @@ else23:                                           ; preds = %free_done21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  store i32 1, i32* %j, align 4
-  %50 = load i32, i32* %j, align 4
+  store i32 1, ptr %j, align 4
+  %50 = load i32, ptr %j, align 4
   %51 = icmp ne i32 %50, 1
   br i1 %51, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -232,37 +233,37 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %52 = load i32, i32* %i, align 4
+  %52 = load i32, ptr %i, align 4
   %53 = add i32 %52, 2
-  store i32 %53, i32* %call_arg_value, align 4
-  call void @f(i32* %call_arg_value, i32* %j)
+  store i32 %53, ptr %call_arg_value, align 4
+  call void @f(ptr %call_arg_value, ptr %j)
   %54 = alloca i64, align 8
-  %55 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.3, i32 0, i32 0), i64* %54, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %j)
-  %56 = load i64, i64* %54, align 8
-  %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
-  store i8* %55, i8** %57, align 8
-  %58 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1
-  store i64 %56, i64* %58, align 8
-  %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 0
-  %60 = load i8*, i8** %59, align 8
-  %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1
-  %62 = load i64, i64* %61, align 8
+  %55 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.3, ptr %54, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %j)
+  %56 = load i64, ptr %54, align 8
+  %57 = getelementptr %string_descriptor, ptr %stringFormat_desc28, i32 0, i32 0
+  store ptr %55, ptr %57, align 8
+  %58 = getelementptr %string_descriptor, ptr %stringFormat_desc28, i32 0, i32 1
+  store i64 %56, ptr %58, align 8
+  %59 = getelementptr %string_descriptor, ptr %stringFormat_desc28, i32 0, i32 0
+  %60 = load ptr, ptr %59, align 8
+  %61 = getelementptr %string_descriptor, ptr %stringFormat_desc28, i32 0, i32 1
+  %62 = load i64, ptr %61, align 8
   %63 = trunc i64 %62 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %60, i32 %63, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
-  %64 = icmp eq i8* %55, null
+  call void @_lfortran_printf(ptr @23, ptr %60, i32 %63, ptr @22, i32 1)
+  %64 = icmp eq ptr %55, null
   br i1 %64, label %free_done30, label %free_nonnull29
 
 free_nonnull29:                                   ; preds = %ifcont27
-  call void @_lfortran_free_alloc(i8* %2, i8* %55)
+  call void @_lfortran_free_alloc(ptr %2, ptr %55)
   br label %free_done30
 
 free_done30:                                      ; preds = %free_nonnull29, %ifcont27
-  %65 = load i32, i32* %j, align 4
+  %65 = load i32, ptr %j, align 4
   %66 = icmp ne i32 %65, 4
   br i1 %66, label %then31, label %else32
 
 then31:                                           ; preds = %free_done30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @25, ptr @"ERROR STOP", ptr @24)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -281,11 +282,11 @@ FINALIZE_SYMTABLE_subroutines_01:                 ; preds = %return
   ret i32 0
 }
 
-define void @f(i32* %a, i32* %b) {
+define void @f(ptr %a, ptr %b) {
 .entry:
-  %0 = load i32, i32* %a, align 4
+  %0 = load i32, ptr %a, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* %b, align 4
+  store i32 %1, ptr %b, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -295,18 +296,18 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
   ret void
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 
 declare void @exit(i32)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "6b9b7cebc6c92c554cc4d835292472e8756a900e73ec1203eb54202e",
+    "stdout_hash": "fa3e217d2c5c58bfa2c7941eb9a9c301e5cab0880c83301c15fa68be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [6 x i8] c"I4,I4\00", align 1
@@ -27,45 +28,45 @@ target datalayout = "..."
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc13 = alloca %string_descriptor, align 8
   %stringFormat_desc4 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 1, i32* %j, align 4
-  call void @f(i32* %i, i32* %j)
+  store i32 1, ptr %i, align 4
+  store i32 1, ptr %j, align 4
+  call void @f(ptr %i, ptr %j)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i, i32* %j)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i, ptr %j)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load i32, i32* %i, align 4
+  %14 = load i32, ptr %i, align 4
   %15 = icmp ne i32 %14, 1
   br i1 %15, label %then, label %else
 
 then:                                             ; preds = %free_done
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -74,12 +75,12 @@ else:                                             ; preds = %free_done
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %16 = load i32, i32* %j, align 4
+  %16 = load i32, ptr %j, align 4
   %17 = icmp ne i32 %16, 2
   br i1 %17, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -88,34 +89,34 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  call void @g(i32* %i, i32* %j)
+  call void @g(ptr %i, ptr %j)
   %18 = alloca i64, align 8
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.1, i32 0, i32 0), i64* %18, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i, i32* %j)
-  %20 = load i64, i64* %18, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  store i8* %19, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  store i64 %20, i64* %22, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
-  %24 = load i8*, i8** %23, align 8
-  %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
-  %26 = load i64, i64* %25, align 8
+  %19 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %18, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i, ptr %j)
+  %20 = load i64, ptr %18, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  store ptr %19, ptr %21, align 8
+  %22 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  store i64 %20, ptr %22, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 0
+  %24 = load ptr, ptr %23, align 8
+  %25 = getelementptr %string_descriptor, ptr %stringFormat_desc4, i32 0, i32 1
+  %26 = load i64, ptr %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
-  %28 = icmp eq i8* %19, null
+  call void @_lfortran_printf(ptr @7, ptr %24, i32 %27, ptr @6, i32 1)
+  %28 = icmp eq ptr %19, null
   br i1 %28, label %free_done6, label %free_nonnull5
 
 free_nonnull5:                                    ; preds = %ifcont3
-  call void @_lfortran_free_alloc(i8* %2, i8* %19)
+  call void @_lfortran_free_alloc(ptr %2, ptr %19)
   br label %free_done6
 
 free_done6:                                       ; preds = %free_nonnull5, %ifcont3
-  %29 = load i32, i32* %i, align 4
+  %29 = load i32, ptr %i, align 4
   %30 = icmp ne i32 %29, 1
   br i1 %30, label %then7, label %else8
 
 then7:                                            ; preds = %free_done6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -124,12 +125,12 @@ else8:                                            ; preds = %free_done6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %31 = load i32, i32* %j, align 4
+  %31 = load i32, ptr %j, align 4
   %32 = icmp ne i32 %31, 0
   br i1 %32, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -138,34 +139,34 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  call void @h(i32* %i, i32* %j)
+  call void @h(ptr %i, ptr %j)
   %33 = alloca i64, align 8
-  %34 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @serialization_info.2, i32 0, i32 0), i64* %33, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i, i32* %j)
-  %35 = load i64, i64* %33, align 8
-  %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  store i8* %34, i8** %36, align 8
-  %37 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  store i64 %35, i64* %37, align 8
-  %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
-  %39 = load i8*, i8** %38, align 8
-  %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
-  %41 = load i64, i64* %40, align 8
+  %34 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.2, ptr %33, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i, ptr %j)
+  %35 = load i64, ptr %33, align 8
+  %36 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  store ptr %34, ptr %36, align 8
+  %37 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  store i64 %35, ptr %37, align 8
+  %38 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 0
+  %39 = load ptr, ptr %38, align 8
+  %40 = getelementptr %string_descriptor, ptr %stringFormat_desc13, i32 0, i32 1
+  %41 = load i64, ptr %40, align 8
   %42 = trunc i64 %41 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
-  %43 = icmp eq i8* %34, null
+  call void @_lfortran_printf(ptr @13, ptr %39, i32 %42, ptr @12, i32 1)
+  %43 = icmp eq ptr %34, null
   br i1 %43, label %free_done15, label %free_nonnull14
 
 free_nonnull14:                                   ; preds = %ifcont12
-  call void @_lfortran_free_alloc(i8* %2, i8* %34)
+  call void @_lfortran_free_alloc(ptr %2, ptr %34)
   br label %free_done15
 
 free_done15:                                      ; preds = %free_nonnull14, %ifcont12
-  %44 = load i32, i32* %i, align 4
+  %44 = load i32, ptr %i, align 4
   %45 = icmp ne i32 %44, 1
   br i1 %45, label %then16, label %else17
 
 then16:                                           ; preds = %free_done15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -174,12 +175,12 @@ else17:                                           ; preds = %free_done15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %46 = load i32, i32* %j, align 4
+  %46 = load i32, ptr %j, align 4
   %47 = icmp ne i32 %46, 0
   br i1 %47, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -198,11 +199,11 @@ FINALIZE_SYMTABLE_subroutines_02:                 ; preds = %return
   ret i32 0
 }
 
-define void @f(i32* %a, i32* %b) {
+define void @f(ptr %a, ptr %b) {
 .entry:
-  %0 = load i32, i32* %a, align 4
+  %0 = load i32, ptr %a, align 4
   %1 = add i32 %0, 1
-  store i32 %1, i32* %b, align 4
+  store i32 %1, ptr %b, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -212,11 +213,11 @@ FINALIZE_SYMTABLE_f:                              ; preds = %return
   ret void
 }
 
-define void @g(i32* %a, i32* %b) {
+define void @g(ptr %a, ptr %b) {
 .entry:
-  %0 = load i32, i32* %a, align 4
+  %0 = load i32, ptr %a, align 4
   %1 = sub i32 %0, 1
-  store i32 %1, i32* %b, align 4
+  store i32 %1, ptr %b, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -226,9 +227,9 @@ FINALIZE_SYMTABLE_g:                              ; preds = %return
   ret void
 }
 
-define void @h(i32* %a, i32* %b) {
+define void @h(ptr %a, ptr %b) {
 .entry:
-  call void @g(i32* %a, i32* %b)
+  call void @g(ptr %a, ptr %b)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -238,17 +239,17 @@ FINALIZE_SYMTABLE_h:                              ; preds = %return
   ret void
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "031ff2f5f8a12f177dec0f17eb151b44d8212cd7fdd2ab251e04889d",
+    "stdout_hash": "c4da830757361173bc2c640d8c2d3d785aedb8f6b50044fe61a922cc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -1,16 +1,17 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   call void @print_int()
   br label %return
 
@@ -25,27 +26,27 @@ FINALIZE_SYMTABLE_print_it:                       ; preds = %return
 define void @print_int() {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %0 = call i8* @_lfortran_get_default_allocator()
+  %0 = call ptr @_lfortran_get_default_allocator()
   %a = alloca i32, align 4
-  store i32 5, i32* %a, align 4
+  store i32 5, ptr %a, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %a)
-  %3 = load i64, i64* %1, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %2, i8** %4, align 8
-  %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %3, i64* %5, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %7 = load i8*, i8** %6, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %9 = load i64, i64* %8, align 8
+  %2 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %0, ptr null, i64 0, ptr @serialization_info, ptr %1, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %a)
+  %3 = load i64, ptr %1, align 8
+  %4 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %3, ptr %5, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %11 = icmp eq i8* %2, null
+  call void @_lfortran_printf(ptr @1, ptr %7, i32 %10, ptr @0, i32 1)
+  %11 = icmp eq ptr %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %0, i8* %2)
+  call void @_lfortran_free_alloc(ptr %0, ptr %2)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -58,14 +59,14 @@ FINALIZE_SYMTABLE_print_int:                      ; preds = %return
   ret void
 }
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_01-642cab3.json
+++ b/tests/reference/llvm-types_01-642cab3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_01-642cab3.stdout",
-    "stdout_hash": "497d05d87dbced2d3c9eb49cd730d4c8b5b51e6a95b4330dbb8bb43d",
+    "stdout_hash": "3ad667f5e0a00f6cccb57b53e31c7cf5dcabb33076743ef8d5d1c3bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_01-642cab3.stdout
+++ b/tests/reference/llvm-types_01-642cab3.stdout
@@ -1,16 +1,17 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %r = alloca float, align 4
-  store float 1.000000e+00, float* %r, align 4
-  store float 1.500000e+00, float* %r, align 4
-  store float 1.000000e+00, float* %r, align 4
-  store float 2.000000e+00, float* %r, align 4
-  store float 3.000000e+00, float* %r, align 4
+  store float 1.000000e+00, ptr %r, align 4
+  store float 1.500000e+00, ptr %r, align 4
+  store float 1.000000e+00, ptr %r, align 4
+  store float 2.000000e+00, ptr %r, align 4
+  store float 3.000000e+00, ptr %r, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -21,6 +22,6 @@ FINALIZE_SYMTABLE_types_01:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_02-b5bfe0b.json
+++ b/tests/reference/llvm-types_02-b5bfe0b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_02-b5bfe0b.stdout",
-    "stdout_hash": "e60e0140a59db2b5e59c3411ba8fa6b6d01e71704875d19e03e567a4",
+    "stdout_hash": "3d0dc7a7fff955fb6c7a7049440c58121475dc1c21301fc8af6891b2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_02-b5bfe0b.stdout
+++ b/tests/reference/llvm-types_02-b5bfe0b.stdout
@@ -1,17 +1,18 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
-  store i32 1, i32* %i, align 4
-  store float 1.000000e+00, float* %r, align 4
-  %2 = load i32, i32* %i, align 4
+  store i32 1, ptr %i, align 4
+  store float 1.000000e+00, ptr %r, align 4
+  %2 = load i32, ptr %i, align 4
   %3 = sitofp i32 %2 to float
-  store float %3, float* %r, align 4
+  store float %3, ptr %r, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -22,6 +23,6 @@ FINALIZE_SYMTABLE_types_02:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "0f20e3b48e9ff1094209149c10583d43238d7636ee64d884b02dc41b",
+    "stdout_hash": "ff5fa6539be5a1bfdeca225391aa7db5e0b62216c3c37b63192901cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -1,8 +1,9 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
@@ -11,57 +12,57 @@ target datalayout = "..."
 @serialization_info.1 = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc1 = alloca %string_descriptor, align 8
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
-  store float 1.500000e+00, float* %r, align 4
+  store float 1.500000e+00, ptr %r, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* %r)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %r)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
-  %14 = load float, float* %r, align 4
+  %14 = load float, ptr %r, align 4
   %15 = fptosi float %14 to i32
-  store i32 %15, i32* %i, align 4
+  store i32 %15, ptr %i, align 4
   %16 = alloca i64, align 8
-  %17 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %i)
-  %18 = load i64, i64* %16, align 8
-  %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  store i8* %17, i8** %19, align 8
-  %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  store i64 %18, i64* %20, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
-  %22 = load i8*, i8** %21, align 8
-  %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
-  %24 = load i64, i64* %23, align 8
+  %17 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info.1, ptr %16, i32 0, i32 0, i32 0, i32 0, i32 0, ptr %i)
+  %18 = load i64, ptr %16, align 8
+  %19 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  store ptr %17, ptr %19, align 8
+  %20 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  store i64 %18, ptr %20, align 8
+  %21 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 0
+  %22 = load ptr, ptr %21, align 8
+  %23 = getelementptr %string_descriptor, ptr %stringFormat_desc1, i32 0, i32 1
+  %24 = load i64, ptr %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
-  %26 = icmp eq i8* %17, null
+  call void @_lfortran_printf(ptr @3, ptr %22, i32 %25, ptr @2, i32 1)
+  %26 = icmp eq ptr %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
 free_nonnull2:                                    ; preds = %free_done
-  call void @_lfortran_free_alloc(i8* %2, i8* %17)
+  call void @_lfortran_free_alloc(ptr %2, ptr %17)
   br label %free_done3
 
 free_done3:                                       ; preds = %free_nonnull2, %free_done
@@ -75,14 +76,14 @@ FINALIZE_SYMTABLE_types_03:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_04-92449d7.json
+++ b/tests/reference/llvm-types_04-92449d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_04-92449d7.stdout",
-    "stdout_hash": "55bb1dbba824699b8daad136d8a362046fa2f234d7a20bb41d3e30eb",
+    "stdout_hash": "959e30a9845a458fff59dff5867bb8c4e02f979f6952d7371ec1670c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_04-92449d7.stdout
+++ b/tests/reference/llvm-types_04-92449d7.stdout
@@ -1,91 +1,92 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
   %x = alloca float, align 4
-  store float 1.500000e+00, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
-  %3 = load i32, i32* %i, align 4
+  store float 1.500000e+00, ptr %r, align 4
+  store i32 2, ptr %i, align 4
+  %2 = load i32, ptr %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = mul i32 %2, %3
   %5 = sitofp i32 %4 to float
-  store float %5, float* %x, align 4
-  %6 = load float, float* %r, align 4
-  %7 = load float, float* %r, align 4
+  store float %5, ptr %x, align 4
+  %6 = load float, ptr %r, align 4
+  %7 = load float, ptr %r, align 4
   %8 = fmul float %6, %7
-  store float %8, float* %x, align 4
-  %9 = load i32, i32* %i, align 4
+  store float %8, ptr %x, align 4
+  %9 = load i32, ptr %i, align 4
   %10 = sitofp i32 %9 to float
-  %11 = load float, float* %r, align 4
+  %11 = load float, ptr %r, align 4
   %12 = fmul float %10, %11
-  store float %12, float* %x, align 4
-  %13 = load float, float* %r, align 4
-  %14 = load i32, i32* %i, align 4
+  store float %12, ptr %x, align 4
+  %13 = load float, ptr %r, align 4
+  %14 = load i32, ptr %i, align 4
   %15 = sitofp i32 %14 to float
   %16 = fmul float %13, %15
-  store float %16, float* %x, align 4
-  %17 = load i32, i32* %i, align 4
-  %18 = load i32, i32* %i, align 4
+  store float %16, ptr %x, align 4
+  %17 = load i32, ptr %i, align 4
+  %18 = load i32, ptr %i, align 4
   %19 = add i32 %17, %18
   %20 = sitofp i32 %19 to float
-  store float %20, float* %x, align 4
-  %21 = load float, float* %r, align 4
-  %22 = load float, float* %r, align 4
+  store float %20, ptr %x, align 4
+  %21 = load float, ptr %r, align 4
+  %22 = load float, ptr %r, align 4
   %23 = fadd float %21, %22
-  store float %23, float* %x, align 4
-  %24 = load float, float* %r, align 4
-  %25 = load i32, i32* %i, align 4
+  store float %23, ptr %x, align 4
+  %24 = load float, ptr %r, align 4
+  %25 = load i32, ptr %i, align 4
   %26 = sitofp i32 %25 to float
   %27 = fadd float %24, %26
-  store float %27, float* %x, align 4
-  %28 = load i32, i32* %i, align 4
+  store float %27, ptr %x, align 4
+  %28 = load i32, ptr %i, align 4
   %29 = sitofp i32 %28 to float
-  %30 = load float, float* %r, align 4
+  %30 = load float, ptr %r, align 4
   %31 = fadd float %29, %30
-  store float %31, float* %x, align 4
-  %32 = load i32, i32* %i, align 4
-  %33 = load i32, i32* %i, align 4
+  store float %31, ptr %x, align 4
+  %32 = load i32, ptr %i, align 4
+  %33 = load i32, ptr %i, align 4
   %34 = sub i32 %32, %33
   %35 = sitofp i32 %34 to float
-  store float %35, float* %x, align 4
-  %36 = load float, float* %r, align 4
-  %37 = load float, float* %r, align 4
+  store float %35, ptr %x, align 4
+  %36 = load float, ptr %r, align 4
+  %37 = load float, ptr %r, align 4
   %38 = fsub float %36, %37
-  store float %38, float* %x, align 4
-  %39 = load float, float* %r, align 4
-  %40 = load i32, i32* %i, align 4
+  store float %38, ptr %x, align 4
+  %39 = load float, ptr %r, align 4
+  %40 = load i32, ptr %i, align 4
   %41 = sitofp i32 %40 to float
   %42 = fsub float %39, %41
-  store float %42, float* %x, align 4
-  %43 = load i32, i32* %i, align 4
+  store float %42, ptr %x, align 4
+  %43 = load i32, ptr %i, align 4
   %44 = sitofp i32 %43 to float
-  %45 = load float, float* %r, align 4
+  %45 = load float, ptr %r, align 4
   %46 = fsub float %44, %45
-  store float %46, float* %x, align 4
-  %47 = load i32, i32* %i, align 4
-  %48 = load i32, i32* %i, align 4
+  store float %46, ptr %x, align 4
+  %47 = load i32, ptr %i, align 4
+  %48 = load i32, ptr %i, align 4
   %49 = sdiv i32 %47, %48
   %50 = sitofp i32 %49 to float
-  store float %50, float* %x, align 4
-  %51 = load float, float* %r, align 4
-  %52 = load float, float* %r, align 4
+  store float %50, ptr %x, align 4
+  %51 = load float, ptr %r, align 4
+  %52 = load float, ptr %r, align 4
   %53 = fdiv float %51, %52
-  store float %53, float* %x, align 4
-  %54 = load i32, i32* %i, align 4
+  store float %53, ptr %x, align 4
+  %54 = load i32, ptr %i, align 4
   %55 = sitofp i32 %54 to float
-  %56 = load float, float* %r, align 4
+  %56 = load float, ptr %r, align 4
   %57 = fdiv float %55, %56
-  store float %57, float* %x, align 4
-  %58 = load float, float* %r, align 4
-  %59 = load i32, i32* %i, align 4
+  store float %57, ptr %x, align 4
+  %58 = load float, ptr %r, align 4
+  %59 = load i32, ptr %i, align 4
   %60 = sitofp i32 %59 to float
   %61 = fdiv float %58, %60
-  store float %61, float* %x, align 4
+  store float %61, ptr %x, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -96,6 +97,6 @@ FINALIZE_SYMTABLE_types_04:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_05-aa71aa9.json
+++ b/tests/reference/llvm-types_05-aa71aa9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_05-aa71aa9.stdout",
-    "stdout_hash": "88800bf784cd5c190b3c83236fffc5a988dc0f14237515a48b5caa08",
+    "stdout_hash": "57ad9deb98b8f8801c4678adf2fb55b4ff911811ec2f0ff68e673f12",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_05-aa71aa9.stdout
+++ b/tests/reference/llvm-types_05-aa71aa9.stdout
@@ -1,26 +1,27 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
-  store float 2.000000e+00, float* %r, align 4
-  store float 2.000000e+00, float* %r, align 4
-  store float 8.000000e+00, float* %r, align 4
-  store float 4.000000e+00, float* %r, align 4
-  store float 0.000000e+00, float* %r, align 4
-  store float 5.000000e-01, float* %r, align 4
-  store float 5.000000e-01, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  store i32 2, i32* %i, align 4
-  store i32 8, i32* %i, align 4
-  store i32 4, i32* %i, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %i, align 4
+  store float 2.000000e+00, ptr %r, align 4
+  store float 2.000000e+00, ptr %r, align 4
+  store float 8.000000e+00, ptr %r, align 4
+  store float 4.000000e+00, ptr %r, align 4
+  store float 0.000000e+00, ptr %r, align 4
+  store float 5.000000e-01, ptr %r, align 4
+  store float 5.000000e-01, ptr %r, align 4
+  store i32 2, ptr %i, align 4
+  store i32 2, ptr %i, align 4
+  store i32 8, ptr %i, align 4
+  store i32 4, ptr %i, align 4
+  store i32 0, ptr %i, align 4
+  store i32 0, ptr %i, align 4
+  store i32 0, ptr %i, align 4
   br label %return
 
 return:                                           ; preds = %.entry
@@ -31,6 +32,6 @@ FINALIZE_SYMTABLE_types_05:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-types_06-6f66d2c.json
+++ b/tests/reference/llvm-types_06-6f66d2c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_06-6f66d2c.stdout",
-    "stdout_hash": "03d2db6633b763abb0490b54e28bdfede1fdc7d516e3440a0c5037d3",
+    "stdout_hash": "fc786016541bc39c6a773594297b87f2b37a292078ae65ca199f49ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_06-6f66d2c.stdout
+++ b/tests/reference/llvm-types_06-6f66d2c.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -52,20 +53,20 @@ target datalayout = "..."
 @46 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @47 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %r = alloca float, align 4
-  store float 2.000000e+00, float* %r, align 4
-  store i32 2, i32* %i, align 4
-  %2 = load i32, i32* %i, align 4
-  %3 = load i32, i32* %i, align 4
+  store float 2.000000e+00, ptr %r, align 4
+  store i32 2, ptr %i, align 4
+  %2 = load i32, ptr %i, align 4
+  %3 = load i32, ptr %i, align 4
   %4 = icmp slt i32 %2, %3
   br i1 %4, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -74,13 +75,13 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %5 = load float, float* %r, align 4
-  %6 = load float, float* %r, align 4
+  %5 = load float, ptr %r, align 4
+  %6 = load float, ptr %r, align 4
   %7 = fcmp olt float %5, %6
   br i1 %7, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -89,14 +90,14 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %8 = load float, float* %r, align 4
-  %9 = load i32, i32* %i, align 4
+  %8 = load float, ptr %r, align 4
+  %9 = load i32, ptr %i, align 4
   %10 = sitofp i32 %9 to float
   %11 = fcmp olt float %8, %10
   br i1 %11, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -105,14 +106,14 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %12 = load i32, i32* %i, align 4
+  %12 = load i32, ptr %i, align 4
   %13 = sitofp i32 %12 to float
-  %14 = load float, float* %r, align 4
+  %14 = load float, ptr %r, align 4
   %15 = fcmp olt float %13, %14
   br i1 %15, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -121,13 +122,13 @@ else8:                                            ; preds = %ifcont6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %16 = load i32, i32* %i, align 4
-  %17 = load i32, i32* %i, align 4
+  %16 = load i32, ptr %i, align 4
+  %17 = load i32, ptr %i, align 4
   %18 = icmp sgt i32 %16, %17
   br i1 %18, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -136,13 +137,13 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %19 = load float, float* %r, align 4
-  %20 = load float, float* %r, align 4
+  %19 = load float, ptr %r, align 4
+  %20 = load float, ptr %r, align 4
   %21 = fcmp ogt float %19, %20
   br i1 %21, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -151,14 +152,14 @@ else14:                                           ; preds = %ifcont12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  %22 = load float, float* %r, align 4
-  %23 = load i32, i32* %i, align 4
+  %22 = load float, ptr %r, align 4
+  %23 = load i32, ptr %i, align 4
   %24 = sitofp i32 %23 to float
   %25 = fcmp ogt float %22, %24
   br i1 %25, label %then16, label %else17
 
 then16:                                           ; preds = %ifcont15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @13, ptr @"ERROR STOP", ptr @12)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -167,14 +168,14 @@ else17:                                           ; preds = %ifcont15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %26 = load i32, i32* %i, align 4
+  %26 = load i32, ptr %i, align 4
   %27 = sitofp i32 %26 to float
-  %28 = load float, float* %r, align 4
+  %28 = load float, ptr %r, align 4
   %29 = fcmp ogt float %27, %28
   br i1 %29, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @15, ptr @"ERROR STOP", ptr @14)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -183,13 +184,13 @@ else20:                                           ; preds = %ifcont18
   br label %ifcont21
 
 ifcont21:                                         ; preds = %else20, %then19
-  %30 = load i32, i32* %i, align 4
-  %31 = load i32, i32* %i, align 4
+  %30 = load i32, ptr %i, align 4
+  %31 = load i32, ptr %i, align 4
   %32 = icmp ne i32 %30, %31
   br i1 %32, label %then22, label %else23
 
 then22:                                           ; preds = %ifcont21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @17, ptr @"ERROR STOP", ptr @16)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -198,13 +199,13 @@ else23:                                           ; preds = %ifcont21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  %33 = load float, float* %r, align 4
-  %34 = load float, float* %r, align 4
+  %33 = load float, ptr %r, align 4
+  %34 = load float, ptr %r, align 4
   %35 = fcmp une float %33, %34
   br i1 %35, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @19, ptr @"ERROR STOP", ptr @18)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -213,14 +214,14 @@ else26:                                           ; preds = %ifcont24
   br label %ifcont27
 
 ifcont27:                                         ; preds = %else26, %then25
-  %36 = load float, float* %r, align 4
-  %37 = load i32, i32* %i, align 4
+  %36 = load float, ptr %r, align 4
+  %37 = load i32, ptr %i, align 4
   %38 = sitofp i32 %37 to float
   %39 = fcmp une float %36, %38
   br i1 %39, label %then28, label %else29
 
 then28:                                           ; preds = %ifcont27
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @21, ptr @"ERROR STOP", ptr @20)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont30
@@ -229,14 +230,14 @@ else29:                                           ; preds = %ifcont27
   br label %ifcont30
 
 ifcont30:                                         ; preds = %else29, %then28
-  %40 = load i32, i32* %i, align 4
+  %40 = load i32, ptr %i, align 4
   %41 = sitofp i32 %40 to float
-  %42 = load float, float* %r, align 4
+  %42 = load float, ptr %r, align 4
   %43 = fcmp une float %41, %42
   br i1 %43, label %then31, label %else32
 
 then31:                                           ; preds = %ifcont30
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @23, ptr @"ERROR STOP", ptr @22)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont33
@@ -245,14 +246,14 @@ else32:                                           ; preds = %ifcont30
   br label %ifcont33
 
 ifcont33:                                         ; preds = %else32, %then31
-  %44 = load i32, i32* %i, align 4
+  %44 = load i32, ptr %i, align 4
   %45 = add i32 %44, 1
-  %46 = load i32, i32* %i, align 4
+  %46 = load i32, ptr %i, align 4
   %47 = icmp sle i32 %45, %46
   br i1 %47, label %then34, label %else35
 
 then34:                                           ; preds = %ifcont33
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @25, ptr @"ERROR STOP", ptr @24)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont36
@@ -261,14 +262,14 @@ else35:                                           ; preds = %ifcont33
   br label %ifcont36
 
 ifcont36:                                         ; preds = %else35, %then34
-  %48 = load float, float* %r, align 4
+  %48 = load float, ptr %r, align 4
   %49 = fadd float %48, 1.000000e+00
-  %50 = load float, float* %r, align 4
+  %50 = load float, ptr %r, align 4
   %51 = fcmp ole float %49, %50
   br i1 %51, label %then37, label %else38
 
 then37:                                           ; preds = %ifcont36
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @27, ptr @"ERROR STOP", ptr @26)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont39
@@ -277,15 +278,15 @@ else38:                                           ; preds = %ifcont36
   br label %ifcont39
 
 ifcont39:                                         ; preds = %else38, %then37
-  %52 = load float, float* %r, align 4
+  %52 = load float, ptr %r, align 4
   %53 = fadd float %52, 1.000000e+00
-  %54 = load i32, i32* %i, align 4
+  %54 = load i32, ptr %i, align 4
   %55 = sitofp i32 %54 to float
   %56 = fcmp ole float %53, %55
   br i1 %56, label %then40, label %else41
 
 then40:                                           ; preds = %ifcont39
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @29, ptr @"ERROR STOP", ptr @28)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont42
@@ -294,15 +295,15 @@ else41:                                           ; preds = %ifcont39
   br label %ifcont42
 
 ifcont42:                                         ; preds = %else41, %then40
-  %57 = load i32, i32* %i, align 4
+  %57 = load i32, ptr %i, align 4
   %58 = add i32 %57, 1
   %59 = sitofp i32 %58 to float
-  %60 = load float, float* %r, align 4
+  %60 = load float, ptr %r, align 4
   %61 = fcmp ole float %59, %60
   br i1 %61, label %then43, label %else44
 
 then43:                                           ; preds = %ifcont42
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @31, ptr @"ERROR STOP", ptr @30)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont45
@@ -311,14 +312,14 @@ else44:                                           ; preds = %ifcont42
   br label %ifcont45
 
 ifcont45:                                         ; preds = %else44, %then43
-  %62 = load i32, i32* %i, align 4
-  %63 = load i32, i32* %i, align 4
+  %62 = load i32, ptr %i, align 4
+  %63 = load i32, ptr %i, align 4
   %64 = add i32 %63, 1
   %65 = icmp sge i32 %62, %64
   br i1 %65, label %then46, label %else47
 
 then46:                                           ; preds = %ifcont45
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @33, ptr @"ERROR STOP", ptr @32)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont48
@@ -327,14 +328,14 @@ else47:                                           ; preds = %ifcont45
   br label %ifcont48
 
 ifcont48:                                         ; preds = %else47, %then46
-  %66 = load float, float* %r, align 4
-  %67 = load float, float* %r, align 4
+  %66 = load float, ptr %r, align 4
+  %67 = load float, ptr %r, align 4
   %68 = fadd float %67, 1.000000e+00
   %69 = fcmp oge float %66, %68
   br i1 %69, label %then49, label %else50
 
 then49:                                           ; preds = %ifcont48
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @35, ptr @"ERROR STOP", ptr @34)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont51
@@ -343,15 +344,15 @@ else50:                                           ; preds = %ifcont48
   br label %ifcont51
 
 ifcont51:                                         ; preds = %else50, %then49
-  %70 = load float, float* %r, align 4
-  %71 = load i32, i32* %i, align 4
+  %70 = load float, ptr %r, align 4
+  %71 = load i32, ptr %i, align 4
   %72 = add i32 %71, 1
   %73 = sitofp i32 %72 to float
   %74 = fcmp oge float %70, %73
   br i1 %74, label %then52, label %else53
 
 then52:                                           ; preds = %ifcont51
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @37, ptr @"ERROR STOP", ptr @36)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont54
@@ -360,15 +361,15 @@ else53:                                           ; preds = %ifcont51
   br label %ifcont54
 
 ifcont54:                                         ; preds = %else53, %then52
-  %75 = load i32, i32* %i, align 4
+  %75 = load i32, ptr %i, align 4
   %76 = sitofp i32 %75 to float
-  %77 = load float, float* %r, align 4
+  %77 = load float, ptr %r, align 4
   %78 = fadd float %77, 1.000000e+00
   %79 = fcmp oge float %76, %78
   br i1 %79, label %then55, label %else56
 
 then55:                                           ; preds = %ifcont54
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @39, ptr @"ERROR STOP", ptr @38)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont57
@@ -377,14 +378,14 @@ else56:                                           ; preds = %ifcont54
   br label %ifcont57
 
 ifcont57:                                         ; preds = %else56, %then55
-  %80 = load i32, i32* %i, align 4
-  %81 = load i32, i32* %i, align 4
+  %80 = load i32, ptr %i, align 4
+  %81 = load i32, ptr %i, align 4
   %82 = add i32 %81, 1
   %83 = icmp eq i32 %80, %82
   br i1 %83, label %then58, label %else59
 
 then58:                                           ; preds = %ifcont57
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @41, ptr @"ERROR STOP", ptr @40)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont60
@@ -393,14 +394,14 @@ else59:                                           ; preds = %ifcont57
   br label %ifcont60
 
 ifcont60:                                         ; preds = %else59, %then58
-  %84 = load float, float* %r, align 4
-  %85 = load float, float* %r, align 4
+  %84 = load float, ptr %r, align 4
+  %85 = load float, ptr %r, align 4
   %86 = fadd float %85, 1.000000e+00
   %87 = fcmp oeq float %84, %86
   br i1 %87, label %then61, label %else62
 
 then61:                                           ; preds = %ifcont60
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @43, ptr @"ERROR STOP", ptr @42)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont63
@@ -409,15 +410,15 @@ else62:                                           ; preds = %ifcont60
   br label %ifcont63
 
 ifcont63:                                         ; preds = %else62, %then61
-  %88 = load float, float* %r, align 4
-  %89 = load i32, i32* %i, align 4
+  %88 = load float, ptr %r, align 4
+  %89 = load i32, ptr %i, align 4
   %90 = add i32 %89, 1
   %91 = sitofp i32 %90 to float
   %92 = fcmp oeq float %88, %91
   br i1 %92, label %then64, label %else65
 
 then64:                                           ; preds = %ifcont63
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @45, ptr @"ERROR STOP", ptr @44)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont66
@@ -426,15 +427,15 @@ else65:                                           ; preds = %ifcont63
   br label %ifcont66
 
 ifcont66:                                         ; preds = %else65, %then64
-  %93 = load i32, i32* %i, align 4
+  %93 = load i32, ptr %i, align 4
   %94 = sitofp i32 %93 to float
-  %95 = load float, float* %r, align 4
+  %95 = load float, ptr %r, align 4
   %96 = fadd float %95, 1.000000e+00
   %97 = fcmp oeq float %94, %96
   br i1 %97, label %then67, label %else68
 
 then67:                                           ; preds = %ifcont66
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @47, ptr @"ERROR STOP", ptr @46)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont69
@@ -453,9 +454,9 @@ FINALIZE_SYMTABLE_types_06:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "3126adfc39caf17c06b21a415600fcdfa30ec8b502ac0438449e3025",
+    "stdout_hash": "a3b5616472b6d0712afe65b7074c84398e7d39250767da73c5c6680c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -1,146 +1,141 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
-%"~unlimited_polymorphic_type" = type <{ i32 (...)**, i8* }>
+%string_descriptor = type <{ ptr, i64 }>
+%"~unlimited_polymorphic_type" = type <{ ptr, ptr }>
 
-@_Type_Info_integer_8 = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* inttoptr (i32 8 to i8*), i8* inttoptr (i64 8 to i8*), i8* null }, align 8
-@_VTable_integer_8 = linkonce_odr unnamed_addr constant { [5 x i8*] } { [5 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_integer_8 to i8*), i8* bitcast (void (i8*, i8*)* @_copy_integer_8 to i8*), i8* bitcast (void (i8**)* @_allocate_integer_8 to i8*), i8* bitcast (void (i8*)* @finalize_i64_for_UPoly to i8*)] }, align 8
+@_Type_Info_integer_8 = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr inttoptr (i32 8 to ptr), ptr inttoptr (i64 8 to ptr), ptr null }, align 8
+@_VTable_integer_8 = linkonce_odr unnamed_addr constant { [5 x ptr] } { [5 x ptr] [ptr null, ptr @_Type_Info_integer_8, ptr @_copy_integer_8, ptr @_allocate_integer_8, ptr @finalize_i64_for_UPoly] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [10 x i8] c"integer(8)"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data, i32 0, i32 0), i64 10 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 10 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@_Type_Info_integer_4 = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* inttoptr (i32 4 to i8*), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
+@_Type_Info_integer_4 = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr inttoptr (i32 4 to ptr), ptr inttoptr (i64 4 to ptr), ptr null }, align 8
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.1 = private constant [10 x i8] c"integer(4)"
-@string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([10 x i8], [10 x i8]* @string_const_data.1, i32 0, i32 0), i64 10 }>
+@string_const.2 = private global %string_descriptor <{ ptr @string_const_data.1, i64 10 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
-@_Type_Info_real_4 = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* inttoptr (i32 6 to i8*), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
+@_Type_Info_real_4 = linkonce_odr unnamed_addr constant { ptr, ptr, ptr } { ptr inttoptr (i32 6 to ptr), ptr inttoptr (i64 4 to ptr), ptr null }, align 8
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.3 = private constant [4 x i8] c"real"
-@string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.3, i32 0, i32 0), i64 4 }>
+@string_const.4 = private global %string_descriptor <{ ptr @string_const_data.3, i64 4 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data.5 = private constant [7 x i8] c"default"
-@string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.5, i32 0, i32 0), i64 7 }>
+@string_const.6 = private global %string_descriptor <{ ptr @string_const_data.5, i64 7 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  %var = alloca %"~unlimited_polymorphic_type"*, align 8
-  store %"~unlimited_polymorphic_type"* null, %"~unlimited_polymorphic_type"** %var, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  %var = alloca %"~unlimited_polymorphic_type", align 8
+  store ptr null, ptr %var, align 8
   %x = alloca i64, align 8
-  store i64 10, i64* %x, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  %3 = call i8* @_lfortran_malloc_alloc(i8* %2, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %3, i8 0, i32 8, i1 false)
-  %4 = call i8* @_lfortran_get_default_allocator()
-  %5 = call i8* @_lfortran_malloc_alloc(i8* %4, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %5, i8 0, i32 16, i1 false)
-  %6 = bitcast i8* %5 to %"~unlimited_polymorphic_type"*
-  store %"~unlimited_polymorphic_type"* %6, %"~unlimited_polymorphic_type"** %var, align 8
-  %7 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
-  %8 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %7, i32 0, i32 1
-  store i8* %3, i8** %8, align 8
-  %9 = load i8*, i8** %8, align 8
-  %10 = bitcast i8* %9 to i64*
-  %11 = bitcast %"~unlimited_polymorphic_type"* %6 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %11, align 8
-  %12 = load i64, i64* %x, align 8
-  store i64 %12, i64* %10, align 8
-  %13 = alloca i1, align 1
-  %14 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
-  %15 = bitcast %"~unlimited_polymorphic_type"* %14 to i8*
-  %16 = call i8* @__lfortran_dynamic_cast(i8* %15, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_integer_8 to i8*), i1 true)
-  %17 = icmp ne i8* %16, null
-  store i1 %17, i1* %13, align 1
-  %18 = load i1, i1* %13, align 1
-  br i1 %18, label %then, label %else
+  store i64 10, ptr %x, align 8
+  %2 = call ptr @_lfortran_get_default_allocator()
+  %3 = call ptr @_lfortran_malloc_alloc(ptr %2, i64 8)
+  call void @llvm.memset.p0.i32(ptr %3, i8 0, i32 8, i1 false)
+  %4 = call ptr @_lfortran_get_default_allocator()
+  %5 = call ptr @_lfortran_malloc_alloc(ptr %4, i64 16)
+  call void @llvm.memset.p0.i32(ptr %5, i8 0, i32 16, i1 false)
+  store ptr %5, ptr %var, align 8
+  %6 = load ptr, ptr %var, align 8
+  %7 = getelementptr %"~unlimited_polymorphic_type", ptr %6, i32 0, i32 1
+  store ptr %3, ptr %7, align 8
+  %8 = load ptr, ptr %7, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_VTable_integer_8, i32 0, i32 0, i32 2), ptr %5, align 8
+  %9 = load i64, ptr %x, align 8
+  store i64 %9, ptr %8, align 8
+  %10 = alloca i1, align 1
+  %11 = load ptr, ptr %var, align 8
+  %12 = call ptr @__lfortran_dynamic_cast(ptr %11, ptr @_Type_Info_integer_8, i1 true)
+  %13 = icmp ne ptr %12, null
+  store i1 %13, ptr %10, align 1
+  %14 = load i1, ptr %10, align 1
+  br i1 %14, label %then, label %else
 
 then:                                             ; preds = %.entry
   br label %"~select_type_block_.start"
 
 "~select_type_block_.start":                      ; preds = %then
-  %19 = call i8* @llvm.stacksave()
-  %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  %15 = call ptr @llvm.stacksave.p0()
+  %16 = load ptr, ptr @string_const, align 8
+  call void @_lfortran_printf(ptr @1, ptr %16, i32 10, ptr @0, i32 1)
   br label %"~select_type_block_.end"
 
 "~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_"
 
 "FINALIZE_SYMTABLE_~select_type_block_":          ; preds = %"~select_type_block_.end"
-  call void @llvm.stackrestore(i8* %19)
+  call void @llvm.stackrestore.p0(ptr %15)
   br label %ifcont
 
 else:                                             ; preds = %.entry
-  %21 = alloca i1, align 1
-  %22 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
-  %23 = bitcast %"~unlimited_polymorphic_type"* %22 to i8*
-  %24 = call i8* @__lfortran_dynamic_cast(i8* %23, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_integer_4 to i8*), i1 true)
-  %25 = icmp ne i8* %24, null
-  store i1 %25, i1* %21, align 1
-  %26 = load i1, i1* %21, align 1
-  br i1 %26, label %then1, label %else2
+  %17 = alloca i1, align 1
+  %18 = load ptr, ptr %var, align 8
+  %19 = call ptr @__lfortran_dynamic_cast(ptr %18, ptr @_Type_Info_integer_4, i1 true)
+  %20 = icmp ne ptr %19, null
+  store i1 %20, ptr %17, align 1
+  %21 = load i1, ptr %17, align 1
+  br i1 %21, label %then1, label %else2
 
 then1:                                            ; preds = %else
   br label %"~select_type_block_1.start"
 
 "~select_type_block_1.start":                     ; preds = %then1
-  %27 = call i8* @llvm.stacksave()
-  %28 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  %22 = call ptr @llvm.stacksave.p0()
+  %23 = load ptr, ptr @string_const.2, align 8
+  call void @_lfortran_printf(ptr @3, ptr %23, i32 10, ptr @2, i32 1)
   br label %"~select_type_block_1.end"
 
 "~select_type_block_1.end":                       ; preds = %"~select_type_block_1.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_1"
 
 "FINALIZE_SYMTABLE_~select_type_block_1":         ; preds = %"~select_type_block_1.end"
-  call void @llvm.stackrestore(i8* %27)
+  call void @llvm.stackrestore.p0(ptr %22)
   br label %ifcont
 
 else2:                                            ; preds = %else
-  %29 = alloca i1, align 1
-  %30 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
-  %31 = bitcast %"~unlimited_polymorphic_type"* %30 to i8*
-  %32 = call i8* @__lfortran_dynamic_cast(i8* %31, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_real_4 to i8*), i1 true)
-  %33 = icmp ne i8* %32, null
-  store i1 %33, i1* %29, align 1
-  %34 = load i1, i1* %29, align 1
-  br i1 %34, label %then3, label %else4
+  %24 = alloca i1, align 1
+  %25 = load ptr, ptr %var, align 8
+  %26 = call ptr @__lfortran_dynamic_cast(ptr %25, ptr @_Type_Info_real_4, i1 true)
+  %27 = icmp ne ptr %26, null
+  store i1 %27, ptr %24, align 1
+  %28 = load i1, ptr %24, align 1
+  br i1 %28, label %then3, label %else4
 
 then3:                                            ; preds = %else2
   br label %"~select_type_block_2.start"
 
 "~select_type_block_2.start":                     ; preds = %then3
-  %35 = call i8* @llvm.stacksave()
-  %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %36, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  %29 = call ptr @llvm.stacksave.p0()
+  %30 = load ptr, ptr @string_const.4, align 8
+  call void @_lfortran_printf(ptr @5, ptr %30, i32 4, ptr @4, i32 1)
   br label %"~select_type_block_2.end"
 
 "~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_2"
 
 "FINALIZE_SYMTABLE_~select_type_block_2":         ; preds = %"~select_type_block_2.end"
-  call void @llvm.stackrestore(i8* %35)
+  call void @llvm.stackrestore.p0(ptr %29)
   br label %ifcont
 
 else4:                                            ; preds = %else2
   br label %"~select_type_block_3.start"
 
 "~select_type_block_3.start":                     ; preds = %else4
-  %37 = call i8* @llvm.stacksave()
-  %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %38, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  %31 = call ptr @llvm.stacksave.p0()
+  %32 = load ptr, ptr @string_const.6, align 8
+  call void @_lfortran_printf(ptr @7, ptr %32, i32 7, ptr @6, i32 1)
   br label %"~select_type_block_3.end"
 
 "~select_type_block_3.end":                       ; preds = %"~select_type_block_3.start"
   br label %"FINALIZE_SYMTABLE_~select_type_block_3"
 
 "FINALIZE_SYMTABLE_~select_type_block_3":         ; preds = %"~select_type_block_3.end"
-  call void @llvm.stackrestore(i8* %37)
+  call void @llvm.stackrestore.p0(ptr %31)
   br label %ifcont
 
 ifcont:                                           ; preds = %"FINALIZE_SYMTABLE_~select_type_block_3", %"FINALIZE_SYMTABLE_~select_type_block_2", %"FINALIZE_SYMTABLE_~select_type_block_1", %"FINALIZE_SYMTABLE_~select_type_block_"
@@ -153,73 +148,67 @@ FINALIZE_SYMTABLE_unlimited_polymorphic_intrinsic_type_allocate: ; preds = %retu
   br label %Finalize_Variable_var
 
 Finalize_Variable_var:                            ; preds = %FINALIZE_SYMTABLE_unlimited_polymorphic_intrinsic_type_allocate
-  %39 = load %"~unlimited_polymorphic_type"*, %"~unlimited_polymorphic_type"** %var, align 8
-  call void @"finalize_allocatable__StructType_Class__~unlimited_polymorphic_type_3"(%"~unlimited_polymorphic_type"* %39)
+  %33 = load ptr, ptr %var, align 8
+  call void @"finalize_allocatable__StructType_Class__~unlimited_polymorphic_type_3"(ptr %33)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-; Function Attrs: argmemonly nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) #0
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i32(ptr writeonly captures(none), i8, i32, i1 immarg) #0
 
-define linkonce_odr void @_copy_integer_8(i8* %0, i8* %1) {
+define linkonce_odr void @_copy_integer_8(ptr %0, ptr %1) {
 entry:
-  %2 = bitcast i8* %0 to i64*
-  %3 = bitcast i8* %1 to i64*
-  %4 = load i64, i64* %2, align 8
-  store i64 %4, i64* %3, align 8
+  %2 = load i64, ptr %0, align 8
+  store i64 %2, ptr %1, align 8
   ret void
 }
 
-define linkonce_odr void @_allocate_integer_8(i8** %0) {
+define linkonce_odr void @_allocate_integer_8(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = call i8* @_lfortran_malloc_alloc(i8* %1, i64 16)
-  call void @llvm.memset.p0i8.i32(i8* %2, i8 0, i32 16, i1 false)
-  store i8* %2, i8** %0, align 8
-  %3 = bitcast i8* %2 to <{ i32 (...)**, i8* }>*
-  %4 = bitcast <{ i32 (...)**, i8* }>* %3 to i32 (...)***
-  store i32 (...)** bitcast (i8** getelementptr inbounds ({ [5 x i8*] }, { [5 x i8*] }* @_VTable_integer_8, i32 0, i32 0, i32 2) to i32 (...)**), i32 (...)*** %4, align 8
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 8)
-  call void @llvm.memset.p0i8.i32(i8* %6, i8 0, i32 8, i1 false)
-  %7 = getelementptr <{ i32 (...)**, i8* }>, <{ i32 (...)**, i8* }>* %3, i32 0, i32 1
-  store i8* %6, i8** %7, align 8
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_malloc_alloc(ptr %1, i64 16)
+  call void @llvm.memset.p0.i32(ptr %2, i8 0, i32 16, i1 false)
+  store ptr %2, ptr %0, align 8
+  store ptr getelementptr inbounds ({ [5 x ptr] }, ptr @_VTable_integer_8, i32 0, i32 0, i32 2), ptr %2, align 8
+  %3 = call ptr @_lfortran_get_default_allocator()
+  %4 = call ptr @_lfortran_malloc_alloc(ptr %3, i64 8)
+  call void @llvm.memset.p0.i32(ptr %4, i8 0, i32 8, i1 false)
+  %5 = getelementptr <{ ptr, ptr }>, ptr %2, i32 0, i32 1
+  store ptr %4, ptr %5, align 8
   ret void
 }
 
-define internal void @finalize_i64_for_UPoly(i8* %0) {
+define internal void @finalize_i64_for_UPoly(ptr %0) {
 entry:
-  %1 = bitcast i8* %0 to i64*
   ret void
 }
 
-declare i8* @__lfortran_dynamic_cast(i8*, i8*, i1)
+declare ptr @__lfortran_dynamic_cast(ptr, ptr, i1)
 
-; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #1
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare ptr @llvm.stacksave.p0() #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #1
+; Function Attrs: nocallback nofree nosync nounwind willreturn
+declare void @llvm.stackrestore.p0(ptr) #1
 
-define internal void @"finalize_allocatable__StructType_Class__~unlimited_polymorphic_type_3"(%"~unlimited_polymorphic_type"* %0) {
+define internal void @"finalize_allocatable__StructType_Class__~unlimited_polymorphic_type_3"(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = icmp ne %"~unlimited_polymorphic_type"* %0, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = icmp ne ptr %0, null
   br i1 %2, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  call void @"finalize_StructType_Class__~unlimited_polymorphic_type_3"(%"~unlimited_polymorphic_type"* %0)
-  %3 = bitcast %"~unlimited_polymorphic_type"* %0 to i8*
-  call void @_lfortran_free_alloc(i8* %1, i8* %3)
+  call void @"finalize_StructType_Class__~unlimited_polymorphic_type_3"(ptr %0)
+  call void @_lfortran_free_alloc(ptr %1, ptr %0)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
@@ -229,36 +218,35 @@ is_allocated.ifcont:                              ; preds = %is_allocated.else, 
   ret void
 }
 
-define internal void @"finalize_StructType_Class__~unlimited_polymorphic_type_3"(%"~unlimited_polymorphic_type"* %0) {
+define internal void @"finalize_StructType_Class__~unlimited_polymorphic_type_3"(ptr %0) {
 entry:
-  %1 = call i8* @_lfortran_get_default_allocator()
-  %2 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 0
-  %3 = load i32 (...)**, i32 (...)*** %2, align 8
-  %4 = icmp ne i32 (...)** %3, null
+  %1 = call ptr @_lfortran_get_default_allocator()
+  %2 = getelementptr %"~unlimited_polymorphic_type", ptr %0, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  %4 = icmp ne ptr %3, null
   br i1 %4, label %is_allocated.then, label %is_allocated.else
 
 is_allocated.then:                                ; preds = %entry
-  %5 = getelementptr inbounds i32 (...)*, i32 (...)** %3, i32 2
-  %6 = load i8*, i32 (...)** %5, align 8
-  %7 = bitcast i8* %6 to void (i8*)*
-  %8 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
-  %9 = load i8*, i8** %8, align 8
-  call void %7(i8* %9)
+  %5 = getelementptr inbounds ptr, ptr %3, i32 2
+  %6 = load ptr, ptr %5, align 8
+  %7 = getelementptr %"~unlimited_polymorphic_type", ptr %0, i32 0, i32 1
+  %8 = load ptr, ptr %7, align 8
+  call void %6(ptr %8)
   br label %is_allocated.ifcont
 
 is_allocated.else:                                ; preds = %entry
   br label %is_allocated.ifcont
 
 is_allocated.ifcont:                              ; preds = %is_allocated.else, %is_allocated.then
-  %10 = getelementptr %"~unlimited_polymorphic_type", %"~unlimited_polymorphic_type"* %0, i32 0, i32 1
-  %11 = load i8*, i8** %10, align 8
-  call void @_lfortran_free_alloc(i8* %1, i8* %11)
+  %9 = getelementptr %"~unlimited_polymorphic_type", ptr %0, i32 0, i32 1
+  %10 = load ptr, ptr %9, align 8
+  call void @_lfortran_free_alloc(ptr %1, ptr %10)
   ret void
 }
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()
 
-attributes #0 = { argmemonly nounwind willreturn writeonly }
-attributes #1 = { nounwind }
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nosync nounwind willreturn }

--- a/tests/reference/llvm-variables_03-4ba9d62.json
+++ b/tests/reference/llvm-variables_03-4ba9d62.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-variables_03-4ba9d62.stdout",
-    "stdout_hash": "0398dacc81bfafd640e94d9963d430d47f185a697d84f00f38ac2787",
+    "stdout_hash": "5bc983723152ad489fef11b1af5a0fcc5834b88c15a700ba99f7a701",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-variables_03-4ba9d62.stdout
+++ b/tests/reference/llvm-variables_03-4ba9d62.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -12,22 +13,22 @@ target datalayout = "..."
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %b = alloca i32, align 4
   %x = alloca i32, align 4
-  store i32 2, i32* %x, align 4
-  %2 = load i32, i32* %x, align 4
+  store i32 2, ptr %x, align 4
+  %2 = load i32, ptr %x, align 4
   %3 = icmp ne i32 %2, 2
   %4 = zext i1 %3 to i32
-  store i32 %4, i32* %b, align 4
-  %5 = load i32, i32* %b, align 4
+  store i32 %4, ptr %b, align 4
+  %5 = load i32, ptr %b, align 4
   %6 = icmp ne i32 %5, 0
   br i1 %6, label %then, label %else
 
 then:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -36,17 +37,17 @@ else:                                             ; preds = %.entry
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %7 = load i32, i32* %x, align 4
+  %7 = load i32, ptr %x, align 4
   %8 = icmp eq i32 %7, 2
   %9 = zext i1 %8 to i32
-  store i32 %9, i32* %b, align 4
-  %10 = load i32, i32* %b, align 4
+  store i32 %9, ptr %b, align 4
+  %10 = load i32, ptr %b, align 4
   %11 = xor i32 %10, 1
   %12 = icmp ne i32 %11, 0
   br i1 %12, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -55,17 +56,17 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  %13 = load i32, i32* %x, align 4
+  %13 = load i32, ptr %x, align 4
   %14 = icmp eq i32 %13, 2
   %15 = xor i1 %14, true
   %16 = zext i1 %15 to i32
-  store i32 %16, i32* %b, align 4
-  %17 = load i32, i32* %b, align 4
+  store i32 %16, ptr %b, align 4
+  %17 = load i32, ptr %b, align 4
   %18 = icmp ne i32 %17, 0
   br i1 %18, label %then4, label %else5
 
 then4:                                            ; preds = %ifcont3
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont6
@@ -74,19 +75,19 @@ else5:                                            ; preds = %ifcont3
   br label %ifcont6
 
 ifcont6:                                          ; preds = %else5, %then4
-  %19 = load i32, i32* %x, align 4
+  %19 = load i32, ptr %x, align 4
   %20 = icmp eq i32 %19, 2
   %21 = zext i1 %20 to i32
-  store i32 %21, i32* %b, align 4
-  %22 = load i32, i32* %b, align 4
+  store i32 %21, ptr %b, align 4
+  %22 = load i32, ptr %b, align 4
   %23 = xor i32 %22, 1
-  store i32 %23, i32* %b, align 4
-  %24 = load i32, i32* %b, align 4
+  store i32 %23, ptr %b, align 4
+  %24 = load i32, ptr %b, align 4
   %25 = icmp ne i32 %24, 0
   br i1 %25, label %then7, label %else8
 
 then7:                                            ; preds = %ifcont6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -105,9 +106,9 @@ FINALIZE_SYMTABLE_variables_03:                   ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-volatile_02-2beae13.json
+++ b/tests/reference/llvm-volatile_02-2beae13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_02-2beae13.stdout",
-    "stdout_hash": "9669ddb260e729da2bb6259f4290f084759ab8e587b8ab2e17405ead",
+    "stdout_hash": "07fe260e6fbe3c2d67f0b3f4d871a827581029d572cee7888740b68d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_02-2beae13.stdout
+++ b/tests/reference/llvm-volatile_02-2beae13.stdout
@@ -1,38 +1,39 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @volatile_02.iota_2 = internal global float 5.000000e-01
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @serialization_info = private unnamed_addr constant [3 x i8] c"R4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
   %stringFormat_desc = alloca %string_descriptor, align 8
-  %2 = call i8* @_lfortran_get_default_allocator()
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store volatile float 5.000000e-01, float* @volatile_02.iota_2, align 4
+  %2 = call ptr @_lfortran_get_default_allocator()
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store volatile float 5.000000e-01, ptr @volatile_02.iota_2, align 4
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, float* @volatile_02.iota_2)
-  %5 = load i64, i64* %3, align 8
-  %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  store i8* %4, i8** %6, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  store i64 %5, i64* %7, align 8
-  %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
-  %9 = load i8*, i8** %8, align 8
-  %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
-  %11 = load i64, i64* %10, align 8
+  %4 = call ptr (ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(ptr %2, ptr null, i64 0, ptr @serialization_info, ptr %3, i32 0, i32 0, i32 0, i32 0, i32 0, ptr @volatile_02.iota_2)
+  %5 = load i64, ptr %3, align 8
+  %6 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  store ptr %4, ptr %6, align 8
+  %7 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  store i64 %5, ptr %7, align 8
+  %8 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 0
+  %9 = load ptr, ptr %8, align 8
+  %10 = getelementptr %string_descriptor, ptr %stringFormat_desc, i32 0, i32 1
+  %11 = load i64, ptr %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
-  %13 = icmp eq i8* %4, null
+  call void @_lfortran_printf(ptr @1, ptr %9, i32 %12, ptr @0, i32 1)
+  %13 = icmp eq ptr %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
 free_nonnull:                                     ; preds = %.entry
-  call void @_lfortran_free_alloc(i8* %2, i8* %4)
+  call void @_lfortran_free_alloc(ptr %2, ptr %4)
   br label %free_done
 
 free_done:                                        ; preds = %free_nonnull, %.entry
@@ -46,14 +47,14 @@ FINALIZE_SYMTABLE_volatile_02:                    ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
+declare ptr @_lcompilers_string_format_fortran(ptr, ptr, i64, ptr, ptr, i32, i32, i32, i32, i32, ...)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(ptr, ptr, i32, ptr, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-volatile_03-914e4e5.json
+++ b/tests/reference/llvm-volatile_03-914e4e5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_03-914e4e5.stdout",
-    "stdout_hash": "1d95dd4e6bcb4c21e2b9dd8119f541c75d6e0b959daf7cb0a46936fd",
+    "stdout_hash": "b8b9a449a392363301dd38fdb40a2489e9ee05f3a6dac895ca1bd140",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_03-914e4e5.stdout
+++ b/tests/reference/llvm-volatile_03-914e4e5.stdout
@@ -1,27 +1,28 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @y_data = private global [1 x i8] c"2"
-@y = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @y_data, i32 0, i32 0), i64 1 }>
+@y = private global %string_descriptor <{ ptr @y_data, i64 1 }>
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %x = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %x, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 1
-  store i64 1, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 1)
-  store i8* %6, i8** %4, align 8
-  %7 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 0
-  %8 = load i8*, i8** %7, align 8
-  call void @_lfortran_strcpy_alloc(i8* %2, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @y, i32 0, i32 0), i64* getelementptr inbounds (%string_descriptor, %string_descriptor* @y, i32 0, i32 1), i8 0, i8 0, i8* %8, i64 1, i32 1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %x, align 1
+  %3 = getelementptr %string_descriptor, ptr %x, i32 0, i32 1
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %x, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 1)
+  store ptr %6, ptr %4, align 8
+  %7 = getelementptr %string_descriptor, ptr %x, i32 0, i32 0
+  %8 = load ptr, ptr %7, align 8
+  call void @_lfortran_strcpy_alloc(ptr %2, ptr @y, ptr getelementptr (%string_descriptor, ptr @y, i32 0, i32 1), i8 0, i8 0, ptr %8, i64 1, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -31,21 +32,21 @@ FINALIZE_SYMTABLE_volatile_03:                    ; preds = %return
   br label %Finalize_Variable_x
 
 Finalize_Variable_x:                              ; preds = %FINALIZE_SYMTABLE_volatile_03
-  %9 = getelementptr %string_descriptor, %string_descriptor* %x, i32 0, i32 0
-  %10 = load i8*, i8** %9, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %10)
+  %9 = getelementptr %string_descriptor, ptr %x, i32 0, i32 0
+  %10 = load ptr, ptr %9, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %10)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
-declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
+declare void @_lfortran_strcpy_alloc(ptr, ptr, ptr, i8, i8, ptr, i64, i32)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-while_01-3496096.json
+++ b/tests/reference/llvm-while_01-3496096.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_01-3496096.stdout",
-    "stdout_hash": "55e8503ea43270257a2eee56413799ce2accaf46cf04ba51552e8d9e",
+    "stdout_hash": "9420c84967c2ed492438bb191b2e0f6b425410d7f26dde88875e1969",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_01-3496096.stdout
+++ b/tests/reference/llvm-while_01-3496096.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -16,37 +17,37 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 1, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, ptr %i, align 4
   %3 = icmp slt i32 %2, 11
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %j, align 4
-  %5 = load i32, i32* %i, align 4
+  %4 = load i32, ptr %j, align 4
+  %5 = load i32, ptr %i, align 4
   %6 = add i32 %4, %5
-  store i32 %6, i32* %j, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %6, ptr %j, align 4
+  %7 = load i32, ptr %i, align 4
   %8 = add i32 %7, 1
-  store i32 %8, i32* %i, align 4
+  store i32 %8, ptr %i, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j, align 4
+  %9 = load i32, ptr %j, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
 then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -55,12 +56,12 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i, align 4
+  %11 = load i32, ptr %i, align 4
   %12 = icmp ne i32 %11, 11
   br i1 %12, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -69,32 +70,32 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 1, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head4
 
 loop.head4:                                       ; preds = %loop.body5, %ifcont3
-  %13 = load i32, i32* %i, align 4
+  %13 = load i32, ptr %i, align 4
   %14 = icmp sle i32 %13, 10
   br i1 %14, label %loop.body5, label %loop.end6
 
 loop.body5:                                       ; preds = %loop.head4
-  %15 = load i32, i32* %j, align 4
-  %16 = load i32, i32* %i, align 4
+  %15 = load i32, ptr %j, align 4
+  %16 = load i32, ptr %i, align 4
   %17 = add i32 %15, %16
-  store i32 %17, i32* %j, align 4
-  %18 = load i32, i32* %i, align 4
+  store i32 %17, ptr %j, align 4
+  %18 = load i32, ptr %i, align 4
   %19 = add i32 %18, 1
-  store i32 %19, i32* %i, align 4
+  store i32 %19, ptr %i, align 4
   br label %loop.head4
 
 loop.end6:                                        ; preds = %loop.head4
-  %20 = load i32, i32* %j, align 4
+  %20 = load i32, ptr %j, align 4
   %21 = icmp ne i32 %20, 55
   br i1 %21, label %then7, label %else8
 
 then7:                                            ; preds = %loop.end6
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont9
@@ -103,12 +104,12 @@ else8:                                            ; preds = %loop.end6
   br label %ifcont9
 
 ifcont9:                                          ; preds = %else8, %then7
-  %22 = load i32, i32* %i, align 4
+  %22 = load i32, ptr %i, align 4
   %23 = icmp ne i32 %22, 11
   br i1 %23, label %then10, label %else11
 
 then10:                                           ; preds = %ifcont9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -117,32 +118,32 @@ else11:                                           ; preds = %ifcont9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  store i32 1, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 1, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head13
 
 loop.head13:                                      ; preds = %loop.body14, %ifcont12
-  %24 = load i32, i32* %i, align 4
+  %24 = load i32, ptr %i, align 4
   %25 = icmp slt i32 %24, 1
   br i1 %25, label %loop.body14, label %loop.end15
 
 loop.body14:                                      ; preds = %loop.head13
-  %26 = load i32, i32* %j, align 4
-  %27 = load i32, i32* %i, align 4
+  %26 = load i32, ptr %j, align 4
+  %27 = load i32, ptr %i, align 4
   %28 = add i32 %26, %27
-  store i32 %28, i32* %j, align 4
-  %29 = load i32, i32* %i, align 4
+  store i32 %28, ptr %j, align 4
+  %29 = load i32, ptr %i, align 4
   %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  store i32 %30, ptr %i, align 4
   br label %loop.head13
 
 loop.end15:                                       ; preds = %loop.head13
-  %31 = load i32, i32* %j, align 4
+  %31 = load i32, ptr %j, align 4
   %32 = icmp ne i32 %31, 0
   br i1 %32, label %then16, label %else17
 
 then16:                                           ; preds = %loop.end15
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont18
@@ -151,12 +152,12 @@ else17:                                           ; preds = %loop.end15
   br label %ifcont18
 
 ifcont18:                                         ; preds = %else17, %then16
-  %33 = load i32, i32* %i, align 4
+  %33 = load i32, ptr %i, align 4
   %34 = icmp ne i32 %33, 1
   br i1 %34, label %then19, label %else20
 
 then19:                                           ; preds = %ifcont18
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont21
@@ -175,9 +176,9 @@ FINALIZE_SYMTABLE_while_01:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-while_02-3db2b04.json
+++ b/tests/reference/llvm-while_02-3db2b04.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-while_02-3db2b04.stdout",
-    "stdout_hash": "2ab35fbe15e4be254f95dbd358833ce20a432ddbe7bde1a562e0a6a5",
+    "stdout_hash": "3b0446df261bf5b62de3d4ec09ec8ba678eeed292bff25d83e60c512",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-while_02-3db2b04.stdout
+++ b/tests/reference/llvm-while_02-3db2b04.stdout
@@ -1,6 +1,7 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
 @"ERROR STOP" = private unnamed_addr constant [11 x i8] c"ERROR STOP\00", align 1
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@@ -16,37 +17,37 @@ target datalayout = "..."
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 0, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head
 
 loop.head:                                        ; preds = %loop.body, %.entry
-  %2 = load i32, i32* %i, align 4
+  %2 = load i32, ptr %i, align 4
   %3 = icmp slt i32 %2, 10
   br i1 %3, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %4 = load i32, i32* %i, align 4
+  %4 = load i32, ptr %i, align 4
   %5 = add i32 %4, 1
-  store i32 %5, i32* %i, align 4
-  %6 = load i32, i32* %j, align 4
-  %7 = load i32, i32* %i, align 4
+  store i32 %5, ptr %i, align 4
+  %6 = load i32, ptr %j, align 4
+  %7 = load i32, ptr %i, align 4
   %8 = add i32 %6, %7
-  store i32 %8, i32* %j, align 4
+  store i32 %8, ptr %j, align 4
   br label %loop.head
 
 loop.end:                                         ; preds = %loop.head
-  %9 = load i32, i32* %j, align 4
+  %9 = load i32, ptr %j, align 4
   %10 = icmp ne i32 %9, 55
   br i1 %10, label %then, label %else
 
 then:                                             ; preds = %loop.end
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @1, ptr @"ERROR STOP", ptr @0)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont
@@ -55,12 +56,12 @@ else:                                             ; preds = %loop.end
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
-  %11 = load i32, i32* %i, align 4
+  %11 = load i32, ptr %i, align 4
   %12 = icmp ne i32 %11, 10
   br i1 %12, label %then1, label %else2
 
 then1:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @3, ptr @"ERROR STOP", ptr @2)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont3
@@ -69,20 +70,20 @@ else2:                                            ; preds = %ifcont
   br label %ifcont3
 
 ifcont3:                                          ; preds = %else2, %then1
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 0, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head4
 
 loop.head4:                                       ; preds = %ifcont8, %ifcont3
-  %13 = load i32, i32* %i, align 4
+  %13 = load i32, ptr %i, align 4
   %14 = icmp slt i32 %13, 10
   br i1 %14, label %loop.body5, label %loop.end9
 
 loop.body5:                                       ; preds = %loop.head4
-  %15 = load i32, i32* %i, align 4
+  %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
-  store i32 %16, i32* %i, align 4
-  %17 = load i32, i32* %i, align 4
+  store i32 %16, ptr %i, align 4
+  %17 = load i32, ptr %i, align 4
   %18 = icmp eq i32 %17, 2
   br i1 %18, label %then6, label %else7
 
@@ -96,19 +97,19 @@ else7:                                            ; preds = %loop.body5
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %unreachable_after_exit
-  %19 = load i32, i32* %j, align 4
-  %20 = load i32, i32* %i, align 4
+  %19 = load i32, ptr %j, align 4
+  %20 = load i32, ptr %i, align 4
   %21 = add i32 %19, %20
-  store i32 %21, i32* %j, align 4
+  store i32 %21, ptr %j, align 4
   br label %loop.head4
 
 loop.end9:                                        ; preds = %then6, %loop.head4
-  %22 = load i32, i32* %j, align 4
+  %22 = load i32, ptr %j, align 4
   %23 = icmp ne i32 %22, 1
   br i1 %23, label %then10, label %else11
 
 then10:                                           ; preds = %loop.end9
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @5, ptr @"ERROR STOP", ptr @4)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont12
@@ -117,12 +118,12 @@ else11:                                           ; preds = %loop.end9
   br label %ifcont12
 
 ifcont12:                                         ; preds = %else11, %then10
-  %24 = load i32, i32* %i, align 4
+  %24 = load i32, ptr %i, align 4
   %25 = icmp ne i32 %24, 2
   br i1 %25, label %then13, label %else14
 
 then13:                                           ; preds = %ifcont12
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @7, ptr @"ERROR STOP", ptr @6)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont15
@@ -131,20 +132,20 @@ else14:                                           ; preds = %ifcont12
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
-  store i32 0, i32* %i, align 4
-  store i32 0, i32* %j, align 4
+  store i32 0, ptr %i, align 4
+  store i32 0, ptr %j, align 4
   br label %loop.head16
 
 loop.head16:                                      ; preds = %ifcont20, %then18, %ifcont15
-  %26 = load i32, i32* %i, align 4
+  %26 = load i32, ptr %i, align 4
   %27 = icmp slt i32 %26, 10
   br i1 %27, label %loop.body17, label %loop.end21
 
 loop.body17:                                      ; preds = %loop.head16
-  %28 = load i32, i32* %i, align 4
+  %28 = load i32, ptr %i, align 4
   %29 = add i32 %28, 1
-  store i32 %29, i32* %i, align 4
-  %30 = load i32, i32* %i, align 4
+  store i32 %29, ptr %i, align 4
+  %30 = load i32, ptr %i, align 4
   %31 = icmp eq i32 %30, 2
   br i1 %31, label %then18, label %else19
 
@@ -158,19 +159,19 @@ else19:                                           ; preds = %loop.body17
   br label %ifcont20
 
 ifcont20:                                         ; preds = %else19, %unreachable_after_cycle
-  %32 = load i32, i32* %j, align 4
-  %33 = load i32, i32* %i, align 4
+  %32 = load i32, ptr %j, align 4
+  %33 = load i32, ptr %i, align 4
   %34 = add i32 %32, %33
-  store i32 %34, i32* %j, align 4
+  store i32 %34, ptr %j, align 4
   br label %loop.head16
 
 loop.end21:                                       ; preds = %loop.head16
-  %35 = load i32, i32* %j, align 4
+  %35 = load i32, ptr %j, align 4
   %36 = icmp ne i32 %35, 53
   br i1 %36, label %then22, label %else23
 
 then22:                                           ; preds = %loop.end21
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @9, ptr @"ERROR STOP", ptr @8)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont24
@@ -179,12 +180,12 @@ else23:                                           ; preds = %loop.end21
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
-  %37 = load i32, i32* %i, align 4
+  %37 = load i32, ptr %i, align 4
   %38 = icmp ne i32 %37, 10
   br i1 %38, label %then25, label %else26
 
 then25:                                           ; preds = %ifcont24
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  call void (ptr, ...) @_lcompilers_print_error(ptr @11, ptr @"ERROR STOP", ptr @10)
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
   br label %ifcont27
@@ -203,9 +204,9 @@ FINALIZE_SYMTABLE_while_02:                       ; preds = %return
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare void @_lcompilers_print_error(i8*, ...)
+declare void @_lcompilers_print_error(ptr, ...)
 
 declare void @_lfortran_internal_alloc_finalize()
 

--- a/tests/reference/llvm-write3-49c0266.json
+++ b/tests/reference/llvm-write3-49c0266.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-write3-49c0266.stdout",
-    "stdout_hash": "5ac63f8009c1144c7d0e4184260bf30246bad72199eae07f6f285481",
+    "stdout_hash": "bec7878ca5a16bd15d619d8dabd0e006f49382fe758d7b66119d89e7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-write3-49c0266.stdout
+++ b/tests/reference/llvm-write3-49c0266.stdout
@@ -1,39 +1,40 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 target datalayout = "..."
+target triple = "arm64-apple-darwin25.5.0"
 
-%string_descriptor = type <{ i8*, i64 }>
+%string_descriptor = type <{ ptr, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c" \00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @string_const_data = private constant [11 x i8] c"Hello World"
-@string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data, i32 0, i32 0), i64 11 }>
+@string_const = private global %string_descriptor <{ ptr @string_const_data, i64 11 }>
 @2 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define i32 @main(i32 %0, i8** %1) {
+define i32 @main(i32 %0, ptr %1) {
 .entry:
-  %2 = call i8* @_lfortran_get_default_allocator()
+  %2 = call ptr @_lfortran_get_default_allocator()
   %lfortran_iomsg = alloca %string_descriptor, align 8
-  call void @_lpython_call_initial_functions(i32 %0, i8** %1)
-  store %string_descriptor zeroinitializer, %string_descriptor* %lfortran_iomsg, align 1
-  %3 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 1
-  store i64 0, i64* %3, align 8
-  %4 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %5 = call i8* @_lfortran_get_default_allocator()
-  %6 = call i8* @_lfortran_malloc_alloc(i8* %5, i64 1)
-  store i8* %6, i8** %4, align 8
+  call void @_lpython_call_initial_functions(i32 %0, ptr %1)
+  store %string_descriptor zeroinitializer, ptr %lfortran_iomsg, align 1
+  %3 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 1
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %5 = call ptr @_lfortran_get_default_allocator()
+  %6 = call ptr @_lfortran_malloc_alloc(ptr %5, i64 1)
+  store ptr %6, ptr %4, align 8
   %nwrite = alloca i32, align 4
-  store i32 6, i32* %nwrite, align 4
-  store i32 6, i32* %nwrite, align 4
-  %7 = load i32, i32* %nwrite, align 4
-  %8 = alloca i32*, align 8
-  store i32* null, i32** %8, align 8
-  %9 = load i32*, i32** %8, align 8
+  store i32 6, ptr %nwrite, align 4
+  store i32 6, ptr %nwrite, align 4
+  %7 = load i32, ptr %nwrite, align 4
+  %8 = alloca ptr, align 8
+  store ptr null, ptr %8, align 8
+  %9 = load ptr, ptr %8, align 8
   %10 = call i32 @_lfortran_get_decimal_mode(i32 %7)
   %11 = call i32 @_lfortran_get_sign_mode(i32 %7)
   %12 = call i32 @_lfortran_get_round_mode(i32 %7)
-  %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void (i32, i32*, i8*, i64, ...) @_lfortran_file_write(i32 %7, i32* %9, i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i64 4, i8* %13, i64 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0), i64 1)
+  %13 = load ptr, ptr @string_const, align 8
+  call void (i32, ptr, ptr, i64, ...) @_lfortran_file_write(i32 %7, ptr %9, ptr @2, i64 4, ptr %13, i64 11, ptr @1, i64 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -43,18 +44,18 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
   br label %Finalize_Variable_lfortran_iomsg
 
 Finalize_Variable_lfortran_iomsg:                 ; preds = %FINALIZE_SYMTABLE_main
-  %14 = getelementptr %string_descriptor, %string_descriptor* %lfortran_iomsg, i32 0, i32 0
-  %15 = load i8*, i8** %14, align 8
-  call void @_lfortran_free_alloc(i8* %2, i8* %15)
+  %14 = getelementptr %string_descriptor, ptr %lfortran_iomsg, i32 0, i32 0
+  %15 = load ptr, ptr %14, align 8
+  call void @_lfortran_free_alloc(ptr %2, ptr %15)
   call void @_lfortran_internal_alloc_finalize()
   ret i32 0
 }
 
-declare void @_lpython_call_initial_functions(i32, i8**)
+declare void @_lpython_call_initial_functions(i32, ptr)
 
-declare i8* @_lfortran_malloc_alloc(i8*, i64)
+declare ptr @_lfortran_malloc_alloc(ptr, i64)
 
-declare i8* @_lfortran_get_default_allocator()
+declare ptr @_lfortran_get_default_allocator()
 
 declare i32 @_lfortran_get_decimal_mode(i32)
 
@@ -62,8 +63,8 @@ declare i32 @_lfortran_get_sign_mode(i32)
 
 declare i32 @_lfortran_get_round_mode(i32)
 
-declare void @_lfortran_file_write(i32, i32*, i8*, i64, ...)
+declare void @_lfortran_file_write(i32, ptr, ptr, i64, ...)
 
-declare void @_lfortran_free_alloc(i8*, i8*)
+declare void @_lfortran_free_alloc(ptr, ptr)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/run_dbg-runtime_stacktrace_01-c6f5e06.json
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-c6f5e06.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "run_dbg-runtime_stacktrace_01-c6f5e06.stderr",
-    "stderr_hash": "eb3c044e48ac8bbaa776077b6c9cef2ef164ade8cddef1d6a7f06792",
+    "stderr_hash": "2664bd53c8e77b18b5ee0bf9a84cc818258a5a22f0de54dab5c23a8a",
     "returncode": 1
 }

--- a/tests/reference/run_dbg-runtime_stacktrace_01-c6f5e06.stderr
+++ b/tests/reference/run_dbg-runtime_stacktrace_01-c6f5e06.stderr
@@ -1,9 +1,1 @@
-  File "tests/errors/runtime_stacktrace_01.f90", line 3
-    print *, main()
-  File "tests/errors/runtime_stacktrace_01.f90", line 10
-    print *, g()
-  File "tests/errors/runtime_stacktrace_01.f90", line 20
-    call f()
-  File "tests/errors/runtime_stacktrace_01.f90", line 14
-    stop 1
-STOP 1
+semantic error: The `runtime stacktrace` is not enabled. To get the stack traces or debugging information, please re-build LFortran with `-DWITH_RUNTIME_STACKTRACE=yes`


### PR DESCRIPTION
While trying the `%%showllvm` in the xeus kernel I realized the target triple is never set. I particularly needed it to show the `wasm32-unknown-emscripten` triple for the Jupyterlite notebooks.

<img width="791" height="155" alt="image" src="https://github.com/user-attachments/assets/71f27387-ff21-4138-8cf1-94f8348245b0" />

So previously `--show-llvm` and `%%showllvm` (Jupyter kernel) were missing the 'target triple' line because `setTargetTriple()` was never called in `visit_TranslationUnit()`. The data layout was already being set
using the default target triple, so this just adds the matching `setTargetTriple()` call in the same block.