### PR TITLE
fix: check type-bound procedure override interfaces

### DIFF
--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -4392,6 +4392,83 @@ public:
                 sync_pdt_specialization_symbols(clss, proc_scope);
             }
         }
+        check_class_procedure_overrides();
+    }
+
+    // The name of the derived type that declares the binding `x` overrides.
+    std::string overridden_binding_owner(
+            const ASR::StructMethodDeclaration_t &x) {
+        ASR::StructMethodDeclaration_t *base = ASRUtils::overridden_binding(x);
+        if (base == nullptr || base->m_parent_symtab == nullptr) return "";
+        ASR::symbol_t *owner = ASR::down_cast<ASR::symbol_t>(
+            base->m_parent_symtab->asr_owner);
+        return std::string(ASRUtils::symbol_name(owner));
+    }
+
+    // Points a rejected override back at the binding it failed to override,
+    // which is what the type would have had if the override were absent.
+    void adopt_overridden_binding(ASR::StructMethodDeclaration_t *x) {
+        ASR::StructMethodDeclaration_t *base = ASRUtils::overridden_binding(*x);
+        if (base == nullptr) return;
+        x->m_proc = base->m_proc;
+        x->m_proc_name = base->m_proc_name;
+        x->m_self_argument = base->m_self_argument;
+        x->m_is_nopass = base->m_is_nopass;
+    }
+
+    // Fortran 2018 7.5.7.3: an overriding type-bound procedure must have the
+    // same interface as the one it overrides, apart from the passed-object
+    // dummy argument. A dispatch through the parent type is compiled against
+    // the parent's interface, so a mismatch calls the overriding procedure
+    // with arguments it was not declared to take. This runs once every binding
+    // has been added, because a parent declared in the same scoping unit is
+    // not necessarily processed before the type extending it.
+    void check_class_procedure_overrides() {
+        for (auto &proc : class_procedures) {
+            ASR::symbol_t* clss_sym = ASRUtils::symbol_get_past_external(
+                current_scope->resolve_symbol(proc.first));
+            if (clss_sym == nullptr || !ASR::is_a<ASR::Struct_t>(*clss_sym)) {
+                continue;
+            }
+            ASR::Struct_t *clss = ASR::down_cast<ASR::Struct_t>(clss_sym);
+            for (auto &pname : proc.second) {
+                ASR::symbol_t *sym = clss->m_symtab->get_symbol(pname.first);
+                if (sym == nullptr ||
+                        !ASR::is_a<ASR::StructMethodDeclaration_t>(*sym)) {
+                    continue;
+                }
+                ASR::StructMethodDeclaration_t *binding =
+                    ASR::down_cast<ASR::StructMethodDeclaration_t>(sym);
+                ASR::symbol_t *proc_sym = ASRUtils::symbol_get_past_external(
+                    binding->m_proc);
+                if (proc_sym == nullptr ||
+                        !ASR::is_a<ASR::Function_t>(*proc_sym)) {
+                    continue;
+                }
+                std::string what = "Type bound procedure '" +
+                    std::string(binding->m_name) + "' of '" +
+                    std::string(clss->m_name) + "' overriding the binding of "
+                    "the same name in '" + overridden_binding_owner(*binding) +
+                    "'";
+                ASRUtils::InterfaceMismatch m =
+                    ASRUtils::binding_override_mismatch(*binding,
+                        ASR::down_cast<ASR::Function_t>(proc_sym), what, true);
+                if (m.mismatch) {
+                    diag.add(diag::Diagnostic(m.message,
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("", {pname.second["procedure"].loc})}));
+                    if (!compiler_options.continue_compilation) {
+                        throw SemanticAbort();
+                    }
+                    // Continuing means the rest of the file still has to be
+                    // walked, and every later stage assumes a binding it can
+                    // dispatch through. Leaving this one in place hands them a
+                    // procedure the parent's interface does not describe, so
+                    // the type keeps the binding it inherited instead.
+                    adopt_overridden_binding(binding);
+                }
+            }
+        }
     }
 
     void visit_Use(const AST::Use_t &x) {

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -4406,6 +4406,247 @@ ASR::expr_t* get_expr_size_expr(ASR::expr_t* x, bool inside_binop /* = false*/) 
 }
 
 
