### PR TITLE
fix: scale() with a negative exponent by computing 2**i in floating point

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1831,6 +1831,7 @@ RUN(NAME intrinsics_472 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_A
 RUN(NAME intrinsics_473 LABELS gfortran llvm) # maxloc/minloc with compile-time mask evaluation on 2D arrays
 RUN(NAME intrinsics_474 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_broadcast
 RUN(NAME intrinsics_475 LABELS gfortran llvm) # ishftc with SIZE keeps high bits of I
+RUN(NAME intrinsics_476 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # scale with a negative exponent
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME storage_size_01 LABELS gfortran llvm) # storage_size of allocatable character
 

--- a/integration_tests/intrinsics_476.f90
+++ b/integration_tests/intrinsics_476.f90
@@ -1,0 +1,64 @@
+program intrinsics_476
+    ! scale(x, i) with a negative i. The runtime implementation used to compute
+    ! 2**i in integer arithmetic, which truncates to 0 for every i < 0, so
+    ! scale(x, -1) wrongly returned 0.0 instead of x/2.
+    !
+    ! The arguments are deliberately variables, not parameters: a constant
+    ! expression is folded at compile time by a separate code path that was
+    ! never affected by the bug.
+    implicit none
+    real(8) :: x8, r8
+    real(4) :: x4, r4
+    integer :: k
+    integer :: arr_i(3)
+    real(8) :: arr8(3)
+
+    x8 = 1.0_8
+    k = -1
+    r8 = scale(x8, k)
+    print *, r8
+    ! 0.5 is exactly representable in binary FP, so require an exact match
+    if (r8 /= 0.5_8) error stop
+
+    ! larger negative exponent
+    k = -3
+    r8 = scale(x8, k)
+    print *, r8
+    if (r8 /= 0.125_8) error stop
+
+    ! negative exponent on a negative value
+    x8 = -6.0_8
+    k = -2
+    r8 = scale(x8, k)
+    print *, r8
+    if (r8 /= -1.5_8) error stop
+
+    ! real(4) must behave the same way
+    x4 = 1.0_4
+    k = -2
+    r4 = scale(x4, k)
+    print *, r4
+    if (r4 /= 0.25_4) error stop
+
+    ! positive exponent still works (guards against over-correcting the fix)
+    x8 = 3.0_8
+    k = 4
+    r8 = scale(x8, k)
+    print *, r8
+    if (r8 /= 48.0_8) error stop
+
+    ! i == 0 is the identity
+    x8 = 7.25_8
+    k = 0
+    r8 = scale(x8, k)
+    print *, r8
+    if (r8 /= 7.25_8) error stop
+
+    ! elemental form with a mix of negative, zero and positive exponents
+    arr8 = [1.0_8, 8.0_8, 5.0_8]
+    arr_i = [-1, -3, 0]
+    print *, scale(arr8, arr_i)
+    if (any(scale(arr8, arr_i) /= [0.5_8, 1.0_8, 5.0_8])) error stop
+
+    print *, "PASS"
+end program

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -1315,7 +1315,9 @@ namespace Scale {
         */
 
        //TODO: Radix for most of the device is 2, so we can use the b.i2r_t(2, real32) instead of args[1]. Fix (find a way to get the radix of the device and use it here)
-        body.push_back(al, b.Assignment(result, b.Mul(args[0], b.i2r_t(b.Pow(b.i_t(2, arg_types[1]), args[1]), return_type))));
+        // The exponentiation must be done in floating point: `i` may be negative,
+        // and integer 2**i truncates to 0 for any i < 0.
+        body.push_back(al, b.Assignment(result, b.Mul(args[0], b.Pow(b.f_t(2.0, return_type), b.i2r_t(args[1], return_type)))));
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args, body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);
         return b.Call(f_sym, new_args, return_type, nullptr);


### PR DESCRIPTION
fixes #12282
The runtime implementation of scale(x, i) built 2**i with an integer
base and integer exponent, converting to real only afterwards:

    b.i2r_t(b.Pow(b.i_t(2, arg_types[1]), args[1]), return_type)

Integer exponentiation truncates, so 2**i evaluated to 0 for every
i < 0 and scale(x, i) returned 0.0 instead of x * 2**i. scale(1.0_dp, -1)
returned 0.0 where gfortran returns 0.5. Positive exponents happened to
work, which is why this went unnoticed.

Do the exponentiation in floating point instead, using a real base and a
real exponent so Pow's equal-type requirement is satisfied:

    b.Pow(b.f_t(2.0, return_type), b.i2r_t(args[1], return_type))

The compile-time path (eval_Scale) already used std::pow in double
precision and was unaffected, so only expressions with non-constant
arguments were wrong.

Added integration_tests/intrinsics_476.f90 covering negative exponents for
real(4) and real(8), negative values, the elemental array form, i == 0,
and a positive exponent to guard against over-correcting. The arguments
are variables rather than parameters on purpose: constant expressions
fold through eval_Scale, so a parameter-based test would pass against the
unfixed compiler. The existing intrinsics_141 tested only positive
exponents, which is the gap that allowed this bug.
