### PR TITLE
[ci] Update Exhaustive-Checks-CI.yml to use latest versions of each Github actions (pins to hash of latest version)

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '1.5.10-0'
-          environment-file: src/ci/environment_linux.yml
+          environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
 

--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -36,19 +36,19 @@ jobs:
           (github.event_name == 'pull_request' &&
            contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           path: src
 
-      - uses: mamba-org/setup-micromamba@v1.8.0
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '1.5.10-0'
           environment-file: src/ci/environment_linux.yml
           create-args: >-
             python=3.10
 
-      - uses: hendrikmuhs/ccache-action@main
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
@@ -100,18 +100,18 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
           create-args: >-
             python=3.10
 
-      - uses: hendrikmuhs/ccache-action@main
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
@@ -226,11 +226,11 @@ jobs:
             llvm-version: "22"
             python-version: "3.10"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '19')
         with:
           micromamba-version: '2.0.4-0'
@@ -248,7 +248,7 @@ jobs:
             zlib=1.3.1
             zstd-static=1.5.6
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '10')
         with:
           micromamba-version: '2.0.4-0'
@@ -266,7 +266,7 @@ jobs:
             zstd-static=1.5.6
             xonsh=0.16.0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '18')
         with:
           micromamba-version: '2.0.4-0'
@@ -283,7 +283,7 @@ jobs:
             zstd-static=1.5.6
             openmpi=5.0.6=hb85ec53_102
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '20')
         with:
           micromamba-version: '2.0.4-0'
@@ -300,7 +300,7 @@ jobs:
             zlib=1.3.1
             zstd-static=1.5.7
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '21')
         with:
           micromamba-version: '2.0.4-0'
@@ -314,7 +314,7 @@ jobs:
             make=4.3
             openmpi=5.0.6=hb85ec53_102
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '22') && contains(matrix.os, 'ubuntu')
         with:
           micromamba-version: '2.0.4-0'
@@ -330,7 +330,7 @@ jobs:
             binutils=2.45.1
             zstd-static=1.5.7
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.os, 'macos')
         with:
           micromamba-version: '2.0.4-0'
@@ -344,7 +344,7 @@ jobs:
             openmpi=5.0.10
             zstd-static=1.5.7
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: contains(matrix.llvm-version, '12')
         with:
           micromamba-version: '2.0.4-0'
@@ -358,7 +358,7 @@ jobs:
             make=4.3
             openmpi=5.0.3
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         if: ${{! ( contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '12') || contains(matrix.llvm-version, '18') || contains(matrix.llvm-version, '19') || contains(matrix.llvm-version, '20') || contains(matrix.llvm-version, '21') || contains(matrix.llvm-version, '22') )}}
         with:
           micromamba-version: '2.0.4-0'
@@ -372,7 +372,7 @@ jobs:
             make=4.3
             openmpi=5.0.6=hb85ec53_102
 
-      - uses: hendrikmuhs/ccache-action@main
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.llvm-version }}
@@ -496,11 +496,11 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -531,11 +531,11 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux.yml
@@ -555,11 +555,11 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml
@@ -570,7 +570,7 @@ jobs:
             llvm-openmp=19.1.6
             libunwind=1.7.2
 
-      - uses: hendrikmuhs/ccache-action@main
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
@@ -607,16 +607,16 @@ jobs:
       ${{ github.event_name == 'push' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Tests::Run-Exhaustive')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v2.0.2
+      - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_docs_linux.yml
 
-      - uses: hendrikmuhs/ccache-action@main
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           variant: sccache
           key: ${{ github.job }}-${{ matrix.os }}
@@ -668,13 +668,13 @@ jobs:
       USER: lfortran
       PROJECT: lfortran
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Log in to the Container registry
         if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.USER }}
@@ -691,7 +691,7 @@ jobs:
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
@@ -707,12 +707,12 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Install build0 prerequisites
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           environment-file: ci/environment_linux.yml
           init-shell: bash
@@ -753,7 +753,7 @@ jobs:
               --output-dir dist
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./dist
 
@@ -771,4 +771,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
           micromamba-version: '1.5.10-0'
-          environment-file: ci/environment_linux.yml
+          environment-file: src/ci/environment_linux.yml
           create-args: >-
             python=3.10
 


### PR DESCRIPTION
This PR updates the versions of every Github action in Exhaustive-Checks-CI.yml to the latest version. I used the full Git hash as i've been told its best to pin actions to a particular immutable version. I've ended each line with a hash followed by the version it is pinned to, to make it can at a quick glance be seen which version is being used.

I'll follow up this PR with PRs to update the other workflow files.