+ASR::ttype_t* typed_expr_type(const ASR::expr_t *e)
+{
+    if (e == nullptr) return nullptr;
+    if (!ASR::is_a<ASR::Var_t>(*e)) return ASRUtils::expr_type(e);
+    ASR::symbol_t *s = ASR::down_cast<ASR::Var_t>(e)->m_v;
+    if (s == nullptr) return nullptr;
+    if (ASR::is_a<ASR::ExternalSymbol_t>(*s)) {
+        s = ASR::down_cast<ASR::ExternalSymbol_t>(s)->m_external;
+        if (s == nullptr || ASR::is_a<ASR::ExternalSymbol_t>(*s)) return nullptr;
+    }
+    if (!ASR::is_a<ASR::Function_t>(*s) && !ASR::is_a<ASR::Variable_t>(*s)
+            && !ASR::is_a<ASR::Struct_t>(*s)) {
+        return nullptr;
+    }
+    return ASRUtils::expr_type(e);
+}
+
+bool is_procedure_type(ASR::ttype_t *t)
+{
+    return t != nullptr
+        && ASR::is_a<ASR::FunctionType_t>(*ASRUtils::type_get_past_array(
+            ASRUtils::type_get_past_allocatable_pointer(t)));
+}
+
+bool is_struct_like_type(ASR::ttype_t *t)
+{
+    if (t == nullptr) return false;
+    ASR::ttype_t *t2 = ASRUtils::type_get_past_array(
+        ASRUtils::type_get_past_allocatable_pointer(t));
+    return ASR::is_a<ASR::StructType_t>(*t2) || ASRUtils::is_class_type(t2);
+}
+
+// `check_equal_type` does not look at a character length, but a caller
+// compiled against `character(len=5)` reserves five bytes for a result the
+// implementation writes ten into.
+static InterfaceMismatch string_length_mismatch(const std::string &what,
+    ASR::ttype_t *impl, ASR::ttype_t *decl, const std::string &code)
+{
+    if (impl == nullptr || decl == nullptr) return {};
+    if (!ASRUtils::is_character(*impl) || !ASRUtils::is_character(*decl)) {
+        return {};
+    }
+    ASR::String_t *a = ASRUtils::get_string_type(impl);
+    ASR::String_t *b = ASRUtils::get_string_type(decl);
+    if (a == nullptr || b == nullptr) return {};
+    int64_t a_len = -1, b_len = -1;
+    if (a->m_len == nullptr || b->m_len == nullptr) return {};
+    if (!ASRUtils::extract_value(ASRUtils::expr_value(a->m_len), a_len) ||
+            !ASRUtils::extract_value(ASRUtils::expr_value(b->m_len), b_len)) {
+        return {};
+    }
+    if (a_len == b_len) return {};
+    return {true, code, what + " must have character length " +
+        std::to_string(b_len) + ", not " + std::to_string(a_len)};
+}
+
+// The dummy argument `impl` declares at position `i`, compared against the one
+// `decl` declares in the same position.
+static InterfaceMismatch argument_mismatch(const std::string &what, size_t i,
+    ASR::Function_t *impl, ASR::Function_t *decl, bool use_expr_context)
+{
+    if (!ASR::is_a<ASR::Var_t>(*impl->m_args[i]) ||
+            !ASR::is_a<ASR::Var_t>(*decl->m_args[i])) {
+        return {};
+    }
+    ASR::symbol_t *sym = ASR::down_cast<ASR::Var_t>(impl->m_args[i])->m_v;
+    ASR::symbol_t *decl_sym = ASR::down_cast<ASR::Var_t>(decl->m_args[i])->m_v;
+    if (!ASR::is_a<ASR::Variable_t>(*sym) ||
+            !ASR::is_a<ASR::Variable_t>(*decl_sym)) {
+        return {};
+    }
+    ASR::Variable_t *arg = ASR::down_cast<ASR::Variable_t>(sym);
+    ASR::Variable_t *decl_arg = ASR::down_cast<ASR::Variable_t>(decl_sym);
+    std::string which = what + ", argument " + std::to_string(i + 1) +
+        " '" + std::string(arg->m_name) + "',";
+    if (arg->m_intent != decl_arg->m_intent) {
+        return {true, "argument_intent_matches",
+            which + " must have the same intent as '" +
+            std::string(decl_arg->m_name) + "'"};
+    }
+    if (arg->m_presence != decl_arg->m_presence) {
+        return {true, "argument_presence_matches",
+            which + " must agree with '" + std::string(decl_arg->m_name) +
+            "' on the OPTIONAL attribute"};
+    }
+    ASR::ttype_t *type = arg->m_type;
+    ASR::ttype_t *decl_type = decl_arg->m_type;
+    if (type == nullptr || decl_type == nullptr) return {};
+    if (ASRUtils::is_allocatable(type) != ASRUtils::is_allocatable(decl_type)) {
+        return {true, "argument_allocatable_matches",
+            which + " must agree with '" + std::string(decl_arg->m_name) +
+            "' on the ALLOCATABLE attribute"};
+    }
+    if (ASRUtils::is_pointer(type) != ASRUtils::is_pointer(decl_type)) {
+        return {true, "argument_pointer_matches",
+            which + " must agree with '" + std::string(decl_arg->m_name) +
+            "' on the POINTER attribute"};
+    }
+    if (ASRUtils::extract_n_dims_from_ttype(type) !=
+            ASRUtils::extract_n_dims_from_ttype(decl_type)) {
+        return {true, "argument_rank_matches",
+            which + " must have rank " + std::to_string(
+                ASRUtils::extract_n_dims_from_ttype(decl_type))};
+    }
+    // A derived type argument spells its members out inline, so two
+    // structurally different types can name the same type; those are compared
+    // by the dedicated struct checks instead.
+    if (is_struct_like_type(type) || is_struct_like_type(decl_type) ||
+            is_procedure_type(type) || is_procedure_type(decl_type)) {
+        return {};
+    }
+    if (!ASRUtils::check_equal_type(type, decl_type,
+            use_expr_context ? impl->m_args[i] : nullptr,
+            use_expr_context ? decl->m_args[i] : nullptr)) {
+        return {true, "argument_type_matches",
+            which + " must have type " +
+            ASRUtils::get_type_code(decl_type) + ", not " +
+            ASRUtils::get_type_code(type)};
+    }
+    return {};
+}
+
+InterfaceMismatch interface_mismatch(const std::string &what,
+    ASR::Function_t *impl, ASR::Function_t *decl, size_t skip,
+    bool use_expr_context)
+{
+    bool decl_is_function = decl->m_return_var != nullptr;
+    bool is_function = impl->m_return_var != nullptr;
+    if (decl_is_function != is_function) {
+        return {true, "result_kind_matches", what + " must be a " +
+            std::string(decl_is_function ? "function" : "subroutine")};
+    }
+    if (decl_is_function && is_function) {
+        ASR::ttype_t *decl_type = typed_expr_type(decl->m_return_var);
+        ASR::ttype_t *type = typed_expr_type(impl->m_return_var);
+        if (decl_type != nullptr && type != nullptr &&
+                !is_struct_like_type(decl_type) && !is_struct_like_type(type)) {
+            if (!ASRUtils::check_equal_type(type, decl_type,
+                    use_expr_context ? impl->m_return_var : nullptr,
+                    use_expr_context ? decl->m_return_var : nullptr)) {
+                return {true, "result_type_matches", what + " must return " +
+                    ASRUtils::get_type_code(decl_type) + ", not " +
+                    ASRUtils::get_type_code(type)};
+            }
+            InterfaceMismatch m = string_length_mismatch(what + " result",
+                type, decl_type, "result_type_matches");
+            if (m.mismatch) return m;
+        }
+    }
+    if (impl->n_args != decl->n_args) {
+        return {true, "argument_count_matches", what + " must take " +
+            std::to_string(decl->n_args) + " arguments, not " +
+            std::to_string(impl->n_args)};
+    }
+    for (size_t i = 0; i < impl->n_args; i++) {
+        if (i == skip) continue;
+        InterfaceMismatch m = argument_mismatch(what, i, impl, decl,
+            use_expr_context);
+        if (m.mismatch) return m;
+    }
+    return {};
+}
+
+size_t passed_object_index(const ASR::StructMethodDeclaration_t &x,
+    ASR::Function_t *proc)
+{
+    if (x.m_is_nopass) return proc->n_args;
+    if (x.m_self_argument == nullptr) return 0;
+    std::string self_name = x.m_self_argument;
+    for (size_t i = 0; i < proc->n_args; i++) {
+        if (!ASR::is_a<ASR::Var_t>(*proc->m_args[i])) continue;
+        if (self_name == std::string(ASRUtils::symbol_name(
+                ASR::down_cast<ASR::Var_t>(proc->m_args[i])->m_v))) {
+            return i;
+        }
+    }
+    return proc->n_args;
+}
+
+ASR::StructMethodDeclaration_t* overridden_binding(
+    const ASR::StructMethodDeclaration_t &x)
+{
+    SymbolTable *symtab = x.m_parent_symtab;
+    if (symtab == nullptr || symtab->asr_owner == nullptr ||
+            !ASR::is_a<ASR::symbol_t>(*symtab->asr_owner)) {
+        return nullptr;
+    }
+    ASR::symbol_t *owner = ASR::down_cast<ASR::symbol_t>(symtab->asr_owner);
+    if (!ASR::is_a<ASR::Struct_t>(*owner)) return nullptr;
+    ASR::symbol_t *parent = ASR::down_cast<ASR::Struct_t>(owner)->m_parent;
+    // A parent cycle is diagnosed on its own; here it must only not loop.
+    std::set<const ASR::Struct_t*> seen;
+    while (parent != nullptr) {
+        parent = ASRUtils::symbol_get_past_external(parent);
+        if (parent == nullptr || !ASR::is_a<ASR::Struct_t>(*parent)) {
+            return nullptr;
+        }
+        ASR::Struct_t *s = ASR::down_cast<ASR::Struct_t>(parent);
+        if (!seen.insert(s).second) return nullptr;
+        ASR::symbol_t *sym = s->m_symtab->get_symbol(std::string(x.m_name));
+        if (sym != nullptr &&
+                ASR::is_a<ASR::StructMethodDeclaration_t>(*sym)) {
+            return ASR::down_cast<ASR::StructMethodDeclaration_t>(sym);
+        }
+        parent = s->m_parent;
+    }
+    return nullptr;
+}
+
+InterfaceMismatch binding_override_mismatch(
+    const ASR::StructMethodDeclaration_t &x, ASR::Function_t *proc,
+    const std::string &what, bool use_expr_context)
+{
+    ASR::StructMethodDeclaration_t *base_decl = overridden_binding(x);
+    if (base_decl == nullptr) return {};
+    ASR::symbol_t *base_sym =
+        ASRUtils::symbol_get_past_external(base_decl->m_proc);
+    if (base_sym == nullptr || !ASR::is_a<ASR::Function_t>(*base_sym)) {
+        return {};
+    }
+    ASR::Function_t *base = ASR::down_cast<ASR::Function_t>(base_sym);
+    // An inherited binding names the very same procedure; only a binding that
+    // names a different one overrides anything.
+    if (base == proc) return {};
+
+    if (x.m_is_nopass != base_decl->m_is_nopass) {
+        return {true, "nopass_matches",
+            what + " must agree on the NOPASS attribute"};
+    }
+    size_t self_index = passed_object_index(x, proc);
+    size_t base_self_index = passed_object_index(*base_decl, base);
+    if (self_index != base_self_index) {
+        return {true, "passed_object_matches",
+            what + " must take its passed-object dummy argument in the same "
+            "position"};
+    }
+    // The passed-object dummy argument is declared with the type it is bound
+    // to, so the two deliberately differ there.
+    return interface_mismatch(what, proc, base, self_index, use_expr_context);
+}
+
 //Initialize pointer to zero so that it can be initialized in first call to get_instance
 ASRUtils::LabelGenerator* ASRUtils::LabelGenerator::label_generator = nullptr;
 

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -9120,6 +9120,65 @@ static inline int64_t get_fixed_string_len(const ASR::ttype_t* type_t) {
     return -1;
 }
 
