### PR TITLE
coarray pass: correct value attributes in PRIF lowering and factor

### DIFF
--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -747,30 +747,6 @@ class PRIFInterface {
             ASR::expr_t *alloc_mem = b.Variable(fn_symtab, "allocated_memory", cptr,
                 ASR::intentType::Out, nullptr, ASR::abiType::Source, false);
 
-            ASR::ttype_t *int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
-            ASR::symbol_t *stat_sym = declare_variable(
-                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
-
-            ASR::ttype_t *errmsg_type = ASRUtils::TYPE(ASR::make_String_t(
-                al, loc, 1, nullptr,
-                ASR::string_length_kindType::AssumedLength,
-                ASR::string_physical_typeType::DescriptorString));
-            ASR::symbol_t *errmsg_sym = declare_variable(
-                fn_symtab, loc, "errmsg", errmsg_type, ASR::intentType::InOut, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
-
-            ASR::ttype_t *errmsg_alloc_type = allocatable_deferred_string();
-            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
-                fn_symtab, loc, "errmsg_alloc", errmsg_alloc_type, ASR::intentType::InOut, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
-
             Vec<ASR::expr_t*> args; args.reserve(al, 9);
             args.push_back(al, lcobounds);
             args.push_back(al, ucobounds);
@@ -782,9 +758,7 @@ class PRIFInterface {
 #endif
             args.push_back(al, handle_var);
             args.push_back(al, alloc_mem);
-            args.push_back(al, stat);
-            args.push_back(al, errmsg);
-            args.push_back(al, errmsg_alloc);
+            declare_prif_status_args(fn_symtab, loc, args);
             ASR::asr_t *fn = ASRUtils::make_Function_t_util(
                 al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,
                 args.p, args.n, nullptr, 0, nullptr,
@@ -1091,35 +1065,9 @@ class PRIFInterface {
             }
             SymbolTable *fn_symtab = al.make_new<SymbolTable>(global_scope);
             ASRUtils::ASRBuilder b(al, loc);
-            ASR::ttype_t *int32_type = int32;
-            ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_String_t(
-                al, loc, 1, nullptr,
-                ASR::string_length_kindType::AssumedLength,
-                ASR::string_physical_typeType::DescriptorString));
-            ASR::ttype_t *alloc_str_type = allocatable_deferred_string();
-
-            ASR::symbol_t *stat_sym = declare_variable(
-                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *stat = ASRUtils::EXPR(ASR::make_Var_t(al, loc, stat_sym));
-
-            ASR::symbol_t *errmsg_sym = declare_variable(
-                fn_symtab, loc, "errmsg", str_type, ASR::intentType::InOut, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *errmsg = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_sym));
-
-            ASR::symbol_t *errmsg_alloc_sym = declare_variable(
-                fn_symtab, loc, "errmsg_alloc", alloc_str_type, ASR::intentType::InOut, nullptr,
-                ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, false);
-            ASR::expr_t *errmsg_alloc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, errmsg_alloc_sym));
 
             Vec<ASR::expr_t*> args; args.reserve(al, 3);
-            args.push_back(al, stat);
-            args.push_back(al, errmsg);
-            args.push_back(al, errmsg_alloc);
+            declare_prif_status_args(fn_symtab, loc, args);
 
             ASR::asr_t *fn = ASRUtils::make_Function_t_util(
                 al, loc, fn_symtab, s2c(al, sym_name), nullptr, 0,

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -161,20 +161,20 @@ class PRIFInterface {
             ASR::ttype_t *cptr_type = b.CPtr();
             ASR::expr_t *image_num = b.Variable(fn_symtab, "image_num", int32_type,
                                                ASR::intentType::In, nullptr,
-                                               ASR::abiType::Source, true);
+                                               ASR::abiType::Source, false);
             ASR::symbol_t *handle_sym = get_or_create_prif_coarray_handle_struct(loc);
             ASR::expr_t *coarray_handle = make_struct_var(
                 fn_symtab, loc, "coarray_handle", handle_sym,
                 ASR::intentType::In, ASR::presenceType::Required, false);
             ASR::expr_t *offset = b.Variable(fn_symtab, "offset", int64_type,
                                              ASR::intentType::In, nullptr,
-                                             ASR::abiType::Source, true);
+                                             ASR::abiType::Source, false);
             ASR::expr_t *current_image_buffer = b.Variable(fn_symtab, "current_image_buffer", cptr_type,
                                                            ASR::intentType::In, nullptr,
-                                                           ASR::abiType::Source, true);
+                                                           ASR::abiType::Source, false);
             ASR::expr_t *size_in_bytes = b.Variable(fn_symtab, "size_in_bytes", int64_type,
                                                     ASR::intentType::In, nullptr,
-                                                    ASR::abiType::Source, true);
+                                                    ASR::abiType::Source, false);
             Vec<ASR::expr_t*> args;
             args.reserve(al, 8);
             args.push_back(al, image_num);
