### PR TITLE
test: register integration test for issue #12203

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2518,6 +2518,7 @@ RUN(NAME derived_types_150 LABELS gfortran llvm) # SEQUENCE char(len>1) inline +
 # Free-interface case is a separate file: coexisting with type-bound
 # assignment(=) in one module breaks resolution under LFortran.
 RUN(NAME derived_types_151 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME derived_types_152 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME defined_assignment_01 LABELS llvm flang)
 RUN(NAME defined_assignment_free_interface_01 LABELS gfortran llvm flang)
 

--- a/integration_tests/derived_types_152.f90
+++ b/integration_tests/derived_types_152.f90
@@ -1,0 +1,20 @@
+module m_152
+  implicit none
+  contains
+
+  function method_create(f) result(that)
+    procedure() :: f
+    integer :: that
+  end function
+
+  subroutine compute(n)
+    integer :: n
+  end subroutine
+end module
+
+program derived_types_152
+    use m_152
+    implicit none
+    integer :: ll
+    ll = method_create(compute)
+end program


### PR DESCRIPTION
Closes #12203

Registers `derived_types_152.f90` as an integration test (derived from #11806, simplified per the issue). Verifies that procedure pointer arguments work correctly with `--implicit-interface` mode.

Verified locally with `python run_tests.py -t derived_types_152` — passes.