+// Returns the type of `e`, or nullptr if the expression is malformed in a way
+// that makes its type unobtainable (a Var referencing a symbol that carries no
+// type, such as a Program). Such expressions have their own dedicated checks,
+// so type comparisons must simply be skipped for them instead of asking for a
+// type that does not exist.
+ASR::ttype_t* typed_expr_type(const ASR::expr_t *e);
+
+// Procedure types are compared by their own dedicated checks, and they have no
+// type code, so they cannot take part in the generic type comparisons.
+bool is_procedure_type(ASR::ttype_t *t);
+
+// A StructType spells out its member types inline, so two StructType nodes for
+// the same derived type can differ structurally, for example when a pass
+// rewrites the signature of a procedure pointer component in one of them.
+// Derived type identity is established from the struct symbol, which a bare
+// signature type does not carry, so such types are left to the dedicated
+// struct checks.
+bool is_struct_like_type(ASR::ttype_t *t);
+
+// The one way in which two procedures that must present the same interface
+// fail to do so. `code` names the check that failed, so a caller can label the
+// diagnostic it raises; both fields are empty when the interfaces conform.
+struct InterfaceMismatch {
+    bool mismatch = false;
+    std::string code;
+    std::string message;
+};
+
+// Compares two procedures that must present the same interface. `skip` is the
+// position of the one dummy argument they may declare differently (the
+// passed-object dummy argument), or `impl->n_args` when there is none. `what`
+// names the procedure at the start of the message. Type equality uses the
+// argument expressions to resolve the struct symbols they refer to, which
+// requires dereferencing ExternalSymbol; pass `use_expr_context = false`
+// before externals are resolved to fall back to a structural comparison.
+InterfaceMismatch interface_mismatch(const std::string &what,
+    ASR::Function_t *impl, ASR::Function_t *decl, size_t skip,
+    bool use_expr_context);
+
+// The position of the passed-object dummy argument of a binding, or `n_args`
+// when the binding has none.
+size_t passed_object_index(const ASR::StructMethodDeclaration_t &x,
+    ASR::Function_t *proc);
+
+// The binding of the same name that `x` overrides, searched up the parent
+// chain of the derived type `x` belongs to, or nullptr.
+ASR::StructMethodDeclaration_t* overridden_binding(
+    const ASR::StructMethodDeclaration_t &x);
+
+// Fortran 2018 7.5.7.3: an overriding type-bound procedure and the one it
+// overrides must have the same interface apart from the passed-object dummy
+// argument. Nothing downstream re-derives this, so a mismatch means a dispatch
+// through the parent type calls a procedure whose signature does not match the
+// call site the parent's interface promised. Returns no mismatch when `x`
+// overrides nothing.
+InterfaceMismatch binding_override_mismatch(
+    const ASR::StructMethodDeclaration_t &x, ASR::Function_t *proc,
+    const std::string &what, bool use_expr_context);
+
 } // namespace ASRUtils
 
 } // namespace LCompilers

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -14,6 +14,9 @@ namespace ASR {
 
 using ASRUtils::symbol_name;
 using ASRUtils::symbol_parent_symtab;
+using ASRUtils::typed_expr_type;
+using ASRUtils::is_procedure_type;
+using ASRUtils::is_struct_like_type;
 
 bool valid_char(char c) {
     if (c >= 'a' && c <= 'z') return true;
@@ -31,51 +34,6 @@ bool valid_name(const char *s) {
         if (!valid_char(s[i])) return false;
     }
     return true;
-}
-
-// Returns the type of `e`, or nullptr if the expression is malformed in a way
-// that makes its type unobtainable (a Var referencing a symbol that carries no
-// type, such as a Program). Such expressions have their own dedicated verifier
-// checks, so type comparisons must simply be skipped for them instead of
-// asking for a type that does not exist.
-static ttype_t* typed_expr_type(const expr_t *e)
-{
-    if (e == nullptr) return nullptr;
-    if (!is_a<Var_t>(*e)) return ASRUtils::expr_type(e);
-    symbol_t *s = down_cast<Var_t>(e)->m_v;
-    if (s == nullptr) return nullptr;
-    if (is_a<ExternalSymbol_t>(*s)) {
-        s = down_cast<ExternalSymbol_t>(s)->m_external;
-        if (s == nullptr || is_a<ExternalSymbol_t>(*s)) return nullptr;
-    }
-    if (!is_a<Function_t>(*s) && !is_a<Variable_t>(*s)
-            && !is_a<Struct_t>(*s)) {
-        return nullptr;
-    }
-    return ASRUtils::expr_type(e);
-}
-
-// Procedure types are compared by their own dedicated checks, and they have no
-// type code, so they cannot take part in the generic type comparisons below.
-static bool is_procedure_type(ttype_t *t)
-{
-    return t != nullptr
-        && is_a<FunctionType_t>(*ASRUtils::type_get_past_array(
-            ASRUtils::type_get_past_allocatable_pointer(t)));
-}
-
-// A StructType spells out its member types inline, so two StructType nodes for
-// the same derived type can differ structurally, for example when a pass
-// rewrites the signature of a procedure pointer component in one of them.
-// Derived type identity is established from the struct symbol, which a bare
-// signature type does not carry, so such types are left to the dedicated
-// struct checks.
-static bool is_struct_like_type(ttype_t *t)
-{
-    if (t == nullptr) return false;
-    ttype_t *t2 = ASRUtils::type_get_past_array(
-        ASRUtils::type_get_past_allocatable_pointer(t));
-    return is_a<StructType_t>(*t2) || ASRUtils::is_class_type(t2);
 }
 
 class VerifyVisitor : public BaseWalkVisitor<VerifyVisitor>
@@ -519,11 +477,11 @@ public:
             ASR::Function_t *declared = declared_module_interface(
                 tu_scope, x.m_parent_module, item.first);
             if (declared == nullptr || declared == impl) continue;
-            verify_conforming_signatures(
-                "Module procedure '" + std::string(impl->m_name) +
-                "' implementing the interface in module '" +
-                std::string(x.m_parent_module) + "'",
-                impl, declared, declared->n_args + 1,
+            require_conforming(ASRUtils::interface_mismatch(
+                    "Module procedure '" + std::string(impl->m_name) +
+                    "' implementing the interface in module '" +
+                    std::string(x.m_parent_module) + "'",
+                    impl, declared, declared->n_args + 1, check_external),
                 "asr.verify.module_procedure", x.base.base.loc);
         }
     }
