### PR TITLE
Fix multi-image constant values in `iso_fortran_env`

### DIFF
--- a/ci/test_caffeine.sh
+++ b/ci/test_caffeine.sh
@@ -69,6 +69,11 @@ cd caffeine
 # Release 0.8.0
 git checkout 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
 
+# Cherry-pick a recent fix to -DCAF_IMPORT_TEAM_CONSTANTS
+git config user.email "nobody@nowhere.com"
+git config user.name  "Nobody"
+git cherry-pick 736130c4af77b4ab33e4341e6dcd32ab4c8b7f4a
+
 # Toolchain setup
 
 export FC=lfortran
@@ -83,6 +88,9 @@ clang --version
 
 # inject ISO_Fortran_binding.h into the C include path
 export CPPFLAGS="-I$(lfortran --print-c-include-dir)"
+
+# instruct Caffeine to import the iso_fortran_env constants from LFortran
+CPPFLAGS+=" -DCAF_IMPORT_CONSTANTS"
 
 # GASNet debug options
 

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -49,8 +49,8 @@ integer, parameter :: stat_failed_image = 4              ! F2018
 integer, parameter :: stat_unlocked_failed_image = 5     ! F2018
 
 ! Atomic kinds (F2018)
-integer, parameter :: atomic_int_kind = 4
-integer, parameter :: atomic_logical_kind = 4
+integer, parameter :: atomic_int_kind = 8
+integer, parameter :: atomic_logical_kind = 8
 
 ! Team constants (F2018)
 integer, parameter :: initial_team = 0

--- a/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
+++ b/src/runtime/pure/lfortran_intrinsic_iso_fortran_env.f90
@@ -41,11 +41,11 @@ integer, parameter :: character_storage_size = 8
 integer, parameter :: file_storage_size = 8
 
 ! Coarray stat constants (F2008/F2018)
-integer, parameter :: stat_unlocked = 0
-integer, parameter :: stat_locked = 1
-integer, parameter :: stat_locked_other_image = 2
-integer, parameter :: stat_stopped_image = 3
-integer, parameter :: stat_failed_image = 4              ! F2018
+integer, parameter :: stat_failed_image = -1    ! F2018: negative to indicate no failed image support
+integer, parameter :: stat_unlocked = 1
+integer, parameter :: stat_locked = 2
+integer, parameter :: stat_locked_other_image = 3
+integer, parameter :: stat_stopped_image = 4
 integer, parameter :: stat_unlocked_failed_image = 5     ! F2018
 
 ! Atomic kinds (F2018)


### PR DESCRIPTION
There were several problems with the coarray-relevant constant values chosen in `iso_fortran_env` that would cause integration problems with PRIF/Caffeine in the near future: 

* Caffeine requires `atomic_{int,logical}_kind` to be 64-bit
* `STAT_*` values may not be zero
* `STAT_FAILED_IMAGES` should have a negative value while the compiler does not support failed image detection

Resolve those problems, and change the Caffeine build in test_caffeine.sh to import the repaired constant values.

Towards #12199