### PR TITLE
fix: expand implied-do loop bounds with non-literal size expressions 

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1260,6 +1260,7 @@ RUN(NAME format_105 LABELS gfortran llvm)
 RUN(NAME format_106 LABELS gfortran llvm)
 RUN(NAME format_107 LABELS gfortran llvm)
 RUN(NAME format_108 LABELS gfortran llvm)
+RUN(NAME format_109 LABELS gfortran llvm) # implied-do I/O with size() bound and scalar sibling
 RUN(NAME submodule_01 LABELS gfortran)
 RUN(NAME submodule_02 LABELS gfortran fortran)
 RUN(NAME submodule_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/format_109.f90
+++ b/integration_tests/format_109.f90
@@ -1,0 +1,20 @@
+program format_109
+    ! Regression test for implied-do loop I/O where the upper bound is
+    ! size(arr) rather than a literal integer, and a scalar sibling argument
+    ! follows the implied-do list in the same print statement.
+    ! Previously, LFortran emitted a separate print record per loop iteration
+    ! and duplicated the scalar sibling into every record. GFortran (and the
+    ! Fortran standard) require all items to appear on a single output record.
+    implicit none
+    character(8) :: strings(2) = ['Hello   ', 'World   ']
+    character(100) :: out
+    integer :: i
+
+    ! Write to an internal file so we can compare the result exactly.
+    write(out, "(*(1X,A))") (trim(strings(i)), i=1,size(strings)), '(Implied-do I/O)'
+
+    if (trim(out) /= ' Hello World (Implied-do I/O)') &
+        error stop "format_109 failed: implied-do I/O with size() bound produced wrong output"
+
+    print *, "PASSED"
+end program format_109

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -1794,11 +1794,37 @@ namespace LCompilers {
                     }
                     llvm::Value* base_offset = get_offset(source_llvm_type, source_desc);
                     linear_offset = builder->CreateAdd(linear_offset, base_offset);
-                    // Copy element
-                    llvm::Value* src_elem_ptr = builder->CreateGEP(elem_type, src_data, linear_offset);
-                    llvm::Value* elem_val = builder->CreateLoad(elem_type, src_elem_ptr);
-                    llvm::Value* dest_ptr = builder->CreateGEP(elem_type, data_buffer, iter);
-                    builder->CreateStore(elem_val, dest_ptr);
+                    // Copy element.
+                    // For string arrays (elem_type == string_descriptor), the backing
+                    // storage is ONE string_descriptor with { char_base*, elem_len }.
+                    // Character data is laid out as a flat byte buffer:
+                    //   element i  =>  { char_base + linear_offset * elem_len, elem_len }
+                    // GEP-ing into the descriptor array by linear_offset would read garbage
+                    // because there is only one descriptor, not N.
+                    if (elem_type == llvm_utils->string_descriptor) {
+                        // Load the single backing string_descriptor at index 0.
+                        llvm::Value* back_desc = builder->CreateLoad(elem_type, src_data);
+                        llvm::Value* char_base = builder->CreateExtractValue(back_desc, {0u});
+                        llvm::Value* elem_len  = builder->CreateExtractValue(back_desc, {1u});
+                        // byte_offset = linear_offset * elem_len
+                        llvm::Value* byte_off = builder->CreateMul(
+                            builder->CreateSExtOrTrunc(linear_offset,
+                                llvm::Type::getInt64Ty(context)),
+                            elem_len);
+                        llvm::Value* elem_char_ptr = builder->CreateGEP(
+                            llvm::Type::getInt8Ty(context), char_base, byte_off);
+                        // Build a new string_descriptor for this element.
+                        llvm::Value* new_desc = llvm::Constant::getNullValue(elem_type);
+                        new_desc = builder->CreateInsertValue(new_desc, elem_char_ptr, {0u});
+                        new_desc = builder->CreateInsertValue(new_desc, elem_len,      {1u});
+                        llvm::Value* dest_ptr = builder->CreateGEP(elem_type, data_buffer, iter);
+                        builder->CreateStore(new_desc, dest_ptr);
+                    } else {
+                        llvm::Value* src_elem_ptr = builder->CreateGEP(elem_type, src_data, linear_offset);
+                        llvm::Value* elem_val = builder->CreateLoad(elem_type, src_elem_ptr);
+                        llvm::Value* dest_ptr = builder->CreateGEP(elem_type, data_buffer, iter);
+                        builder->CreateStore(elem_val, dest_ptr);
+                    }
                     // Increment iterator
                     llvm::Value* new_iter = builder->CreateAdd(iter,
                         llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)));

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -1118,21 +1118,68 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             }
         };
         
