### PR TITLE
Enforce C827/C828: deferred vs explicit coarray coshape

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7771,6 +7771,70 @@ public:
                         codims.push_back(al, asr_codim);
                     }
                 }
+                if (corank > 0) {
+                    // C827: A coarray with the ALLOCATABLE attribute shall have
+                    // a coarray-spec that is a deferred-coshape-spec-list (i.e.
+                    // every codimension is a bare ':', no explicit bounds or '*').
+                    // C828: A nonallocatable coarray shall have a coarray-spec
+                    // that is an explicit-coshape-spec (every codimension but the
+                    // last has an explicit upper cobound, and the last is '*').
+                    for (size_t c = 0; c < codims.size(); c++) {
+                        const ASR::codimension_t &codim = codims[c];
+                        bool is_deferred = (codim.m_end == nullptr &&
+                            codim.m_start == nullptr &&
+                            codim.m_end_star != ASR::codimension_typeType::CodimensionStar);
+                        if (is_allocatable) {
+                            if (!is_deferred) {
+                                diag.add(Diagnostic(
+                                    "A coarray with the `allocatable` attribute "
+                                    "must have a deferred coshape (every "
+                                    "codimension written as `:`)",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("", {codim.loc})
+                                    }));
+                                throw SemanticAbort();
+                            }
+                        } else {
+                            if (is_deferred) {
+                                diag.add(Diagnostic(
+                                    "A nonallocatable coarray must have an "
+                                    "explicit coshape; a deferred codimension "
+                                    "(`:`) is only permitted for allocatable "
+                                    "coarrays",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("", {codim.loc})
+                                    }));
+                                throw SemanticAbort();
+                            } else if (c == codims.size() - 1) {
+                                if (codim.m_end_star != ASR::codimension_typeType::CodimensionStar) {
+                                    diag.add(Diagnostic(
+                                        "The last upper cobound of a coarray "
+                                        "must be `*`",
+                                        Level::Error, Stage::Semantic, {
+                                            Label("", {codim.loc})
+                                        }));
+                                    throw SemanticAbort();
+                                }
+                            } else if (codim.m_end_star == ASR::codimension_typeType::CodimensionStar) {
+                                diag.add(Diagnostic(
+                                    "The upper cobound `*` must appear only "
+                                    "in the last codimension",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("", {codim.loc})
+                                    }));
+                                throw SemanticAbort();
+                            } else if (codim.m_end == nullptr) {
+                                diag.add(Diagnostic(
+                                    "A nonallocatable coarray's codimension "
+                                    "must have an explicit upper cobound",
+                                    Level::Error, Stage::Semantic, {
+                                        Label("", {codim.loc})
+                                    }));
+                                throw SemanticAbort();
+                            }
+                        }
+                    }
+                }
                 if (!is_argument && !is_allocatable && !is_pointer
                         && !is_dimension_star && dims.size() > 0) {
                     for (size_t j = 0; j < dims.size(); j++) {

--- a/tests/errors/continue_compilation_coarrays.f90
+++ b/tests/errors/continue_compilation_coarrays.f90
@@ -22,8 +22,8 @@ program continue_compilation_coarrays
     integer :: z[*], a
     a = z[1:5:2]
 
-    real :: cod[4]
-    print *,cod[5]
+    real :: cod[4,*]
+    print *,cod[5,1]
 
     ! ALLOCATE coarray-spec: multiple `*` cobounds -> ERROR
     integer, allocatable :: acoarr[:,:]
@@ -32,5 +32,16 @@ program continue_compilation_coarrays
     ! ALLOCATE coarray-spec: last cobound must be `*` -> ERROR
     integer, allocatable :: acoarr2[:,:]
     allocate(acoarr2[2, 2])
+
+    ! C828: a nonallocatable coarray may not have a deferred coshape -> ERROR
+    integer :: c828a[:]
+    integer :: c828b[:,*]
+    integer :: c828c[2,:,*]
+
+    ! C827: an allocatable coarray may not have an explicit coshape -> ERROR
+    integer, allocatable :: c827a[*]
+    integer, allocatable :: c827b[:,*]
+    integer, allocatable :: c827c[:,4,:]
+    integer, codimension[2,10,*], allocatable :: c827d
 
 end program continue_compilation_coarrays

--- a/tests/errors/continue_compilation_coarrays.f90
+++ b/tests/errors/continue_compilation_coarrays.f90
@@ -42,6 +42,18 @@ program continue_compilation_coarrays
     ! CODIMENSION attribute: last cobound must be `*` → ERROR
     integer, codimension[3, 2] :: w3
 
+    ! last ucobound must be '*' -> ERROR
+    real :: w4[4]
+
+    ! last ucobound must be '*' -> ERROR
+    real :: w5[2:4]
+
+    ! last ucobound must be '*' -> ERROR
+    real, codimension[5] :: w6
+
+    ! last ucobound must be '*' -> ERROR
+    real, codimension[2:5] :: w7
+
     ! C828: a nonallocatable coarray may not have a deferred coshape -> ERROR
     integer :: c828a[:]
     integer :: c828b[:,*]

--- a/tests/errors/continue_compilation_coarrays.f90
+++ b/tests/errors/continue_compilation_coarrays.f90
@@ -33,6 +33,15 @@ program continue_compilation_coarrays
     integer, allocatable :: acoarr2[:,:]
     allocate(acoarr2[2, 2])
 
+    ! Assumed codimension `*` must be the last codimension → ERROR
+    integer :: w1[*, *]
+
+    ! Assumed codimension `*` not in the last position → ERROR
+    integer :: w2[*, 2]
+
+    ! CODIMENSION attribute: last cobound must be `*` → ERROR
+    integer, codimension[3, 2] :: w3
+
     ! C828: a nonallocatable coarray may not have a deferred coshape -> ERROR
     integer :: c828a[:]
     integer :: c828b[:,*]

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_coarrays-85ccad8",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_coarrays.f90",
-    "infile_hash": "9fb58f542033bb170fcf68c2c81dabf8b871cf06f81ffd6db64f89bb",
+    "infile_hash": "3e21f4be08d463045474dca170c5b1d5319d37462a048b8aa1e34aff",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_coarrays-85ccad8.stderr",
-    "stderr_hash": "392ab58fd4850b7e1a09c07f84801adef7d68e458038b0e74d896e8c",
+    "stderr_hash": "f733310b9a6ca59dbb06c009dc9521dc936e86551a69162b8a7fa52a",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_coarrays-85ccad8",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_coarrays.f90",
-    "infile_hash": "33a2bc1537a90c3b46195d98307d3632accab51101e726d0e6410bee",
+    "infile_hash": "9fb58f542033bb170fcf68c2c81dabf8b871cf06f81ffd6db64f89bb",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_coarrays-85ccad8.stderr",
-    "stderr_hash": "29eff556b9a3db81bdbebb3a78af4219c61c333f586b89888ecc87eb",
+    "stderr_hash": "392ab58fd4850b7e1a09c07f84801adef7d68e458038b0e74d896e8c",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_coarrays-85ccad8",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_coarrays.f90",
-    "infile_hash": "bc88c0e8bee99db5bbfb1b26a404faf4666f4b9b010dcb8edd00aa4e",
+    "infile_hash": "33a2bc1537a90c3b46195d98307d3632accab51101e726d0e6410bee",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_coarrays-85ccad8.stderr",
-    "stderr_hash": "62940ff3a25c23ffbfd8f55f1bd7c059882588df25851c5a5f46c4e6",
+    "stderr_hash": "29eff556b9a3db81bdbebb3a78af4219c61c333f586b89888ecc87eb",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
@@ -4,46 +4,64 @@ syntax error: Token ':' is unexpected here
 23 |     a = z[1:5:2]
    |              ^ 
 
-semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:37:22
+semantic error: The upper cobound `*` must appear only in the last codimension
+  --> tests/errors/continue_compilation_coarrays.f90:37:19
    |
-37 |     integer :: c828a[:]
+37 |     integer :: w1[*, *]
+   |                   ^ 
+
+semantic error: The upper cobound `*` must appear only in the last codimension
+  --> tests/errors/continue_compilation_coarrays.f90:40:19
+   |
+40 |     integer :: w2[*, 2]
+   |                   ^ 
+
+semantic error: The last upper cobound of a coarray must be `*`
+  --> tests/errors/continue_compilation_coarrays.f90:43:29
+   |
+43 |     integer, codimension[3, 2] :: w3
+   |                             ^ 
+
+semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
+  --> tests/errors/continue_compilation_coarrays.f90:46:22
+   |
+46 |     integer :: c828a[:]
    |                      ^ 
 
 semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:38:22
+  --> tests/errors/continue_compilation_coarrays.f90:47:22
    |
-38 |     integer :: c828b[:,*]
+47 |     integer :: c828b[:,*]
    |                      ^ 
 
 semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:39:24
+  --> tests/errors/continue_compilation_coarrays.f90:48:24
    |
-39 |     integer :: c828c[2,:,*]
+48 |     integer :: c828c[2,:,*]
    |                        ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:42:35
+  --> tests/errors/continue_compilation_coarrays.f90:51:35
    |
-42 |     integer, allocatable :: c827a[*]
+51 |     integer, allocatable :: c827a[*]
    |                                   ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:43:37
+  --> tests/errors/continue_compilation_coarrays.f90:52:37
    |
-43 |     integer, allocatable :: c827b[:,*]
+52 |     integer, allocatable :: c827b[:,*]
    |                                     ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:44:37
+  --> tests/errors/continue_compilation_coarrays.f90:53:37
    |
-44 |     integer, allocatable :: c827c[:,4,:]
+53 |     integer, allocatable :: c827c[:,4,:]
    |                                     ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:45:26
+  --> tests/errors/continue_compilation_coarrays.f90:54:26
    |
-45 |     integer, codimension[2,10,*], allocatable :: c827d
+54 |     integer, codimension[2,10,*], allocatable :: c827d
    |                          ^ 
 
 semantic error: Variable 'x' is not a coarray; coindex notation [..] requires a codimension attribute

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
@@ -22,46 +22,70 @@ semantic error: The last upper cobound of a coarray must be `*`
 43 |     integer, codimension[3, 2] :: w3
    |                             ^ 
 
-semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:46:22
+semantic error: The last upper cobound of a coarray must be `*`
+  --> tests/errors/continue_compilation_coarrays.f90:46:16
    |
-46 |     integer :: c828a[:]
+46 |     real :: w4[4]
+   |                ^ 
+
+semantic error: The last upper cobound of a coarray must be `*`
+  --> tests/errors/continue_compilation_coarrays.f90:49:16
+   |
+49 |     real :: w5[2:4]
+   |                ^^^ 
+
+semantic error: The last upper cobound of a coarray must be `*`
+  --> tests/errors/continue_compilation_coarrays.f90:52:23
+   |
+52 |     real, codimension[5] :: w6
+   |                       ^ 
+
+semantic error: The last upper cobound of a coarray must be `*`
+  --> tests/errors/continue_compilation_coarrays.f90:55:23
+   |
+55 |     real, codimension[2:5] :: w7
+   |                       ^^^ 
+
+semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
+  --> tests/errors/continue_compilation_coarrays.f90:58:22
+   |
+58 |     integer :: c828a[:]
    |                      ^ 
 
 semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:47:22
+  --> tests/errors/continue_compilation_coarrays.f90:59:22
    |
-47 |     integer :: c828b[:,*]
+59 |     integer :: c828b[:,*]
    |                      ^ 
 
 semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
-  --> tests/errors/continue_compilation_coarrays.f90:48:24
+  --> tests/errors/continue_compilation_coarrays.f90:60:24
    |
-48 |     integer :: c828c[2,:,*]
+60 |     integer :: c828c[2,:,*]
    |                        ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:51:35
+  --> tests/errors/continue_compilation_coarrays.f90:63:35
    |
-51 |     integer, allocatable :: c827a[*]
+63 |     integer, allocatable :: c827a[*]
    |                                   ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:52:37
+  --> tests/errors/continue_compilation_coarrays.f90:64:37
    |
-52 |     integer, allocatable :: c827b[:,*]
+64 |     integer, allocatable :: c827b[:,*]
    |                                     ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:53:37
+  --> tests/errors/continue_compilation_coarrays.f90:65:37
    |
-53 |     integer, allocatable :: c827c[:,4,:]
+65 |     integer, allocatable :: c827c[:,4,:]
    |                                     ^ 
 
 semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
-  --> tests/errors/continue_compilation_coarrays.f90:54:26
+  --> tests/errors/continue_compilation_coarrays.f90:66:26
    |
-54 |     integer, codimension[2,10,*], allocatable :: c827d
+66 |     integer, codimension[2,10,*], allocatable :: c827d
    |                          ^ 
 
 semantic error: Variable 'x' is not a coarray; coindex notation [..] requires a codimension attribute

--- a/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
+++ b/tests/reference/asr-continue_compilation_coarrays-85ccad8.stderr
@@ -4,6 +4,48 @@ syntax error: Token ':' is unexpected here
 23 |     a = z[1:5:2]
    |              ^ 
 
+semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
+  --> tests/errors/continue_compilation_coarrays.f90:37:22
+   |
+37 |     integer :: c828a[:]
+   |                      ^ 
+
+semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
+  --> tests/errors/continue_compilation_coarrays.f90:38:22
+   |
+38 |     integer :: c828b[:,*]
+   |                      ^ 
+
+semantic error: A nonallocatable coarray must have an explicit coshape; a deferred codimension (`:`) is only permitted for allocatable coarrays
+  --> tests/errors/continue_compilation_coarrays.f90:39:24
+   |
+39 |     integer :: c828c[2,:,*]
+   |                        ^ 
+
+semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
+  --> tests/errors/continue_compilation_coarrays.f90:42:35
+   |
+42 |     integer, allocatable :: c827a[*]
+   |                                   ^ 
+
+semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
+  --> tests/errors/continue_compilation_coarrays.f90:43:37
+   |
+43 |     integer, allocatable :: c827b[:,*]
+   |                                     ^ 
+
+semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
+  --> tests/errors/continue_compilation_coarrays.f90:44:37
+   |
+44 |     integer, allocatable :: c827c[:,4,:]
+   |                                     ^ 
+
+semantic error: A coarray with the `allocatable` attribute must have a deferred coshape (every codimension written as `:`)
+  --> tests/errors/continue_compilation_coarrays.f90:45:26
+   |
+45 |     integer, codimension[2,10,*], allocatable :: c827d
+   |                          ^ 
+
 semantic error: Variable 'x' is not a coarray; coindex notation [..] requires a codimension attribute
  --> tests/errors/continue_compilation_coarrays.f90:5:9
   |
@@ -37,7 +79,7 @@ semantic error: Coarray 's' has corank 2 but 1 coindices were provided
 semantic error: Coarray 'cod' coindex 1 is out of bounds: 5 not in [1, 4]
   --> tests/errors/continue_compilation_coarrays.f90:26:17
    |
-26 |     print *,cod[5]
+26 |     print *,cod[5,1]
    |                 ^ 
 
 semantic error: The upper cobound `*` must appear only in the last codimension


### PR DESCRIPTION
Fixes #12465 