### PR TITLE
fix: support VOLATILE attribute statement in semantic analyzer

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -489,6 +489,7 @@ RUN(NAME value_attribute_03 LABELS llvm)
 RUN(NAME volatile_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME volatile_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME volatile_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
+RUN(NAME volatile_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 
 
 RUN(NAME cond_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm c fortran)

--- a/integration_tests/volatile_04.f90
+++ b/integration_tests/volatile_04.f90
@@ -1,0 +1,23 @@
+program volatile_04
+    ! VOLATILE attribute statement (F2018 C868), as opposed to the
+    ! inline `type, volatile ::` attribute covered by volatile_01..03
+    implicit none
+    real :: x
+    integer :: n, m
+    volatile :: x
+    volatile :: n, m
+
+    x = 1.0
+    n = 42
+    m = 7
+
+    x = x + 1.0
+    n = n + 1
+    m = m + 1
+
+    if (abs(x - 2.0) > 1e-6) error stop
+    if (n /= 43) error stop
+    if (m /= 8) error stop
+
+    print *, x, n, m
+end program volatile_04

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5422,7 +5422,11 @@ public:
                                 ::AttrSequence) {
                             // TODO: Implement it for CPP backend
                         } else if (sa->m_attr == AST::simple_attributeType
-                                ::AttrAsynchronous) {                        
+                                ::AttrAsynchronous) {
+                        } else if (sa->m_attr == AST::simple_attributeType
+                                ::AttrVolatile) {
+                            // no-op: LFortran does not perform optimizations
+                            // that VOLATILE would need to suppress
                         } else {
                             diag.add(Diagnostic(
                                 "Attribute declaration not supported yet",
@@ -5889,6 +5893,9 @@ public:
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType::AttrAsynchronous) {
                                     // no-op: valid Fortran 2003, LFortran's runtime is synchronous
+                                } else if (sa->m_attr == AST::simple_attributeType::AttrVolatile) {
+                                    // no-op: LFortran does not perform optimizations
+                                    // that VOLATILE would need to suppress
                                 } else {
                                     diag.add(Diagnostic(
                                         "Attribute declaration not supported",


### PR DESCRIPTION
fixes #12267

AttrVolatile was produced by the parser but never consumed in
ast_common_visitor.h, so `volatile :: x` fell through to a generic
"Attribute declaration not supported" error. Handled as a no-op,
mirroring AttrAsynchronous. The inline `type, volatile ::` form
already worked and was already covered by volatile_01..03; the
statement form had no coverage, hence the gap. Adds volatile_04.
