### PR TITLE
feat: add --show-gpu-kernel-source to emit registrar-free GPU kernels

### DIFF
--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -52,6 +52,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--show-asm`: Show assembly for the given file and exit
 - `--show-wat`: Show WAT (WebAssembly Text Format) and exit
 - `--show-julia`: Show Julia translation source for the given file and exit
+- `--show-gpu-kernel-source`: Show the GPU kernel source for the backend selected by `--gpu` and exit
 - `--show-fortran`: Show Fortran translation source for the given file and exit
 - `--show-stacktrace`: Show internal stacktrace on compiler errors
 - `--symtab-only`: Only create symbol tables in ASR (skip executable stmt)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4949,6 +4949,8 @@ RUN(NAME gpu_metal_193 LABELS gfortran llvm metal)
 RUN(NAME gpu_metal_194 LABELS gfortran llvm metal)
 RUN(NAME gpu_metal_195 LABELS gfortran llvm metal)
 
+RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
+
 RUN(NAME real128_arith_01 LABELS gfortran llvm)
 RUN(NAME real128_arith_02 LABELS gfortran llvm)
 RUN(NAME real128_arith_03 LABELS gfortran llvm)

--- a/integration_tests/gpu_kernel_source_01.f90
+++ b/integration_tests/gpu_kernel_source_01.f90
@@ -1,0 +1,25 @@
+program gpu_kernel_source_01
+! Real arrays: saxpy. Also the reference test for --show-gpu-kernel-source.
+implicit none
+integer, parameter :: n = 1000
+real :: x(n), y(n), y_expected(n)
+real :: a
+integer :: i
+
+a = 2.5
+do i = 1, n
+    x(i) = real(i)
+    y(i) = real(i) * 0.5
+    y_expected(i) = a * real(i) + real(i) * 0.5
+end do
+
+do concurrent (i = 1:n)
+    y(i) = a * x(i) + y(i)
+end do
+
+do i = 1, n
+    if (abs(y(i) - y_expected(i)) > 1e-3) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/run_tests.py
+++ b/run_tests.py
@@ -85,6 +85,7 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
     c = is_included("c")
     is_cumulative_pass = is_included("cumulative")
     julia = is_included("julia")
+    gpu_cuda_kernel = is_included("gpu_cuda_kernel")
     wat = is_included("wat")
     obj = is_included("obj")
     x86 = is_included("x86")
@@ -719,6 +720,14 @@ def single_test(test: Dict, verbose: bool, no_llvm: bool, skip_run_with_dbg: boo
 
     if julia:
         run_test(filename, "julia", "lfortran --no-color --show-julia {infile}",
+                filename,
+                update_reference,
+                verify_hash,
+                extra_args)
+
+    if gpu_cuda_kernel:
+        run_test(filename, "gpu_cuda_kernel",
+                "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
                 filename,
                 update_reference,
                 verify_hash,

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -917,6 +917,42 @@ int emit_c(const std::string &infile,
     }
 }
 
+int emit_gpu_kernel_source(const std::string &infile,
+    LCompilers::PassManager& pass_manager, CompilerOptions &compiler_options)
+{
+    std::string input = read_file_ok(infile);
+
+    LCompilers::FortranEvaluator fe(compiler_options);
+    LCompilers::LocationManager lm;
+    LCompilers::diag::Diagnostics diagnostics;
+    {
+        LCompilers::LocationManager::FileLocations fl;
+        fl.in_filename = infile;
+        lm.files.push_back(fl);
+        lm.file_ends.push_back(input.size());
+    }
+    LCompilers::Result<LCompilers::ASR::TranslationUnit_t*>
+        r = fe.get_asr2(input, lm, diagnostics);
+    std::cerr << diagnostics.render(lm, compiler_options);
+    if (!r.ok) {
+        LCOMPILERS_ASSERT(diagnostics.has_error())
+        return 2;
+    }
+    diagnostics.diagnostics.clear();
+    LCompilers::ASR::TranslationUnit_t* asr = r.result;
+
+    LCompilers::Result<std::string> gpu_result
+        = fe.get_gpu_kernel_source(*asr, diagnostics, pass_manager);
+    std::cerr << diagnostics.render(lm, compiler_options);
+    if (gpu_result.ok) {
+        std::cout << gpu_result.result;
+        return 0;
+    } else {
+        LCOMPILERS_ASSERT(diagnostics.has_error())
+        return 1;
+    }
+}
+
 int emit_julia(const std::string &infile, CompilerOptions &compiler_options)
 {
     std::string input = read_file_ok(infile);
@@ -2828,6 +2864,10 @@ int main_app(int argc, char *argv[]) {
     }
     if (opts.show_julia) {
         return emit_julia(opts.arg_file, compiler_options);
+    }
+    if (opts.show_gpu_kernel_source) {
+        return emit_gpu_kernel_source(opts.arg_file, lfortran_pass_manager,
+            compiler_options);
     }
     if (opts.show_fortran) {
         return emit_fortran(opts.arg_file, lfortran_pass_manager, compiler_options);

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -306,6 +306,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--show-asm", opts.show_asm, "Show assembly for the given file and exit")->group(group_output_debugging_options);
         app.add_flag("--show-wat", opts.show_wat, "Show WAT (WebAssembly Text Format) and exit")->group(group_output_debugging_options);
         app.add_flag("--show-julia", opts.show_julia, "Show Julia translation source for the given file and exit")->group(group_output_debugging_options);
+        app.add_flag("--show-gpu-kernel-source", opts.show_gpu_kernel_source, "Show the GPU kernel source for the backend selected by --gpu and exit")->group(group_output_debugging_options);
         app.add_flag("--show-fortran", opts.show_fortran, "Show Fortran translation source for the given file and exit")->group(group_output_debugging_options);
         app.add_flag("--show-stacktrace", compiler_options.show_stacktrace, "Show internal stacktrace on compiler errors")->group(group_output_debugging_options);
         app.add_flag("--time-report", compiler_options.time_report, "Show compilation time report")->group(group_output_debugging_options);

--- a/src/bin/lfortran_command_line_parser.h
+++ b/src/bin/lfortran_command_line_parser.h
@@ -50,6 +50,7 @@ namespace LCompilers::CommandLineInterface {
         bool show_asm = false;
         bool show_wat = false;
         bool show_julia = false;
+        bool show_gpu_kernel_source = false;
         bool show_fortran = false;
         bool static_link = false;
         bool shared_link = false;

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -5,6 +5,8 @@
 #include <libasr/codegen/asr_to_c.h>
 #include <libasr/codegen/asr_to_wasm.h>
 #include <libasr/codegen/asr_to_julia.h>
+#include <libasr/codegen/asr_to_cuda.h>
+#include <libasr/codegen/asr_to_metal.h>
 #include <libasr/codegen/asr_to_fortran.h>
 #include <libasr/codegen/wasm_to_wat.h>
 #include <lfortran/ast_to_src.h>
@@ -583,6 +585,30 @@ Result<std::string> FortranEvaluator::get_c3(ASR::TranslationUnit_t &asr,
     pass_manager.apply_passes(al, &asr, compiler_options.po, diagnostics);
     // ASR pass -> C
     return asr_to_c(al, asr, diagnostics, compiler_options, default_lower_bound);
+}
+
+Result<std::string> FortranEvaluator::get_gpu_kernel_source(
+        ASR::TranslationUnit_t &asr, diag::Diagnostics &diagnostics,
+        LCompilers::PassManager& pass_manager)
+{
+    // The kernels only exist once gpu_offload has run, so the passes have to
+    // be applied before either backend is asked for source.
+    Allocator al(64*1024*1024);
+    compiler_options.po.always_run = false;
+    compiler_options.po.run_fun = "f";
+    if (!pass_manager.has_user_defined_passes()) {
+        pass_manager.use_default_passes();
+    }
+    pass_manager.apply_passes(al, &asr, compiler_options.po, diagnostics);
+    if (compiler_options.gpu_backend == "cuda") {
+        return asr_to_cuda(al, asr, diagnostics, compiler_options, false);
+    } else if (compiler_options.gpu_backend == "metal") {
+        return asr_to_metal(al, asr, diagnostics, compiler_options);
+    }
+    diagnostics.add(diag::Diagnostic(
+        "no GPU backend selected, pass --gpu=cuda or --gpu=metal",
+        diag::Level::Error, diag::Stage::CodeGen));
+    return Error();
 }
 
 Result<std::string> FortranEvaluator::get_julia(const std::string &code,

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -109,6 +109,10 @@ public:
     Result<std::string> get_c3(ASR::TranslationUnit_t &asr,
         diag::Diagnostics &diagnostics, LCompilers::PassManager& pass_manager,
         int64_t default_lower_bound);
+    // GPU kernel source for the backend selected by --gpu, with no host-side
+    // kernel-registration shim, so that external toolchains can consume it.
+    Result<std::string> get_gpu_kernel_source(ASR::TranslationUnit_t &asr,
+        diag::Diagnostics &diagnostics, LCompilers::PassManager& pass_manager);
     Result<std::string> get_julia(const std::string &code,
         LocationManager &lm, diag::Diagnostics &diagnostics);
     Result<std::unique_ptr<MLIRModule>> get_mlir(

--- a/src/libasr/codegen/asr_to_cuda.cpp
+++ b/src/libasr/codegen/asr_to_cuda.cpp
@@ -20,11 +20,13 @@ public:
     std::stringstream src;
     CompilerOptions &co;
     int indent_level = 0;
+    bool emit_registrar = true;
 
     // Maps for tracking array size parameters
     std::map<std::string, std::string> func_array_size_params;
 
-    ASRToCudaVisitor(CompilerOptions &co) : co(co) {}
+    ASRToCudaVisitor(CompilerOptions &co, bool emit_registrar)
+        : co(co), emit_registrar(emit_registrar) {}
 
     std::string get_indent() {
         return std::string(indent_level * 4, ' ');
@@ -100,6 +102,8 @@ public:
                 visit_GpuKernelFunction(kf);
             }
         }
+
+        if (!emit_registrar) return;
 
         // Emit kernel registration
         src << "\n// Auto-generated kernel registration\n";
@@ -563,9 +567,9 @@ public:
 };
 
 Result<std::string> asr_to_cuda(Allocator & /*al*/, ASR::TranslationUnit_t &asr,
-    diag::Diagnostics &diagnostics, CompilerOptions &co)
+    diag::Diagnostics &diagnostics, CompilerOptions &co, bool emit_registrar)
 {
-    ASRToCudaVisitor v(co);
+    ASRToCudaVisitor v(co, emit_registrar);
     try {
         v.visit_TranslationUnit(asr);
     } catch (const CodeGenError &e) {

--- a/src/libasr/codegen/asr_to_cuda.h
+++ b/src/libasr/codegen/asr_to_cuda.h
@@ -6,8 +6,12 @@
 
 namespace LCompilers {
 
+    // emit_registrar controls the trailing kernel-registration shim, which is
+    // only meaningful to the CUDA runtime's lookup-by-function-pointer launch
+    // path. Consumers that resolve kernels by name want the kernels alone.
     Result<std::string> asr_to_cuda(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics, CompilerOptions &co);
+        diag::Diagnostics &diagnostics, CompilerOptions &co,
+        bool emit_registrar = true);
 
 } // namespace LCompilers
 

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_01-0428e9e",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_01.f90",
+    "infile_hash": "f37e1728d037c1e48887391f53292f3e4bb9506541c5a6e6925e2e47",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout",
+    "stdout_hash": "23456068e44521a0c0fd08d8486077797fe5a1e3d51e10c6005821a7",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, float a, int __loop_end_0) {
+    int __flat_idx;
+    int i;
+    int n;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    y[(i - 1)] = ((a * x[(i - 1)]) + y[(i - 1)]);
+}
+

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4114,6 +4114,10 @@ filename = "errors/matmul_unallocated_01.f90"
 run = true
 
 [[test]]
+filename = "../integration_tests/gpu_kernel_source_01.f90"
+gpu_cuda_kernel = true
+
+[[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true
 


### PR DESCRIPTION
Hi, 

I maintain [Booth](https://github.com/Zaneham/Booth), an open source GPU
compiler, and I've been spending my time lately on getting Fortran to run on
GPUs. I've also done a wee bit in the legacy fortran space within LFortran too.

I ran into this while wiring LFortran up to Booth. The plan was to let LFortran
handle the Fortran and hand the generated kernels over for a non-NVIDIA target,
so I went looking at what `--gpu=cuda` emits. The kernels are good. What gets in
the way is the registration block on the end of every generated `.cu`. It
declares and calls `lfortran_gpu_register_kernel`, so the emitted source is not
self-contained. Compile it on its own and you have an undefined symbol unless
you also link LFortran's CUDA runtime. That block is host side glue for the
`cudaLaunchKernel` path, which finds kernels by function pointer, and anything
resolving by name has to discard it.

The seam is already mostly there, mind. `lfortran_gpu_runtime.h` is eight
functions with no CUDA types in sight, which I assume is the Metal backend
having forced the issue. This is really just finishing that thought.

So this adds `--show-gpu-kernel-source`, which prints the kernel source for
whichever backend `--gpu` selected and then exits, following the same shape as
`--show-c` and `--show-julia`. The registrar is left out, since anything
reaching for this flag is not going through the CUDA runtime.

I tried making the `.cuda.cu` sidecar registrar-free first. That breaks separate
compilation, because the link step reads those sidecars back in and the runtime
resolves kernels through exactly that registry. So this is opt-in and the
compile and link paths are untouched. `asr_to_cuda` takes an `emit_registrar`
parameter defaulting to true, so the existing call site behaves as before.

Testing is a reference test on the CUDA output plus an integration test running
under gfortran and llvm. I also checked the metal path emits, and that passing
the flag without `--gpu` errors sensibly. No CUDA toolkit on this machine, so I
haven't run the output through nvcc and haven't labelled the new test `cuda` for
that reason.

Cheers!
Zane
