### PR TITLE
Fix EXTERNAL procedures: multi-name, arg checks, private modules, leaks

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2195,6 +2195,8 @@ RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_45 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_46 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
     EXTRAFILES implicit_interface_46b.f90 GFORTRAN_ARGS -fallow-argument-mismatch)
+RUN(NAME implicit_interface_47 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES implicit_interface_47b.f90)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2192,6 +2192,7 @@ RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
     EXTRAFILES implicit_interface_44b.f90 GFORTRAN_ARGS -fallow-argument-mismatch)
+RUN(NAME implicit_interface_45 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3479,6 +3479,7 @@ RUN(NAME external_13 LABELS gfortran llvm EXTRA_ARGS --implicit-interface --mang
 RUN(NAME external_14 LABELS gfortran llvm EXTRAFILES external_14_module.f90)
 RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
+RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3488,6 +3488,7 @@ RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_18 LABELS gfortran llvm EXTRAFILES external_18_module.f90 EXTRA_ARGS --implicit-interface)
+RUN(NAME external_19 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3487,6 +3487,7 @@ RUN(NAME external_14 LABELS gfortran llvm EXTRAFILES external_14_module.f90)
 RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_18 LABELS gfortran llvm EXTRAFILES external_18_module.f90 EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2190,6 +2190,8 @@ RUN(NAME implicit_interface_40 LABELS gfortran llvm EXTRA_ARGS --implicit-typing
 RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES implicit_interface_44b.f90 GFORTRAN_ARGS -fallow-argument-mismatch)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2193,6 +2193,8 @@ RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
     EXTRAFILES implicit_interface_44b.f90 GFORTRAN_ARGS -fallow-argument-mismatch)
 RUN(NAME implicit_interface_45 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_46 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES implicit_interface_46b.f90 GFORTRAN_ARGS -fallow-argument-mismatch)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/external_17.f90
+++ b/integration_tests/external_17.f90
@@ -1,0 +1,42 @@
+! Regression test: an EXTERNAL function declared before another EXTERNAL
+! function in a module specification part must keep its own implicit
+! interface. Previously only the last-declared EXTERNAL survived, so calling
+! any earlier one (here `cf`) wrongly reported
+! "More actual than formal arguments in procedure call".
+! Reduced from netcdf-fortran (fortran/netcdf4.F90).
+
+function cf(k)
+  integer :: k
+  character(len=1) :: cf
+  cf = char(iachar('a') + k)
+end function cf
+
+integer function nf(k)
+  integer :: k
+  nf = k + 1
+end function nf
+
+module external_17_mod
+  implicit none
+  character(len=1), external :: cf
+  integer, external :: nf
+contains
+  function cs(k) result(res)
+    integer :: k
+    character(len=1) :: res
+    res = cf(k)
+  end function cs
+
+  integer function ni(k)
+    integer :: k
+    ni = nf(k)
+  end function ni
+end module external_17_mod
+
+program external_17
+  use external_17_mod, only: cs, ni
+  implicit none
+  if (cs(2) /= 'c') error stop
+  if (ni(4) /= 5) error stop
+  print *, cs(2), ni(4)
+end program external_17

--- a/integration_tests/external_18.f90
+++ b/integration_tests/external_18.f90
@@ -1,0 +1,14 @@
+program external_18
+    use external_18_mod
+    implicit none
+    ! Re-declare the (private, hence not use-associated) external function.
+    ! In the original netcdf-fortran failure this declaration came from an
+    ! F77 `include` file; an inline re-declaration exercises the identical
+    ! semantic code path (a bogus "already declared in the same scope" error).
+    character(len=80), external :: get_libvers
+    character(len=80) :: v
+    if (nc_flag /= 42) error stop "public use-associated constant is wrong"
+    v = get_libvers()
+    print *, trim(v)
+    if (trim(v) /= "netcdf-fortran 1.2.3") error stop "wrong version string"
+end program external_18

--- a/integration_tests/external_18_module.f90
+++ b/integration_tests/external_18_module.f90
@@ -1,0 +1,15 @@
+module external_18_mod
+    implicit none
+    private
+    integer, parameter, public :: nc_flag = 42
+    ! A PRIVATE, use-associated external function (mirrors netcdf's
+    ! `nf_inq_libvers`). Because it is private, `use external_18_mod` must
+    ! NOT import this name, so a re-declaration in the caller is legal.
+    character(len=80), external :: get_libvers
+end module external_18_mod
+
+function get_libvers() result(v)
+    implicit none
+    character(len=80) :: v
+    v = "netcdf-fortran 1.2.3"
+end function get_libvers

--- a/integration_tests/external_19.f90
+++ b/integration_tests/external_19.f90
@@ -1,0 +1,37 @@
+! Regression test: a bare `external` procedure declared inside a FUNCTION
+! program unit must not leak into a sibling program unit processed afterwards.
+! The external-procedure bookkeeping done while visiting a FUNCTION was never
+! saved/restored (unlike a SUBROUTINE), so the name `get_msg` stayed marked as
+! external when the following `check` subroutine was analysed. That dropped its
+! explicit `character(len=80)` declaration, wrongly typing `get_msg` as `real`
+! and producing a type mismatch / invalid code.
+! Reduced from netcdf-fortran (nf_test/test_put.F).
+
+double precision function hash_double()
+    implicit none
+    external get_msg
+    hash_double = 0
+end function
+
+subroutine check(err, out)
+    implicit none
+    integer, intent(in) :: err
+    character(len=80), intent(out) :: out
+    character(len=80) :: get_msg
+    external get_msg
+    out = get_msg(err)
+end subroutine
+
+character(len=80) function get_msg(err)
+    implicit none
+    integer :: err
+    get_msg = 'message for error code'
+end function
+
+program external_19
+    implicit none
+    character(len=80) :: out
+    call check(1, out)
+    if (out /= 'message for error code') error stop
+    print *, trim(out)
+end program

--- a/integration_tests/implicit_interface_44.f90
+++ b/integration_tests/implicit_interface_44.f90
@@ -1,0 +1,23 @@
+! Calling an implicit-interface external procedure with different argument
+! types at different call sites must be accepted. This mirrors netcdf-fortran's
+! v2 API `ncagt`, which is called first with a byte (integer(1)) array and then
+! with a short (integer(2)) array. Standard Fortran performs no argument
+! checking for implicit-interface externals, so the second call must not be
+! rejected as a type mismatch (LFortran previously inferred the dummy type from
+! the first call and wrongly rejected the second).
+program implicit_interface_44
+    implicit none
+    integer(1) :: bytval(3)
+    integer(2) :: shval(3)
+
+    bytval = 0_1
+    shval = 0_2
+
+    ! First reference infers the (byte) interface for `store_first`.
+    call store_first(bytval)
+    ! Second reference passes a different type to the same external.
+    call store_first(shval)
+
+    if (bytval(1) /= 7) error stop
+    print *, "ok"
+end program

--- a/integration_tests/implicit_interface_44b.f90
+++ b/integration_tests/implicit_interface_44b.f90
@@ -1,0 +1,5 @@
+subroutine store_first(buf)
+    implicit none
+    integer(1), intent(inout) :: buf(*)
+    buf(1) = 7_1
+end subroutine

--- a/integration_tests/implicit_interface_45.f90
+++ b/integration_tests/implicit_interface_45.f90
@@ -1,0 +1,30 @@
+! A typed external function (implicit interface) called from a program that
+! also has a CONTAINS section with an internal procedure must still be treated
+! as having the arguments passed at the call site. LFortran previously wiped
+! the host scope's list of external procedures while processing the contained
+! subroutine, so the later call `nf_create(ncid)` was wrongly rejected with
+! "More actual than formal arguments in procedure call". This mirrors
+! netcdf-fortran's ftst_path.F, where nf_* externals are declared via
+! netcdf.inc in a program that also CONTAINS a `check` subroutine.
+program implicit_interface_45
+  implicit none
+  integer :: nf_create
+  external :: nf_create
+  integer :: ncid, ierr
+  ncid = 41
+  ierr = nf_create(ncid)
+  call check(ierr)
+  if (ierr /= 42) error stop
+  print *, "ierr =", ierr
+contains
+  subroutine check(errcode)
+    integer, intent(in) :: errcode
+    if (errcode /= 42) error stop
+  end subroutine check
+end program implicit_interface_45
+
+integer function nf_create(x)
+  implicit none
+  integer, intent(in) :: x
+  nf_create = x + 1
+end function nf_create

--- a/integration_tests/implicit_interface_46.f90
+++ b/integration_tests/implicit_interface_46.f90
@@ -1,0 +1,24 @@
+! A module declares an external procedure with an implicit interface (no
+! argument information) and that module is use-associated inside a CONTAINS'd
+! subroutine of a program that ALSO calls the same external by name with actual
+! arguments. Both the module's zero-argument view and the program's call site
+! refer to the same link-time symbol (nf_create) and are emitted with C
+! linkage. LFortran previously let the module's zero-argument declaration win,
+! so the host call `nf_create(1, 2, 3)` was lowered against
+! `declare i32 @nf_create()` and the LLVM verifier rejected the module with
+! "Incorrect number of arguments passed to called function!". This mirrors
+! netcdf-fortran's ftst_path.F, where nf_* externals are declared via
+! netcdf.inc in a program that also CONTAINS a `check` subroutine doing
+! `use netcdf`.
+program implicit_interface_46
+  implicit none
+  integer, external :: nf_create
+  integer :: r
+  r = nf_create(1, 2, 3)
+  print *, r
+  if (r /= 6) error stop
+contains
+  subroutine check()
+    use implicit_interface_46_mod
+  end subroutine check
+end program implicit_interface_46

--- a/integration_tests/implicit_interface_46b.f90
+++ b/integration_tests/implicit_interface_46b.f90
@@ -1,0 +1,8 @@
+module implicit_interface_46_mod
+  integer, external :: nf_create
+end module implicit_interface_46_mod
+
+integer function nf_create(a, b, c)
+  integer :: a, b, c
+  nf_create = a + b + c
+end function nf_create

--- a/integration_tests/implicit_interface_47.f90
+++ b/integration_tests/implicit_interface_47.f90
@@ -1,0 +1,22 @@
+! A module declares a procedure `external` with an implicit interface (no
+! argument information). When that module is compiled to a .mod file and
+! use-associated in a separate program that calls the procedure with actual
+! arguments, LFortran previously rejected the call with "More actual than
+! formal arguments in procedure call": the external, read back from the .mod
+! file, was recorded with zero formal arguments and its implicit-interface
+! nature was lost. Standard Fortran performs no argument checking for
+! implicit-interface externals, so the call is valid (flang and gfortran accept
+! it). This mirrors netcdf-fortran's module_netcdf4_nf_interfaces.F90, which
+! declares `Integer, External :: nf_def_var_fill`, called from
+! nf_test4/f03tst_open_mem.F.
+program implicit_interface_47
+  use implicit_interface_47_mod
+  implicit none
+  integer :: ncid, varid(3), no_fill, retval
+  ncid = 1
+  varid(2) = 2
+  no_fill = 1
+  retval = nf_def_var_fill(ncid, varid(2), no_fill, 88)
+  print *, "retval =", retval
+  if (retval /= 92) error stop
+end program implicit_interface_47

--- a/integration_tests/implicit_interface_47b.f90
+++ b/integration_tests/implicit_interface_47b.f90
@@ -1,0 +1,8 @@
+module implicit_interface_47_mod
+  integer, external :: nf_def_var_fill
+end module implicit_interface_47_mod
+
+integer function nf_def_var_fill(ncid, varid, no_fill, fill_value) result(status)
+  integer, intent(in) :: ncid, varid, no_fill, fill_value
+  status = ncid + varid + no_fill + fill_value
+end function nf_def_var_fill

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8483,6 +8483,16 @@ public:
                                 skip_check = true;
                             }
                         }