@@ -220,7 +220,7 @@ class PRIFInterface {
             dims.push_back(al, d);
             ASR::ttype_t *i64_arr = ASRUtils::make_Array_t_util(al, loc, i64, dims.p, dims.n);
             ASR::expr_t *sub = b.Variable(fn_symtab, "sub", i64_arr,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
 
             ASR::ttype_t *i32 = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
             ASR::symbol_t *initial_team_index_sym = declare_variable(
@@ -688,7 +688,7 @@ class PRIFInterface {
             ASR::symbol_t *handle_struct = get_or_create_prif_coarray_handle_struct(loc);
             ASR::expr_t *handle_arg = make_struct_var(
                 iface_symtab, loc, "handle", handle_struct,
-                ASR::intentType::In, ASR::presenceType::Required, true);
+                ASR::intentType::In, ASR::presenceType::Required, true); // deliberate value attrib
             Vec<ASR::expr_t*> iface_args; iface_args.reserve(al, 1);
             iface_args.push_back(al, handle_arg);
             ASR::asr_t *iface_fn = ASRUtils::make_Function_t_util(
@@ -718,11 +718,11 @@ class PRIFInterface {
             dims.push_back(al, d);
             ASR::ttype_t *i64_arr = ASRUtils::make_Array_t_util(al, loc, i64, dims.p, dims.n);
             ASR::expr_t *lcobounds = b.Variable(fn_symtab, "lcobounds", i64_arr,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
             ASR::expr_t *ucobounds = b.Variable(fn_symtab, "ucobounds", i64_arr,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
             ASR::expr_t *size_arg = b.Variable(fn_symtab, "size_in_bytes", i64,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
 #if CAF_PRIF_VERSION >= 8
             // final_proc: procedure(prif_coarray_cleanup_interface), pointer, intent(in)
             ASR::symbol_t *handle_struct = get_or_create_prif_coarray_handle_struct(loc);
@@ -740,7 +740,7 @@ class PRIFInterface {
                 ASR::intentType::In, cleanup_iface, ASR::abiType::BindC, false);
 #else
             ASR::expr_t *final_func = b.Variable(fn_symtab, "final_func", cptr,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
 #endif
             ASR::expr_t *handle_var = make_struct_var(fn_symtab, loc, "coarray_handle",
                 handle_struct, ASR::intentType::Out, ASR::presenceType::Required, false);
@@ -842,7 +842,7 @@ class PRIFInterface {
             ASR::ttype_t *int32_type = int32;
             // exit_code: integer(c_int), intent(out), optional
             ASR::symbol_t *ec_sym = declare_variable(
-                fn_symtab, loc, "exit_code", int32_type, ASR::intentType::Out, nullptr,
+                fn_symtab, loc, "stat", int32_type, ASR::intentType::Out, nullptr,
                 ASR::abiType::Source, ASR::accessType::Public,
                 ASR::presenceType::Required, false);
             ASR::expr_t *ec_expr = ASRUtils::EXPR(ASR::make_Var_t(al, loc, ec_sym));
@@ -945,18 +945,18 @@ class PRIFInterface {
                 ASR::string_length_kindType::AssumedLength,
                 ASR::string_physical_typeType::DescriptorString));
             ASR::expr_t *quiet = b.Variable(fn_symtab, "quiet", logical_type,
-                ASR::intentType::In, nullptr, ASR::abiType::Source, true);
+                ASR::intentType::In, nullptr, ASR::abiType::Source, false);
             // stop_code_int: integer(c_int), intent(in), optional
             ASR::symbol_t *sci_sym = declare_variable(
                 fn_symtab, loc, "stop_code_int", int32_type, ASR::intentType::In, nullptr,
                 ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, true);
+                ASR::presenceType::Optional, false);
             ASR::expr_t *sci = ASRUtils::EXPR(ASR::make_Var_t(al, loc, sci_sym));
             // stop_code_char: character(*), intent(in), optional
             ASR::symbol_t *scc_sym = declare_variable(
                 fn_symtab, loc, "stop_code_char", str_type, ASR::intentType::In, nullptr,
                 ASR::abiType::Source, ASR::accessType::Public,
-                ASR::presenceType::Optional, true);
+                ASR::presenceType::Optional, false);
             ASR::expr_t *scc = ASRUtils::EXPR(ASR::make_Var_t(al, loc, scc_sym));
             Vec<ASR::expr_t*> args; args.reserve(al, 3);
             args.push_back(al, quiet);

--- a/tests/reference/fortran-coarray_collectives_01-4fd95fc.f90
+++ b/tests/reference/fortran-coarray_collectives_01-4fd95fc.f90
@@ -95,8 +95,8 @@ interface
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
@@ -108,9 +108,9 @@ end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_collectives_01-4fd95fc.json
+++ b/tests/reference/fortran-coarray_collectives_01-4fd95fc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_collectives_01-4fd95fc.f90",
-    "stdout_hash": "c1870a672c0c77881747422bcf104660cfa53837046b54d384d44f48",
+    "stdout_hash": "218bbfdc32e820f88e65d1ad1ea4e92aa843f0b9205668cea8d20372",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_initialization_01-23c9c70.f90
+++ b/tests/reference/fortran-coarray_initialization_01-23c9c70.f90
@@ -102,10 +102,10 @@ interface
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
         procedure(prif_coarray_cleanup_interface), pointer, intent(in) :: final_proc
-        integer(8), dimension(:), intent(in), value :: lcobounds
-        integer(8), intent(in), value :: size_in_bytes
+        integer(8), dimension(:), intent(in) :: lcobounds
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
-        integer(8), dimension(:), intent(in), value :: ucobounds
+        integer(8), dimension(:), intent(in) :: ucobounds
     end subroutine __module_prif_prif_allocate_coarray
 end interface
 
@@ -114,19 +114,19 @@ interface
         &
          stat, errmsg, errmsg_alloc)
         type(prif_coarray_handle), intent(in) :: coarray_handle
-        type(c_ptr), intent(in), value :: current_image_buffer
+        type(c_ptr), intent(in) :: current_image_buffer
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
-        integer(4), intent(in), value :: image_num
-        integer(8), intent(in), value :: offset
-        integer(8), intent(in), value :: size_in_bytes
+        integer(4), intent(in) :: image_num
+        integer(8), intent(in) :: offset
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
     end subroutine __module_prif_prif_get
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
@@ -135,15 +135,15 @@ interface
         type(prif_coarray_handle), intent(in) :: coarray_handle
         integer(4), intent(out) :: initial_team_index
         integer(4), intent(out), optional :: stat
-        integer(8), dimension(:), intent(in), value :: sub
+        integer(8), dimension(:), intent(in) :: sub
     end subroutine __module_prif_prif_initial_team_index
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_initialization_01-23c9c70.json
+++ b/tests/reference/fortran-coarray_initialization_01-23c9c70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_initialization_01-23c9c70.f90",
-    "stdout_hash": "4a73cd472f5d6fa06a630bdfff553df957595cf7cfdc23ddd11cdd81",
+    "stdout_hash": "55e31fabf0be0f06018ce85c19ced43ab7ac6340f0280f07e9886ddf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_operations_01-fb45389.f90
+++ b/tests/reference/fortran-coarray_operations_01-fb45389.f90
@@ -41,10 +41,10 @@ interface
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
         procedure(prif_coarray_cleanup_interface), pointer, intent(in) :: final_proc
-        integer(8), dimension(:), intent(in), value :: lcobounds
-        integer(8), intent(in), value :: size_in_bytes
+        integer(8), dimension(:), intent(in) :: lcobounds
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
-        integer(8), dimension(:), intent(in), value :: ucobounds
+        integer(8), dimension(:), intent(in) :: ucobounds
     end subroutine __module_prif_prif_allocate_coarray
 end interface
 
@@ -53,19 +53,19 @@ interface
         &
          stat, errmsg, errmsg_alloc)
         type(prif_coarray_handle), intent(in) :: coarray_handle
-        type(c_ptr), intent(in), value :: current_image_buffer
+        type(c_ptr), intent(in) :: current_image_buffer
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
-        integer(4), intent(in), value :: image_num
-        integer(8), intent(in), value :: offset
-        integer(8), intent(in), value :: size_in_bytes
+        integer(4), intent(in) :: image_num
+        integer(8), intent(in) :: offset
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
     end subroutine __module_prif_prif_get
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
@@ -74,7 +74,7 @@ interface
         type(prif_coarray_handle), intent(in) :: coarray_handle
         integer(4), intent(out) :: initial_team_index
         integer(4), intent(out), optional :: stat
-        integer(8), dimension(:), intent(in), value :: sub
+        integer(8), dimension(:), intent(in) :: sub
     end subroutine __module_prif_prif_initial_team_index
 end interface
 
@@ -83,21 +83,21 @@ interface
         &
          stat, errmsg, errmsg_alloc)
         type(prif_coarray_handle), intent(in) :: coarray_handle
-        type(c_ptr), intent(in), value :: current_image_buffer
+        type(c_ptr), intent(in) :: current_image_buffer
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
-        integer(4), intent(in), value :: image_num
-        integer(8), intent(in), value :: offset
-        integer(8), intent(in), value :: size_in_bytes
+        integer(4), intent(in) :: image_num
+        integer(8), intent(in) :: offset
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
     end subroutine __module_prif_prif_put
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_operations_01-fb45389.json
+++ b/tests/reference/fortran-coarray_operations_01-fb45389.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_operations_01-fb45389.f90",
-    "stdout_hash": "2b2134c9f7e2fafb1a18a81991a88af8574a4151c8990e3728cf7085",
+    "stdout_hash": "7de5f53bd67c193e2c088810aafd0de371ccd2a6009ce233edbb4e4b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_saved_01-1f96b4c.f90
+++ b/tests/reference/fortran-coarray_saved_01-1f96b4c.f90
@@ -85,24 +85,24 @@ interface
         character(len=*, kind=1), intent(inout), optional :: errmsg
         character(len=:, kind=1), allocatable, intent(inout), optional :: errmsg_alloc
         procedure(prif_coarray_cleanup_interface), pointer, intent(in) :: final_proc
-        integer(8), dimension(:), intent(in), value :: lcobounds
-        integer(8), intent(in), value :: size_in_bytes
+        integer(8), dimension(:), intent(in) :: lcobounds
+        integer(8), intent(in) :: size_in_bytes
         integer(4), intent(out), optional :: stat
-        integer(8), dimension(:), intent(in), value :: ucobounds
+        integer(8), dimension(:), intent(in) :: ucobounds
     end subroutine __module_prif_prif_allocate_coarray
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_saved_01-1f96b4c.json
+++ b/tests/reference/fortran-coarray_saved_01-1f96b4c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_saved_01-1f96b4c.f90",
-    "stdout_hash": "995fba7c8b4367f90c2aeabc063653261a1fa3199133700a98a34b8c",
+    "stdout_hash": "e585aa607a00878d18d197b73ecf98fa02ecd1d65326688669599c91",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_sync_01-4cab83b.f90
+++ b/tests/reference/fortran-coarray_sync_01-4cab83b.f90
@@ -19,16 +19,16 @@ call __module_prif_prif_stop(.false.)
 contains
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_sync_01-4cab83b.json
+++ b/tests/reference/fortran-coarray_sync_01-4cab83b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_sync_01-4cab83b.f90",
-    "stdout_hash": "53be935ee2791ed9b92f29651e5bb0c9024af5b5c9173b2a33294ce3",
+    "stdout_hash": "05749585b523cf326d583de74edc23e793eea5fba1ab16305f487d33",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_teams_01-442657a.f90
+++ b/tests/reference/fortran-coarray_teams_01-442657a.f90
@@ -45,16 +45,16 @@ interface
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_teams_01-442657a.json
+++ b/tests/reference/fortran-coarray_teams_01-442657a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_teams_01-442657a.f90",
-    "stdout_hash": "aea0cef8ec89e16708aa36bc20cfe3d655dab81a284e02e247b8bf62",
+    "stdout_hash": "e0dd863558a65e99242f1a1f77d3b3d847f87a20d87c88e0d76fd3bf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_teams_02-f6f38f1.f90
+++ b/tests/reference/fortran-coarray_teams_02-f6f38f1.f90
@@ -34,16 +34,16 @@ interface
 end interface
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_teams_02-f6f38f1.json
+++ b/tests/reference/fortran-coarray_teams_02-f6f38f1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_teams_02-f6f38f1.f90",
-    "stdout_hash": "0030dfdb550bec33a7b66c078f7bd25b116ee2693853224ccc9ef37c",
+    "stdout_hash": "249d7d752f2ded809a448321ebb26a78df18ed101af8c572087bf988",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/fortran-coarray_var_name_collision_01-94763bf.f90
+++ b/tests/reference/fortran-coarray_var_name_collision_01-94763bf.f90
@@ -16,16 +16,16 @@ call __module_prif_prif_stop(.false.)
 contains
 
 interface
-    subroutine __module_prif_prif_init(exit_code)
-        integer(4), intent(out) :: exit_code
+    subroutine __module_prif_prif_init(stat)
+        integer(4), intent(out) :: stat
     end subroutine __module_prif_prif_init
 end interface
 
 interface
     subroutine __module_prif_prif_stop(quiet, stop_code_int, stop_code_char)
-        logical(1), intent(in), value :: quiet
-        character(len=*, kind=1), intent(in), optional, value :: stop_code_char
-        integer(4), intent(in), optional, value :: stop_code_int
+        logical(1), intent(in) :: quiet
+        character(len=*, kind=1), intent(in), optional :: stop_code_char
+        integer(4), intent(in), optional :: stop_code_int
     end subroutine __module_prif_prif_stop
 end interface
 

--- a/tests/reference/fortran-coarray_var_name_collision_01-94763bf.json
+++ b/tests/reference/fortran-coarray_var_name_collision_01-94763bf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "fortran-coarray_var_name_collision_01-94763bf.f90",
-    "stdout_hash": "e9b0a8c86acf5e2c835a83e6d532d06d2d78e756d59e61fdb8661355",
+    "stdout_hash": "3340966b0fd6a687676b9d2e1e8f094fab45aa739bd60a18500ecd4b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0


### PR DESCRIPTION
PRIF lowering was incorrectly adding unspecified `value` attributes to a number of dummy arguments in PRIF module procedures. Correct these to ensure strict match with the [PRIF specification](https://go.lbl.gov/prif), and update reference tests accordingly.

Also :
* correct the name of the `prif_init` dummy argument
* deploy some missing factorization for the generation sync-stat arguments in `prif_sync_all` and `prif_allocate_coarray`