@@ -706,214 +664,30 @@ public:
         verify_binding_override(x, x_m_proc);
     }
 
-    // The position of the passed-object dummy argument of a binding, or
-    // `n_args` when the binding has none.
-    size_t passed_object_index(const StructMethodDeclaration_t &x,
-            ASR::Function_t *proc) {
-        if (x.m_is_nopass) return proc->n_args;
-        if (x.m_self_argument == nullptr) return 0;
-        std::string self_name = x.m_self_argument;
-        for (size_t i = 0; i < proc->n_args; i++) {
-            if (!ASR::is_a<ASR::Var_t>(*proc->m_args[i])) continue;
-            if (self_name == std::string(ASRUtils::symbol_name(
-                    ASR::down_cast<ASR::Var_t>(proc->m_args[i])->m_v))) {
-                return i;
-            }
-        }
-        return proc->n_args;
+    // Raises the mismatch `m` as a verifier error under `prefix`.
+    void require_conforming(const ASRUtils::InterfaceMismatch &m,
+            const std::string &prefix, const Location &loc) {
+        require_with_loc_id(!m.mismatch, prefix + "." + m.code, m.message, loc);
     }
 
-    // The binding of the same name that `x` overrides, searched up the
-    // parent chain of the derived type `x` belongs to, or nullptr.
-    ASR::StructMethodDeclaration_t* overridden_binding(
-            const StructMethodDeclaration_t &x) {
-        SymbolTable *symtab = x.m_parent_symtab;
-        if (symtab == nullptr || symtab->asr_owner == nullptr ||
-                !ASR::is_a<ASR::symbol_t>(*symtab->asr_owner)) {
-            return nullptr;
-        }
-        ASR::symbol_t *owner = ASR::down_cast<ASR::symbol_t>(symtab->asr_owner);
-        if (!ASR::is_a<ASR::Struct_t>(*owner)) return nullptr;
-        ASR::symbol_t *parent = ASR::down_cast<ASR::Struct_t>(owner)->m_parent;
-        // A parent cycle is diagnosed on its own; here it must only not loop.
-        std::set<const ASR::Struct_t*> seen;
-        while (parent != nullptr) {
-            parent = ASRUtils::symbol_get_past_external(parent);
-            if (parent == nullptr || !ASR::is_a<ASR::Struct_t>(*parent)) {
-                return nullptr;
-            }
-            ASR::Struct_t *s = ASR::down_cast<ASR::Struct_t>(parent);
-            if (!seen.insert(s).second) return nullptr;
-            ASR::symbol_t *sym = s->m_symtab->get_symbol(std::string(x.m_name));
-            if (sym != nullptr &&
-                    ASR::is_a<ASR::StructMethodDeclaration_t>(*sym)) {
-                return ASR::down_cast<ASR::StructMethodDeclaration_t>(sym);
-            }
-            parent = s->m_parent;
-        }
-        return nullptr;
-    }
-
-    // Fortran 2018 7.5.7.3: an overriding type-bound procedure and the one it
-    // overrides must have the same interface apart from the passed-object
-    // dummy argument. Nothing downstream re-derives this, so a mismatch means
-    // a dispatch through the parent type calls a procedure whose signature
-    // does not match the call site the parent's interface promised.
     void verify_binding_override(const StructMethodDeclaration_t &x,
             ASR::Function_t *proc) {
         if (!check_external) return;
-        ASR::StructMethodDeclaration_t *base_decl = overridden_binding(x);
+        ASR::StructMethodDeclaration_t *base_decl =
+            ASRUtils::overridden_binding(x);
         if (base_decl == nullptr) return;
         ASR::symbol_t *base_sym =
             ASRUtils::symbol_get_past_external(base_decl->m_proc);
         if (base_sym == nullptr || !ASR::is_a<ASR::Function_t>(*base_sym)) {
             return;
         }
-        ASR::Function_t *base = ASR::down_cast<ASR::Function_t>(base_sym);
-        // An inherited binding names the very same procedure; only a binding
-        // that names a different one overrides anything.
-        if (base == proc) return;
-
         std::string what = "Type bound procedure '" + std::string(x.m_name) +
-            "' overriding '" + std::string(base->m_name) + "'";
-        require_id(x.m_is_nopass == base_decl->m_is_nopass,
-            "asr.verify.binding_override.nopass_matches",
-            what + " must agree on the NOPASS attribute");
-        size_t self_index = passed_object_index(x, proc);
-        size_t base_self_index = passed_object_index(*base_decl, base);
-        require_id(self_index == base_self_index,
-            "asr.verify.binding_override.passed_object_matches",
-            what + " must take its passed-object dummy argument in the same "
-            "position");
-        // The passed-object dummy argument is declared with the type it is
-        // bound to, so the two deliberately differ there.
-        verify_conforming_signatures(what, proc, base, self_index,
+            "' overriding '" +
+            std::string(ASR::down_cast<ASR::Function_t>(base_sym)->m_name) +
+            "'";
+        require_conforming(
+            ASRUtils::binding_override_mismatch(x, proc, what, check_external),
             "asr.verify.binding_override", x.base.base.loc);
-    }
-
-    // `check_equal_type` does not look at a character length, but a caller
-    // compiled against `character(len=5)` reserves five bytes for a result
-    // the implementation writes ten into.
-    void require_equal_string_length(const std::string &what,
-            ASR::ttype_t *impl, ASR::ttype_t *decl, const std::string &code,
-            const Location &loc) {
-        if (impl == nullptr || decl == nullptr) return;
-        if (!ASRUtils::is_character(*impl) ||
-                !ASRUtils::is_character(*decl)) {
-            return;
-        }
-        ASR::String_t *a = ASRUtils::get_string_type(impl);
-        ASR::String_t *b = ASRUtils::get_string_type(decl);
-        if (a == nullptr || b == nullptr) return;
-        int64_t a_len = -1, b_len = -1;
-        if (a->m_len == nullptr || b->m_len == nullptr) return;
-        if (!ASRUtils::extract_value(ASRUtils::expr_value(a->m_len), a_len) ||
-                !ASRUtils::extract_value(
-                    ASRUtils::expr_value(b->m_len), b_len)) {
-            return;
-        }
-        require_with_loc_id(a_len == b_len, code,
-            what + " must have character length " + std::to_string(b_len) +
-            ", not " + std::to_string(a_len), loc);
-    }
-
-    // Two procedures that must present the same interface. `skip` is the
-    // position of the one dummy argument they may declare differently, or
-    // `n_args` when there is none.
-    void verify_conforming_signatures(const std::string &what,
-            ASR::Function_t *impl, ASR::Function_t *decl, size_t skip,
-            const std::string &prefix, const Location &loc) {
-        bool decl_is_function = decl->m_return_var != nullptr;
-        bool is_function = impl->m_return_var != nullptr;
-        require_with_loc_id(decl_is_function == is_function,
-            prefix + ".result_kind_matches",
-            what + " must be a " +
-            std::string(decl_is_function ? "function" : "subroutine"), loc);
-        if (decl_is_function && is_function) {
-            ASR::ttype_t *decl_type = typed_expr_type(decl->m_return_var);
-            ASR::ttype_t *type = typed_expr_type(impl->m_return_var);
-            if (decl_type != nullptr && type != nullptr &&
-                    !is_struct_like_type(decl_type) &&
-                    !is_struct_like_type(type)) {
-                require_with_loc_id(ASRUtils::check_equal_type(type, decl_type,
-                        type_context(impl->m_return_var),
-                        type_context(decl->m_return_var)),
-                    prefix + ".result_type_matches",
-                    what + " must return " +
-                    ASRUtils::get_type_code(decl_type) + ", not " +
-                    ASRUtils::get_type_code(type), loc);
-                require_equal_string_length(what + " result", type, decl_type,
-                    prefix + ".result_type_matches", loc);
-            }
-        }
-        require_with_loc_id(impl->n_args == decl->n_args,
-            prefix + ".argument_count_matches",
-            what + " must take " + std::to_string(decl->n_args) +
-            " arguments, not " + std::to_string(impl->n_args), loc);
-        for (size_t i = 0; i < impl->n_args; i++) {
-            if (i == skip) continue;
-            verify_conforming_argument(what, i, impl, decl, prefix, loc);
-        }
-    }
-
-    void verify_conforming_argument(const std::string &what, size_t i,
-            ASR::Function_t *proc, ASR::Function_t *base,
-            const std::string &prefix, const Location &loc) {
-        if (!ASR::is_a<ASR::Var_t>(*proc->m_args[i]) ||
-                !ASR::is_a<ASR::Var_t>(*base->m_args[i])) {
-            return;
-        }
-        ASR::symbol_t *sym = ASR::down_cast<ASR::Var_t>(proc->m_args[i])->m_v;
-        ASR::symbol_t *base_sym =
-            ASR::down_cast<ASR::Var_t>(base->m_args[i])->m_v;
-        if (!ASR::is_a<ASR::Variable_t>(*sym) ||
-                !ASR::is_a<ASR::Variable_t>(*base_sym)) {
-            return;
-        }
-        ASR::Variable_t *arg = ASR::down_cast<ASR::Variable_t>(sym);
-        ASR::Variable_t *base_arg = ASR::down_cast<ASR::Variable_t>(base_sym);
-        std::string which = what + ", argument " + std::to_string(i + 1) +
-            " '" + std::string(arg->m_name) + "',";
-        require_with_loc_id(arg->m_intent == base_arg->m_intent,
-            prefix + ".argument_intent_matches",
-            which + " must have the same intent as '" +
-            std::string(base_arg->m_name) + "'", loc);
-        require_with_loc_id(arg->m_presence == base_arg->m_presence,
-            prefix + ".argument_presence_matches",
-            which + " must agree with '" + std::string(base_arg->m_name) +
-            "' on the OPTIONAL attribute", loc);
-        ASR::ttype_t *type = arg->m_type;
-        ASR::ttype_t *base_type = base_arg->m_type;
-        if (type == nullptr || base_type == nullptr) return;
-        require_with_loc_id(ASRUtils::is_allocatable(type) ==
-                ASRUtils::is_allocatable(base_type),
-            prefix + ".argument_allocatable_matches",
-            which + " must agree with '" + std::string(base_arg->m_name) +
-            "' on the ALLOCATABLE attribute", loc);
-        require_with_loc_id(ASRUtils::is_pointer(type) ==
-                ASRUtils::is_pointer(base_type),
-            prefix + ".argument_pointer_matches",
-            which + " must agree with '" + std::string(base_arg->m_name) +
-            "' on the POINTER attribute", loc);
-        require_with_loc_id(ASRUtils::extract_n_dims_from_ttype(type) ==
-                ASRUtils::extract_n_dims_from_ttype(base_type),
-            prefix + ".argument_rank_matches",
-            which + " must have rank " + std::to_string(
-                ASRUtils::extract_n_dims_from_ttype(base_type)), loc);
-        // A derived type argument spells its members out inline, so two
-        // structurally different types can name the same type; those are
-        // compared by the dedicated struct checks instead.
-        if (is_struct_like_type(type) || is_struct_like_type(base_type) ||
-                is_procedure_type(type) || is_procedure_type(base_type)) {
-            return;
-        }
-        require_with_loc_id(ASRUtils::check_equal_type(type, base_type,
-                type_context(proc->m_args[i]),
-                type_context(base->m_args[i])),
-            prefix + ".argument_type_matches",
-            which + " must have type " +
-            ASRUtils::get_type_code(base_type) + ", not " +
-            ASRUtils::get_type_code(type), loc);
     }
 
     // A procedure's dummy variables and its result variable are declared by

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -65,7 +65,7 @@ module continue_compilation_1_mod
     end type type_t
 
 
-
+    type, extends(MyClass) :: derived_binding; contains; procedure :: display => display_override; end type  ! {Error} Type bound procedure 'display' of 'derived_binding' overriding the binding of the same name in 'myclass' must take 2 arguments, not 3
 contains
 
     integer function statement_function_name_conflict()
@@ -182,7 +182,7 @@ contains
         procedure(sub_test), pointer :: pf2
         pf2 => dummy_func
     end subroutine proc_ptr_error_tests
-
+    subroutine display_override(self, a, b); class(derived_binding), intent(in) :: self; integer, intent(in) :: a, b; end subroutine
     function op_clash_f(x) result(y)
         integer, intent(in) :: x
         integer :: y

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "cfd37b383e6f5875fdce5a86041d9f20e41f0c5b9de2628146db3f56",
+    "infile_hash": "84a3b6397734cd4055d21571c3d7b837479ef9b1ec58586c59a46ee1",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2745da5982ca014957f4ed3795ea6c781ead17bb69870d980b248180",
+    "stderr_hash": "76a6b2de5561abe4df3a75104301de648e3e07007d977c9759a59ff3",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -128,6 +128,12 @@ semantic error: Procedure 'op_clash_f' is already defined as an interface body
  38 |            end function
     | ...~~~~~~~~~~~~~~~~~~~~ is already defined here
 
+semantic error: Type bound procedure 'display' of 'derived_binding' overriding the binding of the same name in 'myclass' must take 2 arguments, not 3
+  --> tests/errors/continue_compilation_1.f90:68:58
+   |
+68 |     type, extends(MyClass) :: derived_binding; contains; procedure :: display => display_override; end type  ! {Error} Type bound procedure 'display' of 'derived_binding' overriding the binding of the same name in 'myclass' must take 2 arguments, not 3
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
 semantic error: Defined assignment procedure must not return a value
    --> tests/errors/continue_compilation_1.f90:141:5 - 145:32
     |


### PR DESCRIPTION
An overriding type-bound procedure must present the same interface as the binding it overrides, apart from the passed-object dummy argument. AST->ASR never checked this, so a derived type could override a deferred binding with a procedure taking different arguments; a dispatch through the parent type then calls it with arguments it was not declared to take.

The ASR verifier already caught this, but it runs only in a build configured with WITH_LFORTRAN_ASSERT, so a release compiler accepted the code silently and a debug one reported an internal verifier message instead of a semantic error. The check now runs in AST->ASR, where the decision belongs.

The comparison the verifier performed moves to ASRUtils::interface_mismatch and ASRUtils::binding_override_mismatch so both callers share one implementation; the verifier keeps its existing messages and check identifiers, and its standalone ASR tests pass unchanged.

Under --continue-compilation the rejected binding is pointed back at the one it failed to override, which is what the type would have had without the override. Abandoning the binding instead would leave a deferred one nothing supplies, and keeping it would leave an override no interface describes; both make the translation unit fail verification the next time a USE of any module in it revalidates the tree.

The case added to tests/errors/continue_compilation_1.f90 is written on two lines, one for the type and one for the procedure, so that it fits the blank lines already there and no other error keeps a different line number.

Fixes #12311.