### PR TITLE
CI: Misc coarray improvements

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -484,7 +484,6 @@ jobs:
             RUNNER_OS="${{matrix.os}}" FC=lfortran ci/test_third_party_codes.sh --lapack-mode "${LAPACK_MODE}"
 
       - name: Test coarray runtime with Caffeine
-        if: contains(matrix.os, 'ubuntu')
         shell: bash -e -l {0}
         run: ci/test_caffeine.sh
 

--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -3,6 +3,9 @@ echo "##[group] Setup"
 set -ex
 
 echo "CONDA_PREFIX=$CONDA_PREFIX"
+if [[ $(uname -s) == Linux ]] ; then
+  LINUX=1
+fi
 
 # Use freshly built LFortran
 
@@ -16,8 +19,16 @@ micromamba install -c conda-forge fpm=0.12.0
 which fpm
 fpm --version
 
+if [ $LINUX ] ; then
+
+(set +x
+ echo "##[endgroup]"
+ echo "##[group] Install OpenMPI"
+)
+
 micromamba install -y -c conda-forge openmpi
 export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
+export OMPI_MCA_rmaps_base_oversubscribe=1
 
 (set +x 
  echo "##[endgroup]"
@@ -35,10 +46,15 @@ cmake --install build
 
 export PATH="$HOME/opencoarrays/bin:$PATH"
 
+cd ..
+
 which caf
 caf --version
 
-cd ..
+which cafrun
+cafrun --version
+
+fi # LINUX
 
 (set +x 
  echo "##[endgroup]"
@@ -65,11 +81,8 @@ echo "CXX=${CXX}"
 which clang
 clang --version
 
-which caf
-caf --version
-
-which cafrun
-cafrun --version
+# inject ISO_Fortran_binding.h into the C include path
+export CPPFLAGS="-I$(lfortran --print-c-include-dir)"
 
 # GASNet debug options
 
@@ -171,25 +184,28 @@ gasnetrun_smp -n "$num_images" ./"${base}_lf.out"
 # Cross-check with gfortran/OpenCoarrays, unless OpenCoarrays lacks support
 # ----------------------------------------
 
-skip_opencoarrays=false
-for skip in $opencoarrays_unsupported; do
-    if [ "$base" = "$skip" ]; then
-        skip_opencoarrays=true
-    fi
-done
+if [ $LINUX ] ; then
+  skip_opencoarrays=false
+  for skip in $opencoarrays_unsupported; do
+      if [ "$base" = "$skip" ]; then
+          skip_opencoarrays=true
+      fi
+  done
+else # macOS
+  skip_opencoarrays=true
+fi
 
 if [ "$skip_opencoarrays" = true ]; then
-    echo "Skipping OpenCoarrays cross-check for $testfile (character co_max/co_min not supported by OpenCoarrays)"
+    echo "Skipping OpenCoarrays cross-check for $testfile"
 else
     caf "$testfile" -o "${base}_gf.out"
     cafrun -np "$num_images" ./"${base}_gf.out"
     rm -f "${base}_gf.out"
 fi
 
-echo "PASS: $testfile"
-
 rm -f "${base}_lf.out"
 
+echo "PASS: $testfile"
 
 done
 

--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -199,7 +199,8 @@ if [ "$skip_opencoarrays" = true ]; then
     echo "Skipping OpenCoarrays cross-check for $testfile"
 else
     caf "$testfile" -o "${base}_gf.out"
-    cafrun -np "$num_images" ./"${base}_gf.out"
+    cafrun -np "$num_images" ./"${base}_gf.out" 2>&1 \
+      | sed '/Error: OSC UCX component priority/{N;/\n[[:space:]]*$/d}' # filter persistent non-fatal errors
     rm -f "${base}_gf.out"
 fi
 

--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -158,12 +158,6 @@ time_section "🧪 Testing caffeine" '
   git checkout 0.8.0
   assert_git_commit 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
 
-  # An LFortran-specific fix to the Caffeine test suite
-  # until issue #11191 is resolved
-  git config --global user.email "nobody@nowhere.com"
-  git config --global user.name  "Nobody"
-  git cherry-pick fa9456c34af1914cc02b9d9bffeaca7d880313ac
-
   # Now build and test caffeine with LFortran
   export GASNET_CONFIGURE_ARGS="--enable-rpath --enable-debug" 
   ./install.sh --yes --prefix=$PWD/inst --verbose


### PR DESCRIPTION
Three commits for mostly unrelated, miscellaneous improvements to coarray CI:

1. Revert the cherry-pick to the Caffeine unit tests made unnecessary by recent merge of #12161 
2. Enable coarray runtime testing with Caffeine on macOS
3. Filter some nuisance warnings from OpenMPI in test_caffeine.sh