### PR TITLE
fix: keep the generic-named specific procedure's real name

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2226,6 +2226,8 @@ RUN(NAME generic_name_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_06 LABELS gfortran llvm)
 RUN(NAME generic_name_07 LABELS gfortran llvm)
 RUN(NAME generic_name_08 LABELS gfortran llvm)
+RUN(NAME generic_name_09 LABELS gfortran llvm)
+RUN(NAME generic_name_10 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2228,6 +2228,7 @@ RUN(NAME generic_name_07 LABELS gfortran llvm)
 RUN(NAME generic_name_08 LABELS gfortran llvm)
 RUN(NAME generic_name_09 LABELS gfortran llvm)
 RUN(NAME generic_name_10 LABELS gfortran llvm)
+RUN(NAME generic_name_12 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2213,6 +2213,8 @@ RUN(NAME generic_name_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME generic_name_06 LABELS gfortran llvm)
 RUN(NAME generic_name_07 LABELS gfortran llvm)
 RUN(NAME generic_name_08 LABELS gfortran llvm)
+RUN(NAME generic_name_09 LABELS gfortran llvm)
+RUN(NAME generic_name_10 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_name_09.f90
+++ b/integration_tests/generic_name_09.f90
@@ -1,0 +1,23 @@
+module generic_name_09_mod
+ implicit none
+ interface addCNullChar
+  module procedure addCNullChar
+ end interface
+contains
+ function addCNullChar(x) result(y)
+  integer, intent(in) :: x
+  integer :: y
+  y = x + 1
+ end function addCNullChar
+end module generic_name_09_mod
+
+program generic_name_09
+ use generic_name_09_mod
+ implicit none
+ integer :: r
+ r = addCNullChar(3)
+ print *, r
+ if (r /= 4) error stop
+ if (addCNullChar(10) /= 11) error stop
+ print *, "PASS"
+end program generic_name_09

--- a/integration_tests/generic_name_10.f90
+++ b/integration_tests/generic_name_10.f90
@@ -1,0 +1,31 @@
+module generic_name_10_mod
+ implicit none
+ interface get_text
+  integer function get_text()
+  end function get_text
+  integer function get_text_a(x)
+   integer, intent(in) :: x
+  end function get_text_a
+ end interface
+end module generic_name_10_mod
+
+integer function get_text()
+ get_text = 42
+end function get_text
+
+integer function get_text_a(x)
+ integer, intent(in) :: x
+ get_text_a = x + 1
+end function get_text_a
+
+program generic_name_10
+ use generic_name_10_mod
+ implicit none
+ integer :: r
+ r = get_text()
+ print *, r
+ if (r /= 42) error stop
+ if (get_text() /= 42) error stop
+ if (get_text(10) /= 11) error stop
+ print *, "PASS"
+end program generic_name_10

--- a/integration_tests/generic_name_12.f90
+++ b/integration_tests/generic_name_12.f90
@@ -1,0 +1,40 @@
+module generic_name_12_mod
+   ! A generic interface whose only specific procedure has the same name, with
+   ! the specific called from *inside* the same module. The specific is stored
+   ! under a disambiguated symbol table key while keeping its own name, so
+   ! resolving the call by name finds the GenericProcedure instead of the
+   ! procedure and ASR verification rejects the call. toml-f's terminal.f90
+   ! (`interface escape / module procedure :: escape`, used by `//`) is the
+   ! real-world case; it reaches LFortran through fpm.
+   implicit none
+   private
+   public :: escape, concat
+
+   interface escape
+      module procedure :: escape
+   end interface escape
+
+contains
+
+   pure function escape(code) result(str)
+      integer, intent(in) :: code
+      character(len=1) :: str
+      str = achar(64 + code)
+   end function escape
+
+   pure function concat(lval, code) result(str)
+      character(len=*), intent(in) :: lval
+      integer, intent(in) :: code
+      character(len=len(lval)+1) :: str
+      str = lval // escape(code)
+   end function concat
+
+end module generic_name_12_mod
+
+program generic_name_12
+   use generic_name_12_mod, only: escape, concat
+   implicit none
+   if (escape(1) /= "A") error stop
+   if (concat("x", 2) /= "xB") error stop
+   print *, "ok"
+end program generic_name_12

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8257,7 +8257,7 @@ public:
                             /* a_name */ cname,
                             final_sym,
                             ASRUtils::symbol_name(ASRUtils::get_asr_owner(final_sym)),
-                            nullptr, 0, ASRUtils::symbol_name(final_sym),
+                            nullptr, 0, s2c(al, ASRUtils::symbol_table_key(final_sym)),
                             ASR::accessType::Private);
                         final_sym = ASR::down_cast<ASR::symbol_t>(sub);
                         current_scope->add_symbol(local_sym, final_sym);

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -8115,7 +8115,7 @@ public:
                             /* a_name */ cname,
                             final_sym,
                             ASRUtils::symbol_name(ASRUtils::get_asr_owner(final_sym)),
-                            nullptr, 0, ASRUtils::symbol_name(final_sym),
+                            nullptr, 0, s2c(al, ASRUtils::symbol_table_key(final_sym)),
                             ASR::accessType::Private);
                         final_sym = ASR::down_cast<ASR::symbol_t>(sub);
                         current_scope->add_symbol(local_sym, final_sym);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -34,6 +34,17 @@ namespace LCompilers::LFortran {
 
 static int PDT_SENTINEL = 1000;
 
+// Fortran allows a generic interface to have the same name as one of its
+// specific procedures. Both need an entry in the same symbol table, so the
+// specific is stored under `<name>~genericprocedure` while the
+// GenericProcedure keeps `<name>`.
+//
+// This is a symbol table *key* only. Function::m_name stays the name the user
+// wrote, so the ASR name, the modfile name and the link symbol are all
+// `<name>`. The suffix never leaves AST->ASR: no ASR pass and no backend may
+// reconstruct it, strip it, or depend on it.
+static constexpr char generic_procedure_key_suffix[] = "~genericprocedure";
+
 template <typename T>
 void extract_bind(T &x, ASR::abiType &abi_type, char *&bindc_name, diag::Diagnostics &diag) {
     if (x.m_bind) {
@@ -11715,7 +11726,7 @@ public:
                 /* a_name */ cname,
                 final_sym,
                 ASRUtils::symbol_name(ASRUtils::get_asr_owner(final_sym)),
-                nullptr, 0, ASRUtils::symbol_name(final_sym),
+                nullptr, 0, s2c(al, ASRUtils::symbol_table_key(final_sym)),
                 ASR::accessType::Private
                 );
             final_sym = ASR::down_cast<ASR::symbol_t>(sub);
@@ -20952,15 +20963,22 @@ public:
                     submodule_proc_names.count(item.first) > 0) {
                     continue;
                 }
+                // Import under the module's symbol table key, not under
+                // `m_name`. The two differ for a specific procedure that
+                // shares its generic interface's name: the generic owns the
+                // plain name and the specific is keyed
+                // `<name>~genericprocedure`. `m_original_name` must also be
+                // the key, because that is what fix_external_symbols() looks
+                // up in the module's symbol table.
+                std::string sym = to_lower(item.first);
                 ASR::asr_t *fn = ASR::make_ExternalSymbol_t(
                     al, mfn->base.base.loc,
                     /* a_symtab */ current_scope,
-                    /* a_name */ mfn->m_name,
+                    /* a_name */ s2c(al, sym),
                     (ASR::symbol_t*)mfn,
-                    m->m_name, nullptr, 0, mfn->m_name,
+                    m->m_name, nullptr, 0, s2c(al, item.first),
                     dflt_access
                     );
-                std::string sym = to_lower(mfn->m_name);
                 current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
             } else if (ASR::is_a<ASR::GenericProcedure_t>(*item.second)) {
                 ASR::GenericProcedure_t *gp = ASR::down_cast<
@@ -21119,7 +21137,11 @@ public:
                 Vec<ASR::symbol_t*> gp_procs;
                 gp_procs.reserve(al, gp->n_procs + gp_ext->n_procs);
                 for( size_t i = 0; i < gp->n_procs; i++ ) {
-                    std::string gp_proc_name = ASRUtils::symbol_name(gp->m_procs[i]);
+                    // Resolve by the key the proc is stored under, not by its
+                    // name: they differ for a specific procedure that shares
+                    // its generic interface's name, and resolving by name
+                    // would find the generic itself and never terminate.
+                    std::string gp_proc_name = ASRUtils::symbol_table_key(gp->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_proc_name);
                     if (m_proc != nullptr) {
@@ -21149,7 +21171,7 @@ public:
                     }
                 }
                 for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                    std::string gp_ext_proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string gp_ext_proc_name = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_ext_proc_name);
                     if( m_proc == nullptr ) {
@@ -21182,7 +21204,7 @@ public:
                     gp_procs.push_back(al, gp->m_procs[i]);
                 }
                 for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                    std::string gp_ext_proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string gp_ext_proc_name = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_ext_proc_name);
                     if( m_proc == nullptr ) {
@@ -21211,8 +21233,14 @@ public:
             gp_procs.reserve(al, gp_ext->n_procs);
             bool are_all_present = true;
             for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                ASR::symbol_t* m_proc = current_scope->resolve_symbol(
-                    ASRUtils::symbol_name(gp_ext->m_procs[i]));
+                // Resolve and re-import by the key each proc is stored
+                // under, not by its name. A specific procedure that shares
+                // its generic interface's name is keyed
+                // `<name>~genericprocedure`; looking it up by name finds the
+                // generic instead, and re-importing that queues the same work
+                // again and never terminates.
+                std::string proc_key = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
+                ASR::symbol_t* m_proc = current_scope->resolve_symbol(proc_key);
                 if (m_proc != nullptr) {
                     // Verify the resolved symbol refers to the same function
                     // as the one in the source generic procedure, not a
@@ -21225,7 +21253,7 @@ public:
                 }
                 if( m_proc == nullptr ) {
                     are_all_present = false;
-                    std::string proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string proc_name = proc_key;
                     std::string suffix = "@" + local_sym;
                     std::string extern_name;
                     if (proc_name.length() >= suffix.length()) {
@@ -21253,7 +21281,8 @@ public:
             } else {
                 ep = ASR::make_ExternalSymbol_t(al, t->base.loc,
                     current_scope, s2c(al, local_sym), t,
-                    m->m_name, nullptr, 0, gp_ext->m_name, dflt_access);
+                    m->m_name, nullptr, 0,
+                    s2c(al, ASRUtils::symbol_table_key(t)), dflt_access);
             }
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(ep));
         }
