### PR TITLE
fix: preload runtime .mod files for iso_c_binding in JupyterLite kernel

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -741,8 +741,9 @@ jobs:
       - name: Run WASM evaluator tests
         run: |
           set -ex
+          cd build-wasm/src/lfortran/tests
           micromamba run -n xeus-lfortran-wasm-build \
-            node build-wasm/src/lfortran/tests/test_lfortran.js
+            node test_lfortran.js
 
       - name: Build JupyterLite site
         run: |

--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -723,16 +723,20 @@ jobs:
       - name: Install WASM build environment
         run: micromamba create -f environment-wasm-build.yml -y
 
-      - name: Build WASM kernel
+      - name: Create WASM host environment
         run: |
           set -ex
           micromamba create -f environment-wasm-host.yml -y \
             --platform=emscripten-wasm32 \
             -c https://prefix.dev/emscripten-forge-4x \
             -c https://prefix.dev/conda-forge
-          export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-lfortran-wasm-host
-          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-          micromamba run -n xeus-lfortran-wasm-build ./wasm-build1.sh
+          echo "PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-lfortran-wasm-host" >> $GITHUB_ENV
+
+      - name: Build native runtime .mod files
+        run: ./wasm-build0.sh
+
+      - name: Build WASM kernel
+        run: micromamba run -n xeus-lfortran-wasm-build ./wasm-build1.sh
 
       - name: Run WASM evaluator tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,9 +414,19 @@ if (XEUS_LFORTRAN_WASM_BUILD)
     xeus_wasm_compile_options(xlfortran)
     xeus_wasm_link_options(xlfortran "web,worker")
 
