### PR TITLE
Fix PARAMETER statement: real value on integer and negative literals

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1864,6 +1864,7 @@ RUN(NAME parameter_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME parameter_16 LABELS gfortran llvm)
 RUN(NAME parameter_17 LABELS gfortran llvm)
 RUN(NAME parameter_18 LABELS gfortran llvm)
+RUN(NAME parameter_19 LABELS gfortran llvm)
 
 RUN(NAME fortuno_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1865,6 +1865,7 @@ RUN(NAME parameter_16 LABELS gfortran llvm)
 RUN(NAME parameter_17 LABELS gfortran llvm)
 RUN(NAME parameter_18 LABELS gfortran llvm)
 RUN(NAME parameter_19 LABELS gfortran llvm)
+RUN(NAME parameter_20 LABELS gfortran llvm)
 
 RUN(NAME fortuno_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/parameter_19.f90
+++ b/integration_tests/parameter_19.f90
@@ -1,0 +1,25 @@
+program parameter_19
+  implicit none
+
+  ! Integer parameter given a real literal through a standalone
+  ! `parameter (...)` statement, then used in a real-valued expression.
+  integer :: k
+  parameter (k = 25.0)
+
+  ! Real parameter given an integer literal through a standalone statement.
+  real :: r
+  parameter (r = 7)
+
+  real :: x
+  integer :: y
+
+  x = k + 5.0
+  print *, k, x
+  if (k /= 25) error stop
+  if (abs(x - 30.0) > 1e-6) error stop
+
+  y = r + 1
+  print *, r, y
+  if (abs(r - 7.0) > 1e-6) error stop
+  if (y /= 8) error stop
+end program parameter_19

--- a/integration_tests/parameter_20.f90
+++ b/integration_tests/parameter_20.f90
@@ -1,0 +1,37 @@
+program parameter_20
+  implicit none
+
+  ! Integer parameter given a NEGATIVE real literal through a standalone
+  ! `parameter (...)` statement, then used in a real-valued expression.
+  ! The initializer is a RealUnaryMinus (not a bare RealConstant), so the
+  ! RealToInteger conversion must still be folded to an IntegerConstant.
+  integer :: k
+  parameter (k = -125.0)
+
+  ! Same, but with a kind-8 integer and a double precision literal.
+  integer(8) :: k8
+  parameter (k8 = -125.0d0)
+
+  ! Real parameter given a NEGATIVE integer literal through a standalone
+  ! statement (the symmetric case).
+  real :: r
+  parameter (r = -7)
+
+  real :: x
+  integer :: y
+
+  x = k + 5.0
+  print *, k, x
+  if (k /= -125) error stop
+  if (abs(x - (-120.0)) > 1e-6) error stop
+
+  x = k8 + 5.0
+  print *, k8, x
+  if (k8 /= -125_8) error stop
+  if (abs(x - (-120.0)) > 1e-6) error stop
+
+  y = r + 1
+  print *, r, y
+  if (abs(r - (-7.0)) > 1e-6) error stop
+  if (y /= -6) error stop
+end program parameter_20

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5641,6 +5641,18 @@ public:
                                                         }
                                                     }
                                                 }
+                                                // The folds above only handle initializers that are a bare
+                                                // numeric literal. When the initializer is a constant expression
+                                                // whose value type still differs from the declared parameter
+                                                // type (e.g. `integer :: k` with `parameter (k = -125.0)`, whose
+                                                // initializer is a RealUnaryMinus rather than a bare
+                                                // RealConstant), insert an explicit Cast so the stored value
+                                                // matches the variable's type. set_converted_value is a no-op
+                                                // when the types already match.
+                                                if (ASRUtils::expr_value(init_val)) {
+                                                    ImplicitCastRules::set_converted_value(al, x.base.base.loc,
+                                                        &init_val, ASRUtils::expr_type(init_val), v->m_type, diag);
+                                                }
                                                 v->m_symbolic_value = init_val;
                                                 v->m_value = ASRUtils::expr_value(init_val);
                                                 SetChar variable_dependencies_vec;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5569,6 +5569,14 @@ public:
                                                             ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc,
                                                                 rc->m_r, rc->m_type)),
                                                             ASR::cast_kindType::RealToComplex, v->m_type, complex_value, nullptr));
+                                                    } else if (ASRUtils::is_integer(*v->m_type)) {
+                                                        ASR::expr_t* integer_value = ASRUtils::EXPR(
+                                                            ASR::make_IntegerConstant_t(al, x.base.base.loc,
+                                                                (int64_t)rc->m_r, v->m_type));
+                                                        init_val = ASRUtils::EXPR(ASR::make_Cast_t(al, x.base.base.loc,
+                                                            ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc,
+                                                                rc->m_r, rc->m_type)),
+                                                            ASR::cast_kindType::RealToInteger, v->m_type, integer_value, nullptr));
                                                     } else {
                                                         init_val = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, rc->m_r, v->m_type));
                                                     }


### PR DESCRIPTION
## Summary
Handle PARAMETER with an integer variable initialized from a real value, and
negative literals in PARAMETER statements.

## Scope
- Semantics in the common visitor
- Integration tests `parameter_19`, `parameter_20`

## Verification
- Listed integration tests

## Rationale
Split from the netcdf2 work branch into a focused PR.