### PR TITLE
test: use free form for implicit interface regression

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2190,7 +2190,7 @@ RUN(NAME implicit_interface_40 LABELS gfortran llvm EXTRA_ARGS --implicit-typing
 RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
-RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --fixed-form --implicit-interface GFORTRAN_ARGS -ffixed-form)
+RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_44.f90
+++ b/integration_tests/implicit_interface_44.f90
@@ -1,12 +1,13 @@
 program implicit_interface_44
-double precision diff, x, y, z
-x = 3.0d0
-y = 1.0d0
-z = diff(x, y)
-if (z .ne. 2.0d0) error stop
-end
+    double precision diff, x, y, z
+    external diff
+    x = 3.0d0
+    y = 1.0d0
+    z = diff(x, y)
+    if (z .ne. 2.0d0) error stop
+    end
 
-double precision function diff(x, y)
-double precision x, y
-diff = x - y
-end
+    double precision function diff(x, y)
+        double precision x, y
+        diff = x - y
+        end

--- a/integration_tests/implicit_interface_44.f90
+++ b/integration_tests/implicit_interface_44.f90
@@ -1,12 +1,12 @@
-      program implicit_interface_44
-      double precision diff, x, y, z
-      x = 3.0d0
-      y = 1.0d0
-      z = diff(x, y)
-      if (z .ne. 2.0d0) error stop
-      end
+program implicit_interface_44
+double precision diff, x, y, z
+x = 3.0d0
+y = 1.0d0
+z = diff(x, y)
+if (z .ne. 2.0d0) error stop
+end
 
-      double precision function diff(x, y)
-      double precision x, y
-      diff = x - y
-      end
+double precision function diff(x, y)
+double precision x, y
+diff = x - y
+end

--- a/tests/reference/asr-implicit_interface_44-20224f3.json
+++ b/tests/reference/asr-implicit_interface_44-20224f3.json
@@ -2,12 +2,12 @@
     "basename": "asr-implicit_interface_44-20224f3",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/implicit_interface_44.f90",
-    "infile_hash": "52cc39b1ff5c08d59e6437354b91f2ed5e1a5f2ba675dbe6edd92582",
+    "infile_hash": "e955207ba13f9682f33ebe9ee360e048f3610c6886ead780d0926f3e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-implicit_interface_44-20224f3.stderr",
-    "stderr_hash": "3641306b23013bd06bd4b562f8283acc4d00c2c36f54a4340eb9dc98",
+    "stderr_hash": "5e577427214875d0ef18c2c72983aa2f88cf7f1fcd04bd59f10af74a",
     "returncode": 2
 }

--- a/tests/reference/asr-implicit_interface_44-20224f3.json
+++ b/tests/reference/asr-implicit_interface_44-20224f3.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-implicit_interface_44-20224f3",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/implicit_interface_44.f90",
+    "infile_hash": "52cc39b1ff5c08d59e6437354b91f2ed5e1a5f2ba675dbe6edd92582",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-implicit_interface_44-20224f3.stderr",
+    "stderr_hash": "3641306b23013bd06bd4b562f8283acc4d00c2c36f54a4340eb9dc98",
+    "returncode": 2
+}

--- a/tests/reference/asr-implicit_interface_44-20224f3.stderr
+++ b/tests/reference/asr-implicit_interface_44-20224f3.stderr
@@ -1,0 +1,11 @@
+style suggestion: Use '/=' instead of '.ne.'
+ --> tests/../integration_tests/implicit_interface_44.f90:6:7
+  |
+6 | if (z .ne. 2.0d0) error stop
+  |       ^^^^ help: write this as '/='
+
+semantic error: diff was declared as a variable, it can't be called as a function
+ --> tests/../integration_tests/implicit_interface_44.f90:5:5
+  |
+5 | z = diff(x, y)
+  |     ^^^^^^^^^^ help: use the compiler option "--implicit-interface" to use intrinsic functions

--- a/tests/reference/asr-implicit_interface_44-20224f3.stderr
+++ b/tests/reference/asr-implicit_interface_44-20224f3.stderr
@@ -1,11 +1,11 @@
 style suggestion: Use '/=' instead of '.ne.'
- --> tests/../integration_tests/implicit_interface_44.f90:6:7
+ --> tests/../integration_tests/implicit_interface_44.f90:7:11
   |
-6 | if (z .ne. 2.0d0) error stop
-  |       ^^^^ help: write this as '/='
+7 |     if (z .ne. 2.0d0) error stop
+  |           ^^^^ help: write this as '/='
 
-semantic error: diff was declared as a variable, it can't be called as a function
- --> tests/../integration_tests/implicit_interface_44.f90:5:5
+semantic error: function interface must be specified explicitly; you can enable implicit interfaces with `--implicit-interface`
+ --> tests/../integration_tests/implicit_interface_44.f90:3:14
   |
-5 | z = diff(x, y)
-  |     ^^^^^^^^^^ help: use the compiler option "--implicit-interface" to use intrinsic functions
+3 |     external diff
+  |              ^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4222,6 +4222,10 @@ asr = true
 filename = "errors/external1.f90"
 asr = true
 
+[[test]]
+filename = "../integration_tests/implicit_interface_44.f90"
+asr = true
+
 # Parser
 
 [[test]]


### PR DESCRIPTION
## Summary

- convert `implicit_interface_44.f90` from fixed-form layout to free-form source
- remove the LFortran and GFortran fixed-form runner flags while retaining `--implicit-interface`

## Why

The regression exercises user-function shadowing of an intrinsic through an implicit interface. Fixed-form parsing is unrelated to that behavior and made the test cover an extra concern unnecessarily.

## Impact

The test continues to verify that the two-argument user function `diff` is selected over the one-argument intrinsic and returns `2.0d0`, now through the normal free-form path. Compiler behavior outside the test suite is unchanged.

## Root cause

The test source was written in fixed-form column layout and its runner registration explicitly forced fixed form even though the regression did not depend on source form.

## Checks

- `PATH=/home/ert/code/lfortran-12385/build/src/bin:$PATH ./run_tests.py -b llvm -t '^implicit_interface_44$' --ninja` — 1/1 passed
- `gfortran integration_tests/implicit_interface_44.f90 -o /tmp/lfortran-12385-gfortran-test && /tmp/lfortran-12385-gfortran-test` — passed
- `git diff --check` — passed

Fixes #12385.
