### PR TITLE
Fix BIND(C) VALUE argument passed an array element

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2006,6 +2006,7 @@ RUN(NAME bindc_51 LABELS gfortran llvm)
 RUN(NAME bindc_52 LABELS gfortran llvm)
 # Extension: BIND(C) character(len>1); GFortran rejects, so llvm only
 RUN(NAME bindc_53 LABELS llvm)
+RUN(NAME bindc_54 LABELS gfortran llvm)
 RUN(NAME bindc_iso_fb_01 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_01c.c)
 RUN(NAME bindc_iso_fb_02 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_02c.c)
 RUN(NAME bindc_iso_fb_03 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_03c.c)

--- a/integration_tests/bindc_54.f90
+++ b/integration_tests/bindc_54.f90
@@ -1,0 +1,60 @@
+! Passing an array element to a VALUE dummy of a BIND(C) procedure.
+! Regression test: LFortran used to compute the element address and emit an
+! invalid `bitcast i32* to i32` instead of loading the scalar value, so the
+! generated module failed LLVM verification.
+module bindc_54_mod
+  use iso_c_binding, only: c_int, c_double
+  implicit none
+  integer(c_int) :: last_int = 0
+  real(c_double) :: last_dbl = 0.0d0
+contains
+  subroutine take_int(x) bind(c)
+    integer(c_int), value :: x
+    last_int = x
+  end subroutine take_int
+
+  subroutine take_int_in(x) bind(c)
+    integer(c_int), value, intent(in) :: x
+    last_int = x
+  end subroutine take_int_in
+
+  subroutine take_dbl(y) bind(c)
+    real(c_double), value :: y
+    last_dbl = y
+  end subroutine take_dbl
+end module bindc_54_mod
+
+program bindc_54
+  use bindc_54_mod
+  use iso_c_binding, only: c_int, c_double
+  implicit none
+  integer(c_int) :: a(3)
+  real(c_double) :: b(2)
+
+  a = [11, 22, 33]
+  b = [1.5d0, 2.5d0]
+
+  ! array element to a VALUE dummy (the original failing construct)
+  call take_int(a(1))
+  if (last_int /= 11) error stop
+
+  call take_int(a(2))
+  if (last_int /= 22) error stop
+
+  ! array element with VALUE, INTENT(IN)
+  call take_int_in(a(3))
+  if (last_int /= 33) error stop
+
+  ! expression involving an array element
+  call take_int(a(2) + a(3))
+  if (last_int /= 55) error stop
+
+  ! real array element to a VALUE dummy
+  call take_dbl(b(1))
+  if (abs(last_dbl - 1.5d0) > 1.0d-12) error stop
+
+  call take_dbl(b(2))
+  if (abs(last_dbl - 2.5d0) > 1.0d-12) error stop
+
+  print *, "ok"
+end program bindc_54

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -24536,6 +24536,13 @@ public:
                             llvm::AllocaInst *target = get_call_arg_alloca(tmp->getType());
                             builder->CreateStore(tmp, target);
                             tmp = target;
+                        } else if (tmp->getType()->isPointerTy() && !expected_type->isPointerTy()) {
+                            // A pointer (e.g. the address of an array element or a
+                            // struct member) is being passed to a by-value bind(C)
+                            // parameter. Load the scalar the pointer refers to
+                            // instead of emitting an invalid pointer-to-scalar
+                            // bitcast.
+                            tmp = llvm_utils->CreateLoad2(expected_type, tmp);
                         } else {
                             tmp = builder->CreateBitCast(tmp, expected_type);
                         }


### PR DESCRIPTION
## Summary
Pass BIND(C) VALUE arguments that are array elements correctly (load the element value instead of passing a pointer/descriptor incorrectly).

## Scope
- LLVM codegen for BIND(C) VALUE + array element actual
- Integration test `bindc_54`

## Verification
- `bindc_54` (gfortran, llvm)

## Rationale
Split from the netcdf2 work branch into a focused PR.