### PR TITLE
fix: allow no whitespace after parenthesis in function like `#define`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4091,6 +4091,10 @@ RUN(NAME cpp_pre_17 LABELS gfortran llvm
     EXTRA_ARGS --cpp
     GFORTRAN_ARGS -cpp)
 
+RUN(NAME cpp_pre_18 LABELS gfortran llvm
+    EXTRA_ARGS --cpp
+    GFORTRAN_ARGS -cpp)
+
 RUN(NAME dabs_01 LABELS gfortran llvmImplicit)
 
 RUN(NAME minpack_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/cpp_pre_18.f90
+++ b/integration_tests/cpp_pre_18.f90
@@ -1,0 +1,22 @@
+#define PRINT_TWICE(x)\
+print *, x; \
+print *, x;
+
+#define TWO_INCR()\
+i = i + 1; \
+i = i + 1;
+
+#define RESET() \
+i = 0;
+
+#define ADD(a,b)((a) + (b))
+
+program cpp_pre_18
+implicit none
+integer :: i
+RESET()
+TWO_INCR()
+if (i /= 2) error stop
+if (ADD(2, 3) /= 5) error stop
+PRINT_TWICE('hello')
+end program

--- a/src/lfortran/parser/preprocessor.re
+++ b/src/lfortran/parser/preprocessor.re
@@ -423,10 +423,11 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                 interval_end_type_0(lm, output.size(), cur-string_start);
                 continue;
             }
-            "#" whitespace? "define" whitespace @t1 name @t2 '(' whitespace? ')' whitespace @t3 [^\n\x00]* @t4 newline  {
+            "#" whitespace? "define" whitespace @t1 name @t2 '(' whitespace? ')' whitespace? @t3 [^\n\x00]* @t4 newline  {
                 if (!branch_enabled) continue;
                 std::string macro_name = token(t1, t2),
                         macro_subs = token(t3, t4);
+                handle_continuation_lines(macro_subs, cur);
                 CPPMacro fn;
                 fn.function_like = true;
                 fn.args = {};
@@ -435,7 +436,7 @@ Result<std::string> CPreprocessor::run(const std::string &input, LocationManager
                 interval_end_type_0(lm, output.size(), cur-string_start);
                 continue;
             }
-            "#" whitespace? "define" whitespace @t1 name @t2 '(' whitespace? name whitespace? (',' whitespace? name whitespace?)* ')' (whitespace @t3 [^\n\x00]* @t4)? newline  {
+            "#" whitespace? "define" whitespace @t1 name @t2 '(' whitespace? name whitespace? (',' whitespace? name whitespace?)* ')' whitespace? @t3 [^\n\x00]* @t4 newline  {
                 if (!branch_enabled) continue;
                 std::string macro_name = token(t1, t2),
                         macro_subs = token(t3, t4);


### PR DESCRIPTION
fixes #12313


The function-like macro rules required whitespace between the closing
parenthesis and the macro body, so a definition like

    #define FOO(x)\
    print *, x

matched no rule, fell through to the "#define ignored" warning, and the
stray `\` then caused a tokenizer error. Make the whitespace optional in
both the zero-arg and named-arg rules, always capture the body (fixing
`token(t3, t4)` on unset captures when the old optional group didn't
match), and call handle_continuation_lines in the zero-arg rule so
multi-line bodies are stitched together there as well.

Add integration test cpp_pre_18 covering continuation lines and bodies
starting immediately after `)`, verified against gfortran -cpp.