+        // Attempt to evaluate an expression to a compile-time integer constant.
+        // Returns true and sets `val` on success.
+        bool try_eval_int_const(ASR::expr_t* expr, int64_t& val) {
+            if (!expr) return false;
+            // Direct integer constant
+            if (ASR::is_a<ASR::IntegerConstant_t>(*expr)) {
+                val = ASR::down_cast<ASR::IntegerConstant_t>(expr)->m_n;
+                return true;
+            }
+            // ArraySize(arr, dim) — evaluate via fixed size for dim-less (whole-array) SIZE
+            if (ASR::is_a<ASR::ArraySize_t>(*expr)) {
+                ASR::ArraySize_t* as = ASR::down_cast<ASR::ArraySize_t>(expr);
+                if (as->m_dim == nullptr) {
+                    // size(arr) — total element count
+                    int64_t sz = ASRUtils::get_fixed_size_of_array(
+                        ASRUtils::expr_type(as->m_v));
+                    if (sz > 0) { val = sz; return true; }
+                }
+                // size(arr, dim) — we only handle dim=1 for 1-D arrays
+                if (as->m_dim && ASR::is_a<ASR::IntegerConstant_t>(*as->m_dim)) {
+                    int64_t dim_idx = ASR::down_cast<ASR::IntegerConstant_t>(as->m_dim)->m_n;
+                    ASR::ttype_t* arr_type = ASRUtils::expr_type(as->m_v);
+                    ASR::Array_t* arr = nullptr;
+                    if (ASR::is_a<ASR::Array_t>(*arr_type))
+                        arr = ASR::down_cast<ASR::Array_t>(arr_type);
+                    else if (ASR::is_a<ASR::Allocatable_t>(*arr_type) &&
+                             ASR::is_a<ASR::Array_t>(*ASR::down_cast<ASR::Allocatable_t>(arr_type)->m_type))
+                        arr = ASR::down_cast<ASR::Array_t>(ASR::down_cast<ASR::Allocatable_t>(arr_type)->m_type);
+                    if (arr && dim_idx >= 1 && (size_t)dim_idx <= arr->n_dims) {
+                        ASR::dimension_t& d = arr->m_dims[dim_idx - 1];
+                        if (d.m_length && ASR::is_a<ASR::IntegerConstant_t>(*d.m_length)) {
+                            val = ASR::down_cast<ASR::IntegerConstant_t>(d.m_length)->m_n;
+                            return true;
+                        }
+                    }
+                }
+            }
+            // Fallback: use constant-folded value stored by the semantic pass
+            ASR::expr_t* v = ASRUtils::expr_value(expr);
+            if (v && ASR::is_a<ASR::IntegerConstant_t>(*v)) {
+                val = ASR::down_cast<ASR::IntegerConstant_t>(v)->m_n;
+                return true;
+            }
+            return false;
+        }
+
         bool expand_implied_do_loop_flat(ASR::ImpliedDoLoop_t* idl, Vec<ASR::expr_t*>& result) {
             ASR::expr_t* start = idl->m_start;
             ASR::expr_t* end = idl->m_end;
             ASR::expr_t* step = idl->m_increment;
-            
-            if (!ASR::is_a<ASR::IntegerConstant_t>(*start) ||
-                !ASR::is_a<ASR::IntegerConstant_t>(*end)) {
+
+            int64_t start_val, end_val;
+            if (!try_eval_int_const(start, start_val) ||
+                !try_eval_int_const(end,   end_val)) {
                 return false;
             }
-            
-            int64_t start_val = ASR::down_cast<ASR::IntegerConstant_t>(start)->m_n;
-            int64_t end_val = ASR::down_cast<ASR::IntegerConstant_t>(end)->m_n;
             int64_t step_val = 1;
-            if (step && ASR::is_a<ASR::IntegerConstant_t>(*step)) {
-                step_val = ASR::down_cast<ASR::IntegerConstant_t>(step)->m_n;
+            if (step) {
+                int64_t sv = 1;
+                if (try_eval_int_const(step, sv)) {
+                    step_val = sv;
+                }
             }
             
             if (step_val == 0 || (step_val > 0 && start_val > end_val) || 


### PR DESCRIPTION
Fixes #10561 