@@ -21296,7 +21325,7 @@ public:
                 /* a_symtab */ current_scope,
                 /* a_name */ name.c_str(al),
                 (ASR::symbol_t*)msub,
-                m->m_name, nullptr, 0, msub->m_name,
+                m->m_name, nullptr, 0, s2c(al, ASRUtils::symbol_table_key(t)),
                 dflt_access
                 );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(sub));
@@ -21337,7 +21366,7 @@ public:
                 /* a_symtab */ current_scope,
                 /* a_name */ cname,
                 (ASR::symbol_t*)mfn,
-                m->m_name, nullptr, 0, mfn->m_name,
+                m->m_name, nullptr, 0, s2c(al, ASRUtils::symbol_table_key(t)),
                 dflt_access
                 );
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -34,6 +34,17 @@ namespace LCompilers::LFortran {
 
 static int PDT_SENTINEL = 1000;
 
+// Fortran allows a generic interface to have the same name as one of its
+// specific procedures. Both need an entry in the same symbol table, so the
+// specific is stored under `<name>~genericprocedure` while the
+// GenericProcedure keeps `<name>`.
+//
+// This is a symbol table *key* only. Function::m_name stays the name the user
+// wrote, so the ASR name, the modfile name and the link symbol are all
+// `<name>`. The suffix never leaves AST->ASR: no ASR pass and no backend may
+// reconstruct it, strip it, or depend on it.
+static constexpr char generic_procedure_key_suffix[] = "~genericprocedure";
+
 template <typename T>
 void extract_bind(T &x, ASR::abiType &abi_type, char *&bindc_name, diag::Diagnostics &diag) {
     if (x.m_bind) {
@@ -11849,7 +11860,7 @@ public:
                 /* a_name */ cname,
                 final_sym,
                 ASRUtils::symbol_name(ASRUtils::get_asr_owner(final_sym)),
-                nullptr, 0, ASRUtils::symbol_name(final_sym),
+                nullptr, 0, s2c(al, ASRUtils::symbol_table_key(final_sym)),
                 ASR::accessType::Private
                 );
             final_sym = ASR::down_cast<ASR::symbol_t>(sub);
@@ -21177,15 +21188,22 @@ public:
                     submodule_proc_names.count(item.first) > 0) {
                     continue;
                 }
+                // Import under the module's symbol table key, not under
+                // `m_name`. The two differ for a specific procedure that
+                // shares its generic interface's name: the generic owns the
+                // plain name and the specific is keyed
+                // `<name>~genericprocedure`. `m_original_name` must also be
+                // the key, because that is what fix_external_symbols() looks
+                // up in the module's symbol table.
+                std::string sym = to_lower(item.first);
                 ASR::asr_t *fn = ASR::make_ExternalSymbol_t(
                     al, mfn->base.base.loc,
                     /* a_symtab */ current_scope,
-                    /* a_name */ mfn->m_name,
+                    /* a_name */ s2c(al, sym),
                     (ASR::symbol_t*)mfn,
-                    m->m_name, nullptr, 0, mfn->m_name,
+                    m->m_name, nullptr, 0, s2c(al, item.first),
                     dflt_access
                     );
-                std::string sym = to_lower(mfn->m_name);
                 current_scope->add_symbol(sym, ASR::down_cast<ASR::symbol_t>(fn));
             } else if (ASR::is_a<ASR::GenericProcedure_t>(*item.second)) {
                 ASR::GenericProcedure_t *gp = ASR::down_cast<
@@ -21344,7 +21362,11 @@ public:
                 Vec<ASR::symbol_t*> gp_procs;
                 gp_procs.reserve(al, gp->n_procs + gp_ext->n_procs);
                 for( size_t i = 0; i < gp->n_procs; i++ ) {
-                    std::string gp_proc_name = ASRUtils::symbol_name(gp->m_procs[i]);
+                    // Resolve by the key the proc is stored under, not by its
+                    // name: they differ for a specific procedure that shares
+                    // its generic interface's name, and resolving by name
+                    // would find the generic itself and never terminate.
+                    std::string gp_proc_name = ASRUtils::symbol_table_key(gp->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_proc_name);
                     if (m_proc != nullptr) {
@@ -21374,7 +21396,7 @@ public:
                     }
                 }
                 for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                    std::string gp_ext_proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string gp_ext_proc_name = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_ext_proc_name);
                     if( m_proc == nullptr ) {
@@ -21407,7 +21429,7 @@ public:
                     gp_procs.push_back(al, gp->m_procs[i]);
                 }
                 for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                    std::string gp_ext_proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string gp_ext_proc_name = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
                     ASR::symbol_t* m_proc = current_scope->resolve_symbol(
                         gp_ext_proc_name);
                     if( m_proc == nullptr ) {
@@ -21436,8 +21458,14 @@ public:
             gp_procs.reserve(al, gp_ext->n_procs);
             bool are_all_present = true;
             for( size_t i = 0; i < gp_ext->n_procs; i++ ) {
-                ASR::symbol_t* m_proc = current_scope->resolve_symbol(
-                    ASRUtils::symbol_name(gp_ext->m_procs[i]));
+                // Resolve and re-import by the key each proc is stored
+                // under, not by its name. A specific procedure that shares
+                // its generic interface's name is keyed
+                // `<name>~genericprocedure`; looking it up by name finds the
+                // generic instead, and re-importing that queues the same work
+                // again and never terminates.
+                std::string proc_key = ASRUtils::symbol_table_key(gp_ext->m_procs[i]);
+                ASR::symbol_t* m_proc = current_scope->resolve_symbol(proc_key);
                 if (m_proc != nullptr) {
                     // Verify the resolved symbol refers to the same function
                     // as the one in the source generic procedure, not a
@@ -21450,7 +21478,7 @@ public:
                 }
                 if( m_proc == nullptr ) {
                     are_all_present = false;
-                    std::string proc_name = ASRUtils::symbol_name(gp_ext->m_procs[i]);
+                    std::string proc_name = proc_key;
                     std::string suffix = "@" + local_sym;
                     std::string extern_name;
                     if (proc_name.length() >= suffix.length()) {
@@ -21478,7 +21506,8 @@ public:
             } else {
                 ep = ASR::make_ExternalSymbol_t(al, t->base.loc,
                     current_scope, s2c(al, local_sym), t,
-                    m->m_name, nullptr, 0, gp_ext->m_name, dflt_access);
+                    m->m_name, nullptr, 0,
+                    s2c(al, ASRUtils::symbol_table_key(t)), dflt_access);
             }
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(ep));
         }
