### PR TITLE
Fix ICE when include file is not found (#12156)

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -569,9 +569,14 @@ int emit_prescan(const std::string &infile, CompilerOptions &compiler_options)
     include_dirs.insert(include_dirs.end(),
                           compiler_options.po.include_dirs.begin(),
                           compiler_options.po.include_dirs.end());
-    std::string prescan = LCompilers::LFortran::prescan(input, lm,
-        compiler_options.fixed_form, include_dirs);
-    std::cout << prescan << std::endl;
+    LCompilers::diag::Diagnostics diagnostics;
+    LCompilers::Result<std::string> prescan_res = LCompilers::LFortran::prescan(input, lm,
+        compiler_options.fixed_form, include_dirs, diagnostics);
+    if (!prescan_res.ok) {
+        std::cerr << diagnostics.render(lm, LCompilers::CompilerOptions());
+        return 1;
+    }
+    std::cout << prescan_res.result << std::endl;
     return 0;
 }
 
@@ -596,8 +601,13 @@ int emit_tokens(const std::string &infile, bool line_numbers, const CompilerOpti
         include_dirs.insert(include_dirs.end(),
                             compiler_options.po.include_dirs.begin(),
                             compiler_options.po.include_dirs.end());
-        input = LCompilers::LFortran::prescan(input, lm,
-            compiler_options.fixed_form, include_dirs);
+        LCompilers::Result<std::string> prescan_res = LCompilers::LFortran::prescan(input, lm,
+            compiler_options.fixed_form, include_dirs, diagnostics);
+        if (!prescan_res.ok) {
+            std::cerr << diagnostics.render(lm, LCompilers::CompilerOptions());
+            return 1;
+        }
+        input = prescan_res.result;
     }
     auto res = LCompilers::LFortran::tokens(al, input, diagnostics, &stypes, &locations,
         compiler_options.fixed_form, compiler_options.continue_compilation);

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -267,7 +267,14 @@ Result<LFortran::AST::TranslationUnit_t*> FortranEvaluator::get_ast2(
         include_dirs.insert(include_dirs.end(),
                             compiler_options.po.include_dirs.begin(),
                             compiler_options.po.include_dirs.end());
-        tmp = LFortran::prescan(*code, lm, compiler_options.fixed_form, include_dirs);
+        Result<std::string> prescan_res = LFortran::prescan(*code, lm,
+            compiler_options.fixed_form, include_dirs, diagnostics);
+        if (prescan_res.ok) {
+            tmp = prescan_res.result;
+        } else {
+            LCOMPILERS_ASSERT(diagnostics.has_error())
+            return prescan_res.error;
+        }
         code = &tmp;
     }
     Result<LFortran::AST::TranslationUnit_t*>

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -640,7 +640,7 @@ bool check_newlines(const std::string &s, const std::vector<uint32_t> &newlines)
     return true;
 }
 
-void process_include(std::string& out, const std::string& s,
+bool process_include(std::string& out, const std::string& s,
                      LocationManager& lm, size_t& pos, bool fixed_form,
                      std::vector<std::filesystem::path> &include_dirs,
                      int &col, diag::Diagnostics &diagnostics)
@@ -673,7 +673,7 @@ void process_include(std::string& out, const std::string& s,
             + "' not found. If an include path "
             "is available, please use the `-I` option to specify it.",
             diag::Level::Error, diag::Stage::Parser, {diag::Label("", {loc})}));
-        throw parser_local::ParserAbort();
+        return false;
     }
 
     LocationManager lm_tmp;
