### PR TITLE
feat : add create-mre, fix-mre and repro-issue agent skills

### DIFF
--- a/.agents/skills/create-mre/SKILL.md
+++ b/.agents/skills/create-mre/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: create-mre
+description: >
+  Create a Minimal Reproducible Example (MRE) from a third-party Fortran code
+  failure in LFortran. Use this skill when third-party code fails to build or
+  run with LFortran but works with other Fortran compilers (e.g. GFortran,
+  Flang). Produces standalone .f90 file(s) and a run.sh script that
+  reproduces the bug. Triggers: MRE, minimal reproducible example, reduce,
+  reproduce, reproducer, third-party failure, compilation error, runtime
+  failure, bug reduction.
+---
+
+# Create MRE — Minimal Reproducible Example
+
+Reduce a third-party Fortran code failure into the smallest possible standalone
+example that reproduces the LFortran bug. The MRE must compile and run correctly
+with the reference compiler but fail with LFortran, exhibiting the same error as
+the original third-party code.
+
+## Prerequisites
+
+Before starting, confirm you have:
+
+- A built `lfortran` — `build/src/bin/lfortran` for a standard in-tree build
+  (see `AGENTS.md`). Put it first on `PATH`, or set `$LFORTRAN` to its path.
+- A **reference Fortran compiler** on `PATH`. `gfortran` is the project
+  default — it is what `integration_tests` uses via the `gfortran` label, so
+  prefer it. `flang` works too if that is what you have.
+- Access to the failing third-party code and the exact error message
+
+## Inputs to Gather
+
+Ask the user for (if not already provided):
+
+1. **The third-party project** — name, repo URL, or local path
+2. **The exact error** — full error message or failure description from LFortran
+3. **How to reproduce** — the build command, test command, or steps that trigger
+   the failure
+4. **Failure type** — compilation error, runtime crash, or wrong output
+5. **The file(s) involved** — which source file(s) trigger the error
+
+If the input is a GitHub issue rather than a third-party project, run the
+`repro-issue` skill first — it produces an RE that this skill then reduces.
+
+## Procedure
+
+### Phase 0: Read Project Guidelines
+
+Read `AGENTS.md` in the repository root for build commands and project
+conventions. Follow it, but this SKILL.md takes precedence where they conflict.
+
+### Phase 1: Understand the Failure
+
+1. Reproduce the original failure with LFortran to capture the exact error
+   message and exit code.
+2. Identify the **error category**:
+   - **Compilation error**: parser failure, semantic error, codegen crash
+   - **Runtime failure**: crash, wrong output, hang
+3. Note the specific error text — the MRE must trigger this same error.
+
+### Phase 2: Isolate the Failing Construct
+
+Use a **systematic isolation** approach first:
+
+1. Read the error message carefully. Identify which Fortran construct is
+   implicated (e.g. a specific intrinsic, derived type feature, array
+   operation, module interaction, I/O statement).
+2. Identify the minimal source file(s) that contain this construct.
+3. If the failure involves modules, determine the minimum set of modules
+   needed and their dependency order.
+
+If you are unable to reproduce the error this way, proceed to the next phase.
+
+### Phase 3: Reduce via Binary Search
+
+Apply **binary-search reduction** to shrink the code:
+
+1. Start with the isolated file(s) from Phase 2. If you failed to isolate in
+   Phase 2, start with the whole third-party code.
+2. Remove approximately half of the code that is NOT related to the failing
+   construct (unused subroutines, unrelated variables, comments, etc.).
+3. Test after each removal:
+   - Does the reference compiler still compile/run it successfully?
+   - Does `lfortran` still produce the **same error**?
+4. If the error disappears, undo the last removal and try removing a smaller
+   portion.
+5. Repeat until no further code can be removed without losing the error.
+
+**Guard against false reduction.** A reduction step is only valid if the
+reference compiler still accepts the program. If you reduce until *both*
+compilers fail, you have most likely produced invalid Fortran rather than
+isolated an LFortran bug — back up to the last state where the reference
+compiler succeeded.
+
+### Phase 4: Minimize and Clean Up
+
+1. Remove all unused:
+   - `use` statements and modules
+   - Variables and parameters
+   - Subroutines and functions
+   - Arguments and dummy parameters
+2. Simplify compiler options:
+   - Remove as many lfortran options as possible, while still reproducing the
+     error
+3. Simplify remaining code:
+   - Replace complex expressions with simple literals where possible
+   - Reduce array sizes to the smallest that still triggers the bug
+   - Shorten identifier names for clarity (but keep them meaningful)
+   - Remove all comments, empty lines, etc.
+4. If multiple files are needed (modules), minimize the number of files.
+   Prefer a single file if possible.
+
+### Phase 5: Verify the MRE
+
+Run the final verification:
+
+```bash
+# Must succeed with the reference compiler
+gfortran -o test_ref <mre_file>.f90 && ./test_ref
+echo "reference exit code: $?"
+
+# Must fail with lfortran with the SAME error as the original
+lfortran <mre_file>.f90
+echo "lfortran exit code: $?"
+```
+
+For **runtime failures**, both compilers must compile successfully, but the
+lfortran-compiled binary must produce wrong output or crash:
+
+```bash
+# Both compile
+gfortran -o test_ref <mre_file>.f90
+lfortran <mre_file>.f90 -o test_lfortran
+
+# reference binary works
+./test_ref
+
+# lfortran binary fails
+./test_lfortran
+```
+
+Confirm:
+- [ ] The reference compiler compiles and runs successfully
+- [ ] LFortran fails with the same (or closely related) error as the original
+- [ ] No code can be removed without losing the bug
+- [ ] All MRE files are in the repository root (`./`), not in any subdirectory
+
+### Phase 6: Produce Output Files
+
+**IMPORTANT: All output files MUST be created directly in the repository root
+directory (`./`). Do NOT create a subdirectory (e.g. `mre_dir/`, `mre/`,
+`output/`) for MRE files. Every file — `.f90` files, `run.sh` — goes in `./`.**
+
+These are scratch artifacts, not deliverables. They are ignored via
+`.gitignore` (see the `# repro-issue / create-mre scratch artifacts` block) so
+they never end up in a fix PR. The deliverable is the integration test that
+`fix-mre` adds under `integration_tests/`. Do not `git add -f` the MRE files.
+
+#### 1. The MRE Fortran file(s)
+
+Create the `.f90` file(s) directly in the repository root (`./`).
+Name the file descriptively based on the bug, e.g.:
+- `./mre_derived_type_alloc.f90`
+- `./mre_intrinsic_reshape.f90`
+
+If multiple files are needed (e.g. module dependencies), name them with a
+common prefix and number them in compilation order:
+- `./mre_mod1.f90` (module)
+- `./mre_main.f90` (program)
+
+#### 2. `./run.sh` — Reproduction script
+
+Create an executable bash script **`./run.sh`** in the repository root
+directory (the same directory as `CMakeLists.txt`). Replace any previous
+`./run.sh` if it exists. Do NOT place it inside any subdirectory:
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+# MRE for: <brief description of the bug>
+# Original failure in: <third-party project name>
+# Error type: <compilation error | runtime failure | wrong output>
+#
+# Expected: compiles and runs with the reference compiler
+# Actual:   fails with lfortran — <brief error description>
+
+LFORTRAN="${LFORTRAN:-lfortran}"
+REF="${REF:-gfortran}"
+
+echo "=== Verifying MRE ==="
+
+echo ""
+echo "--- $REF (should succeed) ---"
+$REF -o test_ref <file(s)>
+./test_ref
+echo "reference: OK"
+
+echo ""
+echo "--- lfortran (should fail) ---"
+echo "Expected error: <paste key part of the error message>"
+$LFORTRAN <file(s)> 2>&1 || true
+echo ""
+echo "Done. If lfortran showed the expected error above, the MRE is valid."
+
+# Cleanup
+rm -f test_ref test_lfortran a.out *.mod
+```
+
+Make it executable:
+```bash
+chmod +x run.sh
+```
+
+For **runtime failures**, adjust `run.sh` to compile with both compilers and
+run both binaries, comparing output.
+
+### Phase 7: Summary
+
+Print a summary for the user:
+
+```
+MRE created successfully!
+
+Files (all in repository root ./):
+  <list of .f90 files>
+  ./run.sh
+
+Bug: <one-line description>
+Error type: <compilation | runtime | wrong output>
+Original project: <name>
+
+To reproduce:
+  ./run.sh
+
+The MRE compiles with the reference compiler but fails with lfortran.
+
+Next step: run the `fix-mre` skill to fix the bug and add an integration test.
+```
+
+## Tips
+
+- **Module files**: If lfortran fails during module compilation, the MRE may
+  need separate files compiled in order. Reflect this in `run.sh`.
+- **Compiler flags**: If the bug only manifests with certain flags (e.g.
+  `--fast`), include those flags in `run.sh` and document them.
+- **Multiple errors**: If the third-party code has multiple LFortran failures,
+  create one MRE per distinct bug. Don't combine unrelated issues — `AGENTS.md`
+  requires one bug = one MRE = one PR.
+- **Fixed-form Fortran**: If the original code is fixed-form (`.f` or `.f77`),
+  the MRE can use fixed-form too. Adjust file extensions accordingly.
+- **Large codebases**: For very large projects, start by identifying which
+  translation unit fails, then reduce that single unit first.

--- a/.agents/skills/fix-mre/SKILL.md
+++ b/.agents/skills/fix-mre/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: fix-mre
+description: >
+  Fix an LFortran bug given an MRE (Minimal Reproducible Example) produced by
+  the create-mre skill. Reproduces the bug, diagnoses which compiler phase is
+  at fault, fixes it in the LFortran source, adds an integration test, and
+  runs the integration and reference test suites. Triggers: fix MRE, fix bug,
+  fix lfortran, fix reproducer, implement, resolve, patch, bugfix.
+---
+
+# Fix MRE — Fix an LFortran Bug from a Minimal Reproducible Example
+
+Given an MRE (produced by the `create-mre` skill or written by hand), reproduce
+the LFortran bug, fix it in the compiler source, add an integration test, and
+verify the full suites still pass.
+
+## Prerequisites
+
+- The LFortran repository is the current working directory.
+- A configured build directory. `AGENTS.md` documents the standard dev config:
+  ```bash
+  cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=ON \
+      -DWITH_STACKTRACE=yes
+  ```
+  `./build1.sh` does this for you.
+- `build/src/bin` first on `PATH`, so `lfortran` resolves to the in-tree build
+  you are about to modify. Verify with `which lfortran` before starting —
+  testing against a stale system `lfortran` wastes an entire debug cycle.
+- A **reference Fortran compiler** on `PATH` (`gfortran` preferred; it is what
+  the `gfortran` integration-test label uses).
+
+## Inputs to Gather
+
+Ask the user for (if not already provided):
+
+1. **The MRE** — the `.f90` file(s) and `run.sh` that reproduce the bug. By the
+   `create-mre` convention these are in the repository root.
+
+## Procedure
+
+### Phase 0: Read Project Guidelines
+
+Read `AGENTS.md` in the LFortran repository root to understand project
+conventions, coding style, testing practices, and contribution guidelines.
+Note especially the architecture rules — they determine where a fix belongs:
+
+- Type coercion and casting belong in AST→ASR (semantics). The LLVM/codegen
+  backend must never infer or fix types; it only lowers what ASR gives it.
+  **If codegen appears to need a type workaround, the bug is upstream** — fix
+  it in semantics instead.
+- `libasr` is frontend-independent. Never reference `_lfortran` or other
+  frontend-specific names there.
+- No new C/C++ macros; use `constexpr`, templates, or inline functions.
+
+Follow all instructions therein, but the instructions in this SKILL.md file
+take precedence where they conflict.
+
+### Phase 1: Reproduce the Bug
+
+1. Read `run.sh` to understand the bug.
+2. Run it to confirm the failure:
+   ```bash
+   bash run.sh
+   ```
+3. Note the **exact error message**, **error type** (compilation error, runtime
+   crash, wrong output), and the **Fortran construct** involved.
+
+Do not proceed until you have reproduced the failure locally. A fix for a bug
+you have not observed is a guess.
+
+### Phase 2: Diagnose the Root Cause
+
+1. Analyze the error message to determine which compiler phase is failing:
+   - **Parser** (`src/lfortran/parser/`): syntax errors, tokenizer failures
+   - **Semantics** (`src/lfortran/semantics/`): type errors, symbol resolution
+   - **ASR passes** (`src/libasr/pass/`): transformation errors
+   - **Code generation** (`src/libasr/codegen/`): LLVM IR generation failures
+2. Search the LFortran source for the error message text or error label to find
+   the code that produces it:
+   ```bash
+   grep -rn "error text" src/
+   ```
+3. Inspect the intermediate representations to see where the tree first goes
+   wrong — this is usually faster than reading code:
+   ```bash
+   lfortran --show-ast <mre_file>.f90
+   lfortran --show-asr <mre_file>.f90
+   ```
+4. Understand the code path that leads to the failure. Read surrounding code to
+   understand the intended behavior.
+5. Identify the minimal fix needed. Fix the root cause, not the symptom.
+
+### Phase 3: Implement the Fix
+
+1. Make the code change in the LFortran source. Keep changes minimal and
+   focused on the bug. Match the formatting of the file you are editing;
+   do not reformat surrounding code.
+2. Rebuild:
+   ```bash
+   cmake --build build -j
+   ```
+3. Re-run the MRE to verify the fix:
+   ```bash
+   bash run.sh
+   ```
+4. The MRE should now succeed (compile and/or run correctly) with `lfortran`.
+
+If the fix doesn't work, iterate: re-diagnose, adjust, rebuild, and re-test.
+
+### Phase 4: Add an Integration Test
+
+The integration test — not the MRE — is the deliverable of this skill. The MRE
+files stay untracked; the test is what gets committed.
+
+1. Look at existing integration tests in `integration_tests/` to find similar
+   tests (same Fortran construct, similar naming pattern).
+2. Create a new `.f90` file in `integration_tests/` following the naming
+   convention (e.g. `intrinsic_name_NN.f90`, `derived_type_feature_NN.f90`).
+   Pick the next available number.
+3. The test should be based on the MRE but written as a proper integration test:
+   - Include runtime checks using `if (result /= expected) error stop` idioms.
+   - Keep it minimal but cover the bug scenario.
+4. Register the test in `integration_tests/CMakeLists.txt`:
+   - Find the appropriate section (search for `macro(RUN` and existing
+     `RUN(NAME ...)` entries).
+   - Add a `RUN(NAME <test_name> LABELS gfortran llvm)` style entry.
+   - Use at least the labels `gfortran` and `llvm`. An unregistered test is
+     dead code.
+5. Verify the test compiles with the reference compiler — this confirms the
+   test is valid Fortran and does not depend on LFortran-specific behavior:
+   ```bash
+   gfortran -o /tmp/test_ref integration_tests/<test_name>.f90 && /tmp/test_ref
+   rm -f /tmp/test_ref
+   ```
+6. Verify the test compiles and runs with `lfortran`:
+   ```bash
+   cd integration_tests
+   ./run_tests.py -t <test_name>
+   ```
+
+**Confirm the test actually captures the bug.** `AGENTS.md` requires that every
+fix PR demonstrate the test fails on `main` and passes on the branch. Verify
+this explicitly — `git stash` your source change, rebuild, confirm the new test
+fails, then restore and rebuild. If the test passes without your fix, it does
+not cover the bug and the fix is not understood well enough.
+
+### Phase 5: Run Integration Tests
+
+Run the full integration test suite:
+
+```bash
+cd integration_tests
+./run_tests.py -j16 &> log
+tail -n30 log
+```
+
+**Always redirect test output to a log file and then examine it.** Do not pipe
+to `tail` directly — if you need more output than `tail` shows you have to
+rerun the whole suite, which takes several minutes.
+
+- If all tests pass, proceed to Phase 6.
+- If any test fails:
+  1. Examine the log to identify which test failed and why.
+  2. Determine if the failure is caused by your change (a regression) or a
+     pre-existing issue.
+  3. If your change caused it, fix the regression, rebuild, and re-run tests.
+  4. Repeat until all integration tests pass.
+
+### Phase 6: Run Reference Tests
+
+Return to the LFortran root and run reference tests:
+
+```bash
+cd <lfortran-root>
+./run_tests.py &> log
+```
+
+- If reference tests pass, proceed to Phase 7.
+- If reference tests fail (expected when your fix changes compiler output):
+  1. Update reference results:
+     ```bash
+     ./run_tests.py -u
+     ```
+  2. Review the changes with `git diff` to ensure all reference updates are
+     correct and expected — they should all be consequences of your bug fix,
+     not regressions.
+  3. If any reference change looks wrong, investigate and fix before proceeding.
+
+Never run `-u` blindly. An unreviewed reference update can silently bake a
+regression into the expected output.
+
+### Phase 7: Report
+
+Summarize the work and let the user decide whether to commit. Do not commit or
+push without being asked — `AGENTS.md` requires PRs to go to a fork, never
+upstream, and the user may want to review the diff first.
+
+Before staging anything, confirm the MRE scratch files (`mre_*.f90`,
+`re_*.f90`, `run.sh`, `run_re.sh`) are not included — they are ignored by
+`.gitignore` and are not part of the fix.
+
+Print a summary:
+
+```
+Bug fixed!
+
+Fix: <one-line description of what was changed>
+Files modified:
+  <list of changed source files>
+Integration test: integration_tests/<test_name>.f90
+  fails on main, passes on this branch — verified
+
+Integration tests: pass
+Reference tests:   pass  (<N> reference outputs updated, reviewed)
+
+Not committed. Review the diff, then commit when ready.
+```
+
+If the user asks you to commit, follow the `AGENTS.md` commit conventions:
+small single-topic commits, imperative mood, one bug = one MRE = one PR, and
+never mix refactoring or formatting with a bug fix.
+
+## Tips
+
+- **Multiple errors**: The MRE may expose more than one bug. First fix the bug
+  that the MRE demonstrates. If you discover additional issues that block
+  compiling and running the newly added test, fix them as well — but keep
+  unrelated fixes to separate PRs.
+- **ASR passes**: Many bugs live in ASR passes (`src/libasr/pass/`). These
+  transform the ASR tree and are a common source of codegen failures.
+- **Semantic errors**: If the bug is "not yet implemented", the fix likely
+  involves adding a new case in the semantics or codegen visitor.
+- **Error message style**: Per `AGENTS.md`, messages are lowercase, show
+  explicit kinds (e.g. `integer(4)` vs `integer(8)`), and never expose
+  internal ASR node names to users.
+- **Modfile issues**: If you see "Incompatible format: LFortran Modfile...",
+  the module files are stale — rebuild from scratch (`ninja -C build clean &&
+  cmake --build build -j`) and ensure `build/src/bin` is first on `PATH`.
+- **Rebuild quickly**: `cmake --build build -j` only recompiles changed files.
+  Use it frequently during iteration.
+- **Test naming**: Look at nearby tests in `CMakeLists.txt` for naming
+  conventions. Usually it's `<feature>_<number>`.

--- a/.agents/skills/repro-issue/SKILL.md
+++ b/.agents/skills/repro-issue/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: repro-issue
+description: >
+  Create a Reproducible Example (RE) from a GitHub issue filed against
+  lfortran/lfortran. Fetches the issue, extracts the Fortran code as-posted,
+  minimally extends it if necessary so it can be compiled and run, and produces
+  a standalone .f90 file (or files) plus a run_re.sh script that reproduces
+  the bug with `lfortran` and shows that the same program compiles/runs with
+  a reference compiler. The output is intentionally as close to the issue's
+  original code as possible — reduction/minimization is the job of the
+  create-mre skill, which consumes this skill's output. Triggers: repro issue,
+  reproduce issue, RE, reproducible example, github issue, lfortran issue,
+  issue reproducer.
+---
+
+# Repro Issue — Reproducible Example from a GitHub Issue
+
+Turn a GitHub issue filed at `lfortran/lfortran` into a local **Reproducible
+Example (RE)**. The RE is a standalone Fortran program that:
+
+1. Uses the code from the issue **as closely as possible** — ideally
+   byte-for-byte identical — with only the smallest additions needed to make it
+   compile/run.
+2. **Fails** when compiled/run with `lfortran` (matching the error reported in
+   the issue).
+3. **Succeeds** when compiled/run with the reference compiler (confirming the
+   issue is an LFortran bug, not invalid Fortran).
+
+An RE is **not** a minimized MRE. Do not shrink, rename, or rewrite the issue's
+code. The downstream `create-mre` skill will consume this RE and reduce it.
+The downstream `fix-mre` skill will then fix the bug using the MRE.
+
+Pipeline: **repro-issue → create-mre → fix-mre**
+
+## Prerequisites
+
+Before starting, confirm you have:
+
+- A built `lfortran` — `build/src/bin/lfortran` for a standard in-tree build
+  (see `AGENTS.md`). Put it first on `PATH`, or set `$LFORTRAN` to its path.
+- A **reference Fortran compiler** on `PATH`. `gfortran` is the project
+  default — it is what `integration_tests` uses via the `gfortran` label, so
+  prefer it. `flang` works too if that is what you have.
+- `gh` CLI available on `PATH` and authenticated (`gh auth status`)
+- Working directory is the lfortran repository root (same dir as
+  `CMakeLists.txt`) — output files go here
+
+## Inputs to Gather
+
+Ask the user for (if not already provided):
+
+1. **The issue** — a GitHub issue number (e.g. `1234`) or URL
+   (e.g. `https://github.com/lfortran/lfortran/issues/1234`). Default repo
+   is `lfortran/lfortran`.
+
+## Procedure
+
+### Phase 0: Read Project Guidelines
+
+Read `AGENTS.md` in the repository root. It is the single point of reference
+for build commands, test layout, and contribution rules. Follow it, but the
+instructions in this SKILL.md take precedence where they conflict.
+
+### Phase 1: Fetch the Issue
+
+Use the `gh` CLI to fetch the issue body and title:
+
+```bash
+gh issue view <N> --repo lfortran/lfortran --json number,title,body,labels,url
+```
+
+Also fetch comments if the body alone is insufficient:
+
+```bash
+gh issue view <N> --repo lfortran/lfortran --comments
+```
+
+Extract:
+
+- **Title** (used in the RE header comment)
+- **URL** (used in the RE header comment)
+- **Fortran code blocks** from the body (and comments, if body is incomplete)
+- **Reported error / expected vs actual behavior**
+- **Any reproduction command** the reporter used (e.g. specific `lfortran`
+  flags). Record these verbatim — they must be preserved in `run_re.sh`.
+
+### Phase 2: Extract the Code As-Posted
+
+1. Copy the Fortran code out of the issue **verbatim**. Do not:
+   - Rename identifiers
+   - Reformat, reindent, or reflow the code
+   - Remove comments or unused declarations
+   - "Fix" anything in the user's code
+2. If the issue contains multiple code blocks (e.g. a module plus a program),
+   preserve each as its own file when they are clearly separate compilation
+   units. Otherwise concatenate in the order they appear.
+3. If the issue links to a gist, pastebin, or external repo file, fetch that
+   content and treat it as the code block.
+
+### Phase 3: Minimal Extension (Only If Required)
+
+The goal is that the RE compiles/runs end-to-end. If — and only if — the code
+as-posted cannot compile or run on its own, add the **smallest possible**
+wrapper around it. Permitted additions, in order of preference:
+
+1. Wrap free-standing statements in `program repro ... end program` if no
+   program unit is present.
+2. Add `implicit none` only if the original code already relies on it
+   implicitly; otherwise leave implicit typing as the user wrote it.
+3. Add `use <module>` lines only if the issue clearly depends on them.
+4. Provide trivially obvious sample inputs (e.g. initialize an integer used
+   uninitialized) only when needed to reach the failing construct.
+
+Every addition you make must be marked with a comment:
+
+```fortran
+! [RE-ADDED] wrapper program so the snippet can be compiled standalone
+```
+
+If the issue cannot be reasonably reproduced without substantial invention
+(e.g. it depends on a third-party library, or the code is a tiny fragment
+with no clear surrounding context), **stop and report this to the user**
+rather than guessing.
+
+### Phase 4: Verify the RE
+
+Run both compilers and confirm the RE fails with LFortran and passes with the
+reference compiler.
+
+For a **compilation error** reported in the issue:
+
+```bash
+# Must succeed with the reference compiler
+gfortran -o test_ref <re_file>.f90 && ./test_ref
+echo "reference exit code: $?"
+
+# Must fail with lfortran — ideally with the same error message as the issue
+lfortran <re_file>.f90
+echo "lfortran exit code: $?"
+```
+
+For a **runtime failure** reported in the issue:
+
+```bash
+gfortran -o test_ref <re_file>.f90
+lfortran <re_file>.f90 -o test_lfortran
+
+./test_ref         # must succeed / produce expected output
+./test_lfortran    # must crash or produce wrong output
+```
+
+Confirm:
+
+- [ ] The reference compiler compiles and runs successfully
+- [ ] LFortran fails with (or very close to) the error reported in the issue
+- [ ] The code in the RE file(s) matches the issue's code as closely as possible
+- [ ] Any additions are clearly marked with `! [RE-ADDED]` comments
+- [ ] All RE files live in the repository root (`./`), not in any subdirectory
+
+If lfortran's error does **not** match the issue's error, investigate:
+
+- Is the compiler rebuilt on the relevant branch?
+- Are you missing a flag the reporter used?
+- Did the bug get fixed already (close the loop with the user before continuing)?
+
+### Phase 5: Produce Output Files
+
+**IMPORTANT: All output files MUST be created directly in the repository root
+directory (`./`). Do NOT create a subdirectory. Every file — `.f90` files,
+`run_re.sh` — goes in `./`.** This is the same convention `create-mre` uses,
+so the next stage in the pipeline can pick them up without any path wiring.
+
+These are scratch artifacts, not deliverables. They are ignored via
+`.gitignore` (see the `# repro-issue / create-mre scratch artifacts` block) so
+they never end up in a fix PR. Do not `git add -f` them.
+
+#### 1. The RE Fortran file(s)
+
+Name files with an `re_` prefix and a short descriptor derived from the issue
+(include the issue number to keep things traceable), for example:
+
+- `./re_issue_1234.f90`
+- `./re_issue_1234_mod.f90` + `./re_issue_1234_main.f90` (if multiple units)
+
+#### 2. `./run_re.sh` — Reproduction script
+
+Create an executable bash script **`./run_re.sh`** in the repository root
+directory. Replace any previous `./run_re.sh` if it exists. Do NOT place it
+inside any subdirectory. Template:
+
+```bash
+#!/usr/bin/env bash
+set -e
+
+# RE for: <issue title>
+# Issue:  <issue URL>
+# Error type: <compilation error | runtime failure | wrong output>
+#
+# Expected: compiles and runs with the reference compiler
+# Actual:   fails with lfortran — <brief error description from the issue>
+
+LFORTRAN="${LFORTRAN:-lfortran}"
+REF="${REF:-gfortran}"
+
+echo "=== Verifying RE for issue <N> ==="
+
+echo ""
+echo "--- $REF (should succeed) ---"
+$REF -o test_ref <file(s)>
+./test_ref
+echo "reference: OK"
+
+echo ""
+echo "--- lfortran (should fail) ---"
+echo "Expected error: <paste key part of the error message from the issue>"
+$LFORTRAN <lfortran-flags-from-issue> <file(s)> 2>&1 || true
+echo ""
+echo "Done. If lfortran showed the expected error above, the RE is valid."
+
+# Cleanup
+rm -f test_ref test_lfortran a.out *.mod
+```
+
+Make it executable:
+
+```bash
+chmod +x run_re.sh
+```
+
+For **runtime failures**, adjust `run_re.sh` to compile with both compilers
+and run both binaries, comparing output.
+
+Preserve any `lfortran` flags mentioned in the issue verbatim (e.g.
+`--fast`, `--realloc-lhs`, backend selection). The RE must reproduce under
+the exact invocation the reporter used.
+
+### Phase 6: Summary
+
+Print a summary for the user:
+
+```
+RE created successfully!
+
+Files (all in repository root ./):
+  <list of re_*.f90 files>
+  ./run_re.sh
+
+Issue:      #<N> — <title>
+URL:        <issue URL>
+Error type: <compilation | runtime | wrong output>
+
+To reproduce:
+  ./run_re.sh
+
+The RE compiles with the reference compiler but fails with lfortran,
+matching the issue.
+
+Next step: run the `create-mre` skill on this RE to reduce it to a minimal
+reproducible example, then `fix-mre` to fix the bug.
+```
+
+## Tips
+
+- **Stay faithful to the issue**: the whole point of the RE stage is that it
+  mirrors the reported code. Any reduction, renaming, or simplification belongs
+  in `create-mre`, not here.
+- **Multiple code blocks**: if the issue shows both a module and a program,
+  keep them as separate files; this mirrors how a real project is structured
+  and is friendlier to `create-mre`.
+- **Compiler flags**: some bugs only manifest with specific `lfortran` flags
+  (`--fast`, `--realloc-lhs`, `--openmp`, backend flags). Extract these from
+  the issue text/code fences and bake them into `run_re.sh`.
+- **Fixed-form Fortran**: if the issue uses fixed-form (`.f`/`.f77`), keep
+  that format and extension in the RE.
+- **Reporter's own reduction**: if the issue already contains a minimal
+  snippet (common for well-written issues), your RE may be identical to the
+  MRE. That's fine — the `create-mre` stage will be a no-op or near no-op.
+- **Unreproducible issues**: if you cannot reproduce the failure locally,
+  stop and report back with diagnostics (compiler version, flags tried,
+  actual vs reported error). Do not fabricate a reproduction.
+- **Multiple bugs in one issue**: if an issue mentions several distinct
+  failures, create one RE per distinct failure (e.g. `re_issue_1234_a.f90`,
+  `re_issue_1234_b.f90`) and one `run_re.sh` that exercises each in turn,
+  clearly separated.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,16 @@ build.ninja
 doc/man/lfortran.1
 !doc/src/javascripts/*.js
 !pass_array_by_data_*.f90
+
+## repro-issue / create-mre scratch artifacts
+## Reproducers live in the repo root by convention (see .agents/skills/).
+## They are throwaway inputs to fix-mre; the deliverable is the integration
+## test it adds under integration_tests/.
+/run.sh
+/run_re.sh
+/mre_*.f90
+/re_*.f90
+/test_ref
+/test_lfortran
+/test_gfortran
+/test_flang

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,50 @@ detailed reference how to contribute to the project.
 - `tests/`, `integration_tests/`: unit/E2E suites
 - `doc/`: docs & manpages (site generated from here)
 - `examples/`, `grammar/`, `cmake/`, `ci/`, `share/`: supporting assets
+- `.agents/skills/`: agent skills (see "Agent Skills" below)
+
+## Agent Skills
+
+Reusable, agent-invocable procedures live in `.agents/skills/<name>/SKILL.md`,
+following the [Agent Skills](https://agentskills.io/) open standard. Agents load
+a skill on demand when the task matches its `description`.
+
+`.agents/skills/` is the vendor-neutral location read by Codex, Copilot, and
+Grok. Claude Code only discovers `.claude/skills/`, so `.claude/skills` is a
+symlink to `../.agents/skills` — the same approach as the `CLAUDE.md` →
+`AGENTS.md` symlink. **Skills are stored once, in `.agents/skills/`;** edit them
+there and every agent picks up the change.
+
+Available skills:
+
+| Skill | Purpose |
+| --- | --- |
+| `repro-issue` | Turn a GitHub issue into a faithful Reproducible Example (RE) |
+| `create-mre` | Reduce an RE or third-party failure to a Minimal Reproducible Example (MRE) |
+| `fix-mre` | Fix the compiler bug behind an MRE and add an integration test |
+
+### The reproduce → reduce → fix loop
+
+The three skills chain into a pipeline, each consuming the previous one's output:
+
+```
+repro-issue  ──►  create-mre  ──►  fix-mre
+ (RE: faithful)    (MRE: minimal)   (fix + integration test)
+```
+
+This is designed to be run **in a loop** to bring a third-party Fortran package
+up on LFortran: build the package, take the first failure, reduce it, fix it,
+then rebuild and repeat until the package compiles and its tests pass. Each
+iteration should produce one focused PR — `AGENTS.md`'s "one bug = one MRE =
+one PR" rule applies to every pass through the loop.
+
+Reproducers are written to the repository root by convention (`run.sh`,
+`mre_*.f90`, `re_*.f90`) and are gitignored — they are scratch inputs to
+`fix-mre`. The committed deliverable is always the integration test.
+
+Skills assume `build/src/bin` is first on `PATH` (so `lfortran` is the in-tree
+build) and that a reference compiler — `gfortran`, matching the `gfortran`
+integration-test label — is available for differential testing.
 
 ## Prerequisites
 - Tools: CMake (>=3.10), Ninja, Git, Python (>=3.8), GCC/Clang/MSVC.

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -5,10 +5,12 @@ import subprocess
 # If the file is binary it'd conflict with
 # text mode 'r', leading to raised error `UnicodeDecodeError`.
 def is_file_binary(file_path: str) -> bool:
-    # Only regular files can be binary. Skip symbolic links: opening a
-    # symlink that points to a directory raises `IsADirectoryError`, and
-    # the link itself stores only a path, never binary content.
-    if os.path.islink(file_path) or not os.path.isfile(file_path):
+    # A symbolic link stores a path, not content, so it is never binary.
+    # Skip it: opening a link that points to a directory raises
+    # `IsADirectoryError`, which is not caught below and aborts the check.
+    # A link pointing to a binary is still caught through the target itself,
+    # which git tracks and scans as its own entry.
+    if os.path.islink(file_path):
         return False
     try:
         with open(file_path, 'r') as fp:

--- a/check_binary_file_in_git_history.py
+++ b/check_binary_file_in_git_history.py
@@ -1,9 +1,15 @@
+import os
 import subprocess
 
 # Open file_path, Read it with mode 'r' which expects a utf-8 encode.
 # If the file is binary it'd conflict with
 # text mode 'r', leading to raised error `UnicodeDecodeError`.
 def is_file_binary(file_path: str) -> bool:
+    # Only regular files can be binary. Skip symbolic links: opening a
+    # symlink that points to a directory raises `IsADirectoryError`, and
+    # the link itself stores only a path, never binary content.
+    if os.path.islink(file_path) or not os.path.isfile(file_path):
+        return False
     try:
         with open(file_path, 'r') as fp:
             fp.read(16)


### PR DESCRIPTION
Add three agent skills, adapted from certik/ai_skills, that automate the reproduce -> reduce -> fix loop for LFortran bugs:

  repro-issue  turn a GitHub issue into a faithful Reproducible Example
  create-mre   reduce an MRE or third-party failure to a minimal MRE
  fix-mre      fix the compiler bug and add an integration test

The skills chain into a pipeline that can be run in a loop to bring a third-party Fortran package up on LFortran: build, take the first failure, reduce it, fix it, rebuild, repeat.

Skills live in .agents/skills/, the vendor-neutral location read by Codex, Copilot and Grok. Claude Code only discovers .claude/skills/, so .claude/skills is a symlink to ../.agents/skills, mirroring the existing CLAUDE.md -> AGENTS.md symlink. The skills are stored once and every agent picks up edits.

Adapted from the originals for this repository:

- Replaced hardcoded personal conda/pixi paths with the build and test commands AGENTS.md documents.
- Made the reference compiler configurable and defaulted it to gfortran, matching the gfortran integration-test label. Fixed an undefined $GFORTRAN reference in the create-mre run.sh template.
- fix-mre now reports instead of committing, and verifies the new test fails on main and passes on the branch, per the AGENTS.md requirement.
- Pointed diagnosis at the AGENTS.md architecture rules, notably that a type workaround needed in codegen means the bug is upstream in semantics.

Reproducers are written to the repo root by convention and are gitignored; the committed deliverable is always the integration test.