### PR TITLE
fix:  Store locations along with assign proc names for error messages and lower the proc name before resolving the symbol

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2267,6 +2267,7 @@ RUN(NAME custom_operator_16 LABELS gfortran llvm)
 RUN(NAME custom_operator_17 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME custom_operator_18 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME custom_operator_19 LABELS gfortran llvm)
+RUN(NAME custom_operator_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/custom_operator_20.f90
+++ b/integration_tests/custom_operator_20.f90
@@ -1,0 +1,31 @@
+module m_custom_operator_20
+    implicit none
+
+    type :: t
+        integer :: x
+    end type
+
+    interface assignment(=)
+        module procedure defAsst2
+    end interface
+
+contains
+
+    subroutine defAsst2(lhs, rhs)
+        type(t), intent(out) :: lhs
+        integer, intent(in)  :: rhs
+
+        lhs%x = rhs
+    end subroutine
+end module
+
+program custom_operator_20
+    use m_custom_operator_20
+    implicit none
+
+    type(t) :: a
+    a = 5
+
+    print *, a%x
+    if (a%x /= 5) error stop
+end program

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -32,7 +32,7 @@ public:
     std::map<std::string, std::vector<std::string>> defined_op_procs;
     std::map<std::string, std::map<std::string, std::map<std::string, ClassProcInfo>>> class_procedures;
     std::map<std::string, std::map<std::string, std::map<std::string, Location>>> class_deferred_procedures;
-    std::vector<std::string> assgn_proc_names;
+    std::vector<std::pair<std::string, Location>> assgn_proc_names_locations;
     std::vector<std::pair<std::string,Location>> simd_variables;
     std::map<std::string, std::vector<AST::arg_t>> entry_function_args;
     std::set<std::string> loaded_submodules;
@@ -308,7 +308,7 @@ public:
 
     template <typename T, typename R>
     void visit_ModuleSubmoduleCommon(const T &x, std::string parent_name="") {
-        assgn_proc_names.clear();
+        assgn_proc_names_locations.clear();
         class_procedures.clear();
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
@@ -3315,7 +3315,7 @@ public:
                 defined_op_procs[op] = proc_names;
             }
         }  else if (AST::is_a<AST::InterfaceHeaderAssignment_t>(*x.m_header)) {
-            fill_interface_proc_names(x, assgn_proc_names);
+            fill_interface_proc_names_with_loc(x, assgn_proc_names_locations);
         }  else if (AST::is_a<AST::InterfaceHeaderWrite_t>(*x.m_header)) {
             std::string op_name = to_lower(AST::down_cast<AST::InterfaceHeaderWrite_t>(x.m_header)->m_id);
             if (op_name != "formatted" && op_name != "unformatted") {
@@ -3678,22 +3678,25 @@ public:
     }
 
     void add_assignment_procedures() {
-        if( assgn_proc_names.empty() ) {
+        if( assgn_proc_names_locations.empty() ) {
             return ;
         }
         bool any_error = false;
-        for (const std::string &name : assgn_proc_names) {
-            ASR::symbol_t *sym = current_scope->resolve_symbol(name);
+        std::vector<std::string> assgn_proc_names;
+        assgn_proc_names.reserve(assgn_proc_names_locations.size());
+        for (const auto &name_loc : assgn_proc_names_locations) {
+            ASR::symbol_t *sym = current_scope->resolve_symbol(to_lower(name_loc.first));
             if (!sym) {
                 diag.add(Diagnostic(
-                    "Assignment procedure `" + name + "` not found",
+                    "Assignment procedure `" + name_loc.first + "` not found",
                     Level::Error, Stage::Semantic,
-                    {Label("", {})}
+                    {Label("", {name_loc.second})}
                 ));
                 any_error = true;
                 if (!compiler_options.continue_compilation) throw SemanticAbort();
                 continue;
             }
+            assgn_proc_names.push_back(name_loc.first);
             sym = ASRUtils::symbol_get_past_external(sym);
             // Must be a subroutine
             if (!ASR::is_a<ASR::Function_t>(*sym)) {

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -220,7 +220,7 @@ std::string render_diagnostic_human(const Diagnostic &d, bool use_colors) {
     auto [message_type, primary_color, type_color] = diag_level_to_str(d, use_colors);
     out << type_color << message_type << reset << bold << ": " << d.message << reset << std::endl;
 
-    if (d.labels.size() > 0) {
+    if (d.labels.size() > 0 && d.labels[0].spans.size() > 0) {
         Label l = d.labels[0];
         Span s = l.spans[0];
         int line_num_width = 1;
@@ -354,7 +354,7 @@ std::string render_diagnostic_short(const Diagnostic &d) {
 
     // Message anatomy:
     // <filename>:<line start>-<end>:<column start>-<end>: <severity>: <message>
-    if (d.labels.size() > 0) {
+    if (d.labels.size() > 0 && d.labels[0].spans.size() > 0) {
         Label l = d.labels[0];
         Span s = l.spans[0];
         // TODO: print the primary line+column here, not the first label:


### PR DESCRIPTION
Fixes #12263