### PR TITLE
fix: ICE for norm2 with a scalar argument  

### DIFF
--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -5898,6 +5898,13 @@ namespace Norm2 {
             "atleast 1 and atmost 2 arguments", x.base.base.loc, diagnostics);
         require_impl(x.m_args[0], "`array` argument of `norm2` intrinsic "
             "cannot be nullptr", x.base.base.loc, diagnostics);
+        ASR::ttype_t* array_type = ASRUtils::expr_type(x.m_args[0]);
+        require_impl(ASRUtils::extract_n_dims_from_ttype(array_type) > 0,
+            "`array` argument of `norm2` intrinsic must be an array",
+            x.base.base.loc, diagnostics);
+        require_impl(ASRUtils::is_real(*array_type),
+            "`array` argument of `norm2` intrinsic must be real",
+            x.base.base.loc, diagnostics);
     }
 
     static inline ASR::expr_t *eval_Norm2(Allocator &al,
@@ -5939,10 +5946,28 @@ namespace Norm2 {
         int64_t array_rank = extract_dimensions_from_ttype(ASRUtils::expr_type(args[0]), array_dims);
 
         ASR::ttype_t* array_type = ASRUtils::expr_type(array);
+        if (array_rank == 0) {
+            append_error(diag, "`array` argument of `norm2` intrinsic must be an array",
+                array->base.loc);
+            return nullptr;
+        }
+        if (!ASRUtils::is_real(*array_type)) {
+            append_error(diag, "`array` argument of `norm2` intrinsic must be real",
+                array->base.loc);
+            return nullptr;
+        }
         if ( dim_ != nullptr ) {
             size_t dim_rank = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(dim_));
             if (dim_rank != 0) {
                 append_error(diag, "`dim` argument to `norm2` must be a scalar and must not be an array",
+                    dim_->base.loc);
+                return nullptr;
+            }
+            int64_t dim_value = -1;
+            ASR::expr_t* dim_expr_value = ASRUtils::expr_value(dim_);
+            if (dim_expr_value && ASRUtils::extract_value(dim_expr_value, dim_value) &&
+                    (dim_value < 1 || dim_value > array_rank)) {
+                append_error(diag, "`dim` argument of `norm2` intrinsic is not a valid dimension index",
                     dim_->base.loc);
                 return nullptr;
             }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -898,4 +898,10 @@ program continue_compilation_1
         integer :: x
         data x / "abc" /
     end subroutine
+    subroutine norm2_error()
+        real :: x
+        x = norm2(1.0)
+        x = norm2([1, 2])
+        x = norm2([1.0, 2.0], dim=2)
+    end subroutine
 end program

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "a5ce20e6dd77957a4a239ff9c369d8eb002a6520e1700a132b5feb9f",
+    "infile_hash": "1375a9cc7a5d23c1c5398614d3cbeb9432b68604fa0ec6423ca7d5f7",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "65d49a5312706c8ab1ef63a58d16dd01a7464879903eee7dbeca053f",
+    "stderr_hash": "113e47f2ec08e1cc76a53a167177c43402a6139bcce3acc77e800f5c",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1785,3 +1785,21 @@ semantic error: Cannot initialize integer(4) variable with character(len=3) valu
     |
 899 |         data x / "abc" /
     |         ^^^^^^^^^^^^^^^^ 
+
+semantic error: `array` argument of `norm2` intrinsic must be an array
+   --> tests/errors/continue_compilation_1.f90:903:19
+    |
+903 |         x = norm2(1.0)
+    |                   ^^^ 
+
+semantic error: `array` argument of `norm2` intrinsic must be real
+   --> tests/errors/continue_compilation_1.f90:904:19
+    |
+904 |         x = norm2([1, 2])
+    |                   ^^^^^^ 
+
+semantic error: `dim` argument of `norm2` intrinsic is not a valid dimension index
+   --> tests/errors/continue_compilation_1.f90:905:35
+    |
+905 |         x = norm2([1.0, 2.0], dim=2)
+    |                                   ^ 


### PR DESCRIPTION
fixes #12210 