### PR TITLE
interactive: use modules and procedures from earlier cells

### DIFF
--- a/src/lfortran/fortran_evaluator.cpp
+++ b/src/lfortran/fortran_evaluator.cpp
@@ -428,6 +428,32 @@ void FortranEvaluator::drop_redefinitions(LLVMModule &m)
 }
 #endif
 
+namespace {
+
+// The duplicated symbols carry ExternalSymbols whose m_external still points
+// into the modules they were copied from. A later cell resolves a module by
+// name and finds the copy, so an ExternalSymbol pointing at the original does
+// not match it and the symbol looks absent. Point them at the copies.
+static void relink_external_symbols(SymbolTable *scope, SymbolTable *tu) {
+    for (auto &item : scope->get_scope()) {
+        ASR::symbol_t *s = item.second;
+        if (ASR::is_a<ASR::ExternalSymbol_t>(*s)) {
+            ASR::ExternalSymbol_t *es = ASR::down_cast<ASR::ExternalSymbol_t>(s);
+            ASR::symbol_t *mod = tu->resolve_symbol(es->m_module_name);
+            if (mod == nullptr || !ASR::is_a<ASR::Module_t>(*mod)) continue;
+            ASR::Module_t *m = ASR::down_cast<ASR::Module_t>(mod);
+            ASR::symbol_t *target = m->m_symtab->find_scoped_symbol(
+                es->m_original_name, es->n_scope_names, es->m_scope_names);
+            if (target != nullptr) es->m_external = target;
+        } else {
+            SymbolTable *inner = ASRUtils::symbol_symtab(s);
+            if (inner != nullptr) relink_external_symbols(inner, tu);
+        }
+    }
+}
+
+} // namespace
+
 SymbolTable* FortranEvaluator::snapshot_cell_scope(ASR::TranslationUnit_t &asr)
 {
     // ASR passes rewrite what they are given: pass_array_by_data replaces a
@@ -443,18 +469,49 @@ SymbolTable* FortranEvaluator::snapshot_cell_scope(ASR::TranslationUnit_t &asr)
     // copied: later cells resolve names and read signatures, they never re-run
     // this cell's statements. The copy carries the same names at the same
     // depth, so it mangles to the same symbols this cell just compiled.
-    SymbolTable* snapshot = al.make_new<SymbolTable>(asr.m_symtab->parent);
-    ASR::asr_t* owner = ASR::make_TranslationUnit_t(al, asr.base.base.loc,
-        snapshot, nullptr, 0);
-    snapshot->asr_owner = owner;
+    //
+    // The earlier cells are copied too. Passes do not only add symbols, they
+    // also rewrite the ones they are given in place: the pass that replaces
+    // optional arguments with presence flags rewrites the procedure itself, so
+    // an earlier cell's procedure that this cell's passes touched would be
+    // presented to the next cell with its optional arguments already gone, and
+    // a call omitting them would no longer compile. Each cell therefore hands
+    // the next one a chain that no pass has seen.
+    SymbolTable* parent = copy_cell_chain(asr.m_symtab->parent,
+        asr.base.base.loc);
+    SymbolTable* snapshot = copy_cell_scope(asr.m_symtab, parent,
+        asr.base.base.loc);
+    return snapshot;
+}
+
+// One TranslationUnit scope's symbols, copied into a fresh scope. Only symbols
+// are copied: later cells resolve names and read signatures, they never re-run
+// an earlier cell's statements. The copy carries the same names at the same
+// depth, so it mangles to the same symbols that cell compiled to.
+SymbolTable* FortranEvaluator::copy_cell_scope(SymbolTable *scope,
+    SymbolTable *parent, const Location &loc)
+{
+    SymbolTable* copy = al.make_new<SymbolTable>(parent);
+    ASR::asr_t* owner = ASR::make_TranslationUnit_t(al, loc, copy, nullptr, 0);
+    copy->asr_owner = owner;
     ASRUtils::SymbolDuplicator duplicator(al);
-    for (auto &item : asr.m_symtab->get_scope()) {
+    for (auto &item : scope->get_scope()) {
         // A program unit is executed by the cell that declares it and its name
         // is not referenceable from Fortran, so later cells have no use for it.
         if (ASR::is_a<ASR::Program_t>(*item.second)) continue;
-        duplicator.duplicate_symbol(item.second, snapshot);
+        duplicator.duplicate_symbol(item.second, copy);
     }
-    return snapshot;
+    relink_external_symbols(copy, copy);
+    return copy;
+}
+
+// The chain of earlier cells, oldest first, copied scope by scope.
+SymbolTable* FortranEvaluator::copy_cell_chain(SymbolTable *chain,
+    const Location &loc)
+{
+    if (chain == nullptr) return nullptr;
+    SymbolTable *parent = copy_cell_chain(chain->parent, loc);
+    return copy_cell_scope(chain, parent, loc);
 }
 
 Result<ASR::TranslationUnit_t*> FortranEvaluator::get_asr3(
@@ -560,6 +617,13 @@ Result<std::unique_ptr<LLVMModule>> FortranEvaluator::get_llvm3(
 #ifdef HAVE_LFORTRAN_LLVM
     eval_count++;
     run_fn = "__lfortran_evaluate_" + std::to_string(eval_count);
+
+    if (compiler_options.interactive) {
+        // Nothing in this cell may call a procedure the user declared, but a
+        // later cell still can, so it has to be emitted. Dropping it here
+        // leaves the later cell's call with no definition to link to.
+        pass_manager.skip_pass("unused_functions");
+    }
 
     if (compiler_options.generate_code_for_global_procedures) {
         compiler_options.po.intrinsic_symbols_mangling = true;

--- a/src/lfortran/fortran_evaluator.h
+++ b/src/lfortran/fortran_evaluator.h
@@ -86,6 +86,9 @@ public:
     // Copy of a cell's symbols, taken before the ASR passes rewrite them, to
     // serve as the parent scope of the next cell.
     SymbolTable* snapshot_cell_scope(ASR::TranslationUnit_t &asr);
+    SymbolTable* copy_cell_scope(SymbolTable *scope, SymbolTable *parent,
+        const Location &loc);
+    SymbolTable* copy_cell_chain(SymbolTable *chain, const Location &loc);
 #ifdef HAVE_LFORTRAN_LLVM
     // Turn definitions the JIT already holds into declarations.
     void drop_redefinitions(LLVMModule &m);

--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -1546,6 +1546,54 @@ TEST_CASE("FortranEvaluator program unit in a cell") {
     CHECK(r.result.i32 == 5);
 }
 
+TEST_CASE("FortranEvaluator array-argument module procedure across cells") {
+    // ASR passes rewrite symbols in place. In interactive mode the symbol
+    // table is the session state, so a pass that specialises a procedure --
+    // pass_array_by_data, for an assumed-shape array argument -- used to
+    // leave the module holding only the mangled specialisation, and the next
+    // cell failed with "Function 'sf' not found".
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2(
+        "module mf\n"
+        "implicit none\n"
+        "contains\n"
+        "integer function sf(a)\n"
+        "real, intent(in) :: a(:)\n"
+        "sf = size(a)\n"
+        "end function sf\n"
+        "end module mf\n");
+    CHECK(r.ok);
+
+    // called from a later cell
+    r = e.evaluate2("use mf\nreal :: v(3)\nv = 1\n");
+    CHECK(r.ok);
+    r = e.evaluate2("sf(v)\n");
+    CHECK(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::integer4);
+    CHECK(r.result.i32 == 3);
+
+    // and from another cell again, with a different array
+    r = e.evaluate2("real :: w(5)\nw = 2\n");
+    CHECK(r.ok);
+    r = e.evaluate2("sf(w)\n");
+    CHECK(r.ok);
+    CHECK(r.result.i32 == 5);
+
+    // from inside a program unit too
+    r = e.evaluate2(
+        "program pf\n"
+        "use mf\n"
+        "implicit none\n"
+        "real :: u(7)\n"
+        "u = 3\n"
+        "print *, sf(u)\n"
+        "end program pf\n");
+    CHECK(r.ok);
+}
 
 // Shadowing across interactive cells. Each cell is its own TranslationUnit,
 // chained through SymbolTable::parent, so re-declaring a name in a later cell
@@ -1657,10 +1705,163 @@ end function
 // being compiled. Resolving `use` has to look through the chain; otherwise a
 // modfile is searched for on disk, of which there is none in a notebook.
 
+TEST_CASE("FortranEvaluator module using another module across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2(R"(module ma
+implicit none
+integer, parameter :: c = 5
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(module mb
+use ma
+implicit none
+end module
+)").ok);
+    // A program unit resolves `use` through load_module(), which is the path
+    // that used to report "modfile was not found" for ma, a dependency of mb.
+    CHECK(e.evaluate2(R"(program p
+use mb
+implicit none
+if (c /= 5) error stop
+end program
+)").ok);
+}
 
+TEST_CASE("FortranEvaluator re-exported module symbol across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    // mtop re-exports msub's procedure: its scope holds an ExternalSymbol
+    // pointing into msub. The copy taken for the next cell has to point at the
+    // copy of msub, not at the original, or the symbol looks absent.
+    CHECK(e.evaluate2(R"(module msub
+implicit none
+contains
+    integer function twice(i)
+        integer, intent(in) :: i
+        twice = 2 * i
+    end function
+end module
+module mtop
+use msub
+implicit none
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(program p
+use mtop
+implicit none
+if (twice(3) /= 6) error stop
+end program
+)").ok);
+}
 
+TEST_CASE("FortranEvaluator optional argument across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    // Calling this with the optional argument absent only works if the pass
+    // that replaces optional arguments with presence flags has been applied to
+    // the procedure in the earlier cell as well as to this cell's call.
+    CHECK(e.evaluate2(R"(module mopt
+implicit none
+contains
+    subroutine s(x, lbl)
+        real, intent(in) :: x(:)
+        character(len=*), intent(in), optional :: lbl
+        if (present(lbl)) then
+            if (x(1) /= 1.0) error stop
+        else
+            if (x(1) /= 1.0) error stop
+        end if
+    end subroutine
+end module
+)").ok);
+    CHECK(e.evaluate2(R"(program p
+use mopt
+implicit none
+real :: a(3)
+a = 1.0
+call s(a)
+call s(a, "with label")
+end program
+)").ok);
+}
 
+TEST_CASE("FortranEvaluator re-run a cell calling an optional argument") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    CHECK(e.evaluate2(R"(module mopt2
+implicit none
+contains
+    subroutine s(x, lbl)
+        real, intent(in) :: x(:)
+        character(len=*), intent(in), optional :: lbl
+        if (x(1) /= 1.0) error stop
+        if (present(lbl)) then
+            if (len(lbl) == 0) error stop
+        end if
+    end subroutine
+end module
+)").ok);
+    // Running the same cell twice has to keep working. The pass that replaces
+    // optional arguments with presence flags rewrites the procedure in place,
+    // so if it were let at the copy handed to the next cell, `lbl` would come
+    // back as a required argument and this call would stop compiling.
+    const char *cell = R"(program p
+use mopt2
+implicit none
+real :: a(3)
+a = 1.0
+call s(a)
+end program
+)";
+    CHECK(e.evaluate2(cell).ok);
+    CHECK(e.evaluate2(cell).ok);
+    CHECK(e.evaluate2(cell).ok);
+}
 
+TEST_CASE("FortranEvaluator call a procedure no earlier cell called") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    // `untouched` is never called in the cell that declares it. Dead-code
+    // elimination would drop it there, leaving the next cell's call with no
+    // definition to link to.
+    CHECK(e.evaluate2(R"(module munused
+implicit none
+integer :: counter = 0
+contains
+    subroutine called_now()
+        counter = counter + 1
+    end subroutine
+    subroutine untouched()
+        counter = counter + 10
+    end subroutine
+end module
+
+program p1
+use munused
+implicit none
+call called_now()
+if (counter /= 1) error stop
+end program
+)").ok);
+    CHECK(e.evaluate2(R"(program p2
+use munused
+implicit none
+call untouched()
+if (counter /= 11) error stop
+end program
+)").ok);
+}
 
 TEST_CASE("FortranEvaluator shadow a subroutine across cells") {
     CompilerOptions cu;

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1052,15 +1052,19 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
                             bool generate_object_code,
                             bool load_submodules) {
     LCOMPILERS_ASSERT(symtab);
-    if (symtab->get_symbol(module_name) != nullptr) {
-        ASR::symbol_t *m = symtab->get_symbol(module_name);
+    // In interactive mode each cell is a TranslationUnit chained to the
+    // previous one, so a module declared in an earlier cell lives in a parent
+    // scope. Resolve through the chain: without this the module is not found
+    // here and a modfile is looked for on disk, which there is none of.
+    if (ASR::symbol_t *m = symtab->resolve_symbol(module_name)) {
         if (ASR::is_a<ASR::Module_t>(*m)) {
             return ASR::down_cast<ASR::Module_t>(m);
         } else {
             err("The symbol '" + module_name + "' is not a module", loc);
         }
     }
-    LCOMPILERS_ASSERT(symtab->parent == nullptr);
+    LCOMPILERS_ASSERT(symtab->parent == nullptr ||
+        ASRUtils::is_tu_scope(symtab->parent));
     ASR::TranslationUnit_t* mod1 = nullptr;
     Result<ASR::TranslationUnit_t*, ErrorMessage> res
         = find_and_load_module(al, module_name, *symtab, intrinsic, pass_options, lm);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1923,6 +1923,7 @@ public:
         // TODO: handle dependencies across modules and main program
 
         // Then do all the modules in the right order
+        std::set<ASR::symbol_t*> visited_modules;
         std::vector<std::string> build_order
             = determine_module_dependencies(x);
         for (auto &item : build_order) {
@@ -1936,6 +1937,7 @@ public:
                 }
             }
             if (mod == nullptr) continue;
+            if (!visited_modules.insert(mod).second) continue;
             // An earlier cell's symbols are already defined in the JIT, and
             // this cell holds them as they were before the ASR passes ran, so
             // their bodies are not in a lowered form we could emit anyway.
@@ -1949,6 +1951,9 @@ public:
             if (scope == x.m_symtab) continue;
             for (auto &item : scope->get_scope()) {
                 if (ASR::is_a<ASR::Module_t>(*item.second)) {
+                    // A module an earlier cell declared may already have been
+                    // emitted above as a dependency of this cell's modules.
+                    if (!visited_modules.insert(item.second).second) continue;
                     visit_symbol(*item.second);
                 }
             }

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -220,7 +220,13 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
             // freshly translated AST will be rewritten by the call-site
             // replacer using existing proc2newproc state populated below
             // for newly inserted procedures only.
-            if (current_scope->get_symbol(new_name) != nullptr) {
+            if (ASR::symbol_t* existing = current_scope->get_symbol(new_name)) {
+                // The specialisation is already there: either an earlier run
+                // of this pass in the same interactive session made it, or an
+                // earlier cell did (and the JIT already holds its definition).
+                // Map to it, so that this cell's call sites are rewritten to
+                // the procedure that actually exists.
+                proc2newproc[(ASR::symbol_t*) x] = std::make_pair(existing, indices);
                 return nullptr;
             }
             if( ASR::is_a<ASR::Function_t>( *((ASR::symbol_t*) x) ) ) {
@@ -331,6 +337,23 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
             }    \
 
         void visit_TranslationUnit(const ASR::TranslationUnit_t& x) {
+            // In interactive mode each cell is a TranslationUnit chained to
+            // the previous one, so earlier cells' symbols live in ancestor
+            // scopes. Their procedures were specialised when their own cell
+            // was compiled; specialise them here too so that calls from this
+            // cell resolve to the procedures the JIT already holds. The
+            // generated names are derived from the signature, so they come
+            // out the same as they did then.
+            for (SymbolTable* s = x.m_symtab->parent; s != nullptr; s = s->parent) {
+                if( !ASRUtils::is_tu_scope(s) ) continue;
+                for (auto &a : s->get_scope()) {
+                    if( ASR::is_a<ASR::Module_t>(*a.second) ||
+                        ASR::is_a<ASR::Function_t>(*a.second) ) {
+                        this->visit_symbol(*a.second);
+                    }
+                }
+            }
+
             // Visit functions in global scope first
             bfs_visit_SymbolContainingFunctions();
 

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -433,6 +433,13 @@ namespace LCompilers {
             apply_default_passes = false;
         }
 
+        void skip_pass(const std::string &pass_name) {
+            if( std::find(_skip_passes.begin(), _skip_passes.end(), pass_name)
+                    == _skip_passes.end() ) {
+                _skip_passes.push_back(pass_name);
+            }
+        }
+
         bool has_user_defined_passes() const {
             return !_user_defined_passes.empty();
         }

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -231,6 +231,28 @@ class TransformFunctionsWithOptionalArguments: public PassUtils::PassVisitor<Tra
         }
 
         void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+            // In interactive mode each cell is a TranslationUnit chained to
+            // the previous one. A procedure declared in an earlier cell was
+            // transformed when that cell was compiled, and this cell's calls
+            // to it have to be transformed the same way, so visit the earlier
+            // cells too. Transforming is idempotent: once a procedure takes a
+            // presence flag instead of an optional argument, there is nothing
+            // left for is_optional_argument_present() to find.
+            for (SymbolTable *s = x.m_symtab->parent; s != nullptr; s = s->parent) {
+                if( !ASRUtils::is_tu_scope(s) ) continue;
+                for (auto &item : s->get_scope()) {
+                    if (is_a<ASR::Function_t>(*item.second)) {
+                        ASR::Function_t *f = down_cast<ASR::Function_t>(item.second);
+                        if (is_optional_argument_present(f)) {
+                            transform_functions_with_optional_arguments(f);
+                        }
+                    }
+                }
+                for (auto &item : s->get_scope()) {
+                    this->visit_symbol(*item.second);
+                }
+            }
+
             for (auto &item : x.m_symtab->get_scope()) {
                 if (is_a<ASR::Function_t>(*item.second)) {
                     ASR::Function_t *s = down_cast<ASR::Function_t>(item.second);


### PR DESCRIPTION
## Summary

With one `TranslationUnit` per cell, an earlier cell's symbols live in a parent
scope of the cell being compiled. Five things did not account for that, and
together they made a notebook that declares its modules in one cell and uses
them in the next fail a different way each time one was fixed.

**`load_module` looked only in the cell being compiled.** A module declared
earlier was not found, so a modfile was searched for on disk, of which a
notebook has none. It reported `modfile was not found` naming the *dependency*
of the module being used, which was doubly confusing. It now resolves through
the chain.

**The copy taken for the next cell kept stale `ExternalSymbol` targets.** They
still pointed into the modules they were copied from, so a symbol re-exported
by another module looked absent. They are now pointed at the copies.

**Two passes only visited the cell being compiled.** `pass_array_by_data` and
`transform_optional_argument_functions` left a call to an earlier cell's
procedure in a form its already-compiled definition does not have: an
assumed-shape array argument reached a specialisation that was never emitted,
and an absent optional argument reached code generation as a null argument.
Both now visit the earlier cells, so a call is lowered the way the definition
it links to was.

**Those passes rewrite in place, so the chain needed protecting.** A cell now
hands the next one a copy of the whole chain rather than the scopes its own
passes have seen. Without this, re-running a cell that omits an optional
argument failed with the argument reported as required, because the procedure
the pass had rewritten was the one the next cell resolved against.

**Dead code elimination dropped procedures a later cell may call.** Any
procedure a cell declares may be called by a cell that does not exist yet, so
`unused_functions` is skipped in interactive mode.

## Scope

`load_module`, the evaluator's cell snapshot, `pass_array_by_data`,
`transform_optional_argument_functions`, one dedup in the LLVM backend, and a
`skip_pass` hook on the pass manager.

## Verification

Each fix has a test derived from a minimal reproducer: a module using another
module across cells, a re-exported module symbol, an optional argument,
re-running a cell that omits one, and calling a procedure no earlier cell
called. Unit suite: 116/116.

End to end, the `Plot.ipynb` demo now runs in the JupyterLite lab in Firefox:
its modules are declared in one cell and the program re-run from later cells,
repeatedly, rendering its plot each time.

## Note

Last of a five-PR stack replacing #12480, on top of #12484. Only the last
commit belongs to this PR.

The two chain-walking passes are handled individually. If a third pass needs
the same treatment, that is the point to replace this with something general
rather than extend the pattern again.
