### PR TITLE
test: let the unit tests find the runtime modfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,11 @@ doc/man/lfortran.1
 _lfortran_generated_file*
 /test_gfortran
 /test_flang
+# x86 backend unit tests write their executables into the working directory.
+/cmp32
+/print32
+/print_integer
+/subroutines32
+/subroutines_args32
+/write32
+/write32.asm

--- a/src/lfortran/tests/CMakeLists.txt
+++ b/src/lfortran/tests/CMakeLists.txt
@@ -59,6 +59,17 @@ endif()
 add_executable(test_lfortran ${SRC})
 target_link_libraries(test_lfortran lfortran_lib p::doctest)
 target_compile_definitions(test_lfortran PRIVATE LFORTRAN_PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+# The test binary never calls set_exec_path_and_mode(), so it cannot work out
+# where the runtime modfiles are; a test that uses an intrinsic module would
+# fail with "modfile was not found". Under Emscripten they are preloaded into
+# the virtual filesystem at /lib, the same place xlfortran reads them from.
+if (EMSCRIPTEN)
+    set(LFORTRAN_TEST_RUNTIME_DIR "/lib")
+else()
+    set(LFORTRAN_TEST_RUNTIME_DIR "${CMAKE_BINARY_DIR}/src/runtime")
+endif()
+target_compile_definitions(test_lfortran PRIVATE
+    LFORTRAN_BUILD_RUNTIME_DIR="${LFORTRAN_TEST_RUNTIME_DIR}")
 if (HAVE_BUILD_TO_WASM)
     set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
     # The default Emscripten stack is 64kb, which is far too small for the


### PR DESCRIPTION
Part 1 of 7 splitting #12523, which stays open as the combined branch.

Stack: **this** → #12526 → #12527 → #12528 → #12529 → #12530 → #12531

## Summary

`test_lfortran` never calls `set_exec_path_and_mode()`, so
`get_runtime_library_dir()` has nothing to work from and any test that `use`s
an intrinsic module fails with "modfile was not found". `ci/build.sh` runs the
binary directly rather than through ctest, so an environment variable set on
the ctest target would not reach it either.

Pass the directory in as a compile definition, the same way the source
directory already is. Under Emscripten the modfiles are preloaded into the
virtual filesystem at `/lib`, which is where `xlfortran` reads them from.

Also ignore the executables the x86 unit tests write into the working
directory, so running the unit tests does not leave them next to the sources.

## Verification

No behaviour change. `ctest` 13/13, `./run_tests.py` passes.

Later parts of the stack add a `FortranEvaluator` test that needs this.
