### PR TITLE
fix: let user functions shadow intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2187,6 +2187,7 @@ RUN(NAME implicit_interface_40 LABELS gfortran llvm EXTRA_ARGS --implicit-typing
 RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --fixed-form --implicit-interface GFORTRAN_ARGS -ffixed-form)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_44.f90
+++ b/integration_tests/implicit_interface_44.f90
@@ -1,0 +1,12 @@
+      program implicit_interface_44
+      double precision diff, x, y, z
+      x = 3.0d0
+      y = 1.0d0
+      z = diff(x, y)
+      if (z .ne. 2.0d0) error stop
+      end
+
+      double precision function diff(x, y)
+      double precision x, y
+      diff = x - y
+      end

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -17087,7 +17087,15 @@ public:
         if (( ASR::is_a<ASR::Variable_t>(*v) || is_external_procedure ) && !not_resolvable_to_fncall) {
             bool is_v_dummy_arg = ASR::is_a<ASR::Variable_t>(*v) &&
                 ASRUtils::is_arg_dummy(ASR::down_cast<ASR::Variable_t>(v)->m_intent);
-            if (!is_v_dummy_arg && (intrinsic_procedures.is_intrinsic(var_name) || is_intrinsic_registry_function(var_name))) {
+            ASR::symbol_t *parent_sym = current_scope->parent
+                ? current_scope->parent->resolve_symbol(var_name) : nullptr;
+            bool user_function_found = parent_sym &&
+                ASR::is_a<ASR::Function_t>(
+                    *ASRUtils::symbol_get_past_external(parent_sym)) &&
+                !ASRUtils::is_intrinsic_symbol(parent_sym);
+            if (!is_v_dummy_arg && !user_function_found &&
+                    (intrinsic_procedures.is_intrinsic(var_name) ||
+                    is_intrinsic_registry_function(var_name))) {
                 if (compiler_options.implicit_interface) {
                     bool is_function = true;
                     if ( !is_external_procedure ) {
@@ -17248,7 +17256,9 @@ public:
                 // NOTE: ideally this shouldn't be needed, this is only to handle
                 // 'dble', 'shifta', 'float', 'dfloat', which aren't currently
                 // implemented as intrinsic elemental function
-                intrinsic_as_node(x, is_function);
+                if (!user_function_found) {
+                    intrinsic_as_node(x, is_function);
+                }
                 if (!is_function) {
                     return;
                 }


### PR DESCRIPTION
## Summary
- let enclosing user functions shadow same-named intrinsics
- add a fixed-form regression test

Fixes #12208

## Why
A typed user function was resolved as an intrinsic before the enclosing procedure was considered.

**Stage:** Semantics

## Changes
- [`ast_common_visitor.h#L17090-L17098`](https://github.com/lazy-fortran/lfortran/blob/19c6be159dbcd5cc1e2942133359ff969c7a9369/src/lfortran/semantics/ast_common_visitor.h#L17090-L17098): prefer the enclosing user function over intrinsic fallback

## Tests
- [`implicit_interface_44.f90`](https://github.com/lazy-fortran/lfortran/blob/19c6be159dbcd5cc1e2942133359ff969c7a9369/integration_tests/implicit_interface_44.f90): exact fixed-form `diff` call with a runtime assertion

## Verification

### Test fails on main
```
$ scripts/lf.sh itest -b llvm -t implicit_interface_44
semantic error: Incorrect number of arguments passed to the 'diff' intrinsic. It accepts exactly 1 arguments.
 --> integration_tests/implicit_interface_44.f90:5:11
5 |       z = diff(x, y)
              ^~~~~~~~~~
Command failed.
```

### Test passes after fix
```
$ scripts/lf.sh itest -b llvm -t implicit_interface_44
1/1 Test #1575: implicit_interface_44 ... Passed
100% tests passed, 0 tests failed out of 1
```

### Additional checks
```
$ scripts/lf.sh itest -b gfortran -t implicit_interface_44
100% tests passed, 0 tests failed out of 1

$ scripts/lf.sh itest -b llvm
100% tests passed, 0 tests failed out of 3831

$ scripts/lf.sh test
TESTS PASSED

$ scripts/lf.sh --llvm21 itest -b llvm -t implicit_interface_44
100% tests passed, 0 tests failed out of 1
```
