### PR TITLE
Fix/real kind crash 12297

### DIFF
--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -1177,7 +1177,7 @@ def add_create_func_return_src(func_name):
         if valid_kinds:
             cond = " && ".join(f"kind != {k}" for k in valid_kinds)
             kinds_str = ", ".join(str(k) for k in valid_kinds)
-            src += indent * 3 +     f"if ({cond}) {{\n"
+            src += indent * 3 +     f"if (ASR::is_a<ASR::IntegerConstant_t>(*args[1]) && ({cond})) {{\n"
             src += indent * 4 +         f'append_error(diag, "Unsupported {func_name} kind \'" + std::to_string(kind) + "\' in `{func_name.lower()}()`, must be one of: {kinds_str}", args[1]->base.loc);\n'
             src += indent * 4 +         "return nullptr;\n"
             src += indent * 3 +     "}\n"

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -915,7 +915,8 @@ intrinsic_funcs_args = {
             "args": [("int",), ("real",), ("complex",)],
             "return": "real32",
             "kind_arg": True,
-            "real_32_except_complex": True
+            "real_32_except_complex": True,
+            "valid_kinds": [4, 8, 16]
         },
     ],
     "Int": [
@@ -1172,6 +1173,14 @@ def add_create_func_return_src(func_name):
         src += indent * 4 +         f'append_error(diag, "`kind` argument of the `{func_name}` function must be a scalar Integer constant", args[1]->base.loc);\n'
         src += indent * 4 +         "return nullptr;\n"
         src += indent * 3 +     "}\n"
+        valid_kinds = arg_infos[0].get("valid_kinds", None)
+        if valid_kinds:
+            cond = " && ".join(f"kind != {k}" for k in valid_kinds)
+            kinds_str = ", ".join(str(k) for k in valid_kinds)
+            src += indent * 3 +     f"if ({cond}) {{\n"
+            src += indent * 4 +         f'append_error(diag, "Unsupported {func_name} kind \'" + std::to_string(kind) + "\' in `{func_name.lower()}()`, must be one of: {kinds_str}", args[1]->base.loc);\n'
+            src += indent * 4 +         "return nullptr;\n"
+            src += indent * 3 +     "}\n"
         src += indent * 3 +     "set_kind_to_ttype_t(return_type, kind);\n"
         src += indent * 2 + "}\n"
     real_32_except_complex = arg_infos[0].get("real_32_except_complex", False)

--- a/tests/errors/real_unsupported_kind_01.f90
+++ b/tests/errors/real_unsupported_kind_01.f90
@@ -1,0 +1,3 @@
+program real_unsupported_kind_01
+print *, real(1., 666)
+end program

--- a/tests/reference/asr-real_unsupported_kind_01-764a938.json
+++ b/tests/reference/asr-real_unsupported_kind_01-764a938.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-real_unsupported_kind_01-764a938",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/real_unsupported_kind_01.f90",
+    "infile_hash": "c6618294913612d45bb4051f2f2a2df704b23b3e30138b4534ddd48f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-real_unsupported_kind_01-764a938.stderr",
+    "stderr_hash": "8831bd553a3f85220b7585c916e24e6f4b14f6e5190d181e8bafcecf",
+    "returncode": 2
+}

--- a/tests/reference/asr-real_unsupported_kind_01-764a938.stderr
+++ b/tests/reference/asr-real_unsupported_kind_01-764a938.stderr
@@ -1,0 +1,5 @@
+semantic error: Unsupported Real kind '666' in `real()`, must be one of: 4, 8, 16
+ --> tests/errors/real_unsupported_kind_01.f90:2:19
+  |
+2 | print *, real(1., 666)
+  |                   ^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -503,6 +503,11 @@ filename = "errors/template_error_09.f90"
 asr = true
 
 [[test]]
+filename = "errors/real_unsupported_kind_01.f90"
+asr = true
+
+
+[[test]]
 filename = "errors/maskl_incorrect_bit_size.f90"
 asr = true
 


### PR DESCRIPTION
## Summary
Fixes an internal compiler crash (LCompilersException: Float kind not supported) that occurred when calling the real() intrinsic with an invalid kind argument.

Fixes #12297

## Problem
The following code crashed the compiler instead of producing a normal error message:

print *, real(1., 666)
end

### Before
Internal Compiler Error: Unhandled exception
...
LCompilersException: Float kind not supported

The kind argument (666) was never validated during semantic analysis. It passed straight through to code generation (asr_to_c.cpp -> get_print_type), where it hit an internal switch statement with no matching case, throwing an unhandled LCompilersException and crashing the whole compiler run. This is a compiler bug: user-input errors should never surface as unhandled internal exceptions.

### After
semantic error: Unsupported Real kind '666' in real(), must be one of: 4, 8, 16
 --> test.f90:1:18
  |
1 | print *, real(1.,666)
  |                  ^^^

The invalid kind is now caught immediately during semantic analysis (in create_Real), and the compiler reports a clean, user-facing semantic error pointing at the exact location of the bad argument, instead of crashing later in codegen.

## Root cause
create_Real (which builds the ASR node for the real() intrinsic) parsed the kind argument but never checked whether it was one of the real kinds actually supported by the backends (4, 8, 16). Because of that, an invalid kind survived all the way to code generation, where it was rejected far too late, with a raw internal exception instead of a diagnostic.

## Fix
- Added a valid_kinds option to the intrinsic function generator (src/libasr/intrinsic_func_registry_util_gen.py), used to validate the kind argument right after it is parsed, before it's attached to the return type.
- Set valid_kinds = [4, 8, 16] for the Real intrinsic entry.
- When an unsupported kind is passed, create_Real now reports a proper semantic error (append_error) with the exact source location of the invalid kind argument, instead of allowing it to propagate to codegen.
- Regenerated src/libasr/pass/intrinsic_function_registry_util.h from the updated generator (this file is gitignored/auto-generated, so only the generator source is committed).

## Testing
- Added a new negative test: tests/errors/real_unsupported_kind_01.f90
- Registered it in tests/tests.toml as an asr-stage error test
- Generated its reference output with ./run_tests.py -t real_unsupported_kind_01 -u
- Verified manually:
  $ ./src/bin/lfortran --show-c test.f90
  semantic error: Unsupported Real kind '666' in real(), must be one of: 4, 8, 16
- Ran the existing template test suite to confirm no regressions.