@@ -21521,7 +21550,7 @@ public:
                 /* a_symtab */ current_scope,
                 /* a_name */ name.c_str(al),
                 (ASR::symbol_t*)msub,
-                m->m_name, nullptr, 0, msub->m_name,
+                m->m_name, nullptr, 0, s2c(al, ASRUtils::symbol_table_key(t)),
                 dflt_access
                 );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(sub));
@@ -21562,7 +21591,7 @@ public:
                 /* a_symtab */ current_scope,
                 /* a_name */ cname,
                 (ASR::symbol_t*)mfn,
-                m->m_name, nullptr, 0, mfn->m_name,
+                m->m_name, nullptr, 0, s2c(al, ASRUtils::symbol_table_key(t)),
                 dflt_access
                 );
             current_scope->add_or_overwrite_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(fn));

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1575,8 +1575,11 @@ public:
         bool update_gp = false;
         int gp_index_to_be_updated = -1;
         ASR::symbol_t* f1_ = nullptr;
-        if (parent_scope->get_symbol(sym_name) != nullptr) {
-            f1_ = parent_scope->get_symbol(sym_name);
+        // Symbol table key; differs from `sym_name` only when this specific
+        // procedure shares its generic interface's name (see visit_Function).
+        std::string sym_key = sym_name;
+        if (parent_scope->get_symbol(sym_key) != nullptr) {
+            f1_ = parent_scope->get_symbol(sym_key);
             ASR::symbol_t *f1 = ASRUtils::symbol_get_past_external(f1_);
             if (ASR::is_a<ASR::Function_t>(*f1)) {
                 ASR::Function_t* f2 = ASR::down_cast<ASR::Function_t>(f1);
@@ -1597,7 +1600,7 @@ public:
                         throw SemanticAbort();
                     }
                     // Previous declaration will be shadowed
-                    parent_scope->erase_symbol(sym_name);
+                    parent_scope->erase_symbol(sym_key);
                 } else {
                     diag.add(diag::Diagnostic(
                         "Subroutine already defined " + sym_name,
@@ -1608,7 +1611,7 @@ public:
             } else if( ASR::is_a<ASR::GenericProcedure_t>(*f1) ) {
                 ASR::GenericProcedure_t* gp = ASR::down_cast<ASR::GenericProcedure_t>(f1);
                 if( sym_name == gp->m_name ) {
-                    sym_name = sym_name + "~genericprocedure";
+                    sym_key = sym_name + generic_procedure_key_suffix;
                 }
 
                 if( !ASR::is_a<ASR::GenericProcedure_t>(*f1_) ) {
@@ -1629,11 +1632,11 @@ public:
 
                 // Any import from parent module will be shadowed
                 if (!in_submodule) {
-                    parent_scope->erase_symbol(sym_name);
+                    parent_scope->erase_symbol(sym_key);
                 }
             } else if (compiler_options.implicit_typing && ASR::is_a<ASR::Variable_t>(*f1)) {
                 // function previously added as variable due to implicit typing
-                parent_scope->erase_symbol(sym_name);
+                parent_scope->erase_symbol(sym_key);
             } else {
                 diag.add(diag::Diagnostic(
                     "Subroutine already defined " + sym_name,
@@ -1643,11 +1646,11 @@ public:
             }
         }
         if ( interface_name == sym_name || generic_procedures.find(sym_name) != generic_procedures.end() ) {
-            sym_name = sym_name + "~genericprocedure";
+            sym_key = sym_name + generic_procedure_key_suffix;
         }
 
         // Check for function/subroutine attribute conflict
-        ASR::symbol_t* existing_sym = parent_scope->get_symbol(sym_name);
+        ASR::symbol_t* existing_sym = parent_scope->get_symbol(sym_key);
         if (existing_sym != nullptr) {
             ASR::symbol_t* existing_past_ext = ASRUtils::symbol_get_past_external(existing_sym);
             if (ASR::is_a<ASR::Function_t>(*existing_past_ext)) {
@@ -1667,7 +1670,7 @@ public:
                         throw SemanticAbort();
                     }
                     // In continue mode, keep going after recording the diagnostic.
-                    parent_scope->erase_symbol(sym_name);
+                    parent_scope->erase_symbol(sym_key);
                 }
             }
         }
@@ -1696,7 +1699,7 @@ public:
             nullptr, 0,
             is_requirement, init_deterministic, init_side_effect_free);
         handle_save();
-        parent_scope->add_or_overwrite_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        parent_scope->add_or_overwrite_symbol(sym_key, ASR::down_cast<ASR::symbol_t>(tmp));
 
         // Self referencing procedure declarations
         for (size_t i : procedure_decl_indices) {
@@ -2334,9 +2337,14 @@ public:
             deftype = ASR::deftypeType::Interface;
         }
 
+        // A specific procedure that shares its generic interface's name cannot
+        // use that name as its symbol table key, because the GenericProcedure
+        // owns it. Disambiguate the key only; `sym_name` stays the name the
+        // user wrote and becomes Function::m_name (and hence the link symbol).
+        std::string sym_key = sym_name;
         if (generic_procedures.find(sym_name) != generic_procedures.end()
-            || interface_name == to_lower(sym_name)) {
-            sym_name = sym_name + "~genericprocedure";
+            || interface_name == sym_name) {
+            sym_key = sym_name + generic_procedure_key_suffix;
         }
 
         bool is_pure = false, is_module = false, is_elemental = false;
@@ -2393,11 +2401,11 @@ public:
         ASR::symbol_t* func_sym = ASR::down_cast<ASR::symbol_t>(tmp);
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(func_sym);
 
-        if (parent_scope->get_symbol(sym_name) != nullptr) {
-            ASR::symbol_t *f1 = parent_scope->get_symbol(sym_name);
+        if (parent_scope->get_symbol(sym_key) != nullptr) {
+            ASR::symbol_t *f1 = parent_scope->get_symbol(sym_key);
             if (ASR::is_a<ASR::ExternalSymbol_t>(*f1)) {
                 if (in_submodule) {
-                    parent_scope->erase_symbol(sym_name);
+                    parent_scope->erase_symbol(sym_key);
                 } else {
                     ASR::symbol_t *orig = ASRUtils::symbol_get_past_external(f1);
                     bool is_private_orig = false;
@@ -2406,7 +2414,7 @@ public:
                             orig)->m_access == ASR::accessType::Private;
                     }
                     if (is_private_orig) {
-                        parent_scope->erase_symbol(sym_name);
+                        parent_scope->erase_symbol(sym_key);
                     } else {
                         diag.add(diag::Diagnostic(
                             "Function already defined",
@@ -2458,7 +2466,7 @@ public:
                         in_Subroutine = false;
                         throw SemanticAbort();
                     }
-                    parent_scope->erase_symbol(sym_name);
+                    parent_scope->erase_symbol(sym_key);
                 } else {
                     diag.add(diag::Diagnostic(
                         "Function already defined",
@@ -2468,7 +2476,7 @@ public:
                 }
             } else if (compiler_options.implicit_typing && ASR::is_a<ASR::Variable_t>(*f1)) {
                 // function previously added as variable due to implicit typing
-                parent_scope->erase_symbol(sym_name);
+                parent_scope->erase_symbol(sym_key);
             } else {
                 diag.add(diag::Diagnostic(
                     "Function already defined",
@@ -2478,7 +2486,7 @@ public:
             }
         }
         handle_save();
-        parent_scope->add_symbol(sym_name, ASR::down_cast<ASR::symbol_t>(tmp));
+        parent_scope->add_symbol(sym_key, ASR::down_cast<ASR::symbol_t>(tmp));
 
         // Self referencing procedure declarations
         for (size_t i : procedure_decl_indices) {
@@ -3817,16 +3825,15 @@ public:
             symbols.reserve(al, proc.second.size());
             bool any_error = false;
             for (auto &pname : proc.second) {
-                std::string correct_pname = pname.first;
-                if( pname.first == proc.first ) {
-                    correct_pname = pname.first + "~genericprocedure";
+                // `proc.first` (the generic name) is already lower cased, so
+                // lower case the specific name before comparing, otherwise a
+                // mixed-case self reference such as `interface addCNullChar` /
+                // `module procedure addCNullChar` is not recognised.
+                std::string pkey = to_lower(pname.first);
+                if( pkey == proc.first ) {
+                    pkey += generic_procedure_key_suffix;
                 }
-                Str s;
-                s.from_str_view(correct_pname);
-                char *name = s.c_str(al);
-                // lower case the name
-                name = s2c(al, to_lower(name));
-                ASR::symbol_t *x = current_scope->resolve_symbol(name);
+                ASR::symbol_t *x = current_scope->resolve_symbol(pkey);
                 if (!x) {
                     diag.add(Diagnostic(
                         "Symbol '" + std::string(pname.first) + "' not declared",
@@ -3868,16 +3875,17 @@ public:
                             // If not available, import it from the module
                             // Create an ExternalSymbol using it
                             ASR::Module_t *m = ASRUtils::get_sym_module(sym);
-                            s = m->m_symtab->get_symbol(
-                                ASRUtils::symbol_name(gp->m_procs[i]));
-                            if (ASR::is_a<ASR::Function_t>(*s)) {
+                            std::string proc_key = ASRUtils::symbol_table_key(
+                                gp->m_procs[i]);
+                            s = m->m_symtab->get_symbol(proc_key);
+                            if (s != nullptr && ASR::is_a<ASR::Function_t>(*s)) {
                                 ASR::Function_t *fn = ASR::down_cast<ASR::Function_t>(s);
                                 ASR::symbol_t *ep_s = (ASR::symbol_t *)
                                     ASR::make_ExternalSymbol_t(
                                         al, fn->base.base.loc, current_scope,
-                                        fn->m_name, s, m->m_name, nullptr, 0,
-                                        fn->m_name, dflt_access);
-                                current_scope->add_symbol(fn->m_name, ep_s);
+                                        s2c(al, proc_key), s, m->m_name, nullptr, 0,
+                                        s2c(al, proc_key), dflt_access);
+                                current_scope->add_symbol(proc_key, ep_s);
                                 // Append the ExternalSymbol
                                 symbols.push_back(al, ep_s);
                             }

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3183,7 +3183,7 @@ ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(
                 name.c_str(al),
                 final_sym_past_ext,
                 s2c(al, ASRUtils::symbol_name(owner_sym)), nullptr, 0,
-                s2c(al, ASRUtils::symbol_name(final_sym_past_ext)),
+                s2c(al, ASRUtils::symbol_table_key(final_sym_past_ext)),
                 ASR::accessType::Private
             );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(sub));

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3175,7 +3175,7 @@ ASR::asr_t* symbol_resolve_external_generic_procedure_without_eval(
                 name.c_str(al),
                 final_sym_past_ext,
                 s2c(al, ASRUtils::symbol_name(owner_sym)), nullptr, 0,
-                s2c(al, ASRUtils::symbol_name(final_sym_past_ext)),
+                s2c(al, ASRUtils::symbol_table_key(final_sym_past_ext)),
                 ASR::accessType::Private
             );
             current_scope->add_symbol(local_sym, ASR::down_cast<ASR::symbol_t>(sub));

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1516,6 +1516,29 @@ static inline SymbolTable *symbol_parent_symtab(const ASR::symbol_t *f)
     }
 }
 
+// Returns the key `f` is stored under in its defining symbol table.
+//
+// For nearly every symbol this is just `symbol_name(f)`, but a frontend may
+// legitimately key a symbol under something else when two symbols would
+// otherwise claim the same name (Fortran allows a generic interface and one
+// of its specific procedures to share a name). Use this - not `symbol_name` -
+// for `ExternalSymbol::m_original_name`, because that field is looked up as a
+// key when a modfile is loaded.
+static inline std::string symbol_table_key(const ASR::symbol_t *f)
+{
+    std::string name = symbol_name(f);
+    SymbolTable *parent = symbol_parent_symtab(f);
+    if (parent == nullptr || parent->get_symbol(name) == f) {
+        return name;
+    }
+    for (auto &item : parent->get_scope()) {
+        if (item.second == f) {
+            return item.first;
+        }
+    }
+    return name;
+}
+
 // Returns the `symbol`'s symtab, or nullptr if the symbol has no symtab
 static inline SymbolTable *symbol_symtab(const ASR::symbol_t *f)
 {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -42,7 +42,7 @@
             temp_scope = temp_scope->parent; \
         } \
         if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(final_sym)->get_counter()) { \
-            current_function_dependencies.push_back(al, ASRUtils::symbol_name(final_sym)); \
+            current_function_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(final_sym))); \
         } \
     } \
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1482,6 +1482,29 @@ static inline SymbolTable *symbol_parent_symtab(const ASR::symbol_t *f)
     }
 }
 
+// Returns the key `f` is stored under in its defining symbol table.
+//
+// For nearly every symbol this is just `symbol_name(f)`, but a frontend may
+// legitimately key a symbol under something else when two symbols would
+// otherwise claim the same name (Fortran allows a generic interface and one
+// of its specific procedures to share a name). Use this - not `symbol_name` -
+// for `ExternalSymbol::m_original_name`, because that field is looked up as a
+// key when a modfile is loaded.
+static inline std::string symbol_table_key(const ASR::symbol_t *f)
+{
+    std::string name = symbol_name(f);
+    SymbolTable *parent = symbol_parent_symtab(f);
+    if (parent == nullptr || parent->get_symbol(name) == f) {
+        return name;
+    }
+    for (auto &item : parent->get_scope()) {
+        if (item.second == f) {
+            return item.first;
+        }
+    }
+    return name;
+}
+
 // Returns the `symbol`'s symtab, or nullptr if the symbol has no symtab
 static inline SymbolTable *symbol_symtab(const ASR::symbol_t *f)
 {

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1430,9 +1430,17 @@ public:
                 "ExternalSymbol::m_external cannot be nullptr");
             require(!is_a<ExternalSymbol_t>(*x.m_external),
                 "ExternalSymbol::m_external cannot be an ExternalSymbol");
-            char *orig_name = symbol_name(x.m_external);
-            require(std::string(x.m_original_name) == std::string(orig_name),
-                "ExternalSymbol::m_original_name must match external->m_name");
+            // `m_original_name` is the key under which `m_external` is stored
+            // in its defining scope -- that is what fix_external_symbols()
+            // looks up when a modfile is loaded. For nearly every symbol that
+            // key is also the symbol's name, but it need not be: a specific
+            // procedure that shares its generic interface's name keeps the
+            // plain name and is keyed under a disambiguated key instead.
+            SymbolTable *orig_symtab = ASRUtils::symbol_parent_symtab(x.m_external);
+            require(orig_symtab != nullptr &&
+                    orig_symtab->get_symbol(x.m_original_name) == x.m_external,
+                "ExternalSymbol::m_original_name must be the key of m_external "
+                "in its defining symbol table");
             ASR::Module_t *m = ASRUtils::get_sym_module(x.m_external);
             ASR::Struct_t* sm = nullptr;
             ASR::Enum_t* em = nullptr;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -877,9 +877,17 @@ public:
                 "ExternalSymbol::m_external cannot be nullptr");
             require(!is_a<ExternalSymbol_t>(*x.m_external),
                 "ExternalSymbol::m_external cannot be an ExternalSymbol");
-            char *orig_name = symbol_name(x.m_external);
-            require(std::string(x.m_original_name) == std::string(orig_name),
-                "ExternalSymbol::m_original_name must match external->m_name");
+            // `m_original_name` is the key under which `m_external` is stored
+            // in its defining scope -- that is what fix_external_symbols()
+            // looks up when a modfile is loaded. For nearly every symbol that
+            // key is also the symbol's name, but it need not be: a specific
+            // procedure that shares its generic interface's name keeps the
+            // plain name and is keyed under a disambiguated key instead.
+            SymbolTable *orig_symtab = ASRUtils::symbol_parent_symtab(x.m_external);
+            require(orig_symtab != nullptr &&
+                    orig_symtab->get_symbol(x.m_original_name) == x.m_external,
+                "ExternalSymbol::m_original_name must be the key of m_external "
+                "in its defining symbol table");
             ASR::Module_t *m = ASRUtils::get_sym_module(x.m_external);
             ASR::Struct_t* sm = nullptr;
             ASR::Enum_t* em = nullptr;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -92,7 +92,11 @@ public:
     // does not actually contain it.
     bool symtab_in_scope(const SymbolTable *symtab, const ASR::symbol_t *sym) {
         unsigned int symtab_ID = symbol_parent_symtab(sym)->counter;
-        char *sym_name = symbol_name(sym);
+        // Look the symbol up by the key it is stored under, not by its name:
+        // the two differ for a specific procedure that shares its generic
+        // interface's name, where looking up by name finds the
+        // GenericProcedure instead and this check would wrongly fail.
+        std::string sym_name = ASRUtils::symbol_table_key(sym);
         const SymbolTable *s = symtab;
         while (s != nullptr) {
             if (s->counter == symtab_ID) {
@@ -2328,7 +2332,7 @@ public:
                 temp_scope = temp_scope->parent;
             }
             if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
-                function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+                function_dependencies.push_back(ASRUtils::symbol_table_key(x.m_name));
             }
         }
 
@@ -2455,13 +2459,13 @@ public:
                 temp_scope = temp_scope->parent;
             }
             if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
-                function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+                function_dependencies.push_back(ASRUtils::symbol_table_key(x.m_name));
             }
         }
         if (_return_var_or_intent_out  && _processing_dims &&
             temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
             !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name)) {
-            function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+            function_dependencies.push_back(ASRUtils::symbol_table_key(x.m_name));
         }
 
         if( ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) ) {

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -1482,7 +1482,10 @@ class RemoveArrayByDescriptorProceduresVisitor : public PassUtils::PassVisitor<R
                     sym = ASR::down_cast<ASR::ExternalSymbol_t>(item.second)->m_external;
                 }
                 if( v.proc2newproc.find(sym) != v.proc2newproc.end() ) {
-                    LCOMPILERS_ASSERT(item.first == ASRUtils::symbol_name(item.second))
+                    // Record the symbol table *key*, not the symbol's name:
+                    // the two differ for a specific procedure that shares its
+                    // generic interface's name, and erasing by name would
+                    // leave the entry behind.
                     to_be_erased.push_back({item.first, sym});
                 }
                 if ( ASR::is_a<ASR::Module_t>(*item.second) ||

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -631,13 +631,13 @@ namespace LCompilers {
 
                 void visit_Var(const ASR::Var_t& x) {
                     if( fill_variable_dependencies && ASRUtils::symbol_name(x.m_v) != current_name ) {
-                        variable_dependencies.push_back(al, ASRUtils::symbol_name(x.m_v));
+                        variable_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(x.m_v)));
                     }
                 }
 
                 void visit_FunctionCall(const ASR::FunctionCall_t& x) {
                     if(fill_variable_dependencies){
-                        variable_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                        variable_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(x.m_name)));
                     }
                     if (fill_function_dependencies) {
                         ASR::symbol_t* asr_owner_sym = nullptr;
@@ -661,13 +661,13 @@ namespace LCompilers {
                                 temp_scope = temp_scope->parent;
                             }
                             if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
-                                function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                                function_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(x.m_name)));
                             }
                         }
 
                         if (_return_var_or_intent_out && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
                             !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name)) {
-                            function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                            function_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(x.m_name)));
                         }
                     }
                     if( ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) &&
