### PR TITLE
fix: tokenization of fixed-form loops containing semicolons

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -472,6 +472,7 @@ RUN(NAME fixed_form_stmt_func_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GF
 RUN(NAME fixed_form_do_name_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --use-loop-variable-after-loop GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_where_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_module_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_do_loop_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_do_loop_01.f90
+++ b/integration_tests/fixed_form_do_loop_01.f90
@@ -1,0 +1,17 @@
+      program main
+      implicit none
+      integer, parameter :: n = 2
+      real :: x(n, n)
+      call a1(n, x)
+      if (abs(x(1,1) - 0.0) > 1e-5) error stop 1
+      if (abs(x(2,2) - 0.0) > 1e-5) error stop 2
+      end program main
+
+      subroutine a1(n, x)
+      integer n, i, j
+      real x(n,n)
+      do i = 1, n
+         do j = 1, n
+            x(i,j) = 0.0
+         end do; end do
+      end subroutine a1

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -455,6 +455,42 @@ struct FixedFormRecursiveDescent {
         if (*cur == '\n') cur++;
     }
 
+    void next_statement(unsigned char *&cur) {
+        bool in_string = false;
+        char quote = 0;
+        bool in_comment = false;
+        while (*cur != '\n' && *cur != '\0') {
+            if (*cur == '\r') {
+                cur++;
+                continue;
+            }
+            if (in_comment) {
+                cur++;
+                continue;
+            }
+            if (in_string) {
+                if (*cur == quote) {
+                    if (*(cur+1) == quote) {
+                        cur++; // skip escaped quote
+                    } else {
+                        in_string = false;
+                    }
+                }
+            } else {
+                if (*cur == '\'' || *cur == '"') {
+                    in_string = true;
+                    quote = *cur;
+                } else if (*cur == '!') {
+                    in_comment = true;
+                } else if (*cur == ';') {
+                    break;
+                }
+            }
+            cur++;
+        }
+        if (*cur == '\n' || (!in_string && !in_comment && *cur == ';')) cur++;
+    }
+
     // Push the token_type, YYSTYPE and Location of the token_str at `cur`.
     // (Does not modify `cur`.)
     void push_token_no_advance_token(unsigned char *cur, const std::string &token_str,
@@ -728,9 +764,9 @@ struct FixedFormRecursiveDescent {
      */
     void tokenize_line(unsigned char *&cur) {
         t.cur = cur;
-        next_line(cur);
+        next_statement(cur);
         tokenize_until(cur);
-        LCOMPILERS_ASSERT(*(t.cur-1) == '\n')
+        LCOMPILERS_ASSERT(*(t.cur-1) == '\n' || *(t.cur-1) == ';')
     }
 
     /*
@@ -1600,8 +1636,10 @@ struct FixedFormRecursiveDescent {
         }
         if (*cur == '\n') {
             push_token_no_advance(cur, "\n");
+        } else if (*cur == ';') {
+            push_token_no_advance(cur, "semicolon");
         }
-        next_line(cur);
+        next_statement(cur);
     }
 
     void lex_do_regular(unsigned char *&cur) {


### PR DESCRIPTION
Fixes #12393 