### PR TITLE
make the GPU device compiler configurable via --device-compiler

### DIFF
--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -63,6 +63,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--continue-compilation`: Collect error messages and continue compilation after encountering semantic errors
 - `--error-format TEXT=human`: Control how errors are produced (human, short)
 - `--backend TEXT=llvm`: Select a backend (llvm, cpp, x86, wasm, fortran)
+- `--device-compiler TEXT=nvcc`: Toolchain driver used to compile and link GPU device code
 - `--openmp`: Enable OpenMP
 - `--separate-compilation`: Generate object code into .o files
 - `--rtlib`: Include the full runtime library in the LLVM output

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2170,13 +2170,14 @@ int link_executable(const std::vector<std::string> &infiles,
                     cu_out << cuda_source;
                     cu_out.close();
                 }
-                // Compile kernel .cu with nvcc
-                std::string nvcc_cmd = "nvcc -c -O2 -o " + cuda_kernel_obj
-                    + " " + cuda_kernel_src;
-                int cuda_err = system(nvcc_cmd.c_str());
+                // Compile the kernel .cu with the device compiler
+                std::string device_cc = compiler_options.device_compiler;
+                std::string cuda_kernel_cmd = device_cc + " -c -O2 -o "
+                    + cuda_kernel_obj + " " + cuda_kernel_src;
+                int cuda_err = system(cuda_kernel_cmd.c_str());
                 if (cuda_err) {
                     std::cerr << "Failed to compile CUDA kernel: "
-                        << nvcc_cmd << std::endl;
+                        << cuda_kernel_cmd << std::endl;
                     return 10;
                 }
 
@@ -2185,7 +2186,7 @@ int link_executable(const std::vector<std::string> &infiles,
                     + "/../libasr/runtime/lfortran_gpu_cuda.cu";
                 std::string cuda_runtime_obj = LFORTRAN_TEMP_DIR
                     + "/lfortran_gpu_cuda_" + LCOMPILERS_UNIQUE_ID + ".o";
-                std::string cuda_rt_cmd = "nvcc -c -O2"
+                std::string cuda_rt_cmd = device_cc + " -c -O2"
                     " -I" + runtime_library_dir + "/../libasr/runtime"
                     " -o " + cuda_runtime_obj
                     + " " + cuda_runtime_src;
@@ -2196,8 +2197,9 @@ int link_executable(const std::vector<std::string> &infiles,
                     return 10;
                 }
 
-                // Replace the linker with nvcc for CUDA linking
-                compile_cmd = "nvcc -o " + outfile + " ";
+                // The device compiler also drives the link, since it knows
+                // where its own device runtime lives.
+                compile_cmd = device_cc + " -o " + outfile + " ";
                 for (auto &s : infiles) {
                     compile_cmd += s + " ";
                 }

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -336,6 +336,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_option("--emcc-embed", compiler_options.emcc_embed, "Embed a given file/directory using emscripten for LLVM->WASM")->group(group_backend_codegen_options);
         app.add_flag("--mlir-gpu-offloading", compiler_options.po.enable_gpu_offloading, "Enables gpu offloading using MLIR backend")->group(group_backend_codegen_options);
         app.add_option("--gpu", compiler_options.gpu_backend, "Enable GPU offloading for do concurrent (metal)")->capture_default_str()->group(group_backend_codegen_options);
+        app.add_option("--device-compiler", compiler_options.device_compiler, "Toolchain driver used to compile and link GPU device code")->capture_default_str()->group(group_backend_codegen_options);
 
         // Symbol and lookup-related flags
         app.add_flag("--lookup-name", compiler_options.lookup_name, "Lookup a name specified by --line & --column in the ASR")->group(group_symbol_lookup_options);

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -104,6 +104,8 @@ struct CompilerOptions {
     std::string gpu_backend = "";
     std::string gpu_metal_source = "";
     std::string gpu_cuda_source = "";
+    // Toolchain driver used to compile and link GPU device code.
+    std::string device_compiler = "nvcc";
     std::string openmp_lib_dir = "";
     bool lookup_name = false;
     bool rename_symbol = false;


### PR DESCRIPTION
Follow-up to my other GPU PR, same background. I maintain
[Booth](https://github.com/Zaneham/Booth) and I've been getting Fortran running on GPUs.

The CUDA link path shells out to `nvcc` three times through `system()`, all hardcoded. Once for the generated kernel, once for `lfortran_gpu_cuda.cu`, and once more as the link driver. That's fine when `nvcc` is on PATH, less fine otherwise. If you have CUDA somewhere unusual, or several versions installed, or you want to point at a wrapper, there's currently no way to say so.

So this adds `--device-compiler`, defaulting to `nvcc`, and uses it for all three. Same idea as the existing `--linker` option.

However, there's no automated test here, because the path needs both nvcc and a GPU to reach, and there isn't any existing coverage of it either. I verified it by hand with a stub compiler on PATH, checking the default is still `nvcc` and that the override actually gets executed rather than just accepted. Happy to add something if you can suggest a way to test it that fits the suite.

Cheers!
Zane