+                        // For an implicit-interface external procedure the
+                        // dummy-argument types were inferred from the first
+                        // call site and are not a real interface. Standard
+                        // Fortran performs no argument checking for such
+                        // procedures, so do not reject a later call that passes
+                        // a different type (e.g. netcdf's v2-API `ncagt` called
+                        // first with a byte array and then with a short array).
+                        if (is_implicit_interface_function((ASR::symbol_t*)f)) {
+                            skip_check = true;
+                        }
                         // Check if types are equal
                         if (!skip_check && !ASRUtils::check_equal_type(passed_type, param_type, passed_arg, f->m_args[i+offset])) {
                             std::string passed_type_str = ASRUtils::type_to_str_with_kind(passed_type, nullptr);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8490,7 +8490,7 @@ public:
                         // procedures, so do not reject a later call that passes
                         // a different type (e.g. netcdf's v2-API `ncagt` called
                         // first with a byte array and then with a short array).
-                        if (is_implicit_interface_function((ASR::symbol_t*)f)) {
+                        if (is_implicit_interface_function(&f->base)) {
                             skip_check = true;
                         }
                         // Check if types are equal

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5027,21 +5027,26 @@ public:
     }
 
     bool check_is_external(std::string sym, SymbolTable* scope = nullptr) {
-        if (scope) {
-            external_procedures = external_procedures_mapping[get_hash(scope->asr_owner)];
-        } else if (current_scope->asr_owner) {
-            external_procedures = external_procedures_mapping[get_hash(current_scope->asr_owner)];
-        }
-        if (std::find(external_procedures.begin(), external_procedures.end(), sym) != external_procedures.end()) {
+        // The `external_procedures` member accumulates the external procedures
+        // of the scope currently being built (filled by
+        // `create_external_function`). It is only persisted into
+        // `external_procedures_mapping` once that scope has been fully
+        // processed. We must consult it here *without* overwriting it: the
+        // previous implementation assigned the (still empty) map entry to this
+        // member, which dropped every external procedure declared earlier in
+        // the same scope, leaving only the last one.
+        if (std::find(external_procedures.begin(), external_procedures.end(),
+                sym) != external_procedures.end()) {
             return true;
         }
+        // Then consult the persisted mapping for the owner scope and all of
+        // its parent scopes.
         SymbolTable* s = (scope ? scope : current_scope);
-        s = s->parent;
         while (s && s->asr_owner) {
             auto it = external_procedures_mapping.find(get_hash(s->asr_owner));
             if (it != external_procedures_mapping.end()) {
-                const std::vector<std::string>& parent_procs = it->second;
-                if (std::find(parent_procs.begin(), parent_procs.end(), sym) != parent_procs.end()) {
+                const std::vector<std::string>& procs = it->second;
+                if (std::find(procs.begin(), procs.end(), sym) != procs.end()) {
                     return true;
                 }
             }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -16187,6 +16187,31 @@ public:
             ASRUtils::symbol_get_past_external(f)) != implicit_interface_functions.end();
     }
 
+    // True if `v` is a use-associated procedure that was declared `external`
+    // with an implicit interface inside a module (e.g. `integer, external ::
+    // foo`). Such a declaration is recorded by `create_external_function` as a
+    // zero-argument BindC interface; once written to a .mod file and
+    // use-associated it loses any trace of being an implicit-interface
+    // external. Standard Fortran performs no argument checking for
+    // implicit-interface externals, so a call passing actual arguments must be
+    // accepted. We detect this shape at the call site so the implicit
+    // interface can be synthesized from the call exactly like a locally
+    // declared external.
+    bool is_use_associated_implicit_interface_external(ASR::symbol_t* v) {
+        if (!v || !ASR::is_a<ASR::ExternalSymbol_t>(*v)) {
+            return false;
+        }
+        ASR::symbol_t* f2 = ASRUtils::symbol_get_past_external(v);
+        if (!f2 || !ASR::is_a<ASR::Function_t>(*f2)) {
+            return false;
+        }
+        ASR::FunctionType_t* ft = ASRUtils::get_FunctionType(f2);
+        return ft->m_deftype == ASR::deftypeType::Interface
+            && (ft->m_abi == ASR::abiType::BindC
+                || ft->m_abi == ASR::abiType::ExternalUndefined)
+            && ASR::down_cast<ASR::Function_t>(f2)->n_args == 0;
+    }
+
     template <class Call>
     void create_implicit_interface_function(const Call &x, std::string func_name, bool add_return, ASR::ttype_t* old_type) {
         is_implicit_interface = true;
@@ -16950,6 +16975,15 @@ public:
             if (!v) {
                 v = current_scope->resolve_symbol(var_name);
             }
+        }
+        if (compiler_options.implicit_interface && !is_external_procedure
+                && x.n_args > 0
+                && is_use_associated_implicit_interface_external(v)) {
+            // A module-declared implicit-interface external (read back from a
+            // .mod file) is recorded with zero formal arguments. Treat it like
+            // a locally declared external so the interface is synthesized from
+            // this call site instead of wrongly rejecting the arguments.
+            is_external_procedure = true;
         }
         if (!v || (v && (is_external_procedure || is_explicit_intrinsic))) {
             ASR::symbol_t* external_sym = is_external_procedure ? v : nullptr;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4834,7 +4834,17 @@ public:
             bool is_subroutine = false;
             external_procedures.push_back(sym);
             ASR::symbol_t *sym_ = current_scope->resolve_symbol(sym);
-            assgnd_access[sym] = ASR::accessType::Public;
+            // Respect the default accessibility of the enclosing scope (e.g. a
+            // module `private` statement) as well as any explicit access already
+            // assigned to this name. An external procedure declared in a
+            // `private` module must be private, otherwise `use` would wrongly
+            // import it and later re-declarations (e.g. via an F77 `include`)
+            // would be reported as bogus redeclarations.
+            ASR::accessType ext_access = dflt_access;
+            if (assgnd_access.find(sym) != assgnd_access.end()) {
+                ext_access = assgnd_access[sym];
+            }
+            assgnd_access[sym] = ext_access;
             if (assgnd_pointer.count(sym) > 0) {
                 ASR::ttype_t *type = nullptr;
                 if (determined_type) {
@@ -4877,7 +4887,7 @@ public:
                     variable_dependencies_vec.size(),
                     ASR::intentType::Local, nullptr, nullptr,
                     ASR::storage_typeType::Default, ptr_type, iface_sym,
-                    ASR::abiType::Source, ASR::accessType::Public,
+                    ASR::abiType::Source, ext_access,
                     ASR::presenceType::Required, false);
                 current_scope->add_or_overwrite_symbol(
                     sym, ASR::down_cast<ASR::symbol_t>(var));
@@ -4942,7 +4952,7 @@ public:
                 /* a_body */ nullptr,
                 /* n_body */ 0,
                 /* a_return_var */ to_return,
-                ASR::abiType::BindC, ASR::accessType::Public, ASR::deftypeType::Interface,
+                ASR::abiType::BindC, ext_access, ASR::deftypeType::Interface,
                 nullptr, false, false, false, false, false, nullptr, 0,
                 false, false, false);
             parent_scope->add_or_overwrite_symbol(sym, ASR::down_cast<ASR::symbol_t>(tmp));
@@ -7323,7 +7333,11 @@ public:
                             } else if(sa->m_attr == AST::simple_attributeType
                                     ::AttrExternal) {
                                 is_attr_external = true;
-                                assgnd_access[sym] = ASR::accessType::Public;
+                                // Do not force Public here: an external
+                                // procedure declared in a `private` module must
+                                // keep the default (private) accessibility so
+                                // that `use` does not import it. Only an
+                                // explicit access specification overrides it.
                                 if (assgnd_access.count(sym)) {
                                     s_access = assgnd_access[sym];
                                 }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1773,6 +1773,13 @@ class CommonVisitor : public AST::BaseVisitor<Derived> {
 public:
     diag::Diagnostics &diag;
     std::vector<ASR::Function_t*> implicit_interfaces_to_sync;
+    // Functions synthesized by `create_implicit_interface_function()` for
+    // implicit-interface external procedures. Their dummy-argument types are
+    // inferred from the first call site, so they do NOT represent a real
+    // interface. Standard Fortran performs no argument checking for
+    // implicit-interface externals, hence later calls must not be rejected for
+    // passing a different argument type than the first call.
+    std::set<ASR::symbol_t*> implicit_interface_functions;
     std::map<std::string, std::vector<ASR::Variable_t*>> vars_with_deferred_struct_declaration;
     std::map<std::string, int> assumed_rank_arrays;
     std::map<AST::operatorType, std::string> binop2str = {
@@ -12058,6 +12065,13 @@ public:
 
     void validate_create_function_arguments(Vec<ASR::call_arg_t>& args, ASR::symbol_t *v){
         ASR::symbol_t *f2 = ASRUtils::symbol_get_past_external(v);
+        // An implicit-interface external procedure has no real interface (its
+        // argument types were inferred from the first reference), so standard
+        // Fortran performs no argument checking; do not reject later references
+        // that pass a different type.
+        if (is_implicit_interface_function(f2)) {
+            return;
+        }
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(f2);
         ASR::FunctionType_t* func_type = ASRUtils::get_FunctionType(v);
 
@@ -16165,6 +16179,14 @@ public:
         return nullptr;
     }
 
+    // True if `f` is a procedure interface that LFortran synthesized for an
+    // implicit-interface external (see `implicit_interface_functions`).
+    bool is_implicit_interface_function(ASR::symbol_t* f) {
+        if (!f) return false;
+        return implicit_interface_functions.find(
+            ASRUtils::symbol_get_past_external(f)) != implicit_interface_functions.end();
+    }
+
     template <class Call>
     void create_implicit_interface_function(const Call &x, std::string func_name, bool add_return, ASR::ttype_t* old_type) {
         is_implicit_interface = true;
@@ -16385,6 +16407,7 @@ public:
             nullptr, false, false, false, false, false, nullptr, 0,
             false, false, false);
         sym_scope->add_or_overwrite_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        implicit_interface_functions.insert(ASR::down_cast<ASR::symbol_t>(tmp));
         current_scope = parent_scope;
 
         is_implicit_interface = false;

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1317,6 +1317,13 @@ public:
         // Handle templated subroutines
         std::vector<std::string> saved_explicit_intrinsic_procedures = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures.clear();
+        // Save the externals accumulated by the enclosing scope so they are
+        // restored (not discarded) once this subroutine has been processed.
+        // A contained subroutine must not wipe the host scope's external
+        // procedures; otherwise a later reference in the host (e.g. a typed
+        // external function call in a program that also has a CONTAINS section)
+        // would wrongly be seen as having no interface.
+        std::vector<std::string> saved_external_procedures = external_procedures;
         if (x.n_temp_args > 0) {
             is_template = true;
 
@@ -1714,7 +1721,7 @@ public:
         // populate the external_procedures_mapping
         uint64_t hash = get_hash(tmp);
         external_procedures_mapping[hash] = external_procedures;
-        external_procedures.clear();
+        external_procedures = saved_external_procedures;
         explicit_intrinsic_procedures_mapping[hash] = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures = saved_explicit_intrinsic_procedures;
         if (subroutine_contains_entry_function(sym_name, x.m_items, x.n_items)) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1863,6 +1863,14 @@ public:
         // Handle templated functions
         std::vector<std::string> saved_explicit_intrinsic_procedures = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures.clear();
+        // Save the externals accumulated by the enclosing scope so they are
+        // restored (not discarded) once this function has been processed.
+        // Without this, a bare `external foo` declared inside this function
+        // would leak into a sibling program unit processed afterwards and
+        // wrongly mark a later same-named declaration there as an external
+        // procedure (dropping its explicitly declared type). This mirrors the
+        // handling in visit_Subroutine.
+        std::vector<std::string> saved_external_procedures = external_procedures;
         std::map<std::string, std::vector<std::string>> ext_overloaded_op_procs;
 
         if (x.n_temp_args > 0) {
@@ -2498,6 +2506,7 @@ public:
         // populate the external_procedures_mapping
         uint64_t hash = get_hash(tmp);
         external_procedures_mapping[hash] = external_procedures;
+        external_procedures = saved_external_procedures;
         explicit_intrinsic_procedures_mapping[hash] = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures = saved_explicit_intrinsic_procedures;
         if (subroutine_contains_entry_function(sym_name, x.m_items, x.n_items)) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -8258,9 +8258,23 @@ static inline void Call_t_body(Allocator& al, ASR::symbol_t* a_name,
                 // not setup to return errors, so we need to refactor things.
                 // For now we just do an assert.
                 /*TODO: Remove this if check once intrinsic procedures are implemented correctly*/
-                LCOMPILERS_ASSERT_MSG( ASRUtils::check_equal_type(arg_type, orig_arg_type, arg_expr, orig_arg_expr),
-                    "ASRUtils::check_equal_type(" + ASRUtils::get_type_code(arg_type) + ", " +
-                        ASRUtils::get_type_code(orig_arg_type) + ")");
+                // An implicit-interface external procedure uses the BindC ABI
+                // with a synthesized `Interface` signature whose dummy types
+                // were inferred from an earlier call; standard Fortran does no
+                // argument checking for such procedures, so the actual type
+                // need not match. The raw pointer/value is passed as-is (any
+                // physical-type reconciliation for arrays happens below), so
+                // skip the equal-type guard here. A real explicit interface
+                // (e.g. an `interface ... bind(c)` block) with a mismatching
+                // type is already rejected during semantic analysis.
+                bool is_implicit_interface_external =
+                    func_type->m_abi == ASR::abiType::BindC &&
+                    func_type->m_deftype == ASR::deftypeType::Interface;
+                if (!is_implicit_interface_external) {
+                    LCOMPILERS_ASSERT_MSG( ASRUtils::check_equal_type(arg_type, orig_arg_type, arg_expr, orig_arg_expr),
+                        "ASRUtils::check_equal_type(" + ASRUtils::get_type_code(arg_type) + ", " +
+                            ASRUtils::get_type_code(orig_arg_type) + ")");
+                }
             }
         }
         if( ASRUtils::is_array(arg_type) && ASRUtils::is_array(orig_arg_type) ) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8176,38 +8176,6 @@ public:
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];
-                // Two implicit-interface external procedures can share the
-                // same link name yet be seen with different argument lists,
-                // e.g. a module declares `external :: nf_create` (no
-                // interface, zero args) while the caller passes actual
-                // arguments (nf_create(a, b, c)). The earlier, less complete
-                // declaration would otherwise be reused for the call site and
-                // the LLVM verifier would reject the call ("Incorrect number
-                // of arguments passed to called function!"). When the current
-                // interface has more arguments, replace the earlier
-                // declaration with one matching the current signature so all
-                // call sites use the correct type; existing references are
-                // redirected through a bitcast (they refer to the same
-                // link-time symbol).
-                if (F->getFunctionType() != function_type &&
-                        function_type->getNumParams() >
-                            F->getFunctionType()->getNumParams()) {
-                    llvm::Function* old_F = F;
-                    llvm::Function* new_F = llvm::Function::Create(
-                        function_type, llvm::Function::ExternalLinkage, "",
-                        module.get());
-                    std::string kept_name = old_F->getName().str();
-                    old_F->replaceAllUsesWith(
-                        llvm::ConstantExpr::getBitCast(new_F, old_F->getType()));
-                    old_F->eraseFromParent();
-                    new_F->setName(kept_name);
-                    for (auto& kv : llvm_symtab_fn) {
-                        if (kv.second == old_F) {
-                            kv.second = new_F;
-                        }
-                    }
-                    F = new_F;
-                }
             }
             llvm_symtab_fn[h] = F;
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8176,6 +8176,38 @@ public:
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];
+                // Two implicit-interface external procedures can share the
+                // same link name yet be seen with different argument lists,
+                // e.g. a module declares `external :: nf_create` (no
+                // interface, zero args) while the caller passes actual
+                // arguments (nf_create(a, b, c)). The earlier, less complete
+                // declaration would otherwise be reused for the call site and
+                // the LLVM verifier would reject the call ("Incorrect number
+                // of arguments passed to called function!"). When the current
+                // interface has more arguments, replace the earlier
+                // declaration with one matching the current signature so all
+                // call sites use the correct type; existing references are
+                // redirected through a bitcast (they refer to the same
+                // link-time symbol).
+                if (F->getFunctionType() != function_type &&
+                        function_type->getNumParams() >
+                            F->getFunctionType()->getNumParams()) {
+                    llvm::Function* old_F = F;
+                    llvm::Function* new_F = llvm::Function::Create(
+                        function_type, llvm::Function::ExternalLinkage, "",
+                        module.get());
+                    std::string kept_name = old_F->getName().str();
+                    old_F->replaceAllUsesWith(
+                        llvm::ConstantExpr::getBitCast(new_F, old_F->getType()));
+                    old_F->eraseFromParent();
+                    new_F->setName(kept_name);
+                    for (auto& kv : llvm_symtab_fn) {
+                        if (kv.second == old_F) {
+                            kv.second = new_F;
+                        }
+                    }
+                    F = new_F;
+                }
             }
             llvm_symtab_fn[h] = F;
 

--- a/src/libasr/pass/unused_functions.cpp
+++ b/src/libasr/pass/unused_functions.cpp
@@ -25,8 +25,26 @@ public:
 
     void visit_Function(const ASR::Function_t &x) {
         uint64_t h = get_hash((ASR::asr_t*)&x);
-        if (ASRUtils::get_FunctionType(x)->m_abi != ASR::abiType::BindC
-         && ASRUtils::get_FunctionType(x)->m_abi != ASR::abiType::BindPython) {
+        ASR::FunctionType_t* ftype = ASRUtils::get_FunctionType(x);
+        // BindC/BindPython functions are normally kept even when unused: a
+        // definition with a body may be exported to (and called from) C.
+        // A zero-argument BindC `Interface` function with no body is
+        // different: it is the placeholder `create_external_function`
+        // records for an implicit-interface external declaration (e.g.
+        // `integer, external :: nf_create` in a module). It exists only so
+        // the name resolves during semantic analysis; calls never go
+        // through it (each call site synthesizes its own interface). If it
+        // is unreferenced it must not survive to codegen: its zero-argument
+        // declaration would be emitted first and, deduplicated by link
+        // name, poison a genuine call-site signature of the same external
+        // elsewhere in the unit.
+        bool is_external_placeholder =
+            ftype->m_abi == ASR::abiType::BindC
+            && ftype->m_deftype == ASR::deftypeType::Interface
+            && x.n_args == 0 && x.n_body == 0;
+        if ((ftype->m_abi != ASR::abiType::BindC
+          && ftype->m_abi != ASR::abiType::BindPython)
+          || is_external_placeholder) {
             fn_declarations[h] = x.m_name;
         }
 
@@ -80,6 +98,26 @@ public:
             h = get_hash((ASR::asr_t*)x.m_external);
             fn_used[h] = x.m_name;
         }
+    }
+
+    void visit_Variable(const ASR::Variable_t &x) {
+        // A procedure pointer or dummy procedure references its interface
+        // function through `m_type_declaration`; count that as a use so the
+        // interface is not pruned (a symtab walk alone never reaches it).
+        // Mirrors the handling of function arguments in visit_Function.
+        if (x.m_type_declaration) {
+            ASR::symbol_t* func = x.m_type_declaration;
+            if (ASR::is_a<ASR::ExternalSymbol_t>(*func)) {
+                uint64_t h = get_hash((ASR::asr_t*)func);
+                fn_used[h] = ASR::down_cast<ASR::ExternalSymbol_t>(func)->m_name;
+                func = ASR::down_cast<ASR::ExternalSymbol_t>(func)->m_external;
+            }
+            if (func && ASR::is_a<ASR::Function_t>(*func)) {
+                uint64_t h = get_hash((ASR::asr_t*)func);
+                fn_used[h] = ASR::down_cast<ASR::Function_t>(func)->m_name;
+            }
+        }
+        ASR::BaseWalkVisitor<CollectUnusedFunctionsVisitor>::visit_Variable(x);
     }
 
 


### PR DESCRIPTION
## Summary
Several EXTERNAL / implicit-interface fixes used by codes such as netcdf-fortran:
multi-name EXTERNAL statements, argument type/count checks with CONTAINS and
use-association, private module access, and leaks of external symbols from
function scopes.

## Scope
- Semantics: EXTERNAL list handling, private module external access, function-scope cleanup
- Arg count/type for use-associated and CONTAINS cases
- Integration tests `external_17`–`external_19`, `implicit_interface_44`–`47`

## Verification
- Listed integration tests with `--implicit-interface` where required

## Rationale
Split from the netcdf2 work branch into a focused PR.