### PR TITLE
fix: treat parameter-array element as constant array bound

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -774,6 +774,7 @@ RUN(NAME array_bound_4 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackAr
 RUN(NAME array_bound_5 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME array_bound_6 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays fortran)
 RUN(NAME array_bound_7 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME array_bound_8 LABELS gfortran llvm) # parameter-array element as array bound
 RUN(NAME arrays_op_1 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm fortran)
 RUN(NAME arrays_op_2 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm fortran)
 RUN(NAME arrays_op_3 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray wasm fortran)

--- a/integration_tests/array_bound_8.f90
+++ b/integration_tests/array_bound_8.f90
@@ -1,0 +1,37 @@
+program array_bound_8
+    ! An element of a PARAMETER (named-constant) array is a constant
+    ! expression (F2018 10.1.12) and may be used as an explicit-shape
+    ! array bound, a derived-type component bound, or a character length.
+
+    implicit none
+
+    integer, parameter :: dims(2) = [3, 4]
+    integer, parameter :: n(1) = [5]
+
+    ! 1-D array sized by a parameter-array element.
+    real :: a(dims(1))
+    ! multi-dimensional, mixing both elements of the parameter array.
+    real :: b(dims(1), dims(2))
+    ! the second element of the parameter array.
+    real :: c(dims(2))
+
+    ! a parameter-array element used as a derived-type component bound.
+    type :: box
+        real :: x(dims(1))
+    end type box
+    type(box) :: z
+
+    ! a parameter-array element used as a character length.
+    character(len=n(1)) :: s
+
+    ! --- checks (all declarations above this point) ---
+
+    if (size(a) /= 3) error stop
+    if (size(b) /= 12) error stop
+    if (size(c) /= 4) error stop
+    if (size(z%x) /= 3) error stop
+    if (len(s) /= 5) error stop
+
+    print *, "pass"
+
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1814,7 +1814,8 @@ static inline bool is_value_constant(ASR::expr_t *a_value) {
         case ASR::exprType::RealUnaryMinus:
         case ASR::exprType::IntegerBinOp:
         case ASR::exprType::StructInstanceMember:
-        case ASR::exprType::StringLen: {
+        case ASR::exprType::StringLen:
+        case ASR::exprType::ArrayItem: {
             return is_value_constant(expr_value(a_value));
         }
         case ASR::exprType::ArrayConstructor: {
@@ -2234,7 +2235,8 @@ static inline bool extract_value(ASR::expr_t* value_expr, T& value) { // Returns
         case ASR::exprType::RealUnaryMinus:
         case ASR::exprType::FunctionCall:
         case ASR::exprType::IntegerBinOp:
-        case ASR::exprType::StringLen: {
+        case ASR::exprType::StringLen:
+        case ASR::exprType::ArrayItem: {
             if (!extract_value(expr_value(value_expr), value)) {
                 return false;
             }


### PR DESCRIPTION
fixes #12322

`real :: a(dims(1))` was rejected as "nonconstant bounds" when `dims` is a parameter array, even though `dims(1)` is a constant expression and its value was already being folded.

the gap was just recognition: `is_value_constant` and `extract_value` in `asr_utils.h` had no case for `ArrayItem`, so they fell through to false. added `ArrayItem` to the two switch groups that already delegate to `expr_value` (same pattern as `IntegerBinOp` / `StringLen`). no new folding logic.

```
$ lfortran t.f90   # integer, parameter :: dims(2) = [3,4]; real :: a(dims(1),dims(2)); print *, size(a)
          12
```
