### PR TITLE
fix: flag invalid or not supported intrinsic procedures

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5816,6 +5816,16 @@ public:
                                     }
                                 } else if(sa->m_attr == AST::simple_attributeType
                                         ::AttrIntrinsic) {
+                                    // Check if an intrinsic procedure (function or subroutine) is supported by
+                                    // the compiler or not
+                                    if (!is_intrinsic_registry_function(sym) &&
+                                        !is_intrinsic_registry_subroutine(sym)) {
+                                        diag.add(Diagnostic("Intrinsic procedure '" + sym + "' is not recognized",
+                                             Level::Error, Stage::Semantic,
+                                            {Label("", {s.loc})}));
+                                        throw SemanticAbort();
+                                    }
+
                                     explicit_intrinsic_procedures.push_back(sym);
                                     if (compiler_options.implicit_interface) {
                                         create_intrinsic_function_wrapper(sym, x.m_syms[i].loc);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5816,6 +5816,11 @@ public:
                                     }
                                 } else if(sa->m_attr == AST::simple_attributeType
                                         ::AttrIntrinsic) {
+                                    explicit_intrinsic_procedures.push_back(sym);
+                                    if (compiler_options.implicit_interface) {
+                                        create_intrinsic_function_wrapper(sym, x.m_syms[i].loc);
+                                    }
+
                                     // Check if an intrinsic procedure (function or subroutine) is supported by
                                     // the compiler or not
                                     if (!is_intrinsic_registry_function(sym) &&
@@ -5824,11 +5829,6 @@ public:
                                              Level::Error, Stage::Semantic,
                                             {Label("", {s.loc})}));
                                         throw SemanticAbort();
-                                    }
-
-                                    explicit_intrinsic_procedures.push_back(sym);
-                                    if (compiler_options.implicit_interface) {
-                                        create_intrinsic_function_wrapper(sym, x.m_syms[i].loc);
                                     }
                                 } else if (sa->m_attr == AST::simple_attributeType
                                         ::AttrExternal) {
@@ -15562,7 +15562,8 @@ public:
             ASRUtils::IntrinsicElementalFunctionRegistry::is_intrinsic_function(var_name) ||
             ASRUtils::IntrinsicArrayFunctionRegistry::is_intrinsic_function(var_name) ||
             ASRUtils::IntrinsicImpureFunctionRegistry::is_intrinsic_function(var_name) ||
-            is_specific_type_intrinsic) {
+            is_specific_type_intrinsic || var_name == "dble" || var_name == "float" ||
+            var_name == "dfloat" || var_name == "shifta") {
             return true;
         }
         return false;

--- a/tests/errors/intrinsics16.f90
+++ b/tests/errors/intrinsics16.f90
@@ -1,0 +1,15 @@
+! tests throwing an error when an unsupported or invalid intrinsic procedure is encountered
+
+program intrinsics16
+  call sub()
+contains
+  subroutine sub()
+    intrinsic chdir     ! A valid intrinsic subroutine that is supported only by gnu
+    intrinsic aaaa      ! An invalid intrinsic subroutine
+    intrinsic :: bbbb   ! An invalid intrinsic function
+
+    call chdir('.')
+    call aaaa('.')
+    print *, bbbb('.')
+  end subroutine sub
+end program intrinsics16

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "497bce88b9401ee12670ccb5ca87fe889c4ef3f62d72b51c978d35e7",
+    "stderr_hash": "7ab3aef83c10d18f2482b1bc885d53a5259c07044346970e80503d6d",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -307,6 +307,12 @@ semantic error: An 'allocatable' variable cannot have an initialization expressi
 266 |     character(:), allocatable :: allocate_char = "H"
     |                                  ^^^^^^^^^^^^^^^^^^^ 
 
+semantic error: Intrinsic procedure 'not_real' is not recognized
+   --> tests/errors/continue_compilation_1.f90:267:18
+    |
+267 |     intrinsic :: not_real
+    |                  ^^^^^^^^ 
+
 semantic error: Transformational intrinsic is not permitted in an initialization expression
    --> tests/errors/continue_compilation_1.f90:270:42
     |

--- a/tests/reference/asr-intrinsics16-a8b2530.json
+++ b/tests/reference/asr-intrinsics16-a8b2530.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-intrinsics16-a8b2530",
+    "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
+    "infile": "tests/errors/intrinsics16.f90",
+    "infile_hash": "c64bc535042dab3f4b2eb3edf593622d6f6a8853149e239426dba70d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-intrinsics16-a8b2530.stderr",
+    "stderr_hash": "43429c34d5e511a18cfc5af88944f2285d9f0dfa8554998a10e82130",
+    "returncode": 1
+}

--- a/tests/reference/asr-intrinsics16-a8b2530.stderr
+++ b/tests/reference/asr-intrinsics16-a8b2530.stderr
@@ -1,0 +1,17 @@
+semantic error: Intrinsic procedure 'chdir' is not recognized
+ --> tests/errors/intrinsics16.f90:7:15
+  |
+7 |     intrinsic chdir     ! A valid intrinsic subroutine that is supported only by gnu
+  |               ^^^^^ 
+
+semantic error: Intrinsic procedure 'aaaa' is not recognized
+ --> tests/errors/intrinsics16.f90:8:15
+  |
+8 |     intrinsic aaaa      ! An invalid intrinsic subroutine
+  |               ^^^^ 
+
+semantic error: Intrinsic procedure 'bbbb' is not recognized
+ --> tests/errors/intrinsics16.f90:9:18
+  |
+9 |     intrinsic :: bbbb   ! An invalid intrinsic function
+  |                  ^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5313,3 +5313,8 @@ filename = "cobounds_01.f90"
 fortran = true
 pass = "coarray"
 options = "--coarray=true"
+
+[[test]]
+filename = "errors/intrinsics16.f90"
+semantics_only_cc = true
+options = "--std=f23"


### PR DESCRIPTION
Fixes #12401
Towards #12257 

We need to decide if we should support the `chdir` intrinsic procedure (function and subroutine) that is mentioned in #12257. (According to Gemini the procedure is supported by GNU/POSIX extension but is not in any fortran standard)