### PR TITLE
codegen: Fix ArrayConstant/ArrayConstructor lowering and CPtr null dereference in c_associated

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2780,6 +2780,7 @@ RUN(NAME kinds_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME kinds_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME const_array_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME const_array_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
+RUN(NAME const_array_03 LABELS gfortran llvm)
 
 RUN(NAME concat_char_arrays_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME huge_string_read LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/const_array_03.f90
+++ b/integration_tests/const_array_03.f90
@@ -1,0 +1,22 @@
+module const_array_03_mod
+   use iso_c_binding
+   implicit none
+   type :: my_point
+      integer(c_int) :: x, y
+   end type my_point
+contains
+   subroutine test_const_array()
+      type(my_point), parameter :: pts(2) = [my_point(1, 2), my_point(3, 4)]
+      type(c_ptr), parameter :: ptrs(2) = [c_null_ptr, c_null_ptr]
+      if (pts(1)%x /= 1 .or. pts(1)%y /= 2) error stop "const_array_03 struct 1 failed"
+      if (pts(2)%x /= 3 .or. pts(2)%y /= 4) error stop "const_array_03 struct 2 failed"
+      if (c_associated(ptrs(1)) .or. c_associated(ptrs(2))) error stop "const_array_03 c_ptr failed"
+   end subroutine test_const_array
+end module const_array_03_mod
+
+program const_array_03
+   use const_array_03_mod
+   implicit none
+   call test_const_array()
+   print *, "const_array_03 test passed"
+end program const_array_03

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -7621,6 +7621,16 @@ inline ASR::expr_t* fetch_ArrayConstant_value_helper(Allocator &al, const Locati
                                 s2c(al, str), type));
             return value;
         }
+        case ASR::ttypeType::StructType: {
+            // set_ArrayConstant_data stores an ASR::expr_t* array for struct types
+            ASR::expr_t** expr_data = (ASR::expr_t**)data;
+            return expr_data[i];
+        }
+        case ASR::ttypeType::CPtr: {
+            // set_ArrayConstant_data stores an ASR::expr_t* array for CPtr types
+            ASR::expr_t** expr_data = (ASR::expr_t**)data;
+            return expr_data[i];
+        }
         default:
             throw LCompilersException("Unsupported type for array constant.");
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5450,6 +5450,14 @@ public:
                     throw CodeGenError("Complex kind " + std::to_string(a_kind) + " not supported in array initializer");
                 }
                 arr_elements.push_back(llvm::ConstantStruct::get(struct_type, {re, im}));
+            } else {
+                visit_expr_wrapper(elem);
+                llvm::Constant* c = llvm::dyn_cast<llvm::Constant>(tmp);
+                if (c) {
+                    arr_elements.push_back(c);
+                } else {
+                    throw CodeGenError("Unsupported element type in array constant initializer");
+                }
             }
         }
         if (!arr_type) {
@@ -9061,7 +9069,7 @@ public:
                 ASR::Variable_t* p_var = ASRUtils::EXPR2VAR(x.m_ptr);
                 load_cptr = !is_cptr_dummy_passed_by_value(p_var);
             }
-            if (load_cptr) {
+            if (load_cptr && ptr->getType() != p_llvm_type) {
                 ptr = llvm_utils->CreateLoad2(p_llvm_type, ptr);
             }
         }
@@ -9107,7 +9115,9 @@ public:
             if (load_tgt) {
                 llvm::Type* t_llvm_type = llvm_utils->get_type_from_ttype_t_util(
                     x.m_tgt, ASRUtils::expr_type(x.m_tgt), module.get());
-                tgt = llvm_utils->CreateLoad2(t_llvm_type, tgt);
+                if (tgt->getType() != t_llvm_type) {
+                    tgt = llvm_utils->CreateLoad2(t_llvm_type, tgt);
+                }
             }
             tmp = builder->CreateICmpEQ(to_int64(ptr), to_int64(tgt));
             return ;
@@ -15510,6 +15520,37 @@ public:
             } else {
                 LCOMPILERS_ASSERT(false);
             }
