### PR TITLE
fix: support scalar MASK in reduction intrinsics

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1098,6 +1098,7 @@ RUN(NAME intrinsic_reduce_01 LABELS llvm GFORTRAN_ARGS -std=f2018)
 RUN(NAME intrinsic_reduce_derived_type_01 LABELS llvm)
 RUN(NAME product_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME product_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME product_03 LABELS gfortran llvm)
 
 #gfortran 11-12 does not support reduce()
 RUN(NAME reduce_01 LABELS  llvm llvm_wasm llvm_wasm_emcc) 

--- a/integration_tests/product_03.f90
+++ b/integration_tests/product_03.f90
@@ -1,0 +1,37 @@
+program product_03
+! MASK of PRODUCT (and the other reduction intrinsics) may be a scalar:
+! it is conformable with any array (F2023 16.9.165, 3.32).
+implicit none
+integer :: a(6) = [1, 2, 3, 4, 5, 6]
+integer :: m2(2, 3)
+logical :: t_s, f_s
+m2 = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+t_s = .true.
+f_s = .false.
+
+! scalar mask used alongside array masks in the same scope: each call
+! must get a matching runtime function, not reuse the array-mask one
+if (product(a, mask=f_s) /= 1) error stop 1
+if (product(a, mask=t_s) /= 720) error stop 2
+if (product(a, mask=a > 3) /= 120) error stop 3
+
+if (sum(a, mask=f_s) /= 0) error stop 4
+if (sum(a, mask=t_s) /= 21) error stop 5
+if (sum(a, mask=a > 3) /= 15) error stop 6
+
+if (maxval(a, mask=f_s) /= -huge(1) - 1) error stop 7
+if (minval(a, mask=f_s) /= huge(1)) error stop 8
+if (minval(a, mask=t_s) /= 1) error stop 9
+
+! positional scalar mask
+if (product(a, f_s) /= 1) error stop 10
+if (sum(a, t_s) /= 21) error stop 11
+
+! dim together with a scalar mask
+if (any(product(m2, dim=1, mask=f_s) /= 1)) error stop 12
+if (any(sum(m2, dim=1, mask=t_s) /= [3, 7, 11])) error stop 13
+
+if (iparity(a, mask=f_s) /= 0) error stop 14
+
+print *, "ok"
+end program product_03

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -735,7 +735,7 @@ static inline ASR::asr_t* create_ArrIntrinsic(
             }
             if (args[2] && is_logical(*ASRUtils::expr_type(args[2]))) {
                 mask = args[2];
-                if (!ASRUtils::is_value_constant(mask)) {
+                if (!ASRUtils::is_value_constant(mask) && ASRUtils::is_array(ASRUtils::expr_type(mask))) {
                     if (!is_same_shape(array, mask, intrinsic_func_name, diag, {args[0]->base.loc, args[2]->base.loc})) {
                         return nullptr;
                     }
@@ -752,7 +752,7 @@ static inline ASR::asr_t* create_ArrIntrinsic(
                 return nullptr;
             }
             mask = args[1];
-            if (!ASRUtils::is_value_constant(mask)) {
+            if (!ASRUtils::is_value_constant(mask) && ASRUtils::is_array(ASRUtils::expr_type(mask))) {
                 if (!is_same_shape(array, mask, intrinsic_func_name, diag, {args[0]->base.loc, args[1]->base.loc})) {
                     return nullptr;
                 }
@@ -938,7 +938,8 @@ static inline void generate_body_for_array_mask_input(Allocator& al, const Locat
         },
         [=, &al, &idx_vars, &doloop_body, &builder] () {
             ASR::expr_t* array_ref = PassUtils::create_array_ref(array, idx_vars, al);
-            ASR::expr_t* mask_ref = PassUtils::create_array_ref(mask, idx_vars, al);
+            ASR::expr_t* mask_ref = ASRUtils::is_array(ASRUtils::expr_type(mask)) ?
+                PassUtils::create_array_ref(mask, idx_vars, al) : mask;
             ASR::expr_t* elemental_operation_val = (builder.*elemental_operation)(return_var, array_ref);
             ASR::stmt_t* loop_invariant = builder.Assignment(return_var, elemental_operation_val);
             Vec<ASR::stmt_t*> if_mask;
@@ -1000,7 +1001,8 @@ static inline void generate_body_for_array_dim_mask_input(
         [=, &al, &idx_vars, &target_idx_vars, &doloop_body, &builder, &result] () {
             ASR::expr_t* result_ref = PassUtils::create_array_ref(result, target_idx_vars, al);
             ASR::expr_t* array_ref = PassUtils::create_array_ref(array, idx_vars, al);
-            ASR::expr_t* mask_ref = PassUtils::create_array_ref(mask, idx_vars, al);
+            ASR::expr_t* mask_ref = ASRUtils::is_array(ASRUtils::expr_type(mask)) ?
+                PassUtils::create_array_ref(mask, idx_vars, al) : mask;
             ASR::expr_t* elemental_operation_val = (builder.*elemental_operation)(result_ref, array_ref);
             ASR::stmt_t* loop_invariant = builder.Assignment(result_ref, elemental_operation_val);
             Vec<ASR::stmt_t*> if_mask;
@@ -1229,7 +1231,12 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
                                     ASRUtils::expr_type(f->m_args[0]));
             bool same_allocatable_type = (ASRUtils::is_allocatable(arg_type) ==
                                     ASRUtils::is_allocatable(ASRUtils::expr_type(f->m_args[0])));
-            if (same_allocatable_type && ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
+            int mask_arg_idx = overload_id == id_array_mask ? 1 :
+                (overload_id == id_array_dim_mask ? 2 : -1);
+            bool same_mask_rank = mask_arg_idx == -1 ||
+                ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(f->m_args[mask_arg_idx])) ==
+                ASRUtils::extract_n_dims_from_ttype(arg_types[mask_arg_idx]);
+            if (same_allocatable_type && same_mask_rank && ASRUtils::types_equal(ASRUtils::expr_type(f->m_args[0]),
                     arg_type, f->m_args[0], new_args[0].m_value) && orig_array_rank == rank) {
                 return builder.Call(s, new_args, return_type, nullptr);
             } else {
@@ -1253,9 +1260,12 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
         fill_func_arg("dim", dim_type)
     }
     if( overload_id == id_array_mask || overload_id == id_array_dim_mask ) {
+        // `mask` may also be a scalar (conformable with any array)
+        int mask_rank = ASRUtils::extract_n_dims_from_ttype(
+            arg_types[overload_id == id_array_dim_mask ? 2 : 1]);
         Vec<ASR::dimension_t> mask_dims;
         mask_dims.reserve(al, rank);
-        for( int i = 0; i < rank; i++ ) {
+        for( int i = 0; i < mask_rank; i++ ) {
             ASR::dimension_t mask_dim;
             mask_dim.loc = arg_type->base.loc;
             mask_dim.m_start = nullptr;


### PR DESCRIPTION
closes #12435