### PR TITLE
test: verify rich display data in the native kernel

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -61,8 +61,8 @@ cpack -V
 cd ../..
 
 jupyter kernelspec list --json
-#python ci/test_fortran_kernel.py -v
-#
+python ci/test_fortran_kernel.py -v
+
 cd share/lfortran/nb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo1_out.ipynb Demo1.ipynb
 jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=120 --output Demo2_out.ipynb Demo2.ipynb

--- a/ci/test_fortran_kernel.py
+++ b/ci/test_fortran_kernel.py
@@ -23,5 +23,13 @@ class IRKernelTests(jkt.KernelTests):
         {'code': "integer :: x; x = 5; x*2", 'result': "10"},
     ]
 
+    code_display_data = [
+        {
+            'code': 'use lfortran_display; '
+                    'call display_data("text/html", "<b>Hello</b>")',
+            'mime': 'text/html',
+        },
+    ]
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -563,19 +563,22 @@ namespace LCompilers::LFortran {
 
     nl::json custom_interpreter::kernel_info_request_impl()
     {
-        nl::json result;
         std::string version = LFORTRAN_VERSION;
         std::string banner = ""
             "LFortran " + version + "\n"
             "Jupyter kernel for Fortran";
-        result["banner"] = banner;
-        result["implementation"] = "LFortran";
-        result["implementation_version"] = version;
-        result["language_info"]["name"] = "fortran";
-        result["language_info"]["version"] = "2018";
-        result["language_info"]["mimetype"] = "text/x-fortran";
-        result["language_info"]["file_extension"] = ".f90";
-        return result;
+        return xeus::create_info_reply(
+            "LFortran",
+            version,
+            "fortran",
+            "2018",
+            "text/x-fortran",
+            ".f90",
+            "",
+            std::string("text/x-fortran"),
+            "",
+            banner
+        );
     }
 
     nl::json custom_interpreter::shutdown_request_impl(bool restart) {


### PR DESCRIPTION
```
(lf) anutosh491@Anutoshs-MacBook-Air lfortran % python ci/test_fortran_kernel.py -v
Starting xeus-fortran kernel...

If you want to connect to this kernel from an other client, you can use the /private/var/folders/5b/vf8d2s5d1659wsql4bmvqdlw0000gn/T/tmpfjgr39z_.json file.
Run with XEUS 6.0.5
test_clear_output (__main__.IRKernelTests.test_clear_output) ... skipped 'No code clear output'
test_completion (__main__.IRKernelTests.test_completion) ... skipped 'No completion samples'
test_display_data (__main__.IRKernelTests.test_display_data) ... ok
```

Testing display data passes now !!!

This should be rebased once #12432 goes in