### PR TITLE
Fix generic resolution for defined operators

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4605,6 +4605,7 @@ RUN(NAME str_to_char LABELS gfortran llvm)
 RUN(NAME polymorphic_select_type_01 LABELS gfortran llvm)
 RUN(NAME polymorphic_select_type_02 LABELS gfortran llvm)
 RUN(NAME defined_op_match_01 LABELS gfortran llvm)
+RUN(NAME defined_op_match_02 LABELS gfortran llvm)
 
 #test for forward declaration of derived type
 RUN(NAME proc_ptr_nopass_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/defined_op_match_02.f90
+++ b/integration_tests/defined_op_match_02.f90
@@ -1,0 +1,51 @@
+module m_defined_op_match_02
+   implicit none
+   private
+   public :: operator(.in.)
+
+   interface operator(.in.)
+      ! Elemental scalar overload declared BEFORE the rank-1 overload.
+      module procedure in_scalar
+      module procedure in_list
+   end interface
+
+contains
+
+   elemental function in_scalar(a, b) result(res)
+      integer, intent(in) :: a, b
+      logical :: res
+      res = a == b
+   end function in_scalar
+
+   function in_list(a, b) result(res)
+      integer, intent(in) :: a
+      integer, intent(in) :: b(:)
+      logical :: res
+      res = any(a == b)
+   end function in_list
+
+end module m_defined_op_match_02
+
+
+program defined_op_match_02
+   use m_defined_op_match_02, only: operator(.in.)
+   implicit none
+
+   integer :: arr(3) = [10, 20, 30]
+   logical :: r
+
+   ! scalar .in. rank-1 array must resolve to the non-elemental in_list
+   ! (scalar logical result), not to the elemental in_scalar (which would
+   ! broadcast to a logical array and be rejected by the if statement).
+   if (.not. (20 .in. arr)) error stop "array whole"
+   if (25 .in. arr) error stop "array whole (absent)"
+   if (.not. (30 .in. arr(1:3))) error stop "array section"
+   if (10 .in. arr(2:3)) error stop "array section (absent)"
+
+   ! scalar .in. scalar must still resolve to the elemental in_scalar.
+   r = (20 .in. 20)
+   if (.not. r) error stop "scalar equal"
+   if (20 .in. 21) error stop "scalar not equal"
+
+   print *, "ok"
+end program defined_op_match_02

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -18779,7 +18779,21 @@ public:
         if (is_binary)
             right_type = ASRUtils::expr_type(second_operand);
         bool matched = false;
+        // Resolve the specific procedure with the same priority as
+        // ASRUtils::select_generic_procedure: try non-elemental procedures
+        // first (matching rank exactly), and only fall back to elemental
+        // procedures (which broadcast over array actuals) if none matched.
+        // Otherwise an elemental scalar overload declared before a rank-1
+        // overload would be wrongly selected for an array actual argument.
+        std::vector<size_t> proc_order;
         for (size_t i = 0; i < gen_proc->n_procs; ++i) {
+            if (!ASRUtils::is_elemental(gen_proc->m_procs[i])) proc_order.push_back(i);
+        }
+        for (size_t i = 0; i < gen_proc->n_procs; ++i) {
+            if (ASRUtils::is_elemental(gen_proc->m_procs[i])) proc_order.push_back(i);
+        }
+        for (size_t oi = 0; oi < proc_order.size(); ++oi) {
+            size_t i = proc_order[oi];
             ASR::symbol_t* proc;
             if (ASR::is_a<ASR::StructMethodDeclaration_t>(*gen_proc->m_procs[i])) {
                 proc = ASR::down_cast<ASR::StructMethodDeclaration_t>(gen_proc->m_procs[i])->m_proc;
@@ -18797,11 +18811,15 @@ public:
             ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(ASRUtils::symbol_get_past_external(proc));
             if ((is_binary && func->n_args != 2) || (!is_binary && func->n_args != 1))
                 continue;
-            bool args_match = ASRUtils::check_equal_type(ASRUtils::expr_type(func->m_args[0]), left_type, func->m_args[0], first_operand);
+            // For non-elemental procedures the actual argument rank must match
+            // the dummy argument rank, so compare dimensions; elemental
+            // procedures broadcast, so dimensions are ignored.
+            bool check_dims = !ASRUtils::get_FunctionType(func)->m_elemental;
+            bool args_match = ASRUtils::check_equal_type(ASRUtils::expr_type(func->m_args[0]), left_type, func->m_args[0], first_operand, check_dims);
             if (is_binary) {
                 args_match = args_match
                              && ASRUtils::check_equal_type(ASRUtils::expr_type(func->m_args[1]),
-                                                           right_type, func->m_args[1], second_operand);
+                                                           right_type, func->m_args[1], second_operand, check_dims);
             }
             if (!args_match)
                 continue;


### PR DESCRIPTION
A defined operator (e.g. `.in.`) overloaded with both an elemental scalar function and a rank-1 array function wrongly selected the elemental one for an array actual argument, broadcasting the result to an array. For example `if (i .in. arr)`, where `.in.` has both `in_scalar(integer, integer)` (elemental) and `in_list(integer, integer(:))`, was rejected with:

  Expected logical expression in if statement, but recieved logical[:]
  instead

The resolution loop in `visit_DefTOp` picked the first procedure whose argument types matched in declaration order and compared types with dimensions ignored, so it neither preferred non-elemental procedures nor respected argument rank.

Resolve defined-operator overloads with the same priority as `ASRUtils::select_generic_procedure`: try non-elemental procedures first (comparing dimensions, so the actual argument rank must match the dummy) and only fall back to elemental procedures (which broadcast over array actuals) when none match.

Add integration test defined_op_match_02, which fails before this change and passes after, covering scalar-in-array, array-section, and scalar-in-scalar resolution.

Fixes #12251.