+    # Preload runtime .mod files into the WASM VFS at /lib/
+    file(GLOB LFORTRAN_MOD_FILES "${CMAKE_INSTALL_PREFIX}/lib/*.mod")
+    foreach(MOD_FILE ${LFORTRAN_MOD_FILES})
+        get_filename_component(MOD_NAME ${MOD_FILE} NAME)
+        target_link_options(xlfortran PRIVATE
+            "SHELL:--preload-file ${MOD_FILE}@/lib/${MOD_NAME}"
+        )
+    endforeach()
+
     install(FILES
         "$<TARGET_FILE_DIR:xlfortran>/xlfortran.js"
         "$<TARGET_FILE_DIR:xlfortran>/xlfortran.wasm"
+        "$<TARGET_FILE_DIR:xlfortran>/xlfortran.data"
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,16 +419,25 @@ if (XEUS_LFORTRAN_WASM_BUILD)
     foreach(MOD_FILE ${LFORTRAN_MOD_FILES})
         get_filename_component(MOD_NAME ${MOD_FILE} NAME)
         target_link_options(xlfortran PRIVATE
-            "SHELL:--preload-file ${MOD_FILE}@/lib/${MOD_NAME}"
+            "SHELL:--preload-file \"${MOD_FILE}@/lib/${MOD_NAME}\""
         )
     endforeach()
+    if(LFORTRAN_MOD_FILES)
+        # Track .mod file contents as link dependencies so relinking is
+        # triggered when any preloaded module changes.
+        set_property(TARGET xlfortran APPEND PROPERTY LINK_DEPENDS ${LFORTRAN_MOD_FILES})
+    endif()
 
     install(FILES
         "$<TARGET_FILE_DIR:xlfortran>/xlfortran.js"
         "$<TARGET_FILE_DIR:xlfortran>/xlfortran.wasm"
-        "$<TARGET_FILE_DIR:xlfortran>/xlfortran.data"
         DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
+    # xlfortran.data is only generated when at least one --preload-file is used.
+    if(LFORTRAN_MOD_FILES)
+        install(FILES "$<TARGET_FILE_DIR:xlfortran>/xlfortran.data"
+                DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
 endif()
 
 # JSON OR LSP (`conda install rapidjson`)

--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -33,6 +33,7 @@
 #include <lfortran/semantics/ast_to_asr.h>
 #include <libasr/codegen/asr_to_llvm.h>
 #include <lfortran/fortran_evaluator.h>
+#include <lfortran/utils.h>
 #include <libasr/asr_utils.h>
 #include <libasr/string_utils.h>
 
@@ -85,6 +86,8 @@ namespace LCompilers::LFortran {
     public:
         custom_interpreter() : compiler_options{}, e{compiler_options} {
             e.compiler_options.interactive = true;
+            e.compiler_options.po.runtime_library_dir =
+                LCompilers::LFortran::get_runtime_library_dir();
         }
         virtual ~custom_interpreter() = default;
 

--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -75,6 +75,17 @@ if (XEUS_LFORTRAN_WASM_BUILD)
         "SHELL:-s STACK_SIZE=32mb"
         "SHELL:-s INITIAL_MEMORY=128mb"
     )
+    # Preload the same .mod files that xlfortran embeds.
+    file(GLOB LFORTRAN_TEST_MOD_FILES "${CMAKE_INSTALL_PREFIX}/lib/*.mod")
+    foreach(MOD_FILE ${LFORTRAN_TEST_MOD_FILES})
+        get_filename_component(MOD_NAME ${MOD_FILE} NAME)
+        target_link_options(test_lfortran PRIVATE
+            "SHELL:--preload-file \"${MOD_FILE}@/lib/${MOD_NAME}\""
+        )
+    endforeach()
+    if(LFORTRAN_TEST_MOD_FILES)
+        set_property(TARGET test_lfortran APPEND PROPERTY LINK_DEPENDS ${LFORTRAN_TEST_MOD_FILES})
+    endif()
 endif()
 add_test(test_lfortran ${PROJECT_BINARY_DIR}/test_lfortran)
 

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1428,6 +1428,29 @@ TEST_CASE("FortranEvaluator pass_array_by_data on global random_number") {
 #endif
 
 #ifdef __EMSCRIPTEN__
+TEST_CASE("FortranEvaluator iso_c_binding") {
+    // Regression test for JupyterLite wasm kernel: "use iso_c_binding" must
+    // resolve to the preloaded .mod file at /lib/lfortran_intrinsic_iso_c_binding.mod
+    // (set via --preload-file at link time; on native builds get_runtime_library_dir()
+    // returns the installed lib path directly).
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult>
+    r = e.evaluate2("use iso_c_binding, only: c_int");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::none);
+    r = e.evaluate2("integer(c_int) :: n_cint");
+    CHECK(r.ok);
+    r = e.evaluate2("n_cint = 7_c_int");
+    CHECK(r.ok);
+    r = e.evaluate2("n_cint");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 7);
+}
+
 TEST_CASE("WasmLFortranExecutor basic") {
     // Directly exercise WasmLFortranExecutor bypassing FortranEvaluator
     LCompilers::WasmLFortranExecutor we;

--- a/src/lfortran/utils.cpp
+++ b/src/lfortran/utils.cpp
@@ -66,6 +66,11 @@ std::string get_runtime_library_dir()
 #ifdef HAVE_BUILD_TO_WASM
     return "asset_dir";
 #endif
+#ifdef __EMSCRIPTEN__
+    // JupyterLite (xlfortran): empack mounts $PREFIX at / in the VFS,
+    // so runtime .mod files installed to $PREFIX/lib end up at /lib.
+    return "/lib";
+#endif
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_DIR");
     if (env_p) return env_p;
 

--- a/wasm-build0.sh
+++ b/wasm-build0.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build native lfortran and install runtime .mod files to the WASM host env.
+# Run in the native 'lf' dev env (needs cmake, re2c, bison) before wasm-build1.sh.
+#
+# Prerequisites:
+#   - ./build0.sh already run  (parser/ASR headers generated)
+#   - xeus-lfortran-wasm-host conda env already created
+
+set -ex
+
+export PREFIX=${PREFIX:-$MAMBA_ROOT_PREFIX/envs/xeus-lfortran-wasm-host}
+
+if [ "$(uname)" = "Darwin" ]; then
+    CORES=$(sysctl -n hw.ncpu)
+else
+    CORES=$(nproc)
+fi
+
+rm -rf asset_dir
+
+# Unset any emscripten compiler overrides so cmake picks up the native toolchain.
+unset CC CXX AR RANLIB NM CFLAGS CXXFLAGS LDFLAGS
+
+# Build lfortran binary only; skip the runtime cmake sub-project.
+cmake -S . -B asset_dir \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_LLVM=no \
+    -DLFORTRAN_BUILD_ALL=yes \
+    -DWITH_RUNTIME_LIBRARY=no \
+    -DWITH_STACKTRACE=no \
+    -DWITH_RUNTIME_STACKTRACE=no \
+    -DWITH_XEUS=no \
+    -DWITH_LSP=no \
+    -DWITH_KOKKOS=no \
+    -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"
+
+cmake --build asset_dir -j"$CORES" --target lfortran
+
+# Compile runtime modules using the freshly built lfortran.
+LFORTRAN="$(pwd)/asset_dir/src/bin/lfortran"
+MODDIR="$(pwd)/asset_dir/mods"
+RTDIR="$(pwd)/src/runtime"
+mkdir -p "$MODDIR"
+
+$LFORTRAN --backend=cpp -c -J "$MODDIR" "$RTDIR/pure/lfortran_intrinsic_iso_fortran_env.f90"
+$LFORTRAN --backend=cpp -c -J "$MODDIR" "$RTDIR/custom/lfortran_intrinsic_custom.f90"
+$LFORTRAN --backend=cpp -c -J "$MODDIR" -I "$MODDIR" "$RTDIR/pure/lfortran_intrinsic_ieee_arithmetic.f90"
+$LFORTRAN --backend=cpp -c -J "$MODDIR" "$RTDIR/pure/lfortran_intrinsic_iso_c_binding.f90"
+$LFORTRAN --backend=cpp -c -J "$MODDIR" -I "$MODDIR" "$RTDIR/openmp/omp_lib.f90"
+
+cp "$MODDIR"/*.mod "$PREFIX/lib/"
+rm -rf asset_dir

--- a/wasm-build1.sh
+++ b/wasm-build1.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# WASM build for xlfortran (JupyterLite kernel).
+# WASM kernel build (Phase 2).  Run in the 'xeus-lfortran-wasm-build' env.
+#
 # Prerequisites:
-#   1. emsdk 4.0.9 activated through xeus-lfortran-wasm-host environment (see environment-wasm-host.yml)
-#   2. xeus-lfortran-wasm-host conda env created (environment-wasm-host.yml)
-#   3. ./build0.sh already run (generated parser/ASR headers in source tree)
+#   - ./build0.sh already run
+#   - ./wasm-build0.sh already run  (installs .mod files to $PREFIX/lib/)
+#   - xeus-lfortran-wasm-host and xeus-lfortran-wasm-build envs created
 
-set -e
-set -x
+set -ex
 
 export PREFIX=${PREFIX:-$MAMBA_ROOT_PREFIX/envs/xeus-lfortran-wasm-host}
 


### PR DESCRIPTION
Fixes #11712

The wasm xlfortran kernel was missing the runtime .mod files (e.g. lfortran_intrinsic_iso_c_binding.mod), causing 'modfile was not found' errors when using `use iso_c_binding` in JupyterLite cells.

<img width="2084" height="492" alt="image" src="https://github.com/user-attachments/assets/aab05233-5301-4b8f-9e66-d5412c07d953" />

Three changes fix this:
- utils.cpp: under `__EMSCRIPTEN__`, `get_runtime_library_dir()` now returns "/lib", matching where empack mounts $PREFIX/lib/ in the VFS.
- CMakeLists.txt: when `XEUS_LFORTRAN_WASM_BUILD=yes`, preload each .mod from $PREFIX/lib/ into the WASM VFS at /lib/ via --preload-file, and install the generated `xlfortran.data` alongside `xlfortran.js/.wasm`.
- wasm-build0.sh (new): compiles the runtime .f90 sources with the native lfortran and installs the resulting .mod files to $PREFIX/lib/ so that wasm-build1.sh finds them during the emcmake configure step.


