### PR TITLE
build: generate config.h into the build directory

### DIFF
--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -12,7 +12,13 @@ if (NOT LFORTRAN_VERSION)
         CACHE STRING "LFortran version" FORCE)
 endif ()
 
-configure_file(config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
+# Generated into the binary directory, not the source tree: several build
+# directories (native, build-wasm, the bootstrap in wasm-build0.sh) configure
+# the same source tree, and writing here would leave whichever configured last
+# in charge -- a wasm configure enabling HAVE_LFORTRAN_XEUS then breaks the
+# native link with an undefined run_kernel. ${libasr_BINARY_DIR}/.. is already
+# a public include directory below.
+configure_file(config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 set(SRC
     codegen/asr_to_cpp.cpp


### PR DESCRIPTION
## Summary

`config.h` was generated next to its template in the source tree, so every
build directory configuring this source tree wrote the same file. A native
build and a WASM build then overwrite each other's copy, and whichever
configured last decides what the other compiles against.

Concretely: a WASM configure sets `HAVE_LFORTRAN_XEUS`, and the native link
afterwards fails with an undefined `run_kernel`, from a build directory that
was never reconfigured.

Generate it into the binary directory instead, which is already a public
include directory, so each build directory gets its own.

## Scope

One line in `src/libasr/CMakeLists.txt`, plus a comment recording why.

## Verification

Configured and built the native tree and `build-wasm` from the same source
tree, in both orders; neither disturbs the other. Full unit suite passes.

## Note

First of a five-PR stack that replaces #12480. The rest build on this one, but
this change is independent of them and useful on its own to anyone who builds
both targets.
