### PR TITLE
fix: resolve re-exported custom operators through intermediate modules

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2274,6 +2274,7 @@ RUN(NAME custom_operator_17 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays
 RUN(NAME custom_operator_18 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME custom_operator_19 LABELS gfortran llvm)
 RUN(NAME custom_operator_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME custom_operator_21 LABELS gfortran llvm)
 
 RUN(NAME types_07 LABELS gfortran)
 RUN(NAME types_08 LABELS gfortran)

--- a/integration_tests/custom_operator_21.f90
+++ b/integration_tests/custom_operator_21.f90
@@ -1,0 +1,46 @@
+module m_custom_operator_21_concat
+    implicit none
+
+    private
+
+    public :: operator(//)
+
+    interface operator(//)
+        module procedure string_concat_i4
+    end interface
+
+contains
+
+    function string_concat_i4(str1, i2) result(string)
+        character(len=*), intent(in) :: str1
+        integer,          intent(in) :: i2
+        character(len=:), allocatable :: string
+
+        character(len=32) :: buffer
+        write(buffer, '(I0)') i2
+        string = str1 // trim(buffer)
+    end function
+end module
+
+! Re-export the operator through an intermediate module. Only the operator
+! (not the specific procedure string_concat_i4) is made public here.
+module m_custom_operator_21
+    use m_custom_operator_21_concat
+    implicit none
+
+    private
+
+    public :: operator(//)
+end module
+
+program custom_operator_21
+    use m_custom_operator_21
+    implicit none
+
+    character(len=:), allocatable :: string
+
+    string = 'coucou' // 1
+
+    print *, string
+    if (string /= 'coucou1') error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -19106,15 +19106,30 @@ public:
                 }
             } else {
                 std::string func_name = ASRUtils::symbol_name(v);
-                v = current_scope->resolve_symbol(func_name);
-                if (v == nullptr) {
-                    v = current_scope->resolve_symbol(func_name + "@~concat");
+                ASR::symbol_t* resolved = current_scope->resolve_symbol(func_name);
+                if (resolved == nullptr) {
+                    resolved = current_scope->resolve_symbol(func_name + "@~concat");
                 }
-                if (v == nullptr) {
-                    diag.add(Diagnostic("'" + func_name +
-                        "' not found in current scope", Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                    throw SemanticAbort();
+                if (resolved == nullptr) {
+                    // The specific procedure is not directly accessible in the
+                    // current scope. This happens when the operator interface is
+                    // re-exported through an intermediate module (only the
+                    // operator, not the specific procedures, is made public). The
+                    // procedure symbol `op_proc` is still valid, so import the
+                    // underlying function via an ExternalSymbol pointing to it.
+                    ASR::symbol_t* func_sym = ASRUtils::symbol_get_past_external(op_proc);
+                    ASR::symbol_t* func_parent = ASRUtils::get_asr_owner(func_sym);
+                    resolved = ASR::down_cast<ASR::symbol_t>(
+                        ASR::make_ExternalSymbol_t(
+                            al, x.base.base.loc, current_scope,
+                            s2c(al, func_name), func_sym,
+                            ASRUtils::symbol_name(func_parent), nullptr, 0,
+                            s2c(al, func_name), ASR::accessType::Public
+                        )
+                    );
+                    current_scope->add_symbol(func_name, resolved);
                 }
+                v = resolved;
             }
             ADD_ASR_DEPENDENCIES(current_scope, v, current_function_dependencies);
             ASRUtils::insert_module_dependency(v, al, current_module_dependencies);


### PR DESCRIPTION
fixes #12327

When a user-defined operator (e.g. `//`) is re-exported through an
intermediate module that only makes the operator public (not its specific
procedures), resolving the operator failed with "'<proc>' not found in
current scope".

In visit_StrOp's custom-operator concat path, the code discarded the
already-resolved specific procedure and re-looked it up by name in the
current scope. That name is not accessible when only the operator was
re-exported, so it errored out.

Fix: when the name lookup fails, import the underlying function as an
ExternalSymbol pointing to the resolved procedure, mirroring the existing
type-bound-operator branch. insert_module_dependency then records the
origin module for verify/codegen.
