### PR TITLE
Add scope in do concurrent using block

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -718,7 +718,7 @@ RUN(NAME types_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp wasm fortran
 
 # GFortran + LFortran C++
 RUN(NAME doconcurrentloop_01 LABELS gfortran cpp)
-RUN(NAME doconcurrentloop_03 LABELS llvm llvm_wasm llvm_wasm_emcc fortran) # type-spec in concurrent-header is not yet implemented by gfortran.
+RUN(NAME doconcurrentloop_03 LABELS llvm llvm_wasm llvm_wasm_emcc) # # GFortran does not yet accept a type declaration in a DO CONCURRENT control header, including through the Fortran backend.
 
 RUN(NAME arrays_01 LABELS gfortran cpp llvm llvmStackArray wasm)
 RUN(NAME arrays_01_size LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm fortran)
@@ -4224,6 +4224,7 @@ RUN(NAME do_concurrent_12 LABELS llvm_omp llvm NO_FAST_MATH) # to not include is
 RUN(NAME do_concurrent_13 LABELS llvm_omp llvm) # to not include is that we do a `omp_set_num_threads(xx)` call
 RUN(NAME do_concurrent_14 LABELS llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME do_concurrent_15 LABELS llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME do_concurrent_16 LABELS llvm llvm_wasm llvm_wasm_emcc)
 
 
 RUN(NAME transfer_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/do_concurrent_16.f90
+++ b/integration_tests/do_concurrent_16.f90
@@ -1,0 +1,16 @@
+program do_concurrent_16
+    implicit none
+
+    integer :: i
+    integer :: values(3)
+
+    i = 10
+    values = 0
+
+    do concurrent (integer :: i = 1:3)
+        values(i) = i * i
+    end do
+
+    if (any(values /= [1, 4, 9])) error stop 1
+    if (i /= 10) error stop 2
+end program do_concurrent_16

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -9125,10 +9125,37 @@ public:
         all_loops_blocks_nesting += 1;
         bool in_loop_copy = in_loop;
         in_loop = true;
-        Vec<ASR::do_loop_head_t> heads;  // Create a vector of loop heads
-        heads.reserve(al,x.n_control);
-        AST::decl_attribute_t *current_type = nullptr;
-        for(size_t i=0;i<x.n_control;i++) {
+
+        SymbolTable *parent_scope = current_scope;
+        ASR::symbol_t *block_sym = nullptr;
+        ASR::Block_t *block = nullptr;
+        std::string block_name;
+
+        bool needs_scope_block = false;
+        for (size_t i = 0; i < x.n_control; i++) {
+            AST::ConcurrentControl_t &h = *(AST::ConcurrentControl_t *)x.m_control[i];
+            if (h.m_type) {
+                needs_scope_block = true;
+                break;
+            }
+        }
+        if (needs_scope_block) {
+            current_scope = al.make_new<SymbolTable>(parent_scope);
+            block_name = parent_scope->get_unique_name("~do_concurrent_block_");
+            block_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Block_t(al, x.base.base.loc, current_scope,
+                                                                        s2c(al, block_name), nullptr, 0));
+            block = ASR::down_cast<ASR::Block_t>(block_sym);
+            // Add the Block before lowering the loop so that
+            // current_scope->asr_owner is correctly initialized.
+            parent_scope->add_symbol(block_name, block_sym);
+        }
+
+        try{
+            Vec<ASR::do_loop_head_t> heads;
+            heads.reserve(al, x.n_control);
+            AST::decl_attribute_t *current_type = nullptr;
+
+            for(size_t i=0;i<x.n_control;i++) {
             AST::ConcurrentControl_t &h = *(AST::ConcurrentControl_t*) x.m_control[i];
             if (! h.m_var) {
                 diag.add(Diagnostic(
@@ -9159,18 +9186,17 @@ public:
             if (h.m_type) {
                 current_type = h.m_type;
             }
+
             if (current_type) {
                 // A type-spec (e.g. `do concurrent (integer :: j = ...)`)
-                // declares the index variable. If a variable of the same name
-                // already exists in the current scope, reuse it instead of
-                // adding a duplicate symbol.
+                // A typed concurrent control declares its index variable
+                // in the compiler-generated Block scope.
                 ASR::symbol_t *var_sym = current_scope->get_symbol(var_name);
                 if (var_sym == nullptr) {
-                    AST::decl_attribute_t *decl_type = current_type;
                     Vec<ASR::dimension_t> dims;
                     dims.reserve(al, 1);
                     ASR::symbol_t *type_declaration;
-                    ASR::ttype_t *type = determine_type(x.base.base.loc, var_name, decl_type, false, false,
+                    ASR::ttype_t *type = determine_type(x.base.base.loc, var_name, current_type, false, false,
                                                         dims, nullptr, type_declaration, ASR::abiType::Source);
                     var_sym = ASR::down_cast<ASR::symbol_t>(
                         ASR::make_Variable_t(al, x.base.base.loc, current_scope, s2c(al, var_name),
@@ -9202,9 +9228,9 @@ public:
             head.loc = head.m_v->base.loc;
             heads.push_back(al, head);
         }
-        Vec<ASR::stmt_t*> body;
-        body.reserve(al, x.n_body);
-        transform_stmts(body, x.n_body, x.m_body);
+        Vec<ASR::stmt_t*> lowered_body;
+        lowered_body.reserve(al, x.n_body);
+        transform_stmts(lowered_body, x.n_body, x.m_body);
         Vec<ASR::reduction_expr_t> reductions; reductions.reserve(al, 1);
         Vec<ASR::expr_t*> shared_expr; shared_expr.reserve(al, 1);
         Vec<ASR::expr_t*> local_expr; local_expr.reserve(al, 1);
@@ -9265,8 +9291,31 @@ public:
                 }
             }
         }
-        tmp = ASR::make_DoConcurrentLoop_t(al, x.base.base.loc, heads.p, heads.n, shared_expr.p, shared_expr.n, local_expr.p, local_expr.n, reductions.p, reductions.n, body.p,
-                body.size());
+        Vec<ASR::stmt_t *> do_concurrent_body;
+        if (needs_scope_block) {
+            block->m_body = lowered_body.p;
+            block->n_body = lowered_body.size();
+            do_concurrent_body.reserve(al, 1);
+            do_concurrent_body.push_back(al, ASRUtils::STMT(ASR::make_BlockCall_t(al, x.base.base.loc,
+                                                                                -1, block_sym)));
+        } else {
+            do_concurrent_body.reserve(al, lowered_body.size());
+            for (size_t i = 0; i < lowered_body.size(); i++) {
+                do_concurrent_body.push_back(al, lowered_body.p[i]);
+            }
+        }
+        current_scope = parent_scope;
+        tmp = ASR::make_DoConcurrentLoop_t(al, x.base.base.loc, heads.p, heads.n, shared_expr.p, shared_expr.n, local_expr.p, local_expr.n, reductions.p, reductions.n, do_concurrent_body.p,
+                do_concurrent_body.size());
+        } catch(...) {
+            current_scope = parent_scope;
+            if (needs_scope_block && parent_scope->get_symbol(block_name)) {
+                parent_scope->erase_symbol(block_name);
+            }
+            all_loops_blocks_nesting -= 1;
+            in_loop = in_loop_copy;
+            throw;
+        }
         all_loops_blocks_nesting -= 1;
         in_loop = in_loop_copy;
     }

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1851,15 +1851,40 @@ public:
     }
 
     void visit_DoConcurrentLoop(const DoConcurrentLoop_t &x) {
-        for ( size_t i = 0; i < x.n_local; i++ ) {
-            require(ASR::is_a<ASR::Var_t>(*x.m_local[i]),
+        SymbolTable *parent_symtab = current_symtab;
+        SymbolTable *loop_symtab = nullptr;
+
+        // A typed DO CONCURRENT control is lowered with a generated Block
+        // whose symbol table owns the construct-local index variable.
+        if (x.n_body == 1 && ASR::is_a<ASR::BlockCall_t>(*x.m_body[0])) {
+            ASR::BlockCall_t *block_call = ASR::down_cast<ASR::BlockCall_t>(x.m_body[0]);
+
+            if (ASR::is_a<ASR::Block_t>(*block_call->m_m)) {
+                ASR::Block_t *block = ASR::down_cast<ASR::Block_t>(block_call->m_m);
+                std::string block_name = block->m_name;
+                if (block_name.find("~do_concurrent_block_") == 0) {
+                    loop_symtab = block->m_symtab;
+                }
+            }
+        }
+
+        if (loop_symtab) {
+            current_symtab = loop_symtab;
+        }
+
+        for (size_t i = 0; i < x.n_local; i++) {
+            require(
+                ASR::is_a<ASR::Var_t>(*x.m_local[i]),
                 "DoConcurrentLoop::m_local must be a Var");
         }
-        for ( size_t i = 0; i < x.n_shared; i++ ) {
-            require(ASR::is_a<ASR::Var_t>(*x.m_shared[i]),
+
+        for (size_t i = 0; i < x.n_shared; i++) {
+            require(
+                ASR::is_a<ASR::Var_t>(*x.m_shared[i]),
                 "DoConcurrentLoop::m_shared must be a Var");
         }
         BaseWalkVisitor<VerifyVisitor>::visit_DoConcurrentLoop(x);
+        current_symtab = parent_symtab;
     }
 
 };

--- a/src/libasr/codegen/asr_to_fortran.cpp
+++ b/src/libasr/codegen/asr_to_fortran.cpp
@@ -1286,9 +1286,30 @@ public:
 
     void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
         std::string r = indent;
-
+        ASR::Block_t *scope_block = nullptr;
+        // Typed concurrent controls are represented internally using a
+        // compiler-generated Block whose symbol table owns the index variables.
+        if (x.n_body == 1 && ASR::is_a<ASR::BlockCall_t>(*x.m_body[0])) {
+            ASR::BlockCall_t *block_call =
+            ASR::down_cast<ASR::BlockCall_t>(x.m_body[0]);
+            if (ASR::is_a<ASR::Block_t>(*block_call->m_m)) {
+                ASR::Block_t *block =
+                ASR::down_cast<ASR::Block_t>(block_call->m_m);
+                if (block->m_name && std::string(block->m_name).find("~do_concurrent_block_") == 0) {
+                    scope_block = block;
+                }
+            }
+        }
         r += "do concurrent";
         r += " ( ";
+        // Reconstruct the type declaration from the generated Block scope.
+        if (scope_block && x.n_head > 0 && ASR::is_a<ASR::Var_t>(*x.m_head[0].m_v)) {
+            ASR::symbol_t *loop_var = ASR::down_cast<ASR::Var_t>(x.m_head[0].m_v)->m_v;
+            if (ASRUtils::symbol_parent_symtab(loop_var) == scope_block->m_symtab) {
+                r += get_type(ASRUtils::symbol_type(loop_var));
+                r += " :: ";
+            }
+        }
         for (size_t i = 0; i < x.n_head; i++) {
             visit_expr(*x.m_head[i].m_v);
             r += src;
@@ -1310,7 +1331,13 @@ public:
         r+=" )";
         handle_line_truncation(r, 2);
         r += "\n";
-        visit_body(x, r);
+        if (scope_block) {
+            // The Block is an internal scoping mechanism. Emit its body directly
+            // instead of printing the generated Block construct.
+            visit_body(*scope_block, r);
+        } else {
+            visit_body(x, r);
+        }
         r += indent;
         r += "end do";
         r += "\n";

--- a/src/libasr/pass/do_loops.cpp
+++ b/src/libasr/pass/do_loops.cpp
@@ -49,17 +49,58 @@ public:
         if (pass_options.enable_gpu_offloading) {
             return;
         }
-        Vec<ASR::stmt_t*> body;body.reserve(al,1);
-        for (int i = 0; i < static_cast<int>(x.n_body); i++) {
-            body.push_back(al,x.m_body[i]);
+
+        // Typed DO CONCURRENT controls are represented using a generated
+        // Block whose symbol table owns the construct-local index variables.
+        if (x.n_body == 1 && ASR::is_a<ASR::BlockCall_t>(*x.m_body[0])) {
+            ASR::BlockCall_t *block_call = ASR::down_cast<ASR::BlockCall_t>(x.m_body[0]);
+
+            if (ASR::is_a<ASR::Block_t>(*block_call->m_m)) {
+                ASR::Block_t *block = ASR::down_cast<ASR::Block_t>(block_call->m_m);
+                std::string block_name = block->m_name;
+                if (block_name.find("~do_concurrent_block_") == 0) {
+                    Vec<ASR::stmt_t *> body;
+                    body.reserve(al, block->n_body);
+                    for (size_t i = 0; i < block->n_body; i++) {
+                        body.push_back(al, block->m_body[i]);
+                    }
+                    for (int i = static_cast<int>(x.n_head) - 1;i > 0; i--) {
+                        ASR::asr_t *do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
+                        body = {};
+                        body.reserve(al, 1);
+                        body.push_back(al, ASRUtils::STMT(do_loop));
+                    }
+
+                    ASR::asr_t *outer_do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[0], body.p, body.n, nullptr, 0);
+
+                    const ASR::DoLoop_t &outer_do_loop_ref = (const ASR::DoLoop_t &)(*outer_do_loop);
+
+                    Vec<ASR::stmt_t *> lowered_body = PassUtils::replace_doloop(al, outer_do_loop_ref, -1, use_loop_variable_after_loop, block->m_symtab);
+                    block->m_body = lowered_body.p;
+                    block->n_body = lowered_body.size();
+
+                    pass_result.reserve(al, 1);
+                    pass_result.push_back(al, x.m_body[0]);
+                    return;
+                }
+            }
+        }
+
+        // Existing lowering for DO CONCURRENT loops without a generated Block.
+        Vec<ASR::stmt_t *> body;
+        body.reserve(al, x.n_body);
+
+        for (size_t i = 0; i < x.n_body; i++) {
+            body.push_back(al, x.m_body[i]);
         }
         for (int i = static_cast<int>(x.n_head) - 1; i > 0; i--) {
-            ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
-            body={};body.reserve(al,1);
-            body.push_back(al,ASRUtils::STMT(do_loop));
+            ASR::asr_t *do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[i], body.p, body.n, nullptr, 0);
+            body = {};
+            body.reserve(al, 1);
+            body.push_back(al, ASRUtils::STMT(do_loop));
         }
-        ASR::asr_t* do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[0], body.p, body.n, nullptr, 0);
-        const ASR::DoLoop_t &do_loop_ref = (const ASR::DoLoop_t&)(*do_loop);
+        ASR::asr_t *do_loop = ASR::make_DoLoop_t(al, x.base.base.loc, s2c(al, ""), x.m_head[0], body.p, body.n, nullptr, 0);
+        const ASR::DoLoop_t &do_loop_ref = (const ASR::DoLoop_t &)(*do_loop);;
         pass_result = PassUtils::replace_doloop(al, do_loop_ref, -1, use_loop_variable_after_loop, this->current_scope);
     }
 };

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -582,6 +582,40 @@ class EditProcedureVisitor: public ASR::CallReplacerOnExpressionsVisitor<EditPro
     EditProcedureVisitor(PassArrayByDataProcedureVisitor& v_):
     v(v_), replacer(v) {}
 
+    void visit_DoConcurrentLoop(const ASR::DoConcurrentLoop_t &x) {
+        SymbolTable *current_scope_copy = current_scope;
+
+        // A typed DO CONCURRENT control is owned by the compiler-generated
+        // Block scope. Visit the loop head and body using that scope so the
+        // construct-local index is not resolved to a same-named symbol in
+        // the enclosing scope.
+        if (x.n_body == 1 &&
+                ASR::is_a<ASR::BlockCall_t>(*x.m_body[0])) {
+            ASR::BlockCall_t *block_call =
+                ASR::down_cast<ASR::BlockCall_t>(x.m_body[0]);
+
+            if (ASR::is_a<ASR::Block_t>(*block_call->m_m)) {
+                ASR::Block_t *block =
+                    ASR::down_cast<ASR::Block_t>(
+                        block_call->m_m);
+
+                if (block->m_name &&
+                        std::string(block->m_name).find(
+                            "~do_concurrent_block_") == 0) {
+                    current_scope = block->m_symtab;
+                }
+            }
+        }
+
+        try {
+            ASR::CallReplacerOnExpressionsVisitor<EditProcedureVisitor>::visit_DoConcurrentLoop(x);
+        } catch (...) {
+            current_scope = current_scope_copy;
+            throw;
+        }
+        current_scope = current_scope_copy;
+    }
+
     void call_replacer() {
         replacer.current_expr = current_expr;
         replacer.current_scope = current_scope;


### PR DESCRIPTION
This change adds an owned symbol table to the ASR DoConcurrentLoop node.

A DO CONCURRENT construct can introduce variables whose scope is limited to the construct itself. The most direct example is a loop index declared in the concurrent header:

``` fortran
do concurrent (integer :: i = 1:3)
    values(i) = i * i
end do
```
The i declared in this header is not the same variable as an i declared in an enclosing procedure or program. It is a construct-local variable whose lifetime and visibility are limited to the DO CONCURRENT construct.

Previously, DoConcurrentLoop was represented only as a statement containing loop heads, locality specifications, reductions, and a body. It did not own a symbol table. As a result, construct-local declarations could not be represented with the correct lexical scope. They could incorrectly resolve to an enclosing variable and could overwrite or otherwise interfere with that variable during lowering or code generation.

The ASR representation now gives each DoConcurrentLoop its own symbol table. This brings the ASR representation in line with the Fortran scoping rules and allows the compiler to distinguish construct-local entities from variables declared in surrounding scopes.

Minimum Reproducible Error:

``` fortran
program concurrent_scope_test
    implicit none

    integer :: i
    integer :: values(3)

    i = 10

    do concurrent (integer :: i = 1:3)
        values(i) = i * i
    end do

    if (any(values /= [1, 4, 9])) error stop 1
    print *, i
end program concurrent_scope_test
```

Here, the current version shows the output as `3`, but the output should be `10`.
The PR makes sure that it happens by introducing symbol table to `do_concurrent` even though it is a `statement` and not a `symbol`.

TO DO:
- [ ] Add new tests for all the changes.