+        } else if (ASR::is_a<ASR::StructType_t>(*x_m_type) ||
+                   ASR::is_a<ASR::CPtr_t>(*x_m_type)) {
+            // Struct and CPtr elements: allocate a flat [N x T] array on the
+            // stack, store each element into it and return a pointer to element 0.
+            // The resulting pointer is compatible with the FixedSizeArray memcpy
+            // path in set_VariableInital_value.
+            int64_t simd_n = ASRUtils::get_fixed_size_of_array(x.m_type);
+            // Evaluate the first element to get the concrete LLVM type
+            int64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 2;
+            this->visit_expr_wrapper(x.m_args[0], true);
+            ptr_loads = ptr_loads_copy;
+            llvm::Value *first_elem = tmp;
+            el_type = first_elem->getType();
+
+            llvm::Type* arr_alloca_type = llvm::ArrayType::get(el_type, simd_n > 0 ? simd_n : 0);
+            llvm::AllocaInst *p = llvm_utils->CreateAlloca(*builder, arr_alloca_type);
+
+            llvm::Value *slot0 = llvm_utils->create_gep2(arr_alloca_type, p, 0);
+            builder->CreateStore(first_elem, slot0);
+
+            for (int64_t i = 1; i < simd_n; i++) {
+                llvm::Value *slot = llvm_utils->create_gep2(arr_alloca_type, p, i);
+                ptr_loads_copy = ptr_loads;
+                ptr_loads = 2;
+                this->visit_expr_wrapper(x.m_args[i], true);
+                ptr_loads = ptr_loads_copy;
+                builder->CreateStore(tmp, slot);
+            }
+            tmp = llvm_utils->create_gep2(arr_alloca_type, p, 0);
+            return;
         } else {
             throw CodeGenError("ConstArray type not supported yet");
         }
@@ -15570,6 +15611,36 @@ public:
             } else {
                 LCOMPILERS_ASSERT(false);
             }
+        } else if (ASR::is_a<ASR::StructType_t>(*x_m_type) || ASR::is_a<ASR::CPtr_t>(*x_m_type)) {
+            // Struct and CPtr element arrays: cannot be emitted as a global LLVM
+            // ConstantArray (elements are complex IR values). Fall back to the
+            // allocate-and-store approach used by visit_ArrayConstructorUtil.
+            int64_t simd_n = ASRUtils::get_fixed_size_of_array(x.m_type);
+            ASR::expr_t *el0 = ASRUtils::fetch_ArrayConstant_value(al, x, 0);
+            int64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 2;
+            this->visit_expr_wrapper(el0, true);
+            ptr_loads = ptr_loads_copy;
+            llvm::Value *first_elem = tmp;
+            el_type = first_elem->getType();
+
+            llvm::Type* arr_alloca_type = llvm::ArrayType::get(el_type, simd_n > 0 ? simd_n : 0);
+            llvm::AllocaInst *p = llvm_utils->CreateAlloca(*builder, arr_alloca_type);
+
+            llvm::Value *slot0 = llvm_utils->create_gep2(arr_alloca_type, p, 0);
+            builder->CreateStore(first_elem, slot0);
+
+            for (int64_t i = 1; i < simd_n; i++) {
+                llvm::Value *slot = llvm_utils->create_gep2(arr_alloca_type, p, i);
+                ASR::expr_t *el = ASRUtils::fetch_ArrayConstant_value(al, x, i);
+                ptr_loads_copy = ptr_loads;
+                ptr_loads = 2;
+                this->visit_expr_wrapper(el, true);
+                ptr_loads = ptr_loads_copy;
+                builder->CreateStore(tmp, slot);
+            }
+            tmp = llvm_utils->create_gep2(arr_alloca_type, p, 0);
+            return;
         } else {
             throw CodeGenError("ConstArray type not supported yet");
         }
@@ -24097,6 +24168,11 @@ public:
                             value = convert_class_to_type(x.m_args[i].m_value, ASRUtils::EXPR(ASR::make_Var_t(
                                 al, orig_arg->base.base.loc, &orig_arg->base)),
                                 orig_arg->m_type, value);
+                        }
+                        if (orig_arg && !orig_arg->m_value_attr && ASR::is_a<ASR::CPtr_t>(*arg_type)) {
+                            llvm::AllocaInst *target = get_call_arg_alloca(target_type);
+                            builder->CreateStore(value, target);
+                            value = target;
                         }
                         use_value = true;
                     } else if ( (ASR::is_a<ASR::ComplexRe_t>(*x.m_args[i].m_value) ||


### PR DESCRIPTION
Separated commits from #12486