### PR TITLE
feat: support character results in the Fortran evaluator

### DIFF
--- a/ci/test_fortran_kernel.py
+++ b/ci/test_fortran_kernel.py
@@ -22,6 +22,7 @@ class IRKernelTests(jkt.KernelTests):
         {'code': "1+2+3", 'result': "6"},
         {'code': "1+2", 'result': "3"},
         {'code': "integer :: x; x = 5; x*2", 'result': "10"},
+        {'code': "'hello'", 'result': "hello"},
     ]
 
     code_display_data = [

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -1,3 +1,5 @@
+#include <array>
+#include <cstring>
 #include <fstream>
 
 #include <lfortran/fortran_evaluator.h>
@@ -37,6 +39,27 @@ namespace LCompilers {
 #endif
 
 namespace LCompilers {
+
+class StringDescriptor {
+    std::array<unsigned char, sizeof(char *) + sizeof(int64_t)> storage{};
+
+public:
+    void *pointer() {
+        return storage.data();
+    }
+
+    char *data() const {
+        char *data;
+        std::memcpy(&data, storage.data(), sizeof(data));
+        return data;
+    }
+
+    int64_t length() const {
+        int64_t length;
+        std::memcpy(&length, storage.data() + sizeof(char *), sizeof(length));
+        return length;
+    }
+};
 
 
 /* ------------------------------------------------------------------------- */
@@ -131,6 +154,11 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
         result.asr = pickle(*asr, true, false, false, false);
     }
 
+    bool character_result = asr->n_items > 0
+        && asr->m_items[asr->n_items - 1]->type == ASR::asrType::expr
+        && ASRUtils::is_character(*ASRUtils::expr_type(
+            ASRUtils::EXPR(asr->m_items[asr->n_items - 1])));
+
     // ASR -> LLVM
     Result<std::unique_ptr<LLVMModule>> res3 = get_llvm3(*asr,
         pass_manager, diagnostics, lm, lm.files.back().in_filename,
@@ -148,6 +176,9 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
     }
 
     std::string return_type = m->get_return_type(run_fn);
+    if (character_result) {
+        return_type = "character";
+    }
 
     // With full-width logical types, logicals are now i32/i64 in LLVM
     // (same as integers). Check the ASR to distinguish logical from integer.
@@ -202,6 +233,22 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
         int32_t r = e.execfn<int32_t>(run_fn);
         result.type = EvalResult::boolean;
         result.b = (r != 0);
+    } else if (return_type == "character") {
+        StringDescriptor descriptor;
+        e.execfn<void>(run_fn, descriptor.pointer());
+        result.type = EvalResult::character;
+        char *data = descriptor.data();
+        int64_t length = descriptor.length();
+        if (data && length > 0) {
+            result.str.assign(data, length);
+        }
+        if (data) {
+            const std::string allocator_fn = compiler_options.detect_leaks
+                ? "_lfortran_get_compiler_mem_dbg_allocator"
+                : "_lfortran_get_default_allocator";
+            void *allocator = e.execfn<void *>(allocator_fn);
+            e.execfn<void>("_lfortran_free_alloc", allocator, data);
+        }
     } else if (return_type == "void") {
         e.execfn<void>(run_fn);
         result.type = EvalResult::statement;

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -44,7 +44,8 @@ public:
 
     struct EvalResult {
         enum {
-            integer4, integer8, real4, real8, complex4, complex8, boolean, statement, none
+            integer4, integer8, real4, real8, complex4, complex8, boolean,
+            character, statement, none
         } type;
         union {
             bool b;
@@ -55,6 +56,7 @@ public:
             struct {float re, im;} c32;
             struct {double re, im;} c64;
         };
+        std::string str;
         std::string ast;
         std::string asr;
         std::string llvm_ir;

--- a/src/lfortran/fortran_kernel.cpp
+++ b/src/lfortran/fortran_kernel.cpp
@@ -428,6 +428,12 @@ namespace LCompilers::LFortran {
                 publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
                 break;
             }
+            case (LCompilers::FortranEvaluator::EvalResult::character) : {
+                nl::json pub_data;
+                pub_data["text/plain"] = r.str;
+                publish_execution_result(execution_counter, std::move(pub_data), nl::json::object());
+                break;
+            }
             case (LCompilers::FortranEvaluator::EvalResult::statement) : {
                 break;
             }

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -477,6 +477,17 @@ r
     CHECK(r.result.f32 == 3);
 }
 
+TEST_CASE("FortranEvaluator character result") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("'hello'");
+    REQUIRE(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::character);
+    CHECK(r.result.str == "hello");
+}
+
 TEST_CASE("FortranEvaluator 3") {
     CompilerOptions cu;
     cu.interactive = true;

--- a/src/libasr/codegen/evaluator.h
+++ b/src/libasr/codegen/evaluator.h
@@ -89,11 +89,11 @@ public:
     static void print_targets();
     static std::string get_default_target_triple();
 
-    template<class T>
-    T execfn(const std::string &name) {
+    template<class T, class... Args>
+    T execfn(const std::string &name, Args... args) {
         intptr_t addr = get_symbol_address(name);
-        T (*f)() = (T (*)())addr;
-        return f();
+        T (*f)(Args...) = (T (*)(Args...))addr;
+        return f(args...);
     }
 };
 
@@ -114,11 +114,11 @@ public:
     intptr_t get_symbol_address(const std::string &name);
     llvm::LLVMContext &get_context();
 
-    template<class T>
-    T execfn(const std::string &name) {
+    template<class T, class... Args>
+    T execfn(const std::string &name, Args... args) {
         intptr_t addr = get_symbol_address(name);
-        T (*f)() = (T (*)())addr;
-        return f();
+        T (*f)(Args...) = (T (*)(Args...))addr;
+        return f(args...);
     }
 
 private:

--- a/src/libasr/pass/global_stmts.cpp
+++ b/src/libasr/pass/global_stmts.cpp
@@ -107,6 +107,25 @@ void pass_wrap_global_stmts(Allocator &al,
                 fn_scope->add_symbol(std::string(var_name), down_cast<ASR::symbol_t>(return_var));
                 target = return_var_ref;
                 idx++;
+            } else if (ASRUtils::is_character(*ASRUtils::expr_type(value))) {
+                s.from_str(al, fn_name_s + std::to_string(idx));
+                var_name = s.c_str(al);
+                ASR::String_t *value_type = down_cast<ASR::String_t>(
+                    ASRUtils::extract_type(ASRUtils::expr_type(value)));
+                type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
+                    ASRUtils::TYPE(ASR::make_String_t(al, loc,
+                        value_type->m_kind, nullptr, ASR::DeferredLength,
+                        value_type->m_physical_type))));
+                return_var = ASRUtils::make_Variable_t_util(al, loc,
+                    fn_scope, var_name, nullptr, 0, ASRUtils::intent_local, nullptr, nullptr,
+                    ASR::storage_typeType::Default, type,
+                    nullptr, ASR::abiType::Source,
+                    ASR::Public, ASR::presenceType::Required, false);
+                return_var_ref = EXPR(ASR::make_Var_t(al, loc,
+                    down_cast<ASR::symbol_t>(return_var)));
+                fn_scope->add_symbol(std::string(var_name), down_cast<ASR::symbol_t>(return_var));
+                target = return_var_ref;
+                idx++;
             } else {
                 throw LCompilersException("Return type not supported in interactive mode");
             }


### PR DESCRIPTION
This PR lays the foundation for the "Pull" mechanism we were discussing on Zulip.

Pull-style rich display depends on the kernel being able to receive a value from the final expression in a cell. Character expressions were not previously supported by the evaluator, so even a simple final value such as 'hello' could not be returned.

This is a small prerequisite for implementing rich MIME results later.

Major changes being 
- Support character expressions in the global-statements wrapper.
- Return character data from the LLVM evaluator using LFortran's string descriptor.


