### PR TITLE
fix: LLVM codegen for allocatable and pointer array shapes in c_f_pointer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3985,6 +3985,7 @@ RUN(NAME c_ptr_15 LABELS gfortran llvm)
 RUN(NAME c_ptr_16 LABELS gfortran llvm EXTRAFILES c_ptr_16_module.f90)
 RUN(NAME c_ptr_17 LABELS gfortran llvm EXTRAFILES c_ptr_17_module.f90)
 RUN(NAME target_01 LABELS gfortran llvm)
+RUN(NAME c_f_pointer_01 LABELS gfortran llvm)
 
 RUN(NAME c_f_proc_ptr_01 LABELS gfortran llvm EXTRAFILES c_f_proc_ptr_01.c) # c_f_procpointer
 

--- a/integration_tests/c_f_pointer_01.f90
+++ b/integration_tests/c_f_pointer_01.f90
@@ -1,0 +1,19 @@
+program c_f_pointer_01
+   use iso_c_binding, only: c_ptr, c_f_pointer, c_loc
+   implicit none
+   integer :: j
+   real, target :: r_data(3, 4)
+   real, pointer :: r_ptr(:,:)
+   type(c_ptr) :: cptr
+   integer, allocatable :: shp(:)
+
+   r_data = reshape([(real(j), j=1,12)], [3, 4])
+   allocate(shp(2))
+   shp = [3, 4]
+
+   cptr = c_loc(r_data(1,1))
+   call c_f_pointer(cptr, r_ptr, shp)
+   if (size(r_ptr, 1) /= 3 .or. size(r_ptr, 2) /= 4) error stop
+   if (r_ptr(1,1) /= 1.0 .or. r_ptr(3,4) /= 12.0) error stop
+   print *, "Ok"
+end program c_f_pointer_01

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8867,8 +8867,19 @@ public:
             ASR::ttype_t* asr_shape_type = nullptr;
             if( shape ) {
                 asr_shape_type = ASRUtils::get_contained_type(ASRUtils::expr_type(shape));
+                int ptr_loads_copy_shape = ptr_loads;
+                if( ASRUtils::extract_physical_type(asr_shape_type) ==
+                    ASR::array_physical_typeType::DescriptorArray ||
+                    ASRUtils::extract_physical_type(asr_shape_type) ==
+                    ASR::array_physical_typeType::PointerArray ) {
+                    if( ASR::is_a<ASR::Allocatable_t>(*ASRUtils::expr_type(shape)) ||
+                        ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(shape)) ) {
+                        ptr_loads = 1;
+                    }
+                }
                 this->visit_expr(*shape);
                 llvm_shape = tmp;
+                ptr_loads = ptr_loads_copy_shape;
             }
             ASR::ttype_t* fptr_type = ASRUtils::expr_type(fptr);
             llvm::Type* llvm_fptr_type = llvm_utils->get_type_from_ttype_t_util(fptr,
@@ -8896,11 +8907,14 @@ public:
             llvm::Value* shape_data = llvm_shape;
             if( llvm_shape && (ASRUtils::extract_physical_type(asr_shape_type) ==
                 ASR::array_physical_typeType::DescriptorArray) ) {
-                ASR::ttype_t* shape_elem_asr_type = ASRUtils::type_get_past_pointer(ASRUtils::expr_type(shape));
-                llvm::Type* shape_elem_llvm_type = llvm_utils->get_type_from_ttype_t_util( nullptr, shape_elem_asr_type, module.get());
-                llvm::Type* shape_llvm_type = llvm_utils->get_type_from_ttype_t_util(
-                    nullptr, ASRUtils::expr_type(shape), module.get());
-                shape_data = llvm_utils->CreateLoad2(shape_elem_llvm_type, arr_descr->get_pointer_to_data(shape_llvm_type, llvm_shape));
+                ASR::ttype_t* shape_asr_type = ASRUtils::expr_type(shape);
+                ASR::ttype_t* shape_contained_type = ASRUtils::type_get_past_allocatable_pointer(shape_asr_type);
+                llvm::Type* shape_scalar_type = llvm_utils->get_type_from_ttype_t_util(
+                    nullptr, ASRUtils::extract_type(shape_asr_type), module.get());
+                llvm::Type* shape_desc_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                    nullptr, shape_contained_type, module.get());
+                shape_data = llvm_utils->CreateLoad2(shape_scalar_type->getPointerTo(),
+                    arr_descr->get_pointer_to_data(shape_desc_llvm_type, llvm_shape));
             }
             if( llvm_shape && (ASRUtils::extract_physical_type(asr_shape_type) ==
                 ASR::array_physical_typeType::FixedSizeArray) ) {


### PR DESCRIPTION
Fixes #12218 