### PR TITLE
Fix variable name collision in coarray pass (#12225)

### DIFF
--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -51,8 +51,13 @@ class PRIFInterface {
                                         ASR::abiType abi, ASR::accessType access,
                                         ASR::presenceType presence, bool value_attr) {
             ASRUtils::ASRBuilder b(al, loc);
-            b.VariableDeclaration(symtab, name, type, intent, type_decl, abi, value_attr);
-            ASR::symbol_t *sym = symtab->get_symbol(name);
+            // Use a unique name to avoid clashing with user-defined variables
+            // that may already exist in `symtab` (e.g. a user variable
+            // literally named "stat"); internal compiler-generated names
+            // must never collide with source-level identifiers.
+            std::string unique_name = symtab->get_unique_name(name, false);
+            b.VariableDeclaration(symtab, unique_name, type, intent, type_decl, abi, value_attr);
+            ASR::symbol_t *sym = symtab->get_symbol(unique_name);
             LCOMPILERS_ASSERT(sym);
             ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(sym);
             var->m_access = access;

--- a/tests/coarray_var_name_collision_01.f90
+++ b/tests/coarray_var_name_collision_01.f90
@@ -1,0 +1,7 @@
+program coarray_var_name_collision_01
+    implicit none
+    integer :: stat
+    stat = 0
+    sync all(stat=stat)
+    print *, stat
+end program coarray_var_name_collision_01

--- a/tests/reference/fortran-coarray_var_name_collision_01-94763bf.json
+++ b/tests/reference/fortran-coarray_var_name_collision_01-94763bf.json
@@ -1,0 +1,13 @@
+{
+    "basename": "fortran-coarray_var_name_collision_01-94763bf",
+    "cmd": "lfortran --pass=coarray --show-fortran --no-color {infile} -o {outfile} --no-error-banner  --line=-1 --column=-1 --coarray=true",
+    "infile": "tests/coarray_var_name_collision_01.f90",
+    "infile_hash": "9860ce393d288259e0d42a680b07e13a10086f1edd6845a025870242",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "fortran-coarray_var_name_collision_01-94763bf.stdout",
+    "stdout_hash": "e9b0a8c86acf5e2c835a83e6d532d06d2d78e756d59e61fdb8661355",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/fortran-coarray_var_name_collision_01-94763bf.stdout
+++ b/tests/reference/fortran-coarray_var_name_collision_01-94763bf.stdout
@@ -1,0 +1,40 @@
+type :: prif_coarray_handle
+    type(c_ptr) :: info
+end type prif_coarray_handle
+
+program coarray_var_name_collision_01
+implicit none
+integer(4) :: stat
+integer(4) :: stat1
+call __module_prif_prif_init(stat1)
+call __module_prif_prif_sync_all()
+stat = 0
+call __module_prif_prif_sync_all(stat)
+print *, stat
+call __module_prif_prif_stop(.false.)
+
+contains
+
+interface
+    subroutine __module_prif_prif_init(exit_code)
+        integer(4), intent(out) :: exit_code
+    end subroutine __module_prif_prif_init
+end interface
+
+interface
+    subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
+        logical(1), intent(in), value :: quiet
+        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
+        integer(4), intent(in), optional, value :: stop_code_int
+    end subroutine __module_prif_prif_stop
+end interface
+
+interface
+    subroutine __module_prif_prif_sync_all(stat, errmsg, errmsg_alloc)
+        character(len=*, kind=1), intent(inout), optional :: errmsg
+        character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
+        integer(4), intent(out), optional :: stat
+    end subroutine __module_prif_prif_sync_all
+end interface
+
+end program coarray_var_name_collision_01

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5258,3 +5258,9 @@ fortran = true
 pass = "coarray"
 options = "--coarray=true"
 
+
+[[test]]
+filename = "coarray_var_name_collision_01.f90"
+fortran = true
+pass = "coarray"
+options = "--coarray=true"


### PR DESCRIPTION
Fixes #12225

The coarray lowering pass (`src/libasr/pass/coarray.cpp`) declares internal
temp variables into the same scope as user code — for example, a temp for
`prif_init`'s exit code. When a user variable happened to share the name
the pass wanted to use (e.g. `stat`, via `sync all(stat=stat)`), the pass
would try to insert a symbol with a name already present in the scope,
triggering: 

## Fix

Uniquify the internal temp's name via `get_unique_name` before declaring
it, so it no longer collides with an existing symbol in the same scope.
The user's `stat` keeps its name; the pass-generated temp becomes `stat1`
(or the next available uniquified name).

This fix is at the shared `declare_variable`-style call site used across
the pass, so it covers all coarray keyword arguments that go through this
path (`stat`, `errmsg`, `team`, `image_num`, etc.), not just `stat`.

## Before / After

**Before:** compiling the MRE below crashed with `AssertFailed:
scope.find(name) == scope.end()` during the coarray pass.

**After:** the pass now declares two distinct symbols in the same scope
— `stat` (the user's) and `stat1` (the pass-generated temp) — and each is
used for its correct purpose:

```fortran
program test_stat
    implicit none
    integer :: stat
    stat = 0
    sync all(stat=stat)
    print *, stat
end program test_stat
```

Confirmed via `--show-asr --pass=coarray` that:
- `stat1` is used for `prif_init`'s exit code.
- `stat` is correctly threaded through to `prif_sync_all`, matching the
  user's original `sync all(stat=stat)` call.

## Testing

- Added `tests/coarray_var_name_collision_01.f90`, a minimal reproduction
  of the collision.
- Ran the full coarray integration test suite (`coarray*.f90`,
  `coarrays_*.f90`) compile-only — no regressions.
- Ran the full test suite (`./run_tests.py`) — all tests pass.
- Regenerated reference files for `coarray_saved_01` and
  `coarray_initialization_01` - no diff, confirming this fix doesn't
  alter their expected output.

## Notes for reviewers

The original crash reproduces at the ASR/compile stage. Linking a full
coarray program additionally requires the Caffeine/PRIF runtime (built
separately in CI, not part of the standard build), so this was validated
with `-c` (compile-only) and `--show-asr`, which is sufficient to exercise
the fixed code path.