### PR TITLE
fix: dereference scalar pointer/allocatable items in namelist I/O

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1139,6 +1139,7 @@ RUN(NAME namelist_34 LABELS gfortran llvm)
 
 
 RUN(NAME namelist_35 LABELS gfortran llvm)
+RUN(NAME namelist_36 LABELS gfortran llvm)
 
 RUN(NAME nested_namelist_01 LABELS gfortran llvm)
 

--- a/integration_tests/namelist_36.f90
+++ b/integration_tests/namelist_36.f90
@@ -1,0 +1,46 @@
+program namelist_36
+    implicit none
+
+    type :: options
+        integer :: maxcalls = 0
+        real(8) :: mintime = 0.0d0
+        character(20) :: name = ''
+    end type
+
+    integer, target :: count_t
+    integer, pointer :: count => null()
+    real(8), allocatable :: tol
+    type(options), target :: opts_t
+    type(options), pointer :: opts => null()
+
+    namelist /config/ count, tol, opts
+
+    count => count_t
+    allocate(tol)
+    opts => opts_t
+
+    count = 42
+    tol = 0.125d0
+    opts%maxcalls = 10
+    opts%mintime = 50.0d0
+    opts%name = 'run1'
+
+    open(10, status="scratch", delim="apostrophe")
+    write(10, nml=config)
+    rewind(10)
+
+    count = 0
+    tol = 0.0d0
+    opts%maxcalls = 0
+    opts%mintime = 0.0d0
+    opts%name = ''
+    read(10, nml=config)
+    close(10)
+
+    if (count /= 42) error stop
+    if (tol /= 0.125d0) error stop
+    if (opts%maxcalls /= 10) error stop
+    if (opts%mintime /= 50.0d0) error stop
+    if (trim(opts%name) /= 'run1') error stop
+    print *, "scalar pointer/allocatable namelist ok"
+end program namelist_36

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -16913,6 +16913,17 @@ public:
                     nullptr, desc_type_asr, module.get());
                 data_ptr = llvm_utils->CreateLoad2(
                     desc_llvm_type->getPointerTo(), data_ptr);
+            } else if ((ASR::is_a<ASR::Allocatable_t>(*item_type_asr) ||
+                        ASR::is_a<ASR::Pointer_t>(*item_type_asr)) &&
+                       !ASRUtils::is_character(*item_type_asr)) {
+                // For scalar allocatables/pointers, the symtab value stores the
+                // address of the target. Load through it so the namelist item
+                // points at the target's data, not at the pointer variable.
+                ASR::ttype_t* tgt_type_asr = ASRUtils::type_get_past_allocatable_pointer(item_type_asr);
+                llvm::Type* tgt_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                    nullptr, tgt_type_asr, module.get());
+                data_ptr = llvm_utils->CreateLoad2(
+                    tgt_llvm_type->getPointerTo(), data_ptr);
             }
 
             // Determine type code


### PR DESCRIPTION
fixes #12302 


In build_namelist_descriptor, the symtab value for scalar pointer and
allocatable namelist items was used directly as the data pointer, so
the runtime read the pointer variable's own storage instead of its
target. This produced garbage values for intrinsic types and a
segfault for pointers to derived types with character components.

Load through the symtab value for non-character scalar
pointer/allocatable items, matching the existing handling of
pointer/allocatable arrays.

Adds integration test namelist_36 (round-trips a scalar integer
pointer, a scalar real allocatable, and a pointer to a derived type
with a character component).