@@ -703,7 +703,7 @@ namespace LCompilers {
                                 temp_scope = temp_scope->parent;
                             }
                             if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
-                                function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                                function_dependencies.push_back(al, s2c(al, ASRUtils::symbol_table_key(x.m_name)));
                             }
                         }
                     }

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -36,7 +36,9 @@ public:
     void write_symbol(const ASR::symbol_t &x) {
         write_int64(symbol_parent_symtab(&x)->counter);
         write_int8(x.type);
-        write_string(symbol_name(&x));
+        // read_symbol() resolves this with SymbolTable::get_symbol(), so write
+        // the key `x` is stored under, which is not always its name.
+        write_string(ASRUtils::symbol_table_key(&x));
     }
 
     // A kind=16 RealConstant does not keep its value in m_r: a double cannot

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -37,7 +37,9 @@ public:
     void write_symbol(const ASR::symbol_t &x) {
         write_int64(symbol_parent_symtab(&x)->counter);
         write_int8(x.type);
-        write_string(symbol_name(&x));
+        // read_symbol() resolves this with SymbolTable::get_symbol(), so write
+        // the key `x` is stored under, which is not always its name.
+        write_string(ASRUtils::symbol_table_key(&x));
     }
 
     // A kind=16 RealConstant does not keep its value in m_r: a double cannot

