### PR TITLE
fix: enable Fortran kernel protocol tests in CI

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -61,8 +61,8 @@ cpack -V
 cd ../..
 
 jupyter kernelspec list --json
-#python ci/test_fortran_kernel.py -v
-#
+python ci/test_fortran_kernel.py -v
+
 cd share/lfortran/nb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo1_out.ipynb Demo1.ipynb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo2_out.ipynb Demo2.ipynb

--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -563,19 +563,22 @@ namespace LCompilers::LFortran {
 
     nl::json custom_interpreter::kernel_info_request_impl()
     {
-        nl::json result;
         std::string version = LFORTRAN_VERSION;
         std::string banner = ""
             "LFortran " + version + "\n"
             "Jupyter kernel for Fortran";
-        result["banner"] = banner;
-        result["implementation"] = "LFortran";
-        result["implementation_version"] = version;
-        result["language_info"]["name"] = "fortran";
-        result["language_info"]["version"] = "2018";
-        result["language_info"]["mimetype"] = "text/x-fortran";
-        result["language_info"]["file_extension"] = ".f90";
-        return result;
+        return xeus::create_info_reply(
+            "LFortran",
+            version,
+            "fortran",
+            "2018",
+            "text/x-fortran",
+            ".f90",
+            "",
+            std::string("text/x-fortran"),
+            "",
+            banner
+        );
     }
 
     nl::json custom_interpreter::shutdown_request_impl(bool restart) {


### PR DESCRIPTION
All tests pass for me locally

```
(lf) anutosh491@Anutoshs-MacBook-Air lfortran % python ci/test_fortran_kernel.py -v
Starting xeus-fortran kernel...

If you want to connect to this kernel from an other client, you can use the /private/var/folders/5b/vf8d2s5d1659wsql4bmvqdlw0000gn/T/tmpf3bw12uw.json file.
Run with XEUS 6.0.5
test_clear_output (__main__.IRKernelTests.test_clear_output) ... skipped 'No code clear output'
test_completion (__main__.IRKernelTests.test_completion) ... skipped 'No completion samples'
test_display_data (__main__.IRKernelTests.test_display_data) ... skipped 'No code display data'
test_error (__main__.IRKernelTests.test_error) ... skipped 'No code generate error'
test_execute_result (__main__.IRKernelTests.test_execute_result) ... ok
test_execute_stderr (__main__.IRKernelTests.test_execute_stderr) ... skipped 'No code stderr'
test_execute_stdout (__main__.IRKernelTests.test_execute_stdout) ... ok
test_history (__main__.IRKernelTests.test_history) ... 
  test_history (__main__.IRKernelTests.test_history) (hist_access_type='tail') ... skipped 'History tail not supported'
  test_history (__main__.IRKernelTests.test_history) (hist_access_type='range') ... skipped 'History range not supported'
  test_history (__main__.IRKernelTests.test_history) (hist_access_type='search') ... skipped 'No code history pattern'
test_inspect (__main__.IRKernelTests.test_inspect) ... skipped 'No code inspect sample'
test_is_complete (__main__.IRKernelTests.test_is_complete) ... skipped 'Not testing is_complete'
test_kernel_info (__main__.IRKernelTests.test_kernel_info) ... ok
test_pager (__main__.IRKernelTests.test_pager) ... skipped 'No code page something'

----------------------------------------------------------------------
Ran 12 tests in 2.046s

OK (skipped=11)
```