### PR TITLE
Fix: RANDOM_SEED() with no args must reseed and refresh state (#12428)

### DIFF
--- a/integration_tests/random_seed_01.f90
+++ b/integration_tests/random_seed_01.f90
@@ -4,6 +4,22 @@ program random_seed_01
     call random_seed(size=sz)
     if (sz <= 0) error stop "random_seed size must be positive"
     block
+        integer, allocatable :: got0(:)
+        allocate(got0(sz))
+        ! random_seed(get=...) called before any prior put/bare random_seed()
+        ! must not observe the seed buffer's initial all-zero state
+        ! (regression test for #12428)
+        call random_seed(get=got0)
+        block
+            logical :: all_zero
+            all_zero = .true.
+            do i = 1, sz
+                if (got0(i) /= 0) all_zero = .false.
+            end do
+            if (all_zero) error stop "random_seed(get=...) returned all zeros before any prior seed"
+        end block
+    end block
+    block
         integer, allocatable :: vals(:), got(:)
         allocate(vals(sz), got(sz))
         vals = 42
@@ -18,12 +34,12 @@ program random_seed_01
         call random_seed()
         call random_seed(get=got)
         block
-            logical :: all_zero
-            all_zero = .true.
+            logical :: unchanged
+            unchanged = .true.
             do i = 1, sz
-                if (got(i) /= 0) all_zero = .false.
+                if (got(i) /= vals(i)) unchanged = .false.
             end do
-            if (all_zero) error stop "random_seed() did not reseed (got all zeros)"
+            if (unchanged) error stop "random_seed() did not reseed"
         end block
     end block
 end program random_seed_01

--- a/integration_tests/random_seed_01.f90
+++ b/integration_tests/random_seed_01.f90
@@ -1,12 +1,29 @@
 program random_seed_01
     implicit none
-    integer :: sz
+    integer :: sz, i
     call random_seed(size=sz)
     if (sz <= 0) error stop "random_seed size must be positive"
     block
-        integer :: vals(sz)
+        integer, allocatable :: vals(:), got(:)
+        allocate(vals(sz), got(sz))
         vals = 42
         call random_seed(put=vals)
-        call random_seed(get=vals)
+        call random_seed(get=got)
+        do i = 1, sz
+            if (got(i) /= vals(i)) error stop "random_seed get did not match put"
+        end do
+
+        ! bare `random_seed()` must reseed and refresh the internal state,
+        ! not leave it unchanged (regression test for #12428)
+        call random_seed()
+        call random_seed(get=got)
+        block
+            logical :: all_zero
+            all_zero = .true.
+            do i = 1, sz
+                if (got(i) /= 0) all_zero = .false.
+            end do
+            if (all_zero) error stop "random_seed() did not reseed (got all zeros)"
+        end block
     end block
 end program random_seed_01

--- a/src/libasr/pass/intrinsic_subroutines.h
+++ b/src/libasr/pass/intrinsic_subroutines.h
@@ -229,6 +229,34 @@ namespace RandomSeed {
             fill_func_arg_sub("get", real32, In);
         }
 
+        if (is_real(*arg_types[0]) && is_real(*arg_types[1]) && is_real(*arg_types[2])) {
+            // `call random_seed()` with no arguments must reseed the RNG and
+            // refresh the internal seed buffer, matching
+            // `random_init(repeatable=.false., image_distinct=.false.)`.
+            std::string c_func_name_2 = "_lfortran_random_init";
+            SymbolTable *fn_symtab_2 = al.make_new<SymbolTable>(fn_symtab);
+            Vec<ASR::expr_t*> args_2; args_2.reserve(al, 2);
+            ASR::expr_t *rep_arg = b.Variable(fn_symtab_2, "repeatable_c",
+                logical, ASR::intentType::In, nullptr, ASR::abiType::BindC, true);
+            args_2.push_back(al, rep_arg);
+            ASR::expr_t *img_arg = b.Variable(fn_symtab_2, "image_distinct_c",
+                logical, ASR::intentType::In, nullptr, ASR::abiType::BindC, true);
+            args_2.push_back(al, img_arg);
+            ASR::expr_t *return_var_2 = b.Variable(fn_symtab_2, c_func_name_2,
+                logical, ASRUtils::intent_return_var, nullptr, ASR::abiType::BindC, false);
+            SetChar dep_2; dep_2.reserve(al, 1);
+            Vec<ASR::stmt_t*> body_2; body_2.reserve(al, 1);
+            ASR::symbol_t *s_2 = make_ASR_Function_t(c_func_name_2, fn_symtab_2, dep_2, args_2,
+                body_2, return_var_2, ASR::abiType::BindC, ASR::deftypeType::Interface, s2c(al, c_func_name_2));
+            fn_symtab->add_symbol(c_func_name_2, s_2);
+            dep.push_back(al, s2c(al, c_func_name_2));
+            Vec<ASR::expr_t*> call_args_2; call_args_2.reserve(al, 2);
+            call_args_2.push_back(al, b.bool_t(false, logical));
+            call_args_2.push_back(al, b.bool_t(false, logical));
+            ASR::expr_t* discard_2 = declare("_lcompilers_random_seed_init_result", logical, Local);
+            body.push_back(al, b.Assignment(discard_2, b.Call(s_2, call_args_2, logical)));
+        }
+
         ASR::symbol_t *new_symbol = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, nullptr, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, new_symbol);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5628,17 +5628,43 @@ LFORTRAN_API int64_t _lfortran_int64_rand_num() {
 }
 
 static int32_t _lfortran_seed_buffer[8] = {0};
+static bool _lfortran_seed_initialized = false;
 
 static void _lfortran_seed_buffer_init_repeatable(void) {
     for (int i = 0; i < 8; i++) {
         _lfortran_seed_buffer[i] = 0;
     }
+    _lfortran_seed_initialized = true;
 }
 
 static void _lfortran_seed_buffer_init_random(void) {
     for (int i = 0; i < 8; i++) {
         _lfortran_seed_buffer[i] = rand();
     }
+    _lfortran_seed_initialized = true;
+}
+
+// Seeds `srand()` from a mix of the current time and a call counter, then
+// (re)fills `_lfortran_seed_buffer` with fresh values. Used both by
+// `_lfortran_random_init(.false., ...)` and to lazily initialize the seed
+// buffer the first time it is read (e.g. `random_seed(get=...)` called
+// before any prior `put`/bare `random_seed()`), so a GET never observes the
+// buffer's initial all-zero state.
+static void _lfortran_seed_buffer_seed_from_time(void) {
+    static unsigned int call_count = 0;
+    unsigned int seed;
+#if defined(_WIN32)
+    seed = (unsigned int)clock() ^ (++call_count * 2654435761u);
+#else
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        seed = (unsigned int)(ts.tv_nsec) ^ (++call_count * 2654435761u);
+    } else {
+        seed = (unsigned int)time(NULL) ^ (++call_count * 2654435761u);
+    }
+#endif
+    srand(seed);
+    _lfortran_seed_buffer_init_random();
 }
 
 LFORTRAN_API bool _lfortran_random_init(bool repeatable, bool image_distinct) {
@@ -5646,20 +5672,7 @@ LFORTRAN_API bool _lfortran_random_init(bool repeatable, bool image_distinct) {
         srand(0);
         _lfortran_seed_buffer_init_repeatable();
     } else {
-        static unsigned int call_count = 0;
-        unsigned int seed;
-#if defined(_WIN32)
-        seed = (unsigned int)clock() ^ (++call_count * 2654435761u);
-#else
-        struct timespec ts;
-        if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-            seed = (unsigned int)(ts.tv_nsec) ^ (++call_count * 2654435761u);
-        } else {
-            seed = (unsigned int)time(NULL) ^ (++call_count * 2654435761u);
-        }
-#endif
-        srand(seed);
-        _lfortran_seed_buffer_init_random();
+        _lfortran_seed_buffer_seed_from_time();
     }
     return false;
 }
@@ -5680,10 +5693,14 @@ LFORTRAN_API void _lfortran_random_seed_put_i32(int32_t value, int32_t index)
     if (index == 1) {
         srand((unsigned)value);
     }
+    _lfortran_seed_initialized = true;
 }
 
 LFORTRAN_API int32_t _lfortran_random_seed_get_i32(int32_t index)
 {
+    if (!_lfortran_seed_initialized) {
+        _lfortran_seed_buffer_seed_from_time();
+    }
     if (index >= 1 && index <= 8) {
         return _lfortran_seed_buffer[index - 1];
     }


### PR DESCRIPTION
closes #12428

`call random_seed()` with no arguments had no effect — the internal
seed buffer was never updated, so a following `get=` always returned
zeros even though `random_number()` kept advancing.

Fixed by making the no-args case call the same runtime routine
`random_init` uses to reseed and refresh the buffer. Also removed an
unintended `srand(seed)` call that fired just from querying `size=`.

Extended `integration_tests/random_seed_01.f90` to check that `get=`
matches a prior `put=`, and that a bare `random_seed()` call actually
changes the seed.