### PR TITLE
fix: lower character functions across interactive cells

### DIFF
--- a/src/lfortran/tests/test_llvm.cpp
+++ b/src/lfortran/tests/test_llvm.cpp
@@ -492,6 +492,43 @@ TEST_CASE("FortranEvaluator character result") {
     CHECK(r.result.str == "hello");
 }
 
+TEST_CASE("FortranEvaluator character function across cells") {
+    CompilerOptions cu;
+    cu.interactive = true;
+    cu.po.runtime_library_dir = LCompilers::LFortran::get_runtime_library_dir();
+    FortranEvaluator e(cu);
+    LCompilers::Result<FortranEvaluator::EvalResult> r = e.evaluate2(
+        "module display_result\n"
+        "contains\n"
+        "function wrap(data) result(result)\n"
+        "character(len=*), intent(in) :: data\n"
+        "character(len=:), allocatable :: result\n"
+        "result = \"[\" // data // \"]\"\n"
+        "end function\n"
+        "end module\n");
+    REQUIRE(r.ok);
+
+    r = e.evaluate2(
+        "use display_result\n"
+        "wrap(\"hello\")");
+    REQUIRE(r.ok);
+    CHECK(r.result.type == FortranEvaluator::EvalResult::character);
+    CHECK(r.result.str == "[hello]");
+
+    // A later cell must still see the clean function signature, not the
+    // subroutine produced by the character-return lowering pass.
+    r = e.evaluate2(
+        "use display_result\n"
+        "wrap(\"second cell\")");
+    REQUIRE(r.ok);
+    CHECK(r.result.str == "[second cell]");
+
+    // The imported name remains available without another USE statement.
+    r = e.evaluate2("wrap(\"third cell\")");
+    REQUIRE(r.ok);
+    CHECK(r.result.str == "[third cell]");
+}
+
 TEST_CASE("FortranEvaluator 3") {
     CompilerOptions cu;
     cu.interactive = true;

--- a/src/libasr/pass/subroutine_from_function.cpp
+++ b/src/libasr/pass/subroutine_from_function.cpp
@@ -36,6 +36,16 @@ public:
             std::unordered_map<ASR::Function_t*, ASR::ttype_t*> &Function__ReturnType_MAP)
             : al(al_), Function__TO__ReturnType_MAP_(Function__ReturnType_MAP){}
 
+        void visit_ExternalSymbol(const ASR::ExternalSymbol_t &x) {
+            ASR::symbol_t *target = ASRUtils::symbol_get_past_external(
+                x.m_external);
+            if (ASR::is_a<ASR::Function_t>(*target)) {
+                this->visit_Function(*down_cast<ASR::Function_t>(target));
+            } else if (ASR::is_a<ASR::Module_t>(*target)) {
+                this->visit_Module(*down_cast<ASR::Module_t>(target));
+            }
+        }
+
 
         void visit_Function(const ASR::Function_t& x) {
             ASR::Function_t* x_ptr = &const_cast<ASR::Function_t&>(x);


### PR DESCRIPTION
## Summary

`subroutine_from_function` transformed calls in the current cell but did not transform character-returning procedures reached through `ExternalSymbol`s or earlier cell scopes. This left the lowered call and procedure signature with different argument counts.

So we visit imported procedures and ancestor translation units so both sides use the same hidden-result ABI. 

I added a regression test covering repeated calls across cells, with and without another `use` statement.