### PR TITLE
fix: preserve high bits in ishftc when SIZE is given

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1829,6 +1829,7 @@ RUN(NAME intrinsics_471 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_A
 RUN(NAME intrinsics_472 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_min
 RUN(NAME intrinsics_473 LABELS gfortran llvm) # maxloc/minloc with compile-time mask evaluation on 2D arrays
 RUN(NAME intrinsics_474 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_broadcast
+RUN(NAME intrinsics_475 LABELS gfortran llvm) # ishftc with SIZE keeps high bits of I
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME storage_size_01 LABELS gfortran llvm) # storage_size of allocatable character
 

--- a/integration_tests/intrinsics_475.f90
+++ b/integration_tests/intrinsics_475.f90
@@ -60,6 +60,22 @@ program intrinsics_475
     res_8 = ishftc(120_8, -2_8, 4_8)
     if (res_8 /= 114_8) error stop
 
+    ! ----- SHIFT == 0: value is unchanged (early-return path) -----
+
+    if (ishftc(120_4, 0_4, 4_4)   /= 120)           error stop
+    if (ishftc(120_4, 0_4, 32_4)  /= 120)           error stop
+    if (ishftc(120_8, 0_8, 64_8)  /= 120_8)         error stop
+    if (ishftc(huge(0_8), 0_8, 64_8) /= huge(0_8))  error stop
+
+    ! ----- SIZE == BIT_SIZE(I): full-width rotation (mask == ~0ULL branch) -----
+
+    ! kind=4, SIZE=32
+    if (ishftc(120_4, 2_4, 32_4)  /= 480)           error stop
+    ! kind=8, SIZE=64 -> exercises the bits_size == 64 mask branch
+    if (ishftc(120_8, 2_8, 64_8)  /= 480_8)         error stop
+    if (ishftc(120_8, -2_8, 64_8) /= 30_8)          error stop
+    if (ishftc(huge(0_8), 2_8, 64_8) /= -3_8)       error stop
+
     print *, "pass"
 
 contains

--- a/integration_tests/intrinsics_475.f90
+++ b/integration_tests/intrinsics_475.f90
@@ -1,0 +1,79 @@
+program intrinsics_475
+    ! Verify ishftc with the optional SIZE argument preserves the bits of I
+    ! that lie above position SIZE. Only the rightmost SIZE bits are rotated;
+    ! the higher bits must be left unchanged. (See F2018 16.9.130.)
+
+    implicit none
+
+    integer(kind=1) :: res_1
+    integer(kind=2) :: res_2
+    integer(kind=4) :: res_4
+    integer(kind=8) :: res_8
+
+    integer(kind=4), parameter :: p1 = ishftc(120_4, 2_4, 4_4)
+    integer(kind=8), parameter :: p2 = ishftc(120_8, -2_8, 4_8)
+
+    ! ----- compile-time fold (parameter) path -----
+
+    ! 120 = 0b01111000: low 4 bits 1000 rotate left 2 -> 0010, high 01110000 kept
+    if (p1 /= 114) error stop
+    ! same value rotated right by 2: low 4 bits 1000 rotate right 2 -> 0010
+    if (p2 /= 114_8) error stop
+
+    if (ishftc(7_4, 2_4, 3_4)   /= 7)   error stop   ! 111 rot L2 -> 111
+    if (ishftc(8_4, 1_4, 4_4)   /= 1)   error stop   ! 1000 rot L1 -> 0001
+    if (ishftc(1_4, 1_4, 4_4)   /= 2)   error stop   ! 0001 rot L1 -> 0010
+    if (ishftc(255_4, 4_4, 4_4) /= 255) error stop  ! low nibble 1111 unchanged
+    if (ishftc(240_4, 1_4, 4_4) /= 240) error stop  ! low nibble 0000 unchanged
+    if (ishftc(176_4, 1_4, 4_4) /= 176) error stop  ! low nibble 0000 unchanged
+    if (ishftc(49_4, 2_4, 4_4)  /= 52)  error stop  ! low 0001 rot L2 -> 0100
+    if (ishftc(49_4, -2_4, 4_4) /= 52)  error stop  ! low 0001 rot R2 -> 0100
+
+    ! ----- runtime path (values not known at compile time) -----
+
+    res_4 = runtime_i4(120_4, 2_4, 4_4)
+    if (res_4 /= 114) error stop
+    res_4 = runtime_i4(120_4, -2_4, 4_4)
+    if (res_4 /= 114) error stop
+    res_8 = runtime_i8(120_8, 2_8, 4_8)
+    if (res_8 /= 114_8) error stop
+
+    ! ----- all kinds, identical rotation (high bits preserved) -----
+
+    res_1 = ishftc(120_1, 2_1, 4_1)
+    if (res_1 /= 114) error stop
+    res_2 = ishftc(120_2, 2_2, 4_2)
+    if (res_2 /= 114) error stop
+    res_4 = ishftc(120_4, 2_4, 4_4)
+    if (res_4 /= 114) error stop
+    res_8 = ishftc(120_8, 2_8, 4_8)
+    if (res_8 /= 114_8) error stop
+
+    ! ----- negative shift keeps high bits too -----
+
+    res_1 = ishftc(120_1, -2_1, 4_1)
+    if (res_1 /= 114) error stop
+    res_2 = ishftc(120_2, -2_2, 4_2)
+    if (res_2 /= 114) error stop
+    res_4 = ishftc(120_4, -2_4, 4_4)
+    if (res_4 /= 114) error stop
+    res_8 = ishftc(120_8, -2_8, 4_8)
+    if (res_8 /= 114_8) error stop
+
+    print *, "pass"
+
+contains
+
+    function runtime_i4(i, s, z) result(r)
+        integer(kind=4), intent(in) :: i, s, z
+        integer(kind=4) :: r
+        r = ishftc(i, s, z)
+    end function runtime_i4
+
+    function runtime_i8(i, s, z) result(r)
+        integer(kind=8), intent(in) :: i, s, z
+        integer(kind=8) :: r
+        r = ishftc(i, s, z)
+    end function runtime_i8
+
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5081,13 +5081,6 @@ namespace Leadz {
 
 namespace Ishftc {
 
-    static uint64_t cutoff_extra_bits(uint64_t num, uint32_t bits_size, uint32_t max_bits_size) {
-        if (bits_size == max_bits_size) {
-            return num;
-        }
-        return (num & ((1lu << bits_size) - 1lu));
-    }
-
     static ASR::expr_t *eval_Ishftc(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& diag) {
         uint64_t val = (uint64_t)ASR::down_cast<ASR::IntegerConstant_t>(args[0])->m_n;
@@ -5111,12 +5104,22 @@ namespace Ishftc {
             return nullptr;
         }
 
-        val = cutoff_extra_bits(val, bits_size, max_bits_size);
+        // Rotate only the low `bits_size` bits of val; leave the higher bits
+        // unchanged. The high bits are captured before the rotation and OR'd
+        // back into the result, so they survive even when bits_size < bit_width.
+        uint64_t mask = (bits_size == max_bits_size)
+            ? ~0lu
+            : ((1lu << bits_size) - 1lu);
+        uint64_t high = val & ~mask;
+        uint64_t low = val & mask;
         uint64_t result;
-        if (negative_shift) {
-            result = (val >> shift) | cutoff_extra_bits(val << (bits_size - shift), bits_size, max_bits_size);
+        if (shift == 0) {
+            // No rotation: the low bits stay where they are.
+            result = val;
+        } else if (negative_shift) {
+            result = high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
         } else {
-            result = cutoff_extra_bits(val << shift, bits_size, max_bits_size) | ((val >> (bits_size - shift)));
+            result = high | (((low << shift) & mask) | (low >> (bits_size - shift)));
         }
         if (kind == 1) {
             result = static_cast<int8_t>(result);

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5107,9 +5107,10 @@ namespace Ishftc {
         // Rotate only the low `bits_size` bits of val; leave the higher bits
         // unchanged. The high bits are captured before the rotation and OR'd
         // back into the result, so they survive even when bits_size < bit_width.
+        // 64-bit literals (0ULL/1ULL) keep the mask correct on LLP64 targets (MSVC).
         uint64_t mask = (bits_size == max_bits_size)
-            ? ~0lu
-            : ((1lu << bits_size) - 1lu);
+            ? ~0ULL
+            : ((1ULL << bits_size) - 1ULL);
         uint64_t high = val & ~mask;
         uint64_t low = val & mask;
         uint64_t result;

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -4448,52 +4448,36 @@ LFORTRAN_API float _lfortran_sbesselyn( int n, float x ) {
     return yn(n, x);
 }
 
+// Rotate the low `bits_size` bits of `val` by `shift` (left when `negative_shift`
+// is false, right when true), leaving the bits at positions >= bits_size unchanged.
+// `shift` is the absolute value and must be <= bits_size. Uses 64-bit literals
+// (0ULL/1ULL) so the mask is correct on LLP64 targets such as MSVC.
+static uint64_t ishftc_rotate(uint64_t val, uint32_t shift, bool negative_shift,
+                              uint32_t bits_size) {
+    uint64_t mask = (bits_size == 64) ? ~0ULL : ((1ULL << bits_size) - 1ULL);
+    uint64_t high = val & ~mask;
+    uint64_t low = val & mask;
+    if (shift == 0) {
+        return val;
+    }
+    if (negative_shift) {
+        return high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
+    }
+    return high | (((low << shift) & mask) | (low >> (bits_size - shift)));
+}
+
 LFORTRAN_API int _lfortran_sishftc(int val, int shift_signed, int bits_size) {
-    uint32_t max_bits_size = 64;
     bool negative_shift = (shift_signed < 0);
     uint32_t shift = (shift_signed < 0 ? -shift_signed : shift_signed);
-
-    // Rotate only the low `bits_size` bits of val; leave the higher bits
-    // unchanged. The high bits are captured before the rotation and OR'd
-    // back into the result, so they survive even when bits_size < bit_width.
-    uint64_t mask = ((uint32_t)bits_size == max_bits_size)
-        ? ~0lu
-        : ((1lu << bits_size) - 1lu);
-    uint64_t high = (uint64_t)val & ~mask;
-    uint64_t low = (uint64_t)val & mask;
-    uint64_t result;
-    if (shift == 0) {
-        result = (uint64_t)val;
-    } else if (negative_shift) {
-        result = high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
-    } else {
-        result = high | (((low << shift) & mask) | (low >> (bits_size - shift)));
-    }
-    return result;
+    return (int)ishftc_rotate((uint64_t)val, shift, negative_shift,
+                              (uint32_t)bits_size);
 }
 
 LFORTRAN_API int64_t _lfortran_dishftc(int64_t val, int64_t shift_signed, int64_t bits_size) {
-    uint32_t max_bits_size = 64;
     bool negative_shift = (shift_signed < 0);
     uint32_t shift = llabs(shift_signed);
-
-    // Rotate only the low `bits_size` bits of val; leave the higher bits
-    // unchanged. The high bits are captured before the rotation and OR'd
-    // back into the result, so they survive even when bits_size < bit_width.
-    uint64_t mask = ((uint32_t)bits_size == max_bits_size)
-        ? ~0lu
-        : ((1lu << bits_size) - 1lu);
-    uint64_t high = (uint64_t)val & ~mask;
-    uint64_t low = (uint64_t)val & mask;
-    uint64_t result;
-    if (shift == 0) {
-        result = (uint64_t)val;
-    } else if (negative_shift) {
-        result = high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
-    } else {
-        result = high | (((low << shift) & mask) | (low >> (bits_size - shift)));
-    }
-    return result;
+    return (int64_t)ishftc_rotate((uint64_t)val, shift, negative_shift,
+                                  (uint32_t)bits_size);
 }
 
 // sin -------------------------------------------------------------------------

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -4448,24 +4448,26 @@ LFORTRAN_API float _lfortran_sbesselyn( int n, float x ) {
     return yn(n, x);
 }
 
-uint64_t cutoff_extra_bits(uint64_t num, uint32_t bits_size, uint32_t max_bits_size) {
-    if (bits_size == max_bits_size) {
-        return num;
-    }
-    return (num & ((1lu << bits_size) - 1lu));
-}
-
 LFORTRAN_API int _lfortran_sishftc(int val, int shift_signed, int bits_size) {
     uint32_t max_bits_size = 64;
     bool negative_shift = (shift_signed < 0);
     uint32_t shift = (shift_signed < 0 ? -shift_signed : shift_signed);
 
-    uint64_t val1 = cutoff_extra_bits((uint64_t)val, (uint32_t)bits_size, max_bits_size);
+    // Rotate only the low `bits_size` bits of val; leave the higher bits
+    // unchanged. The high bits are captured before the rotation and OR'd
+    // back into the result, so they survive even when bits_size < bit_width.
+    uint64_t mask = ((uint32_t)bits_size == max_bits_size)
+        ? ~0lu
+        : ((1lu << bits_size) - 1lu);
+    uint64_t high = (uint64_t)val & ~mask;
+    uint64_t low = (uint64_t)val & mask;
     uint64_t result;
-    if (negative_shift) {
-        result = (val1 >> shift) | cutoff_extra_bits(val1 << (bits_size - shift), bits_size, max_bits_size);
+    if (shift == 0) {
+        result = (uint64_t)val;
+    } else if (negative_shift) {
+        result = high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
     } else {
-        result = cutoff_extra_bits(val1 << shift, bits_size, max_bits_size) | ((val1 >> (bits_size - shift)));
+        result = high | (((low << shift) & mask) | (low >> (bits_size - shift)));
     }
     return result;
 }
@@ -4475,12 +4477,21 @@ LFORTRAN_API int64_t _lfortran_dishftc(int64_t val, int64_t shift_signed, int64_
     bool negative_shift = (shift_signed < 0);
     uint32_t shift = llabs(shift_signed);
 
-    uint64_t val1 = cutoff_extra_bits((uint64_t)val, (uint32_t)bits_size, max_bits_size);
+    // Rotate only the low `bits_size` bits of val; leave the higher bits
+    // unchanged. The high bits are captured before the rotation and OR'd
+    // back into the result, so they survive even when bits_size < bit_width.
+    uint64_t mask = ((uint32_t)bits_size == max_bits_size)
+        ? ~0lu
+        : ((1lu << bits_size) - 1lu);
+    uint64_t high = (uint64_t)val & ~mask;
+    uint64_t low = (uint64_t)val & mask;
     uint64_t result;
-    if (negative_shift) {
-        result = (val1 >> shift) | cutoff_extra_bits(val1 << (bits_size - shift), bits_size, max_bits_size);
+    if (shift == 0) {
+        result = (uint64_t)val;
+    } else if (negative_shift) {
+        result = high | ((low >> shift) | ((low << (bits_size - shift)) & mask));
     } else {
-        result = cutoff_extra_bits(val1 << shift, bits_size, max_bits_size) | ((val1 >> (bits_size - shift)));
+        result = high | (((low << shift) & mask) | (low >> (bits_size - shift)));
     }
     return result;
 }


### PR DESCRIPTION
fixes #12200

`ishftc(i, shift, size)` was throwing away the bits of `i` above position `size` instead of leaving them alone, so e.g. `ishftc(120, 2, 4)` returned `2` rather than `114`.

the high bits are now kept off to the side and OR'd back in after the rotation. fixed in all three spots (the compile-time fold and the two runtime functions). adds `intrinsics_475` covering it.

```
$ lfortran t.f90   # print *, ishftc(120, 2, 4)
114
```
