### PR TITLE
interactive: one TranslationUnit per cell

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -153,6 +153,7 @@ progress
 design
 developer_tutorial
 ast_and_asr
+interactive_cells
 jupyterlite
 contributing
 ```

--- a/doc/src/interactive_cells.md
+++ b/doc/src/interactive_cells.md
@@ -1,0 +1,132 @@
+# Interactive evaluation: one TranslationUnit per cell
+
+This page describes how LFortran represents an interactive session — the REPL,
+the Jupyter kernel and the JupyterLite lab — in ASR, and what that means for
+code that walks symbol tables. Ordinary (ahead-of-time) compilation is not
+affected by any of it: there is one `TranslationUnit`, no chaining and no
+copying.
+
+## The shape
+
+Every cell is compiled into its own `TranslationUnit`. Their symbol tables are
+chained through `SymbolTable::parent`, oldest first:
+
+```
+cell 1   TranslationUnit   symtab(parent = nullptr)
+cell 2   TranslationUnit   symtab(parent = cell 1's symtab)
+cell 3   TranslationUnit   symtab(parent = cell 2's symtab)
+```
+
+Two properties follow directly from that shape:
+
+* **Cells are additive.** A cell sees everything declared before it, and
+  nothing can reach forward into a later cell.
+* **Redeclaring shadows.** A name declared again in a later cell does not
+  overwrite the earlier one; it hides it, the way a nested scope does. Code
+  compiled earlier keeps using what it resolved to then, and later cells
+  resolve to the new declaration. This is what a Python notebook does when you
+  re-run a cell: the name is rebound, and objects created earlier keep the
+  binding they were made with.
+
+So this session prints `1`, then `2`, then `1` again:
+
+```fortran
+integer function f()
+f = 1
+end function
+```
+```fortran
+f()          ! 1
+```
+```fortran
+integer function f()
+f = 2
+end function
+```
+```fortran
+f()          ! 2
+```
+
+The first `f` is still there and still returns 1 — Fortran simply gives you no
+way to name it once it is shadowed. The same holds for variables and modules;
+a module redefined in a later cell leaves procedures compiled against the
+earlier one using the earlier one.
+
+## Walking the chain
+
+Before cells were chained, a scope chain ended at the one and only
+`TranslationUnit`, so "walk to the root" and "find the translation unit" were
+the same thing. They are no longer. A walk looking for the translation unit has
+to stop at the *nearest* one, which is the cell being compiled — otherwise
+symbols generated during compilation land in the session's first cell, which
+was compiled long ago and cannot be added to any more.
+
+`ASRUtils::is_tu_scope()` is the test, and the walks that use it are
+`get_tu_symtab()`, `get_sym_module()`, `get_sym_module0()`,
+`get_scope_names()` and `SymbolTable::get_tu_scope()`. With a single
+`TranslationUnit` the nearest one is also the root, so ordinary compilation
+sees no change. **New code that walks up a scope chain looking for the
+translation unit should stop at `is_tu_scope()`, not at `parent == nullptr`.**
+
+## Qualifying symbols by cell
+
+Two live declarations of the same name need two distinct symbols in the
+generated code. Symbols declared at cell scope are therefore qualified by the
+cell they belong to, the way symbols in a module are qualified by the module:
+`ASRUtils::cell_prefix()` returns `__cell<N>_` for the Nth cell.
+
+The first cell is deliberately unqualified, so that it and ordinary compilation
+produce identical symbols. The wrapper each cell is run through
+(`__lfortran_evaluate_<N>`) is never qualified — the evaluator looks it up by
+that name.
+
+Codegen derives the prefix from the scope that *declares* a symbol, not from
+the cell being compiled (`tu_symbol_prefix()` in `asr_to_llvm.cpp`), which is
+what makes a reference from a later cell resolve to the earlier cell's symbol.
+
+## The snapshot
+
+The ASR passes rewrite what they are given: `pass_array_by_data` replaces a
+procedure taking an assumed-shape array with a specialisation under a mangled
+name, for instance. A cell is compiled from the tree semantic analysis
+produced, and the passes may do as they like to it — it is thrown away
+afterwards. What the *next* cell is parented to is a copy of this cell's
+symbols taken beforehand (`FortranEvaluator::snapshot_cell_scope()`), so that
+later cells resolve names against the signatures the user wrote rather than
+the lowered ones.
+
+Only symbols are copied. Later cells resolve names and read signatures; they
+never re-run an earlier cell's statements.
+
+This has a consequence worth knowing: because a later cell resolves to the
+*unspecialised* procedure, a pass that changes signatures has to specialise
+earlier cells' procedures too, so that the call reaches the procedure the JIT
+actually holds. The generated names are derived from the signature, so they
+come out the same as they did when that cell was compiled, and the call links
+to the definition already in the JIT. `pass_array_by_data` does this by
+visiting ancestor cell scopes.
+
+## Codegen and the JIT
+
+When a cell is compiled, earlier cells' symbols are *declared*, not defined:
+their definitions are already in the JIT, and this cell holds them in their
+pre-pass form anyway. Compiler-generated helpers are recreated by the passes on
+every evaluation, and redefining a symbol is an error for the JIT, so
+`FortranEvaluator::drop_redefinitions()` turns definitions the JIT already
+holds into declarations.
+
+A cell containing a `program` unit is compiled into
+`__lfortran_evaluate_<N>_program` and called from the evaluator; without that,
+the program would be compiled and never run, and the cell would silently
+produce no output.
+
+## Tests
+
+`src/lfortran/tests/test_llvm.cpp` holds the interactive tests. The shadowing
+ones (`FortranEvaluator shadow a variable/function/module across cells`) are
+the executable description of the semantics above: each checks that the new
+binding is visible *and* that the old one is still alive.
+
+One cell is one `evaluate2()` call, so a test is written as a sequence of them.
+See {doc}`jupyterlite` for reproducing a lab bug in the browser and reducing it
+to such a test.

--- a/doc/src/jupyterlite.md
+++ b/doc/src/jupyterlite.md
@@ -330,10 +330,11 @@ lfortran mre.f90 && ./a.out
   Write an ordinary **integration test** in `integration_tests/` and register it
   in `integration_tests/CMakeLists.txt` with the `gfortran` and `llvm` labels.
   That is the preferred form of every LFortran test.
-* If it only fails when the code is split across cells (state persisting in the
-  global symbol table between cells, modules defined in one cell and used in the
-  next, a symbol re-added on a second evaluation, ...), it is an *interactive
-  mode* bug and needs an evaluator test — continue below.
+* If it only fails when the code is split across cells (state persisting
+  between cells, modules defined in one cell and used in the next, a symbol
+  re-added on a second evaluation, ...), it is an *interactive mode* bug and
+  needs an evaluator test — continue below. {doc}`interactive_cells` describes
+  how cells are represented in ASR, which is usually where such a bug lives.
 
 ### Step 2 — write the MRE as an evaluator test
 

--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <cstring>
 #include <fstream>
+#include <set>
 
 #include <lfortran/fortran_evaluator.h>
 #include <libasr/codegen/asr_to_cpp.h>
@@ -25,6 +26,8 @@
 
 #ifdef HAVE_LFORTRAN_LLVM
 #include <libasr/codegen/evaluator.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
 #include <libasr/codegen/asr_to_llvm.h>
 #ifdef HAVE_LFORTRAN_MLIR
 #include <libasr/codegen/asr_to_mlir.h>
@@ -159,7 +162,9 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
         && ASRUtils::is_character(*ASRUtils::expr_type(
             ASRUtils::EXPR(asr->m_items[asr->n_items - 1])));
 
-    // ASR -> LLVM
+    // ASR -> LLVM. The passes rewrite this tree; that is fine, it is this
+    // cell's own and is discarded afterwards. What later cells resolve
+    // against is the snapshot taken in get_asr3().
     Result<std::unique_ptr<LLVMModule>> res3 = get_llvm3(*asr,
         pass_manager, diagnostics, lm, lm.files.back().in_filename,
         nullptr);
@@ -188,6 +193,9 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
 
     // With full-width logical types, logicals are now i32/i64 in LLVM
     // (same as integers). Check the ASR to distinguish logical from integer.
+    // This has to look at the tree that was compiled: `run_fn` does not exist
+    // in the session ASR, it is created by the wrap-global-statements pass, so
+    // in interactive mode it only ever appears in the copy.
     if (asr->m_symtab->get_symbol(run_fn) != nullptr) {
         ASR::symbol_t *fn_sym = asr->m_symtab->get_symbol(run_fn);
         if (ASR::is_a<ASR::Function_t>(*fn_sym)) {
@@ -199,6 +207,10 @@ Result<FortranEvaluator::EvalResult> FortranEvaluator::evaluate(
                 }
             }
         }
+    }
+
+    if (compiler_options.interactive) {
+        drop_redefinitions(*m);
     }
 
     // LLVM -> Machine code -> Execution
@@ -395,32 +407,83 @@ Result<ASR::TranslationUnit_t*> FortranEvaluator::get_asr2(
     }
 }
 
+
+#ifdef HAVE_LFORTRAN_LLVM
+void FortranEvaluator::drop_redefinitions(LLVMModule &m)
+{
+    // Each interactive evaluation compiles a fresh copy of the session ASR, so
+    // the passes regenerate their helper procedures every time: intrinsic
+    // lowerings such as __lcompilers_optimization_mod_i32, or the
+    // pass_array_by_data specialisation of a procedure that lives in the
+    // session. Adding a second definition of a symbol the JIT already holds is
+    // an error, and the existing definition is equivalent, so keep the
+    // declaration and drop the body.
+    for (llvm::Function &fn : *m.m_m) {
+        if (fn.isDeclaration()) continue;
+        std::string name = fn.getName().str();
+        if (!defined_symbols.insert(name).second) {
+            fn.deleteBody();
+        }
+    }
+}
+#endif
+
+SymbolTable* FortranEvaluator::snapshot_cell_scope(ASR::TranslationUnit_t &asr)
+{
+    // ASR passes rewrite what they are given: pass_array_by_data replaces a
+    // procedure taking an assumed-shape array with a specialisation under a
+    // mangled name, for instance. This cell's scope is the parent of the next
+    // cell's, so if later cells resolved names against the tree the passes
+    // just rewrote, they would see lowered signatures instead of the ones the
+    // user wrote.
+    //
+    // So the cell is compiled from the tree semantic analysis produced -- the
+    // passes may do as they like to it, it is thrown away afterwards -- while
+    // the chain gets a copy of its symbols taken beforehand. Only symbols are
+    // copied: later cells resolve names and read signatures, they never re-run
+    // this cell's statements. The copy carries the same names at the same
+    // depth, so it mangles to the same symbols this cell just compiled.
+    SymbolTable* snapshot = al.make_new<SymbolTable>(asr.m_symtab->parent);
+    ASR::asr_t* owner = ASR::make_TranslationUnit_t(al, asr.base.base.loc,
+        snapshot, nullptr, 0);
+    snapshot->asr_owner = owner;
+    ASRUtils::SymbolDuplicator duplicator(al);
+    for (auto &item : asr.m_symtab->get_scope()) {
+        // A program unit is executed by the cell that declares it and its name
+        // is not referenceable from Fortran, so later cells have no use for it.
+        if (ASR::is_a<ASR::Program_t>(*item.second)) continue;
+        duplicator.duplicate_symbol(item.second, snapshot);
+    }
+    return snapshot;
+}
+
 Result<ASR::TranslationUnit_t*> FortranEvaluator::get_asr3(
     LFortran::AST::TranslationUnit_t &ast, diag::Diagnostics &diagnostics, LCompilers::LocationManager &lm)
 {
     ASR::TranslationUnit_t* asr;
     // AST -> ASR
-    // Remove the old execution function if it exists
-    if (symbol_table) {
-        if (symbol_table->get_symbol(run_fn) != nullptr) {
-            symbol_table->erase_symbol(run_fn);
+    //
+    // Each interactive evaluation gets its own TranslationUnit, whose scope is
+    // parented to the previous one. Cells are therefore purely additive: a cell
+    // sees everything declared before it, and nothing can reach forward into a
+    // later cell. Redeclaring a name shadows the earlier one the way a nested
+    // scope does, so code compiled earlier keeps using what it resolved to
+    // then, while later cells resolve to the new declaration. That is the
+    // behaviour of a Python notebook, where re-running a cell rebinds the name
+    // and objects created earlier keep the old one.
+    //
+    // Ordinary compilation has none of this: one translation unit, no chaining
+    // and no copying, so that it is not slowed down by it.
+    SymbolTable *cell_scope = symbol_table;
+    if (compiler_options.interactive) {
+        if (symbol_table) {
+            // Everything declared before this cell is already compiled, so it
+            // is referenced rather than emitted again.
+            symbol_table->mark_all_variables_external(al);
         }
-        // Remove program units left by earlier evaluations. A program cannot be
-        // referenced from a later cell, and keeping it would make re-running a
-        // cell that defines one fail with "symbol already declared", which is
-        // the ordinary edit-and-run-again loop in a notebook.
-        std::vector<std::string> old_programs;
-        for (auto &item : symbol_table->get_scope()) {
-            if (ASR::is_a<ASR::Program_t>(*item.second)) {
-                old_programs.push_back(item.first);
-            }
-        }
-        for (auto &name : old_programs) {
-            symbol_table->erase_symbol(name);
-        }
-        symbol_table->mark_all_variables_external(al);
+        cell_scope = al.make_new<SymbolTable>(symbol_table);
     }
-    auto res = LFortran::ast_to_asr(al, ast, diagnostics, symbol_table,
+    auto res = LFortran::ast_to_asr(al, ast, diagnostics, cell_scope,
         compiler_options.symtab_only, compiler_options, lm);
     if (res.ok) {
         asr = res.result;
@@ -428,7 +491,11 @@ Result<ASR::TranslationUnit_t*> FortranEvaluator::get_asr3(
         LCOMPILERS_ASSERT(diagnostics.has_error())
         return res.error;
     }
-    if (!symbol_table) symbol_table = asr->m_symtab;
+    if (compiler_options.interactive) {
+        // The next cell is parented to a snapshot of this one, not to the tree
+        // about to be handed to the passes.
+        symbol_table = snapshot_cell_scope(*asr);
+    }
 
     return asr;
 }

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -2,6 +2,7 @@
 #define LFORTRAN_FORTRAN_EVALUATOR_H
 
 #include <memory>
+#include <set>
 
 #include <libasr/alloc.h>
 #include <lfortran/parser/parser.h>
@@ -82,6 +83,13 @@ public:
     Result<ASR::TranslationUnit_t*> get_asr3(
         LCompilers::LFortran::AST::TranslationUnit_t &ast,
         diag::Diagnostics &diagnostics, LCompilers::LocationManager &lm);
+    // Copy of a cell's symbols, taken before the ASR passes rewrite them, to
+    // serve as the parent scope of the next cell.
+    SymbolTable* snapshot_cell_scope(ASR::TranslationUnit_t &asr);
+#ifdef HAVE_LFORTRAN_LLVM
+    // Turn definitions the JIT already holds into declarations.
+    void drop_redefinitions(LLVMModule &m);
+#endif
     Result<std::string> get_llvm(const std::string &code,
         LocationManager &lm, LCompilers::PassManager& pass_manager,
         diag::Diagnostics &diagnostics);
@@ -133,6 +141,11 @@ private:
 #ifdef HAVE_LFORTRAN_LLVM
     std::unique_ptr<LLVMEvaluator> e;
     int eval_count;
+    // Functions already defined by an earlier evaluation. Compiler-generated
+    // helpers (intrinsic lowerings, procedure specialisations) are recreated
+    // by the passes on every evaluation; redefining them would be rejected by
+    // the JIT, so later modules only declare them. See drop_redefinitions().
+    std::set<std::string> defined_symbols;
 #endif
 #ifdef __EMSCRIPTEN__
     std::unique_ptr<WasmLFortranExecutor> wasm_exec;

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -5102,7 +5102,7 @@ public:
 
         ASR::symbol_t *t = current_scope->resolve_symbol(msym);
         if (!t) {
-            SymbolTable *tu_symtab = current_scope->get_global_scope();
+            SymbolTable *tu_symtab = current_scope->get_tu_scope();
             std::set<std::string> loaded_submodules;
             t = (ASR::symbol_t*)(ASRUtils::load_module(al, tu_symtab,
                 msym, x.base.base.loc, false, loaded_submodules, compiler_options.po, true,

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -21107,7 +21107,7 @@ public:
                 // Only do this for top-level modules (whose parent is the
                 // TranslationUnit), not for nested modules like enums.
                 if (std::string(es0->m_module_name) != std::string(m->m_name)) {
-                    ASR::symbol_t* origin_mod_sym = current_scope->get_global_scope()->get_symbol(es0->m_module_name);
+                    ASR::symbol_t* origin_mod_sym = current_scope->get_tu_scope()->get_symbol(es0->m_module_name);
                     if (origin_mod_sym && ASR::is_a<ASR::Module_t>(*origin_mod_sym)) {
                         current_module_dependencies.push_back(al, es0->m_module_name);
                     }
@@ -21560,7 +21560,7 @@ public:
             // Only do this for top-level modules (whose parent is the
             // TranslationUnit), not for nested modules like enums.
             if (std::string(ext_sym->m_module_name) != std::string(m->m_name)) {
-                ASR::symbol_t* origin_mod_sym = current_scope->get_global_scope()->get_symbol(ext_sym->m_module_name);
+                ASR::symbol_t* origin_mod_sym = current_scope->get_tu_scope()->get_symbol(ext_sym->m_module_name);
                 if (origin_mod_sym && ASR::is_a<ASR::Module_t>(*origin_mod_sym)) {
                     current_module_dependencies.push_back(al, ext_sym->m_module_name);
                 }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1140,7 +1140,7 @@ public:
 
     void visit_Procedure(const AST::Procedure_t &x) {
         ASR::Module_t* interface_module = ASR::down_cast<ASR::Module_t>(current_module_sym);
-        SymbolTable* tu_symtab = current_scope->get_global_scope();
+        SymbolTable* tu_symtab = current_scope->get_tu_scope();
         std::string proc_name = to_lower(std::string(x.m_name));
 
         ASR::Function_t* proc_interface = nullptr;
@@ -3385,7 +3385,7 @@ public:
         std::string base_module_name = "file_common_block_";
         std::string base_struct_instance_name = "struct_instance_";
 
-        SymbolTable* global_scope = current_scope->get_global_scope();
+        SymbolTable* global_scope = current_scope->get_tu_scope();
 
         if (x.m_name) {
             ASR::symbol_t* gs = global_scope->get_symbol(x.m_name);
@@ -4404,7 +4404,7 @@ public:
         current_module_dependencies.push_back(al, msym_cc);
 
         ASR::symbol_t *t = current_scope->resolve_symbol(msym);
-        SymbolTable *tu_symtab = current_scope->get_global_scope();
+        SymbolTable *tu_symtab = current_scope->get_tu_scope();
         bool load_submodules = (!compiler_options.separate_compilation && in_program);
         if (!t) {
             t = (ASR::symbol_t*)(ASRUtils::load_module(al, tu_symtab,

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1,6 +1,9 @@
 #include <tests/doctest.h>
 
 #include <cmath>
+#include <cstring>
+#include <iostream>
+#include <sstream>
 #include <fstream>
 
 #include <lfortran/fortran_evaluator.h>
@@ -1543,3 +1546,283 @@ TEST_CASE("FortranEvaluator program unit in a cell") {
     CHECK(r.result.i32 == 5);
 }
 
+
+// Shadowing across interactive cells. Each cell is its own TranslationUnit,
+// chained through SymbolTable::parent, so re-declaring a name in a later cell
+// does not overwrite the earlier one: code compiled in earlier cells keeps
+// using the binding that was in scope when it was compiled, and new code sees
+// the new one. This mirrors what Python does in a notebook.
+
+TEST_CASE("FortranEvaluator shadow a variable across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2("integer :: i").ok);
+    CHECK(e.evaluate2("i = 1").ok);
+    // A function compiled now binds to the `i` that exists now.
+    CHECK(e.evaluate2(R"(integer function old_i()
+old_i = i
+end function
+)").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("old_i()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+
+    // Re-declaring `i` shadows it; the old one stays alive.
+    CHECK(e.evaluate2("integer :: i").ok);
+    CHECK(e.evaluate2("i = 2").ok);
+    r = e.evaluate2("i");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    r = e.evaluate2("old_i()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+}
+
+TEST_CASE("FortranEvaluator shadow a function across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2(R"(integer function f()
+f = 1
+end function
+)").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("f()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+
+    // Re-defining `f` shadows it: new code calls the new one.
+    CHECK(e.evaluate2(R"(integer function f()
+f = 2
+end function
+)").ok);
+    r = e.evaluate2("f()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+
+    // The first `f` is still there. Fortran gives no way to name it once it
+    // is shadowed, so this checks the symbol the first cell emitted: the two
+    // definitions live under different names (the second cell qualifies its
+    // symbols by its cell) and both are defined in the JIT.
+    //
+    // The WASM build executes through WasmLFortranExecutor and has no JIT to
+    // look a symbol up in. `FortranEvaluator old and new function side by
+    // side` covers the same ground there, in Fortran rather than by symbol.
+#ifndef __EMSCRIPTEN__
+    CHECK(e.get_llvm_evaluator().execfn<int32_t>("f") == 1);
+#endif
+}
+
+TEST_CASE("FortranEvaluator shadow a module across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2(R"(module m
+implicit none
+integer, parameter :: c = 1
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(integer function old_c()
+use m, only: c
+old_c = c
+end function
+)").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("old_c()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+
+    CHECK(e.evaluate2(R"(module m
+implicit none
+integer, parameter :: c = 2
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(integer function new_c()
+use m, only: c
+new_c = c
+end function
+)").ok);
+    r = e.evaluate2("new_c()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    // The function compiled against the first `m` still sees c == 1.
+    r = e.evaluate2("old_c()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+}
+
+// A module declared in an earlier cell is in a parent scope, not in the cell
+// being compiled. Resolving `use` has to look through the chain; otherwise a
+// modfile is searched for on disk, of which there is none in a notebook.
+
+
+
+
+
+
+TEST_CASE("FortranEvaluator shadow a subroutine across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2("integer :: r").ok);
+    CHECK(e.evaluate2(R"(subroutine sub()
+r = 1
+end subroutine
+)").ok);
+    // Compiled now, so it calls the `sub` that exists now.
+    CHECK(e.evaluate2(R"(subroutine call_old_sub()
+call sub()
+end subroutine
+)").ok);
+    CHECK(e.evaluate2("call call_old_sub()").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("r");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+
+    // Re-defining `sub` shadows it: a call made now runs the new one.
+    CHECK(e.evaluate2(R"(subroutine sub()
+r = 2
+end subroutine
+)").ok);
+    CHECK(e.evaluate2("call sub()").ok);
+    r = e.evaluate2("r");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+
+    // The subroutine compiled against the first `sub` still runs the first one.
+    CHECK(e.evaluate2("call call_old_sub()").ok);
+    r = e.evaluate2("r");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+}
+
+// Both bindings have to be reachable from a single cell: an accessor compiled
+// against the old one and an accessor compiled against the new one, called
+// side by side. Re-evaluating the old accessor then rebinds it to the new
+// symbol, which is what a notebook user re-running a cell expects.
+
+TEST_CASE("FortranEvaluator old and new variable side by side") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    const char *accessor = R"(integer function f1()
+f1 = x
+end function
+)";
+    CHECK(e.evaluate2("integer :: x").ok);
+    CHECK(e.evaluate2("x = 1").ok);
+    CHECK(e.evaluate2(accessor).ok);
+    CHECK(e.evaluate2("integer :: x").ok);
+    CHECK(e.evaluate2("x = 2").ok);
+    CHECK(e.evaluate2(R"(integer function f2()
+f2 = x
+end function
+)").ok);
+    // One cell, both accessors: the two `x` are live at the same time.
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("f1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+    r = e.evaluate2("f2()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    CHECK(e.evaluate2(R"(if (f1() /= 1) error stop
+if (f2() /= 2) error stop
+if (f1() == f2()) error stop
+)").ok);
+
+    // Re-evaluating f1 rebinds it to the `x` that is in scope now.
+    CHECK(e.evaluate2(accessor).ok);
+    r = e.evaluate2("f1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    CHECK(e.evaluate2("if (f1() /= f2()) error stop").ok);
+}
+
+TEST_CASE("FortranEvaluator old and new function side by side") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    const char *caller = R"(integer function g1()
+g1 = f()
+end function
+)";
+    CHECK(e.evaluate2(R"(integer function f()
+f = 1
+end function
+)").ok);
+    CHECK(e.evaluate2(caller).ok);
+    CHECK(e.evaluate2(R"(integer function f()
+f = 2
+end function
+)").ok);
+    CHECK(e.evaluate2(R"(integer function g2()
+g2 = f()
+end function
+)").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("g1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+    r = e.evaluate2("g2()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    CHECK(e.evaluate2(R"(if (g1() /= 1) error stop
+if (g2() /= 2) error stop
+if (g1() == g2()) error stop
+)").ok);
+
+    CHECK(e.evaluate2(caller).ok);
+    r = e.evaluate2("g1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    CHECK(e.evaluate2("if (g1() /= g2()) error stop").ok);
+}
+
+TEST_CASE("FortranEvaluator old and new module side by side") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    const char *accessor = R"(integer function a1()
+use mshadow, only: c
+a1 = c
+end function
+)";
+    CHECK(e.evaluate2(R"(module mshadow
+implicit none
+integer, parameter :: c = 1
+end module
+)").ok);
+    CHECK(e.evaluate2(accessor).ok);
+    CHECK(e.evaluate2(R"(module mshadow
+implicit none
+integer, parameter :: c = 2
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(integer function a2()
+use mshadow, only: c
+a2 = c
+end function
+)").ok);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2("a1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 1);
+    r = e.evaluate2("a2()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    // Both modules are usable at the same time, from one cell.
+    CHECK(e.evaluate2(R"(if (a1() /= 1) error stop
+if (a2() /= 2) error stop
+if (a1() == a2()) error stop
+)").ok);
+
+    CHECK(e.evaluate2(accessor).ok);
+    r = e.evaluate2("a1()");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 2);
+    CHECK(e.evaluate2("if (a1() /= a2()) error stop").ok);
+}

--- a/src/libasr/asr_scopes.cpp
+++ b/src/libasr/asr_scopes.cpp
@@ -26,6 +26,14 @@ SymbolTable::SymbolTable(SymbolTable *parent) : parent{parent} {
     counter = symbol_table_counter;
 }
 
+SymbolTable* SymbolTable::get_tu_scope() {
+    SymbolTable* s = this;
+    while (s->parent && !ASRUtils::is_tu_scope(s)) {
+        s = s->parent;
+    }
+    return s;
+}
+
 void SymbolTable::reset_global_counter() {
     symbol_table_counter = 0;
 }

--- a/src/libasr/asr_scopes.h
+++ b/src/libasr/asr_scopes.h
@@ -50,13 +50,11 @@ struct SymbolTable {
         return scope[name];
     }
 
-    SymbolTable* get_global_scope() {
-        SymbolTable* global_scope = this;
-        while (global_scope->parent) {
-            global_scope = global_scope->parent;
-        }
-        return global_scope;
-    }
+    // The symbol table of the TranslationUnit this scope belongs to. In
+    // interactive mode there is one TranslationUnit per cell, chained through
+    // `parent`, so this stops at the innermost one: new symbols belong to the
+    // cell being compiled, not to the first cell of the session.
+    SymbolTable* get_tu_scope();
 
     const std::map<std::string, ASR::symbol_t*>& get_scope() const {
         return scope;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1552,10 +1552,40 @@ static inline ASR::symbol_t *get_asr_owner(const ASR::symbol_t *sym) {
     return ASR::down_cast<ASR::symbol_t>(s->asr_owner);
 }
 
+// True if this scope belongs to a TranslationUnit.
+//
+// Interactive evaluation chains one TranslationUnit per cell, each scope
+// parented to the previous cell's, so a scope chain no longer ends at the only
+// TranslationUnit -- it passes through one per cell. Walks that look for "the"
+// translation unit therefore have to stop at the nearest one, which is the cell
+// currently being compiled. With a single TranslationUnit (ordinary
+// compilation) the nearest one is also the root, so nothing changes.
+static inline bool is_tu_scope(const SymbolTable *s) {
+    return s->asr_owner != nullptr && ASR::is_a<ASR::unit_t>(*s->asr_owner);
+}
+
+// Interactive evaluation compiles one TranslationUnit per cell, chained by
+// scope, and a cell may redeclare a name an earlier cell already used. Both
+// declarations stay live -- code compiled earlier keeps using the old one -- so
+// they need distinct symbols. Qualify by the cell a symbol belongs to, the way
+// symbols in a module are qualified by the module. The first cell is
+// unqualified, so that it and ordinary compilation produce identical symbols.
+static inline std::string cell_prefix(const SymbolTable *s) {
+    const SymbolTable *tu = s;
+    while (tu != nullptr && !is_tu_scope(tu)) tu = tu->parent;
+    if (tu == nullptr) return "";
+    int depth = 1;
+    for (const SymbolTable *p = tu->parent; p != nullptr; p = p->parent) {
+        if (is_tu_scope(p)) depth++;
+    }
+    if (depth == 1) return "";
+    return "__cell" + std::to_string(depth) + "_";
+}
+
 // Returns the Module_t the symbol is in, or nullptr if not in a module
 static inline ASR::Module_t *get_sym_module(const ASR::symbol_t *sym) {
     const SymbolTable *s = symbol_parent_symtab(sym);
-    while (s->parent != nullptr) {
+    while (s->parent != nullptr && !is_tu_scope(s)) {
         ASR::symbol_t *asr_owner = ASR::down_cast<ASR::symbol_t>(s->asr_owner);
         if (ASR::is_a<ASR::Module_t>(*asr_owner)) {
             return ASR::down_cast<ASR::Module_t>(asr_owner);
@@ -1591,7 +1621,7 @@ static inline ASR::symbol_t *get_asr_owner(const ASR::expr_t *expr) {
 // or no asr_owner yet
 static inline ASR::Module_t *get_sym_module0(const ASR::symbol_t *sym) {
     const SymbolTable *s = symbol_parent_symtab(sym);
-    while (s->parent != nullptr) {
+    while (s->parent != nullptr && !is_tu_scope(s)) {
         if (s->asr_owner != nullptr) {
             ASR::symbol_t *asr_owner = ASR::down_cast<ASR::symbol_t>(s->asr_owner);
             if (ASR::is_a<ASR::Module_t>(*asr_owner)) {
@@ -2693,7 +2723,7 @@ static inline Vec<ASR::expr_t*> call_arg2expr(Allocator &al, const Vec<ASR::call
 // Returns the TranslationUnit_t's symbol table by going via parents
 static inline SymbolTable *get_tu_symtab(SymbolTable *symtab) {
     SymbolTable *s = symtab;
-    while (s->parent != nullptr) {
+    while (s->parent != nullptr && !is_tu_scope(s)) {
         s = s->parent;
     }
     LCOMPILERS_ASSERT(ASR::is_a<ASR::unit_t>(*s->asr_owner))
@@ -2705,7 +2735,7 @@ static inline Vec<char*> get_scope_names(Allocator &al, const SymbolTable *symta
     Vec<char*> scope_names;
     scope_names.reserve(al, 4);
     const SymbolTable *s = symtab;
-    while (s->parent != nullptr) {
+    while (s->parent != nullptr && !is_tu_scope(s)) {
         char *owner_name = symbol_name(ASR::down_cast<ASR::symbol_t>(s->asr_owner));
         scope_names.push_back(al, owner_name);
         s = s->parent;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -109,8 +109,14 @@ public:
         current_symtab = x.m_symtab;
         require(x.m_symtab != nullptr,
             "The TranslationUnit::m_symtab cannot be nullptr");
-        require(x.m_symtab->parent == nullptr,
-            "The TranslationUnit::m_symtab->parent must be nullptr");
+        // Interactive evaluation chains one TranslationUnit per cell, each
+        // scope parented to the previous cell's, so that later cells see
+        // earlier declarations and may shadow them. Outside that, a
+        // TranslationUnit is the root and has no parent.
+        require(x.m_symtab->parent == nullptr ||
+                ASRUtils::is_tu_scope(x.m_symtab->parent),
+            "The TranslationUnit::m_symtab->parent must be nullptr or the "
+            "symbol table of another TranslationUnit");
         require(id_symtab_map.find(x.m_symtab->counter) == id_symtab_map.end(),
             "TranslationUnit::m_symtab->counter must be unique");
         require(x.m_symtab->asr_owner == (ASR::asr_t*)&x,
@@ -158,7 +164,7 @@ public:
             "The Program::m_symtab cannot be nullptr");
         require(x.m_symtab->parent == parent_symtab,
             "The Program::m_symtab->parent is not the right parent");
-        require(x.m_symtab->parent->parent == nullptr,
+        require(ASRUtils::is_tu_scope(x.m_symtab->parent),
             "The Program::m_symtab's parent must be TranslationUnit");
         require(id_symtab_map.find(x.m_symtab->counter) == id_symtab_map.end(),
             "Program::m_symtab->counter must be unique");
@@ -330,7 +336,7 @@ public:
             "The Module::m_symtab cannot be nullptr");
         require(x.m_symtab->parent == parent_symtab,
             "The Module::m_symtab->parent is not the right parent");
-        require(x.m_symtab->parent->parent == nullptr,
+        require(ASRUtils::is_tu_scope(x.m_symtab->parent),
             "The Module::m_symtab's parent must be TranslationUnit");
         require(id_symtab_map.find(x.m_symtab->counter) == id_symtab_map.end(),
             "Module::m_symtab->counter must be unique");

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1870,11 +1870,26 @@ public:
         fname2arg_type["lbound"] = std::make_pair(bound_arg, bound_arg->getPointerTo());
         fname2arg_type["ubound"] = std::make_pair(bound_arg, bound_arg->getPointerTo());
 
+        // In interactive mode this translation unit is one cell, parented to
+        // the previous cell's, and code here may use anything declared by an
+        // earlier cell. Those symbols were emitted when their own cell was
+        // compiled and are marked ExternalUndefined, so walking them here only
+        // declares them. Oldest cell first, so that a name redeclared by a
+        // newer cell is the one left in llvm_symtab.
+        std::vector<SymbolTable*> cell_scopes;
+        for (SymbolTable *s = x.m_symtab; s != nullptr; s = s->parent) {
+            cell_scopes.push_back(s);
+        }
+        std::reverse(cell_scopes.begin(), cell_scopes.end());
+
         // Process Variables first:
-        for (auto &item : x.m_symtab->get_scope()) {
-            if (is_a<ASR::Variable_t>(*item.second) ||
-                is_a<ASR::Enum_t>(*item.second)) {
-                visit_symbol(*item.second);
+        for (SymbolTable *scope : cell_scopes) {
+            mangle_prefix = ASRUtils::cell_prefix(scope);
+            for (auto &item : scope->get_scope()) {
+                if (is_a<ASR::Variable_t>(*item.second) ||
+                    is_a<ASR::Enum_t>(*item.second)) {
+                    visit_symbol(*item.second);
+                }
             }
         }
 
@@ -1894,12 +1909,16 @@ public:
 
         prototype_only = true;
         // Generate function prototypes
-        for (auto &item : x.m_symtab->get_scope()) {
-            if (is_a<ASR::Function_t>(*item.second)) {
-                visit_Function(*ASR::down_cast<ASR::Function_t>(item.second));
+        for (SymbolTable *scope : cell_scopes) {
+            mangle_prefix = ASRUtils::cell_prefix(scope);
+            for (auto &item : scope->get_scope()) {
+                if (is_a<ASR::Function_t>(*item.second)) {
+                    visit_Function(*ASR::down_cast<ASR::Function_t>(item.second));
+                }
             }
         }
         prototype_only = false;
+        mangle_prefix = "";
 
         // TODO: handle dependencies across modules and main program
 
@@ -1908,17 +1927,45 @@ public:
             = determine_module_dependencies(x);
         for (auto &item : build_order) {
             if (!item.compare("_lcompilers_mlir_gpu_offloading")) continue;
-            ASR::symbol_t *mod = x.m_symtab->get_symbol(item);
+            ASR::symbol_t *mod = nullptr;
+            SymbolTable *mod_scope = nullptr;
+            for (SymbolTable *scope : cell_scopes) {
+                if (ASR::symbol_t *m = scope->get_symbol(item)) {
+                    mod = m;
+                    mod_scope = scope;
+                }
+            }
             if (mod == nullptr) continue;
+            // An earlier cell's symbols are already defined in the JIT, and
+            // this cell holds them as they were before the ASR passes ran, so
+            // their bodies are not in a lowered form we could emit anyway.
+            // Declare them, do not define them.
+            prototype_only = (mod_scope != x.m_symtab);
             visit_symbol(*mod);
+            prototype_only = false;
         }
-
-        // Then do all the procedures
-        for (auto &item : x.m_symtab->get_scope()) {
-            if( ASR::is_a<ASR::Function_t>(*item.second) ) {
-                visit_symbol(*item.second);
+        prototype_only = true;
+        for (SymbolTable *scope : cell_scopes) {
+            if (scope == x.m_symtab) continue;
+            for (auto &item : scope->get_scope()) {
+                if (ASR::is_a<ASR::Module_t>(*item.second)) {
+                    visit_symbol(*item.second);
+                }
             }
         }
+        prototype_only = false;
+
+        // Then do all the procedures
+        for (SymbolTable *scope : cell_scopes) {
+            mangle_prefix = ASRUtils::cell_prefix(scope);
+            prototype_only = (scope != x.m_symtab);
+            for (auto &item : scope->get_scope()) {
+                if( ASR::is_a<ASR::Function_t>(*item.second) ) {
+                    visit_symbol(*item.second);
+                }
+            }
+        }
+        prototype_only = false;
 
         // Then the main program
         for (auto &item : x.m_symtab->get_scope()) {
@@ -5617,10 +5664,12 @@ public:
                 llvm_var_name = x.m_name;
             } else {
                 // bind(c, name='') — empty name, use mangled name
-                llvm_var_name = mangle_prefix + x.m_name;
+                llvm_var_name = tu_symbol_prefix(x.m_parent_symtab, mangle_prefix, x.m_name)
+                    + x.m_name;
             }
         } else {
-            llvm_var_name = mangle_prefix + x.m_name;
+            llvm_var_name = tu_symbol_prefix(x.m_parent_symtab, mangle_prefix, x.m_name)
+                + x.m_name;
         }
 
         if (alias_target) {
@@ -6213,10 +6262,29 @@ public:
         llvm_symtab_fn[h]->removeFromParent();
     }
 
+    // Qualification for a symbol declared directly by a translation unit.
+    // Interactive evaluation compiles one TranslationUnit per cell, so a
+    // symbol of an earlier cell must be named the way that cell named it,
+    // whichever cell is currently being compiled. Everything else (module
+    // members, nested procedures) keeps the prefix of the scope being walked.
+    std::string tu_symbol_prefix(const SymbolTable *parent,
+            const std::string &ambient, const std::string &sym_name) {
+        // The per-evaluation wrapper and the program of a cell already carry
+        // the evaluation counter and are looked up by that name, so they are
+        // left alone.
+        if (sym_name.rfind("__lfortran_evaluate_", 0) == 0) {
+            return "";
+        }
+        if (parent != nullptr && ASRUtils::is_tu_scope(parent)) {
+            return ASRUtils::cell_prefix(parent);
+        }
+        return ambient;
+    }
+
     void visit_Module(const ASR::Module_t &x) {
         SymbolTable* current_scope_copy = current_scope;
         current_scope = x.m_symtab;
-        mangle_prefix = "__module_" + std::string(x.m_name) + "_";
+        mangle_prefix = ASRUtils::cell_prefix(x.m_symtab) + "__module_" + std::string(x.m_name) + "_";
 
         start_module_init_function_prototype(x);
         std::vector<ASR::symbol_t*> variables;
@@ -6252,10 +6320,10 @@ public:
                         }
                     }
                 }
-                mangle_prefix = "__module_" + root_module + "_";
+                mangle_prefix = ASRUtils::cell_prefix(x.m_symtab) + "__module_" + root_module + "_";
             }
             instantiate_function(*v);
-            mangle_prefix = "__module_" + std::string(x.m_name) + "_";
+            mangle_prefix = ASRUtils::cell_prefix(x.m_symtab) + "__module_" + std::string(x.m_name) + "_";
         }
         for (auto &sym: variables) {
             ASR::Variable_t *v = down_cast<ASR::Variable_t>(
@@ -6267,7 +6335,7 @@ public:
         finish_module_init_function_prototype(x);
 
         visit_procedures(x);
-        mangle_prefix = "";
+        mangle_prefix = ASRUtils::cell_prefix(current_scope_copy);
         current_scope = current_scope_copy;
     }
 
@@ -8180,7 +8248,8 @@ public:
             // Compute the mangled function name using centralized logic
             ASR::FunctionType_t *ftype = ASRUtils::get_FunctionType(x);
             std::string fn_name = compute_llvm_function_name(
-                sym_name, ftype, compiler_options, mangle_prefix, parent_function
+                sym_name, ftype, compiler_options,
+                tu_symbol_prefix(x.m_symtab->parent, mangle_prefix, sym_name), parent_function
             );
             if (llvm_symtab_fn_names.find(fn_name) == llvm_symtab_fn_names.end()) {
                 llvm_symtab_fn_names[fn_name] = h;

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -633,6 +633,25 @@ void WasmLFortranExecutor::add_module(std::unique_ptr<LLVMModule> lm, int eval_c
     if (llvm::Function *fn = mod->getFunction(logical_stem + "_program"))
         fn->setName(unique_stem + "_program");
 
+    // Symbols qualified by their cell (__cell<N>_...) are named per session,
+    // so two executors in one process emit the same names. The wasm dynamic
+    // linker has one global namespace, so the second definition collides with
+    // the first -- and if their signatures differ, a module importing the name
+    // fails to link. Give each instance its own, the same way the run function
+    // above is made unique. Renaming here covers definitions and the
+    // declarations other modules of this instance import them through, so they
+    // still resolve to each other.
+    {
+        const std::string cell_prefix = "__cell";
+        const std::string instance = "__e" + std::to_string(m_id) + "_";
+        auto qualify = [&](llvm::GlobalValue &g) {
+            std::string n = g.getName().str();
+            if (n.rfind(cell_prefix, 0) == 0) g.setName(instance + n);
+        };
+        for (llvm::Function &f : mod->functions()) qualify(f);
+        for (llvm::GlobalVariable &g : mod->globals()) qualify(g);
+    }
+
     const std::string triple = "wasm32-unknown-emscripten";
     std::string err;
 #if LLVM_VERSION_MAJOR >= 21

--- a/src/libasr/pass/function_call_in_declaration.cpp
+++ b/src/libasr/pass/function_call_in_declaration.cpp
@@ -228,7 +228,7 @@ public:
 
         std::vector<ArgInfo> indices = get_arg_indices_used::get(&x->base, current_scope);
 
-        SymbolTable* global_scope = current_scope->get_global_scope();
+        SymbolTable* global_scope = current_scope->get_tu_scope();
         SetChar current_function_dependencies; current_function_dependencies.clear(al);
         SymbolTable* new_scope = al.make_new<SymbolTable>(global_scope);
         SymbolTable* new_function_scope_copy = new_function_scope;

--- a/src/libasr/pass/intrinsic_subroutine.cpp
+++ b/src/libasr/pass/intrinsic_subroutine.cpp
@@ -105,10 +105,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
             SymbolTable* current_scope_copy = current_scope;
             current_scope = x.m_symtab;
 
-            global_scope = x.m_symtab;
-            while( global_scope->parent ) {
-                global_scope = global_scope->parent;
-            }
+            global_scope = x.m_symtab->get_tu_scope();
 
             std::vector<std::string> build_order
                 = ASRUtils::determine_module_dependencies(x);
@@ -133,10 +130,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
             SymbolTable* current_scope_copy = current_scope;
             current_scope = x.m_symtab;
 
-            global_scope = x.m_symtab;
-            while( global_scope->parent ) {
-                global_scope = global_scope->parent;
-            }
+            global_scope = x.m_symtab->get_tu_scope();
 
             // Now visit everything else
             for (auto &item : x.m_symtab->get_scope()) {
@@ -151,11 +145,7 @@ class ReplaceIntrinsicSubroutines : public ASR::CallReplacerOnExpressionsVisitor
             ASR::Program_t& xx = const_cast<ASR::Program_t&>(x);
             SymbolTable* current_scope_copy = current_scope;
             current_scope = xx.m_symtab;
-            global_scope = xx.m_symtab;
-
-            while( global_scope->parent ) {
-                global_scope = global_scope->parent;
-            }
+            global_scope = xx.m_symtab->get_tu_scope();
 
             for (auto &item : x.m_symtab->get_scope()) {
                 if (ASR::is_a<ASR::AssociateBlock_t>(*item.second)) {

--- a/tests/reference/pass_global_stmts-expr1-213371d.json
+++ b/tests/reference/pass_global_stmts-expr1-213371d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-expr1-213371d.stdout",
-    "stdout_hash": "69f2f9c1f4c2ea5420451e4b90e08b0165e49b5cdb6c5c7ef3ba7a86",
+    "stdout_hash": "56a48069ddea8e7707250f9a8b221c193781bcf4cc9781bdd513f688",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-expr1-213371d.stdout
+++ b/tests/reference/pass_global_stmts-expr1-213371d.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     ReturnVar
@@ -50,13 +50,13 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerConstant 5 (Integer 4) Decimal)
                         ()
                         .false.
                         .false.
                     )]
-                    (Var 2 f1)
+                    (Var 3 f1)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-expr2-22f4149.json
+++ b/tests/reference/pass_global_stmts-expr2-22f4149.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-expr2-22f4149.stdout",
-    "stdout_hash": "49eaeb966bf0759fa415ac65d7219b323b7cc8311ca8c88d3d4d279c",
+    "stdout_hash": "f519986465d7bd4c21587d429bf56140b8c8c401f4903e7f6cf2f801",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-expr2-22f4149.stdout
+++ b/tests/reference/pass_global_stmts-expr2-22f4149.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     ReturnVar
@@ -50,7 +50,7 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -62,7 +62,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f1)
+                    (Var 3 f1)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-expr3-c9c0bd7.json
+++ b/tests/reference/pass_global_stmts-expr3-c9c0bd7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-expr3-c9c0bd7.stdout",
-    "stdout_hash": "b778a4f9bc2efae9a53255667776ca61c1841ebf2f3e7fd70e705e35",
+    "stdout_hash": "545b84b87c87bc28fcd774665c5e6211140aad299da153bfd429886f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-expr3-c9c0bd7.stdout
+++ b/tests/reference/pass_global_stmts-expr3-c9c0bd7.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -33,7 +33,7 @@
                                 ),
                             f2:
                                 (Variable
-                                    2
+                                    3
                                     f2
                                     []
                                     Local
@@ -57,7 +57,7 @@
                                 ),
                             f3:
                                 (Variable
-                                    2
+                                    3
                                     f3
                                     []
                                     Local
@@ -81,7 +81,7 @@
                                 ),
                             f4:
                                 (Variable
-                                    2
+                                    3
                                     f4
                                     []
                                     Local
@@ -105,7 +105,7 @@
                                 ),
                             f5:
                                 (Variable
-                                    2
+                                    3
                                     f5
                                     []
                                     Local
@@ -129,7 +129,7 @@
                                 ),
                             f6:
                                 (Variable
-                                    2
+                                    3
                                     f6
                                     []
                                     Local
@@ -153,7 +153,7 @@
                                 ),
                             f7:
                                 (Variable
-                                    2
+                                    3
                                     f7
                                     []
                                     Local
@@ -177,7 +177,7 @@
                                 ),
                             f8:
                                 (Variable
-                                    2
+                                    3
                                     f8
                                     []
                                     ReturnVar
@@ -218,14 +218,14 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerConstant 5 (Integer 4) Decimal)
                         ()
                         .false.
                         .false.
                     )
                     (Assignment
-                        (Var 2 f2)
+                        (Var 3 f2)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -238,7 +238,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f3)
+                        (Var 3 f3)
                         (IntegerBinOp
                             (IntegerBinOp
                                 (IntegerConstant 5 (Integer 4) Decimal)
@@ -257,7 +257,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f4)
+                        (Var 3 f4)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -276,7 +276,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f5)
+                        (Var 3 f5)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Sub
@@ -289,7 +289,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f6)
+                        (Var 3 f6)
                         (IntegerBinOp
                             (IntegerConstant 4 (Integer 4) Decimal)
                             Pow
@@ -302,7 +302,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f7)
+                        (Var 3 f7)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -315,7 +315,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f8)
+                        (Var 3 f8)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -327,7 +327,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f8)
+                    (Var 3 f8)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-expr4-eea496b.json
+++ b/tests/reference/pass_global_stmts-expr4-eea496b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-expr4-eea496b.stdout",
-    "stdout_hash": "1c22346dc4610a12f44a8fcb558d3347d6c2b4e7c7ab7040998ccb78",
+    "stdout_hash": "b1093f78194cdb5ef49e08484a65b900e0f6fde66f4e9ef1a47769fc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-expr4-eea496b.stdout
+++ b/tests/reference/pass_global_stmts-expr4-eea496b.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -33,7 +33,7 @@
                                 ),
                             f2:
                                 (Variable
-                                    2
+                                    3
                                     f2
                                     []
                                     Local
@@ -57,7 +57,7 @@
                                 ),
                             f3:
                                 (Variable
-                                    2
+                                    3
                                     f3
                                     []
                                     Local
@@ -81,7 +81,7 @@
                                 ),
                             f4:
                                 (Variable
-                                    2
+                                    3
                                     f4
                                     []
                                     Local
@@ -105,7 +105,7 @@
                                 ),
                             f5:
                                 (Variable
-                                    2
+                                    3
                                     f5
                                     []
                                     Local
@@ -129,7 +129,7 @@
                                 ),
                             f6:
                                 (Variable
-                                    2
+                                    3
                                     f6
                                     []
                                     ReturnVar
@@ -170,7 +170,7 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (RealConstant
                             5.000000
                             (Real 4)
@@ -180,7 +180,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f2)
+                        (Var 3 f2)
                         (RealBinOp
                             (RealConstant
                                 5.000000
@@ -202,7 +202,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f3)
+                        (Var 3 f3)
                         (RealBinOp
                             (RealBinOp
                                 (RealConstant
@@ -236,7 +236,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f4)
+                        (Var 3 f4)
                         (RealBinOp
                             (RealConstant
                                 5.000000
@@ -270,7 +270,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f5)
+                        (Var 3 f5)
                         (RealBinOp
                             (RealConstant
                                 5.000000
@@ -292,7 +292,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f6)
+                        (Var 3 f6)
                         (RealBinOp
                             (RealConstant
                                 4.000000
@@ -313,7 +313,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f6)
+                    (Var 3 f6)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-expr6-a926072.json
+++ b/tests/reference/pass_global_stmts-expr6-a926072.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-expr6-a926072.stdout",
-    "stdout_hash": "e193590ceb1905470d7bd728a4e3257c1d212b7937757a954c8a1825",
+    "stdout_hash": "f38164fd8df9fe618dfbe8d636e8c8b161484eb9fdbcdc9affd9f509",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-expr6-a926072.stdout
+++ b/tests/reference/pass_global_stmts-expr6-a926072.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -33,7 +33,7 @@
                                 ),
                             f2:
                                 (Variable
-                                    2
+                                    3
                                     f2
                                     []
                                     ReturnVar
@@ -74,7 +74,7 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 5 (Integer 4) Decimal)
                             Add
@@ -87,7 +87,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f2)
+                        (Var 3 f2)
                         (RealConstant
                             5.300000
                             (Real 4)
@@ -96,7 +96,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f2)
+                    (Var 3 f2)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-global_scope2-64078e2.json
+++ b/tests/reference/pass_global_stmts-global_scope2-64078e2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope2-64078e2.stdout",
-    "stdout_hash": "ad64fc1c7d426fbe4446e13ee7602bd1854a51d760d66cc86239fbd7",
+    "stdout_hash": "38e18d5bc3872d0a4f75d340b7c2c56279e68dd92a1fbaa5474ea817",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope2-64078e2.stdout
+++ b/tests/reference/pass_global_stmts-global_scope2-64078e2.stdout
@@ -5,7 +5,7 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             
                         })

--- a/tests/reference/pass_global_stmts-global_scope3-a36d20b.json
+++ b/tests/reference/pass_global_stmts-global_scope3-a36d20b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope3-a36d20b.stdout",
-    "stdout_hash": "baaf51c3a08267784186cb005c1037a2a16cc2c2500388ceb23dc1e9",
+    "stdout_hash": "e8d1ac5b330bf258f426d3fce9383c41851c01b122fd9df881d2510e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope3-a36d20b.stdout
+++ b/tests/reference/pass_global_stmts-global_scope3-a36d20b.stdout
@@ -5,7 +5,7 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             
                         })

--- a/tests/reference/pass_global_stmts-global_scope4-2d4061d.json
+++ b/tests/reference/pass_global_stmts-global_scope4-2d4061d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope4-2d4061d.stdout",
-    "stdout_hash": "9cdea6c5b35324e681a285045c89cec68f4d2410c3519452405f6442",
+    "stdout_hash": "4527f2cf1283f74fa51fccb4b749e4abfbe51cc77cc33015f4e14e22",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope4-2d4061d.stdout
+++ b/tests/reference/pass_global_stmts-global_scope4-2d4061d.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     ReturnVar
@@ -70,7 +70,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 3 (Integer 4) Decimal)
                             Mul
@@ -82,7 +82,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f1)
+                    (Var 3 f1)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-global_scope5-fb3716b.json
+++ b/tests/reference/pass_global_stmts-global_scope5-fb3716b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope5-fb3716b.stdout",
-    "stdout_hash": "403c420127d415bb7359ccb220d5ff8973040b17f1f34de51cf0b97e",
+    "stdout_hash": "9f64a4c2b4ce6fff2e0dcfc2cfc86b432f829dbbff1afdecf896fe39",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope5-fb3716b.stdout
+++ b/tests/reference/pass_global_stmts-global_scope5-fb3716b.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -33,7 +33,7 @@
                                 ),
                             f2:
                                 (Variable
-                                    2
+                                    3
                                     f2
                                     []
                                     ReturnVar
@@ -81,7 +81,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 2 (Integer 4) Decimal)
                             Mul
@@ -107,7 +107,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f2)
+                        (Var 3 f2)
                         (IntegerBinOp
                             (IntegerConstant 3 (Integer 4) Decimal)
                             Mul
@@ -119,7 +119,7 @@
                         .false.
                         .false.
                     )]
-                    (Var 2 f2)
+                    (Var 3 f2)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-global_scope6-278bd63.json
+++ b/tests/reference/pass_global_stmts-global_scope6-278bd63.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope6-278bd63.stdout",
-    "stdout_hash": "2e81724c477597264f64e5c78236d606e92d70ebf494fa18bf4a7029",
+    "stdout_hash": "6d81fb824901733729f526d51aa511f6d9d244e1839871ce086d0f8f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope6-278bd63.stdout
+++ b/tests/reference/pass_global_stmts-global_scope6-278bd63.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -57,7 +57,7 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 2 (Integer 4) Decimal)
                             Mul

--- a/tests/reference/pass_global_stmts-global_scope7-d6ec187.json
+++ b/tests/reference/pass_global_stmts-global_scope7-d6ec187.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope7-d6ec187.stdout",
-    "stdout_hash": "97b2e00f239c2debf57a5b035a007ce757be71017595c20e4646b1fa",
+    "stdout_hash": "efba5d99fbb73cf62ba71e4e72f876cd829138b43eaa30be33619268",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope7-d6ec187.stdout
+++ b/tests/reference/pass_global_stmts-global_scope7-d6ec187.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     Local
@@ -50,7 +50,7 @@
                     []
                     []
                     [(Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (IntegerBinOp
                             (IntegerConstant 2 (Integer 4) Decimal)
                             Mul

--- a/tests/reference/pass_global_stmts-global_scope8-95c3673.json
+++ b/tests/reference/pass_global_stmts-global_scope8-95c3673.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope8-95c3673.stdout",
-    "stdout_hash": "abbd88eeb771cc172a9ce347bc00a3cb0d732b8a25b4c61e06446690",
+    "stdout_hash": "566248aab9bb5f25a1cc63b8cca11d3ad27130fa063cf3a46c417363",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope8-95c3673.stdout
+++ b/tests/reference/pass_global_stmts-global_scope8-95c3673.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     ReturnVar
@@ -57,13 +57,13 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (Var 1 x)
                         ()
                         .false.
                         .false.
                     )]
-                    (Var 2 f1)
+                    (Var 3 f1)
                     Public
                     .false.
                     .false.

--- a/tests/reference/pass_global_stmts-global_scope9-4cbbc3e.json
+++ b/tests/reference/pass_global_stmts-global_scope9-4cbbc3e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_global_stmts-global_scope9-4cbbc3e.stdout",
-    "stdout_hash": "55e9f778ee1174847f9f11e03c8fb32ac2c9429fe36a4c1cab797cf9",
+    "stdout_hash": "d5c60bd210a3a12049336d6505d7fa325745fe52ae416b22797de4a9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_global_stmts-global_scope9-4cbbc3e.stdout
+++ b/tests/reference/pass_global_stmts-global_scope9-4cbbc3e.stdout
@@ -5,11 +5,11 @@
             f:
                 (Function
                     (SymbolTable
-                        2
+                        3
                         {
                             f1:
                                 (Variable
-                                    2
+                                    3
                                     f1
                                     []
                                     ReturnVar
@@ -63,13 +63,13 @@
                         .false.
                     )
                     (Assignment
-                        (Var 2 f1)
+                        (Var 3 f1)
                         (Var 1 x)
                         ()
                         .false.
                         .false.
                     )]
-                    (Var 2 f1)
+                    (Var 3 f1)
                     Public
                     .false.
                     .false.


### PR DESCRIPTION
## Summary

Every cell was evaluated into a single, shared symbol table, so a name could
only ever have one meaning in a session: re-declaring it either clashed or
overwrote what earlier cells had been compiled against.

Each cell now gets its own `TranslationUnit`, and their symbol tables are
chained through `SymbolTable::parent`, oldest first:

```
cell 1   TranslationUnit   symtab(parent = nullptr)
cell 2   TranslationUnit   symtab(parent = cell 1's symtab)
cell 3   TranslationUnit   symtab(parent = cell 2's symtab)
```

Two properties follow from that shape. Cells are additive: a cell sees
everything declared before it, and nothing can reach forward into a later cell.
And re-declaring a name shadows it rather than replacing it, the way a nested
scope does, so code compiled earlier keeps using what it resolved to then,
while later cells resolve to the new declaration. That is what a Python
notebook does when a cell is re-run.

Two live declarations of one name need two symbols in the generated code, so
symbols declared at cell scope are qualified by their cell (`__cell<N>_`), the
way symbols in a module are qualified by the module. The first cell is left
unqualified, so it and ordinary compilation emit identical symbols.

## For reviewers writing new scope walks

Walks that looked for "the" translation unit by climbing to the root of a scope
chain now stop at the nearest one, which is the cell being compiled
(`ASRUtils::is_tu_scope`). With a single `TranslationUnit` the nearest one is
also the root, so ordinary compilation is unaffected. New code that climbs a
scope chain looking for the translation unit should stop there rather than at
`parent == nullptr`.

Ordinary compilation gets none of the chaining or copying, so it is not slowed
down by any of this.

## Scope

`asr_utils.h`, `asr_scopes`, `asr_verify`, the LLVM backend's symbol naming,
`fortran_evaluator`, one open-coded scope walk in `intrinsic_subroutine`, the
design note in `doc/src/interactive_cells.md`, tests, and reference updates.

## Verification

Tests cover shadowing a variable, a function, a subroutine and a module. Each
checks that the new binding is visible and that code compiled against the old
one still uses the old one; for a variable, function and module, an accessor
for each is also called side by side from a single cell, so both symbols are
demonstrably live at once. Unit suite: 110/110.

The reference tests that run with `--interactive-parse` shift their symbol
table counters by one, since each cell now has a scope of its own. Only the
numbering changes; the updated files contain no other difference.

## Note

Fourth of a five-PR stack replacing #12480, on top of #12483. Only the last
commit belongs to this PR.

Known limitation, filed as #12479: an `interface` block naming a procedure from
an earlier cell binds by link name, which cell qualification changes, so it
does not resolve. Ordinary cross-cell calls are unaffected -- a procedure from
an earlier cell can be called directly, without an interface block.