--- a/tests/reference/asr-functions_04-ea50b75.json
+++ b/tests/reference/asr-functions_04-ea50b75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-functions_04-ea50b75.stdout",
-    "stdout_hash": "7ee7167e6b17eb8f3e44123b2279c397e3fffb6253885102ff6848cc",
+    "stdout_hash": "7adbb72300aede9ed6d9c050762010598e525cc1f913bd54be988055",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-functions_04-ea50b75.stdout
+++ b/tests/reference/asr-functions_04-ea50b75.stdout
@@ -41,11 +41,11 @@
                                     to_negative
                                     Public
                                 ),
-                            to_negative@to_negative~genericprocedure:
+                            to_negative@to_negative:
                                 (ExternalSymbol
                                     4
-                                    to_negative@to_negative~genericprocedure
-                                    2 to_negative~genericprocedure
+                                    to_negative@to_negative
+                                    2 to_negative
                                     stdlib_int
                                     []
                                     to_negative~genericprocedure
@@ -55,7 +55,7 @@
                                 (ExternalSymbol
                                     4
                                     to_negative~genericprocedure
-                                    2 to_negative~genericprocedure
+                                    2 to_negative
                                     stdlib_int
                                     []
                                     to_negative~genericprocedure
@@ -68,7 +68,7 @@
                         ()
                         (IntegerCompare
                             (FunctionCall
-                                4 to_negative@to_negative~genericprocedure
+                                4 to_negative@to_negative
                                 4 to_negative
                                 [((Var 4 int))]
                                 (Integer 4)
@@ -104,7 +104,7 @@
                         ()
                         (IntegerCompare
                             (FunctionCall
-                                4 to_negative@to_negative~genericprocedure
+                                4 to_negative@to_negative
                                 4 to_negative
                                 [((Var 4 int))]
                                 (Integer 4)
@@ -135,7 +135,7 @@
                                 (GenericProcedure
                                     2
                                     to_negative
-                                    [2 to_negative~genericprocedure]
+                                    [2 to_negative]
                                     Public
                                 ),
                             to_negative~genericprocedure:
@@ -192,7 +192,7 @@
                                                     []
                                                 )
                                         })
-                                    to_negative~genericprocedure
+                                    to_negative
                                     (FunctionType
                                         [(Integer 4)]
                                         (Integer 4)

--- a/tests/reference/asr-interface_generic_procedure_same_name-708e46e.json
+++ b/tests/reference/asr-interface_generic_procedure_same_name-708e46e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-interface_generic_procedure_same_name-708e46e.stdout",
-    "stdout_hash": "423b5f4b842eb992fe5b0dda70df419efe38b4ea1675a813a16de8be",
+    "stdout_hash": "26109ce735318e381bb5fc03a30400814472ca78aecdbaeac87f9209",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-interface_generic_procedure_same_name-708e46e.stdout
+++ b/tests/reference/asr-interface_generic_procedure_same_name-708e46e.stdout
@@ -11,7 +11,7 @@
                                 (GenericProcedure
                                     2
                                     frexp
-                                    [2 frexp~genericprocedure]
+                                    [2 frexp]
                                     Public
                                 ),
                             frexp~genericprocedure:
@@ -92,7 +92,7 @@
                                                     []
                                                 )
                                         })
-                                    frexp~genericprocedure
+                                    frexp
                                     (FunctionType
                                         [(Real 4)
                                         (Integer 4)]

--- a/tests/reference/asr-string1-f6332d9.json
+++ b/tests/reference/asr-string1-f6332d9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string1-f6332d9.stdout",
-    "stdout_hash": "3b7bc247dca95e8a393df16f66f963ec69e839df932d63132afb71da",
+    "stdout_hash": "2f2a0e6db430f18a14f5521734a002666d19f95381ee028da8088b8d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string1-f6332d9.stdout
+++ b/tests/reference/asr-string1-f6332d9.stdout
@@ -41,7 +41,7 @@
                                 (GenericProcedure
                                     2
                                     f_string
-                                    [2 f_string~genericprocedure
+                                    [2 f_string
                                     2 f_string_cptr
                                     2 f_string_cptr_n]
                                     Public
@@ -427,7 +427,7 @@
                                                     []
                                                 )
                                         })
-                                    f_string~genericprocedure
+                                    f_string
                                     (FunctionType
                                         [(Array
                                             (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)

--- a/tests/reference/asr-string2-3425046.json
+++ b/tests/reference/asr-string2-3425046.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-string2-3425046.stdout",
-    "stdout_hash": "2ca7d2cc6ad441bdbc5bd9e5287a91952ead20b62b330f6cf86bf877",
+    "stdout_hash": "4d157b5c43b67943e7d0e464eaad99b9a91f1dda1e0e6f3da6d37792",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-string2-3425046.stdout
+++ b/tests/reference/asr-string2-3425046.stdout
@@ -61,7 +61,7 @@
                                 (ExternalSymbol
                                     2
                                     f_string~genericprocedure@f_string
-                                    4 f_string~genericprocedure
+                                    4 f_string
                                     fpm_strings
                                     []
                                     f_string~genericprocedure
@@ -103,11 +103,11 @@
                                                     ()
                                                     []
                                                 ),
-                                            f_string@f_string~genericprocedure:
+                                            f_string@f_string:
                                                 (ExternalSymbol
                                                     21
-                                                    f_string@f_string~genericprocedure
-                                                    4 f_string~genericprocedure
+                                                    f_string@f_string
+                                                    4 f_string
                                                     fpm_strings
                                                     []
                                                     f_string~genericprocedure
@@ -162,7 +162,7 @@
                                     [(Assignment
                                         (Var 21 tempfile)
                                         (FunctionCall
-                                            21 f_string@f_string~genericprocedure
+                                            21 f_string@f_string
                                             2 f_string
                                             [((Var 21 c_tempfile))]
                                             (Allocatable
@@ -392,7 +392,7 @@
                                 (GenericProcedure
                                     4
                                     f_string
-                                    [4 f_string~genericprocedure
+                                    [4 f_string
                                     4 f_string_cptr
                                     4 f_string_cptr_n]
                                     Public
@@ -778,7 +778,7 @@
                                                     []
                                                 )
                                         })
-                                    f_string~genericprocedure
+                                    f_string
                                     (FunctionType
                                         [(Array
                                             (String 1 (IntegerConstant 1 (Integer 4) Decimal) ExpressionLength DescriptorString)

--- a/tests/reference/asr-subroutines_06-1ab6665.json
+++ b/tests/reference/asr-subroutines_06-1ab6665.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-subroutines_06-1ab6665.stdout",
-    "stdout_hash": "bcc2f689ba95f2343c6b05d30e4f7ed7d6d41331a0dfe1eb6cc110e4",
+    "stdout_hash": "63e6a23c3e9cf6b2991ca0324e2448a7b93703cac3c9ae014f793916",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-subroutines_06-1ab6665.stdout
+++ b/tests/reference/asr-subroutines_06-1ab6665.stdout
@@ -41,7 +41,7 @@
                                 (ExternalSymbol
                                     7
                                     error_handler~genericprocedure
-                                    2 error_handler~genericprocedure
+                                    2 error_handler
                                     subroutines_06_bitset
                                     []
                                     error_handler~genericprocedure
@@ -241,7 +241,7 @@
                                 (GenericProcedure
                                     2
                                     error_handler
-                                    [2 error_handler~genericprocedure]
+                                    [2 error_handler]
                                     Public
                                 ),
                             error_handler~genericprocedure:
@@ -370,7 +370,7 @@
                                                     []
                                                 )
                                         })
-                                    error_handler~genericprocedure
+                                    error_handler
                                     (FunctionType
                                         [(String 1 () AssumedLength DescriptorString)
                                         (Integer 4)


### PR DESCRIPTION
## Summary

Fortran allows a generic interface to have the same name as one of its specific procedures. Both need an entry in the same symbol table, so LFortran stores the specific under `<name>~genericprocedure` — but it also writes that string into `Function::m_name`, and `m_name` is what the backends use for the link symbol. When the specific procedure is defined outside the module (a global procedure, or one compiled separately — this is how netcdf's `get_text` is written) the call site references `<name>~genericprocedure` while the definition is emitted as `<name>`:

```
Undefined symbols for architecture arm64:
  "_get_text~genericprocedure", referenced from: _main
```

This makes the suffix a symbol table **key** only and leaves `m_name` as the name the user wrote.

## Rationale

A symbol's key was never required to equal its name: the ASR pickle prints them on separate lines, the binary modfile writes the key separately from the symbol body, and no verifier tied them together. Putting the disambiguation where it belongs means **no backend change is needed at all** — LLVM, C, WASM and x86 already name functions from `m_name` — and no new ASR field, so `--show-asr` output and modfiles stop containing the mangled string too.

What *did* conflate key and name is the code that re-finds a symbol in a symbol table. `ExternalSymbol::m_original_name` and the symbol references written by `write_symbol()` are both resolved with `SymbolTable::get_symbol()` (in `fix_external_symbols()` and `read_symbol()` respectively), yet were being filled in with `ASRUtils::symbol_name()`. That worked only because the two always coincided.

This PR adds `ASRUtils::symbol_table_key()` — which returns the name whenever the two agree, so it is free for every other symbol — uses it at those sites, and tightens the ASR verifier from

> `ExternalSymbol::m_original_name` must match `external->m_name`

to

> `ExternalSymbol::m_original_name` must be the key of `m_external` in its defining symbol table

which is the property the loader actually depends on. That verifier change is what located the remaining sites.

## Scope

- Semantics: `sym_name` (→ `m_name`) split from `sym_key` (→ symbol table key) in `visit_Function` / `visit_Subroutine`; generic import and resolution paths look up by key
- `libasr`: `ASRUtils::symbol_table_key()`, `write_symbol()` writes the key, verifier invariant
- Also: compare the specific's name against the generic's after lower casing, so a mixed-case self reference (`interface addCNullChar` / `module procedure addCNullChar`) is recognised
- No ASR schema change and no backend change

## Verification

Fails before, passes after:

- `integration_tests/generic_name_10.f90` — self-named specific defined as a global procedure. Before: link failure above. After: PASS.
- `integration_tests/generic_name_09.f90` — mixed-case self-named module procedure. Before: `semantic error: Symbol 'addCNullChar' not declared`. After: PASS.

Separately checked by hand, since it is the shape that motivated this — module with a self-named generic in one file, program in another, plus a module variable used by host association in the specific:

```
$ lfortran -c sepmod.f90 -o sepmod.o && lfortran sepprog.f90 sepmod.o -o sep && ./sep
 PASS
```

One `.mod` file, and `flang` agrees on the result.

Suites (Debug, LLVM, macOS arm64):

```
$ ./run_tests.py            → TESTS PASSED
$ cd integration_tests && ./run_tests.py -b llvm -j16
  100% tests passed, 0 tests failed out of 3847
```

## Reference output

Five ASR references change, 27 lines total. Every one is the same edit — the suffix disappearing from a `Function` name while the symbol table key keeps it:

```
-                                    2 error_handler~genericprocedure
+                                    2 error_handler
-                                    [2 error_handler~genericprocedure]
+                                    [2 error_handler]
-                                    error_handler~genericprocedure
+                                    error_handler
```

## Relation to other PRs

Supersedes the approach in #12273 (backend strips the suffix) and #12384 (`Function.link_name` ASR field). Both leave `m_name` mangled; #12384 additionally regenerates ~1500 reference files and only teaches the LLVM backend about the new field. Fixing `m_name` itself makes all backends correct at once.

The `generic_name_09` fix and both integration tests are @certik's, from #12273.