@@ -687,7 +687,7 @@ void process_include(std::string& out, const std::string& s,
     if (include_res.ok) {
         include = include_res.result;
     } else {
-        throw parser_local::ParserAbort();
+        return false;
     }
 
     // Possible it goes here
@@ -696,6 +696,7 @@ void process_include(std::string& out, const std::string& s,
     while (pos < s.size() && s[pos] != '\n') pos++;
     lm.files.back().out_start.push_back(out.size());
     lm.files.back().in_start.push_back(pos);
+    return true;
 }
 
 bool is_include(const std::string &s, uint32_t pos) {
@@ -727,7 +728,6 @@ Result<std::string> prescan(const std::string &s, LocationManager &lm,
         bool fixed_form, std::vector<std::filesystem::path> &include_dirs,
         diag::Diagnostics &diagnostics)
 {
-  try {
     if (fixed_form) {
         // `pos` is the position in the original code `s`
         // `out` is the final code (outcome)
@@ -817,8 +817,11 @@ Result<std::string> prescan(const std::string &s, LocationManager &lm,
                     pos += 7;
                     while (pos < s.size() && s[pos] == ' ') pos++;
                     if ((s[pos] == '"') || (s[pos] == '\'')) {
-                        process_include(out, s, lm, pos, fixed_form,
-                            include_dirs, col, diagnostics);
+                        if (!process_include(out, s, lm, pos, fixed_form,
+                                include_dirs, col, diagnostics)) {
+                            Error error;
+                            return error;
+                        }
                     }
                     break;
                 }
@@ -854,7 +857,10 @@ Result<std::string> prescan(const std::string &s, LocationManager &lm,
                 pos += 7;
                 while (pos < s.size() && s[pos] == ' ') pos++;
                 LCOMPILERS_ASSERT(pos < s.size() && ((s[pos] == '"') || (s[pos] == '\'')));
-                process_include(out, s, lm, pos, fixed_form, include_dirs, col, diagnostics);
+                if (!process_include(out, s, lm, pos, fixed_form, include_dirs, col, diagnostics)) {
+                    Error error;
+                    return error;
+                }
             }
             newline = false;
             if (s[pos] == '!' && !in_string) in_comment = true;
@@ -900,10 +906,6 @@ Result<std::string> prescan(const std::string &s, LocationManager &lm,
         lm.files.back().out_start.push_back(out.size());
         return out;
     }
-  } catch (const parser_local::ParserAbort &) {
-    Error error;
-    return error;
-  }
 }
 
 

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -643,7 +643,7 @@ bool check_newlines(const std::string &s, const std::vector<uint32_t> &newlines)
 void process_include(std::string& out, const std::string& s,
                      LocationManager& lm, size_t& pos, bool fixed_form,
                      std::vector<std::filesystem::path> &include_dirs,
-                     int &col)
+                     int &col, diag::Diagnostics &diagnostics)
 {
     std::string include_filename;
     parse_string(include_filename, s, pos, fixed_form, col);
@@ -665,9 +665,15 @@ void process_include(std::string& out, const std::string& s,
     }
 
     if (!file_found) {
-        throw LCompilersException("Include file '" + include_filename
+        Location loc;
+        loc.first = pos;
+        loc.last = pos;
+        diagnostics.add(diag::Diagnostic(
+            "Include file '" + include_filename
             + "' not found. If an include path "
-            "is available, please use the `-I` option to specify it.");
+            "is available, please use the `-I` option to specify it.",
+            diag::Level::Error, diag::Stage::Parser, {diag::Label("", {loc})}));
+        throw parser_local::ParserAbort();
     }
 
     LocationManager lm_tmp;
@@ -676,7 +682,13 @@ void process_include(std::string& out, const std::string& s,
         fl.in_filename = include_filename;
         lm_tmp.files.push_back(fl);
     }
-    include = prescan(include, lm_tmp, fixed_form, include_dirs);
+    Result<std::string> include_res = prescan(include, lm_tmp, fixed_form,
+        include_dirs, diagnostics);
+    if (include_res.ok) {
+        include = include_res.result;
+    } else {
+        throw parser_local::ParserAbort();
+    }
 
     // Possible it goes here
     // lm.files.back().out_start.push_back(out.size());
@@ -711,9 +723,11 @@ The prescan phase includes:
 - Conversion to lowercase (fixed-form only)
 - Handling of fixed-form column rules (columns 1–6 for labels/comments)
 */
-std::string prescan(const std::string &s, LocationManager &lm,
-        bool fixed_form, std::vector<std::filesystem::path> &include_dirs)
+Result<std::string> prescan(const std::string &s, LocationManager &lm,
+        bool fixed_form, std::vector<std::filesystem::path> &include_dirs,
+        diag::Diagnostics &diagnostics)
 {
+  try {
     if (fixed_form) {
         // `pos` is the position in the original code `s`
         // `out` is the final code (outcome)
@@ -804,7 +818,7 @@ std::string prescan(const std::string &s, LocationManager &lm,
                     while (pos < s.size() && s[pos] == ' ') pos++;
                     if ((s[pos] == '"') || (s[pos] == '\'')) {
                         process_include(out, s, lm, pos, fixed_form,
-                            include_dirs, col);
+                            include_dirs, col, diagnostics);
                     }
                     break;
                 }
@@ -840,7 +854,7 @@ std::string prescan(const std::string &s, LocationManager &lm,
                 pos += 7;
                 while (pos < s.size() && s[pos] == ' ') pos++;
                 LCOMPILERS_ASSERT(pos < s.size() && ((s[pos] == '"') || (s[pos] == '\'')));
-                process_include(out, s, lm, pos, fixed_form, include_dirs, col);
+                process_include(out, s, lm, pos, fixed_form, include_dirs, col, diagnostics);
             }
             newline = false;
             if (s[pos] == '!' && !in_string) in_comment = true;
@@ -886,6 +900,10 @@ std::string prescan(const std::string &s, LocationManager &lm,
         lm.files.back().out_start.push_back(out.size());
         return out;
     }
+  } catch (const parser_local::ParserAbort &) {
+    Error error;
+    return error;
+  }
 }
 
 

--- a/src/lfortran/parser/parser.h
+++ b/src/lfortran/parser/parser.h
@@ -55,8 +55,9 @@ Result<std::vector<int>> tokens(Allocator &al, const std::string &input,
 // Converts token number to text
 std::string token2text(const int token);
 
-std::string prescan(const std::string &s, LocationManager &lm,
-        bool fixed_form, std::vector<std::filesystem::path> &include_dirs);
+Result<std::string> prescan(const std::string &s, LocationManager &lm,
+        bool fixed_form, std::vector<std::filesystem::path> &include_dirs,
+        diag::Diagnostics &diagnostics);
 
 } // namespace LCompilers::LFortran
 

--- a/tests/errors/missing_include_01.f90
+++ b/tests/errors/missing_include_01.f90
@@ -1,0 +1,5 @@
+program p
+  implicit none
+  include 'does_not_exist.fi'
+  print *, "hello"
+end program p

--- a/tests/reference/ast-missing_include_01-8c58b3e.json
+++ b/tests/reference/ast-missing_include_01-8c58b3e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "ast-missing_include_01-8c58b3e",
+    "cmd": "lfortran --show-ast --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/missing_include_01.f90",
+    "infile_hash": "755a25dcb293c6a885e00df64b3266382756a374773a00bd047a34a6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "ast-missing_include_01-8c58b3e.stderr",
+    "stderr_hash": "d7f4621a447a0b86d97e69a09aeab66c273d105a581da7a7d34b8d6a",
+    "returncode": 2
+}

--- a/tests/reference/ast-missing_include_01-8c58b3e.stderr
+++ b/tests/reference/ast-missing_include_01-8c58b3e.stderr
@@ -1,0 +1,5 @@
+syntax error: Include file 'does_not_exist.fi' not found. If an include path is available, please use the `-I` option to specify it.
+ --> tests/errors/missing_include_01.f90:3:30
+  |
+3 |   include 'does_not_exist.fi'
+  |                              ^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5264,3 +5264,6 @@ filename = "coarray_var_name_collision_01.f90"
 fortran = true
 pass = "coarray"
 options = "--coarray=true"
+[[test]]
+filename = "errors/missing_include_01.f90"
+ast = true


### PR DESCRIPTION
Closes #12156

## Summary
Fixes an Internal Compiler Error that occurs when a Fortran `include` statement references a file that can't be found. Previously this crashed with a full stack trace instead of producing a normal diagnostic.

## Before
```fortran
program p
  implicit none
  include 'does_not_exist.fi'
  print *, "hello"
end program p
```
```
$ lfortran missing_include.f90
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file ".../bin/lfortran", ...
  ... (several frames) ...
LCompilersException: Include file 'does_not_exist.fi' not found. If an include path is available, please use the `-I` option to specify it.
```

## After
```
$ lfortran missing_include.f90
syntax error: Include file 'does_not_exist.fi' not found. If an include path is available, please use the `-I` option to specify it.
 --> missing_include.f90:3:30
  |
3 |   include 'does_not_exist.fi'
  |                              ^

EXIT CODE: 1
```

## Root cause
`process_include()` in `parser.cpp` threw a bare `LCompilersException` when a file wasn't found. `prescan()` (which calls it) had no `diagnostics` parameter and returned a plain `std::string`, so there was no way to report the error as a normal diagnostic — it could only escape as a raw exception, which the top-level handler in `lfortran.cpp` always treats as a genuine internal compiler bug.

## Fix
- Changed `prescan()`'s signature to accept `diag::Diagnostics &diagnostics` and return `Result<std::string>`, matching the existing pattern used by `parse()`.
- Updated `process_include()` to populate `diagnostics` with a proper `diag::Diagnostic` (`Stage::Parser`) and throw the existing lightweight `parser_local::ParserAbort` marker exception instead of `LCompilersException`, mirroring the pattern already used elsewhere in `parser.cpp` (e.g. `fix_program_without_program_line`).
- Wrapped `prescan()`'s body in a `try`/`catch` for `ParserAbort`, converting it into a clean `Error()` result.
- Updated all call sites (`fortran_evaluator.cpp`, `lfortran.cpp`'s `emit_prescan`/`emit_tokens`, and the recursive `prescan()` call inside `process_include()` itself for nested includes) to pass `diagnostics` through and handle the new `Result<std::string>` return type.

## Testing
- Added `tests/errors/missing_include_01.f90` reproducing the original MRE from the issue.
- Ran the full test suite (`./run_tests.py`) — all tests pass, no regressions from the `prescan()` signature change.