### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ free to contact Ondřej Čertík (ondrej@certik.us).
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lfortran/lfortran&type=Date)](https://star-history.com/#lfortran/lfortran&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lfortran/lfortran&type=Date)](https://star-history.dera.page/#lfortran/lfortran&Date)


### PR DESCRIPTION
The star history chart in the README is broken due to GitHub stargazer API restrictions. This change updates the chart link to a working endpoint that uses an alternative data source, so the chart renders correctly again.