### PR TITLE
fix: check a call's arguments against the procedure at every point

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4321,6 +4321,8 @@ RUN(NAME arrayprint_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME print_arr_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME print_arr_09 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME pointer_to_cptr LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME pointer_intent_in_01 LABELS gfortran llvm)
+RUN(NAME sequence_assoc_01 LABELS gfortran llvm)
 
 RUN(NAME binop_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME binop_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
@@ -4587,6 +4589,7 @@ RUN(NAME separate_compilation_47 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compilation_48a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_51 LABELS gfortran llvm EXTRAFILES separate_compilation_51a.f90 EXTRA_ARGS --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/pointer_intent_in_01.f90
+++ b/integration_tests/pointer_intent_in_01.f90
@@ -1,0 +1,28 @@
+program pointer_intent_in_01
+  implicit none
+  ! A POINTER, INTENT(IN) dummy also accepts a non-pointer actual that has
+  ! the TARGET attribute; the dummy becomes associated with it.
+  integer, target :: n
+  character(len=:), allocatable, target :: text
+  n = 42
+  call check_int(n)
+
+  text = "hello"
+  call check_text(text)
+
+contains
+
+  subroutine check_int(p)
+    integer, pointer, intent(in) :: p
+    if (.not. associated(p)) error stop "dummy is not associated"
+    if (p /= 42) error stop "wrong value through the dummy"
+  end subroutine
+
+  subroutine check_text(s)
+    character(len=:), pointer, intent(in) :: s
+    if (.not. associated(s)) error stop "string dummy is not associated"
+    if (len(s) /= 5) error stop "wrong length through the dummy"
+    if (s /= "hello") error stop "wrong contents through the dummy"
+  end subroutine
+
+end program

--- a/integration_tests/separate_compilation_51.f90
+++ b/integration_tests/separate_compilation_51.f90
@@ -1,0 +1,27 @@
+program separate_compilation_51
+  use separate_compilation_51a, only: stop_cb_iface, register_cb, fire, ncalls
+  implicit none
+  ! A procedure pointer declared with an interface holds a copy of that
+  ! interface's signature. The pass that turns an optional dummy into a
+  ! presence flag rewrites the interface and the procedure it points at, so
+  ! the copy has to be rewritten with them.
+  procedure(stop_cb_iface), pointer :: callback_ptr
+  callback_ptr => callback
+  call register_cb(callback_ptr)
+  call fire()
+  if (ncalls /= 2) error stop "callback was not invoked twice"
+contains
+  subroutine callback(is_error, quiet, code_int, code_char)
+    logical, intent(in) :: is_error, quiet
+    integer, intent(in), optional :: code_int
+    character(len=*), intent(in), optional :: code_char
+    ncalls = ncalls + 1
+    if (present(code_int)) then
+      if (code_int /= 7) error stop "wrong optional integer"
+      if (.not. present(code_char)) error stop "expected both optionals"
+      if (code_char /= "code") error stop "wrong optional string"
+    else
+      if (present(code_char)) error stop "expected neither optional"
+    end if
+  end subroutine
+end program

--- a/integration_tests/separate_compilation_51a.f90
+++ b/integration_tests/separate_compilation_51a.f90
@@ -1,0 +1,23 @@
+module separate_compilation_51a
+  implicit none
+  abstract interface
+    subroutine stop_cb_iface(is_error, quiet, code_int, code_char)
+      logical, intent(in) :: is_error, quiet
+      integer, intent(in), optional :: code_int
+      character(len=*), intent(in), optional :: code_char
+    end subroutine
+  end interface
+  procedure(stop_cb_iface), pointer :: saved => null()
+  integer :: ncalls = 0
+contains
+  subroutine register_cb(callback)
+    procedure(stop_cb_iface), pointer :: callback
+    saved => callback
+  end subroutine
+
+  subroutine fire()
+    if (.not. associated(saved)) error stop "callback was not registered"
+    call saved(.false., .true.)
+    call saved(.true., .false., 7, "code")
+  end subroutine
+end module

--- a/integration_tests/sequence_assoc_01.f90
+++ b/integration_tests/sequence_assoc_01.f90
@@ -1,0 +1,45 @@
+module sequence_assoc_01_mod
+  implicit none
+  type :: worker
+  contains
+    procedure, nopass :: take_explicit
+    procedure, nopass :: take_assumed_size
+  end type
+contains
+
+  subroutine take_explicit(x, n)
+    integer, intent(in) :: n
+    real, intent(in) :: x(n)
+    ! covers a(3:7) = 3+4+5+6+7
+    if (abs(sum(x) - 25.0) > 1.0e-5) error stop "explicit-shape dummy"
+  end subroutine
+
+  subroutine take_assumed_size(x)
+    real, intent(in) :: x(*)
+    if (abs(x(1) - 6.0) > 1.0e-5) error stop "assumed-size dummy first"
+    if (abs(x(5) - 10.0) > 1.0e-5) error stop "assumed-size dummy last"
+  end subroutine
+
+  subroutine outer(me, work, n)
+    class(worker), intent(inout) :: me
+    integer, intent(in) :: n
+    real, intent(inout) :: work(n)
+    ! Sequence association: an array element is the actual argument for an
+    ! explicit-shape or assumed-size dummy, which then covers the elements
+    ! of the actual's array from that element on.
+    call me%take_explicit(work(3), 5)
+    call me%take_assumed_size(work(6))
+  end subroutine
+end module
+
+program sequence_assoc_01
+  use sequence_assoc_01_mod
+  implicit none
+  type(worker) :: me
+  real :: a(10)
+  integer :: i
+  do i = 1, 10
+    a(i) = real(i)
+  end do
+  call outer(me, a, 10)
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7924,13 +7924,15 @@ public:
                         SetChar variable_dependencies_vec;
                         variable_dependencies_vec.reserve(al, 1);
                         ASRUtils::collect_variable_dependencies(al, variable_dependencies_vec, type);
+                        // The result belongs to the interface's own scope, not
+                        // to the scope that declares `external :: x`.
                         ASR::asr_t *return_var = ASRUtils::make_Variable_t_util(al, x.base.base.loc,
-                            current_scope, s2c(al, return_var_name), variable_dependencies_vec.p,
+                            f->m_symtab, s2c(al, return_var_name), variable_dependencies_vec.p,
                             variable_dependencies_vec.size(), ASRUtils::intent_return_var,
                             nullptr, nullptr, ASR::storage_typeType::Default, type, nullptr,
                             ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required,
                             false);
-                        current_scope->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
+                        f->m_symtab->add_symbol(return_var_name, ASR::down_cast<ASR::symbol_t>(return_var));
                         f->m_return_var = ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                             ASR::down_cast<ASR::symbol_t>(return_var)));
                         ASR::FunctionType_t *ft = ASR::down_cast<ASR::FunctionType_t>(f->m_function_signature);

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -926,12 +926,9 @@ public:
     // the procedure itself. One that resolves in an enclosing scope instead
     // is a host variable the procedure would then write through as if it
     // owned it. A dummy procedure is exempt: it names the procedure symbol
-    // itself, which lives where that procedure was declared. Only for a
-    // complete graph: a procedure the frontend synthesizes for an implicit
-    // interface borrows both its dummies and its result from the caller.
+    // itself, which lives where that procedure was declared.
     void require_own_symbol(ASR::expr_t *e, const std::string &owner,
             const std::string &what) {
-        if (!check_standalone_rules) return;
         if (e == nullptr || !ASR::is_a<ASR::Var_t>(*e)) return;
         ASR::symbol_t *sym = ASR::down_cast<ASR::Var_t>(e)->m_v;
         if (sym == nullptr || !ASR::is_a<ASR::Variable_t>(*sym)) return;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -3042,7 +3042,7 @@ public:
     // dimension array and crashes the compiler rather than diagnosing it.
     void verify_dimension_argument(const char *name, ASR::expr_t *array,
             ASR::expr_t *dim, const Location &loc) {
-        if (!check_standalone_rules || diagnostics.has_error()
+        if (diagnostics.has_error()
                 || array == nullptr || dim == nullptr) {
             return;
         }

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -84,7 +84,6 @@ private:
     // For checking correct parent symbtab relationship
     SymbolTable *current_symtab;
     bool check_external;
-    bool check_standalone_rules;
     diag::Diagnostics &diagnostics;
     std::string current_name;
 
@@ -111,9 +110,8 @@ private:
     const ASR::expr_t* current_expr {}; // current expression being visited 
 
 public:
-    VerifyVisitor(bool check_external, bool check_standalone_rules,
+    VerifyVisitor(bool check_external,
         diag::Diagnostics &diagnostics) : check_external{check_external},
-        check_standalone_rules{check_standalone_rules},
         diagnostics{diagnostics}, non_global_symbol_visited{false}, _is_return_type_string{false} {}
 
     // Requires the condition `cond` to be true. Raise an exception otherwise.
@@ -541,10 +539,6 @@ public:
         ASR::ttype_t *target = typed_expr_type(x.m_target);
         ASR::ttype_t *value = typed_expr_type(x.m_value);
         if (target == nullptr || value == nullptr) return;
-        // Only for a complete graph: `procedure(), pointer` declares no
-        // interface at all yet gets the same empty FunctionType that an
-        // explicit no-argument interface does.
-        if (!check_standalone_rules) return;
         verify_procedure_interface(value, target,
             "Procedure pointer association", x.base.base.loc);
     }
@@ -2154,6 +2148,13 @@ public:
         ASR::FunctionType_t *actual = as_procedure_type(actual_type);
         ASR::FunctionType_t *formal = as_procedure_type(formal_type);
         if (actual == nullptr || formal == nullptr) return;
+        // An interface that declares no arguments constrains nothing: that is
+        // the shape `EXTERNAL f` and `procedure(), pointer` produce, and ASR
+        // has no way yet to tell it apart from a genuine argumentless one.
+        auto unconstrained = [](ASR::FunctionType_t *t) {
+            return t->n_arg_types == 0;
+        };
+        if (unconstrained(actual) || unconstrained(formal)) return;
         require_with_loc_id(
             (actual->m_return_var_type == nullptr) ==
                 (formal->m_return_var_type == nullptr),
@@ -2285,7 +2286,7 @@ public:
                     || is_struct_like_type(formal_type);
                 bool procedure_argument = is_procedure_type(actual_type)
                     || is_procedure_type(formal_type);
-                if (procedure_argument && check_standalone_rules) {
+                if (procedure_argument) {
                     verify_procedure_interface(
                         actual_type, formal_type,
                         "Procedure argument '" +
@@ -2299,61 +2300,99 @@ public:
                         !ASRUtils::is_intrinsic_symbol(x.m_name) &&
                         !struct_argument &&
                         !procedure_argument) {
-                    // These wrapper and rank rules hold for a complete
-                    // standalone graph. After a pass the dummy may have been
-                    // rewritten (openmp turns allocatable into pointer;
-                    // pass_array_by_data changes ranks), so they are not
-                    // applied to intermediate ASR.
-                    if (check_standalone_rules) {
-                        // check_equal_type strips Allocatable and Pointer.
-                        // An allocatable or pointer dummy requires an actual
-                        // of the same wrapper; the other direction is valid
-                        // Fortran (an allocatable actual may be passed to a
-                        // nonallocatable dummy). A scalar actual for an array
-                        // dummy (or the converse) is invalid, except for
-                        // assumed-rank and elemental. Sequence association can
-                        // pass a 2-D actual to a 1-D dummy, so ranks of two
-                        // arrays need not match.
-                        if (ASRUtils::is_allocatable(formal_type)) {
-                            require_with_loc_id(
-                                ASRUtils::is_allocatable(actual_type),
-                                "asr.verify.call.actual_allocatable_matches_formal",
-                                "Actual argument type " +
-                                    ASRUtils::get_type_code(actual_type) +
-                                    " is not allocatable, but the dummy is " +
-                                    ASRUtils::get_type_code(formal_type),
-                                passed_arg_expr->base.loc);
+                    // These three describe how the implementation receives
+                    // its arguments. With --implicit-interface the frontend
+                    // infers an interface from one call site rather than
+                    // reading a declared one, and ASR cannot yet tell the two
+                    // apart, so they are only applied where the procedure
+                    // itself is in hand.
+                    bool callee_is_defined =
+                        ASRUtils::get_FunctionType(func)->m_deftype ==
+                            ASR::deftypeType::Implementation;
+                    // check_equal_type strips Allocatable and Pointer.
+                    // An allocatable or pointer dummy requires an actual
+                    // of the same wrapper; the other direction is valid
+                    // Fortran (an allocatable actual may be passed to a
+                    // nonallocatable dummy). A scalar actual for an array
+                    // dummy (or the converse) is invalid, except for
+                    // assumed-rank and elemental. Sequence association can
+                    // pass a 2-D actual to a 1-D dummy, so ranks of two
+                    // arrays need not match.
+                    if (callee_is_defined &&
+                            ASRUtils::is_allocatable(formal_type)) {
+                        require_with_loc_id(
+                            ASRUtils::is_allocatable(actual_type),
+                            "asr.verify.call.actual_allocatable_matches_formal",
+                            "Actual argument type " +
+                                ASRUtils::get_type_code(actual_type) +
+                                " is not allocatable, but the dummy is " +
+                                ASRUtils::get_type_code(formal_type),
+                            passed_arg_expr->base.loc);
+                    }
+                    // A pointer dummy takes a pointer actual, except when it
+                    // is INTENT(IN): that one may also take any valid target
+                    // for it, and becomes associated with the actual.
+                    if (callee_is_defined &&
+                            ASRUtils::is_pointer(formal_type) &&
+                            callee_param->m_intent != ASR::intentType::In) {
+                        require_with_loc_id(
+                            ASRUtils::is_pointer(actual_type),
+                            "asr.verify.call.actual_pointer_matches_formal",
+                            "Actual argument type " +
+                                ASRUtils::get_type_code(actual_type) +
+                                " is not a pointer, but the dummy is " +
+                                ASRUtils::get_type_code(formal_type),
+                            passed_arg_expr->base.loc);
+                    }
+                    bool formal_assumed_rank = ASRUtils::is_array(formal_type)
+                        && ASRUtils::extract_physical_type(formal_type)
+                            == ASR::array_physical_typeType::AssumedRankArray;
+                    bool elemental = ASRUtils::get_FunctionType(func)
+                        ->m_elemental;
+                    if (callee_is_defined && !formal_assumed_rank &&
+                            !elemental) {
+                        bool actual_is_array =
+                            ASRUtils::is_array(actual_type);
+                        bool formal_is_array =
+                            ASRUtils::is_array(formal_type);
+                        // Sequence association: an explicit-shape or
+                        // assumed-size dummy may be given an array element,
+                        // which is a scalar, and then covers the actual's
+                        // array from that element on. No other dummy may:
+                        // an assumed-shape one takes its extents from the
+                        // actual, and an allocatable or pointer one carries
+                        // the actual's own storage.
+                        bool formal_takes_element = false;
+                        if (formal_is_array && !actual_is_array &&
+                                !ASRUtils::is_allocatable(formal_type) &&
+                                !ASRUtils::is_pointer(formal_type)) {
+                            ASR::Array_t *formal_array =
+                                ASR::down_cast<ASR::Array_t>(formal_type);
+                            // Assumed size: the last extent is the caller's.
+                            formal_takes_element =
+                                formal_array->m_physical_type ==
+                                    ASR::array_physical_typeType::PointerArray ||
+                                formal_array->m_physical_type ==
+                                    ASR::array_physical_typeType::UnboundedPointerArray;
+                            for (size_t d = 0; d < formal_array->n_dims; d++) {
+                                // Explicit shape: the dummy states its own.
+                                if (formal_array->m_dims[d].m_length
+                                        != nullptr) {
+                                    formal_takes_element = true;
+                                    break;
+                                }
+                            }
                         }
-                        if (ASRUtils::is_pointer(formal_type)) {
-                            require_with_loc_id(
-                                ASRUtils::is_pointer(actual_type),
-                                "asr.verify.call.actual_pointer_matches_formal",
-                                "Actual argument type " +
-                                    ASRUtils::get_type_code(actual_type) +
-                                    " is not a pointer, but the dummy is " +
-                                    ASRUtils::get_type_code(formal_type),
-                                passed_arg_expr->base.loc);
-                        }
-                        bool formal_assumed_rank = ASRUtils::is_array(formal_type)
-                            && ASRUtils::extract_physical_type(formal_type)
-                                == ASR::array_physical_typeType::AssumedRankArray;
-                        bool elemental = ASRUtils::get_FunctionType(func)
-                            ->m_elemental;
-                        if (!formal_assumed_rank && !elemental) {
-                            bool actual_is_array =
-                                ASRUtils::is_array(actual_type);
-                            bool formal_is_array =
-                                ASRUtils::is_array(formal_type);
-                            require_with_loc_id(
-                                actual_is_array == formal_is_array,
-                                "asr.verify.call.actual_rank_matches_formal",
-                                "Actual argument type " +
-                                    ASRUtils::get_type_code(actual_type) +
-                                    " does not match formal argument rank of "
-                                    "type " +
-                                    ASRUtils::get_type_code(formal_type),
-                                passed_arg_expr->base.loc);
-                        }
+                        require_with_loc_id(
+                            actual_is_array == formal_is_array ||
+                                formal_takes_element,
+                            "asr.verify.call.actual_rank_matches_formal",
+                            "Actual argument type " +
+                                ASRUtils::get_type_code(actual_type) +
+                                " does not match formal argument rank of "
+                                "type " +
+                                ASRUtils::get_type_code(formal_type),
+                            passed_arg_expr->base.loc);
                     }
                     require_with_loc_id(
                         ASRUtils::check_equal_type(
@@ -3328,8 +3367,7 @@ public:
 bool asr_verify(const ASR::TranslationUnit_t &unit,
             const ASRVerifyOptions &options,
             diag::Diagnostics &diagnostics) {
-    ASR::VerifyVisitor v(options.check_external,
-        options.check_standalone_rules, diagnostics);
+    ASR::VerifyVisitor v(options.check_external, diagnostics);
     try {
         v.visit_TranslationUnit(unit);
     } catch (const ASRUtils::VerifyAbort &) {

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -2696,7 +2696,15 @@ namespace Spread {
         args_merge1.push_back(al, b.Eq(b.i32(i), b.i32(1)));
         ASR::expr_t* merge_for_i = EXPR(Merge::create_Merge(al, loc, args_merge1, diag));
 
-        args_merge2.push_back(al, b.ArraySize(array, b.i32(i), int32));
+        // `i` runs over the result's dimensions, one more than the array
+        // has. This branch is only selected when `i < dim`, so it is never
+        // the appended dimension, but the index still has to name a
+        // dimension the array actually has for the expression to be
+        // well formed.
+        int64_t array_rank = ASRUtils::extract_n_dims_from_ttype(
+            ASRUtils::expr_type(array));
+        args_merge2.push_back(al, b.ArraySize(
+            array, b.i32(std::min(i, array_rank)), int32));
         args_merge2.push_back(al, b.ArraySize(array, merge_for_i, int32));
         args_merge2.push_back(al, b.Lt(b.i32(i), dim));
         ASR::expr_t* merge_for_i_ne_dim = EXPR(Merge::create_Merge(al, loc, args_merge2, diag));

--- a/src/libasr/pass/intrinsic_function.cpp
+++ b/src/libasr/pass/intrinsic_function.cpp
@@ -33,6 +33,7 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
     std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions>& func2intrinsicid;
     bool& in_debugcheck;
     bool& in_ttype;
+    bool& in_gpu_kernel;
     int index_kind;
 
     public:
@@ -42,9 +43,9 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
 
     ReplaceIntrinsicFunctions(Allocator& al_, SymbolTable* global_scope_,
     std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions>& func2intrinsicid_, bool& in_debugcheck_, bool &in_ttype_,
-    int index_kind_) :
+    bool& in_gpu_kernel_, int index_kind_) :
         al(al_), global_scope(global_scope_), func2intrinsicid(func2intrinsicid_), in_debugcheck(in_debugcheck_), in_ttype(in_ttype_),
-        index_kind(index_kind_) {}
+        in_gpu_kernel(in_gpu_kernel_), index_kind(index_kind_) {}
 
 
     void replace_IntrinsicElementalFunction(ASR::IntrinsicElementalFunction_t* x) {
@@ -55,6 +56,14 @@ class ReplaceIntrinsicFunctions: public ASR::BaseExprReplacer<ReplaceIntrinsicFu
         // If inside DebugCheckArrayBounds and not inside a type
         // Then keep the IntrinsicElementalFunction because its arguments are used to find ArraySize
         if (in_debugcheck && !in_ttype) return;
+        if (in_gpu_kernel) {
+            for( size_t i = 0; i < x->n_args; i++ ) {
+                if( x->m_args[i] != nullptr && ASRUtils::is_array(
+                        ASRUtils::expr_type(x->m_args[i])) ) {
+                    return;
+                }
+            }
+        }
 
         Vec<ASR::call_arg_t> new_args; new_args.reserve(al, x->n_args);
         // Replace any IntrinsicElementalFunctions in the argument first:
@@ -153,11 +162,13 @@ class ReplaceIntrinsicFunctionsVisitor : public ASR::CallReplacerOnExpressionsVi
     public:
         bool in_debugcheck = false;
         bool in_ttype = false;
+        bool in_gpu_kernel = false;
 
         ReplaceIntrinsicFunctionsVisitor(Allocator& al_, SymbolTable* global_scope_,
             std::map<ASR::symbol_t*, ASRUtils::IntrinsicArrayFunctions>& func2intrinsicid_,
             int index_kind_) :
-            replacer(al_, global_scope_, func2intrinsicid_, in_debugcheck, in_ttype, index_kind_) {}
+            replacer(al_, global_scope_, func2intrinsicid_, in_debugcheck, in_ttype,
+                in_gpu_kernel, index_kind_) {}
 
         // Don't replace inside DebugCheckArrayBounds, the arguments for elemental functions might be arrays
         void visit_DebugCheckArrayBounds(const ASR::DebugCheckArrayBounds_t& x) {
@@ -172,6 +183,19 @@ class ReplaceIntrinsicFunctionsVisitor : public ASR::CallReplacerOnExpressionsVi
             in_ttype = true;
             ASR::CallReplacerOnExpressionsVisitor<ReplaceIntrinsicFunctionsVisitor>::visit_ttype(x);
             in_ttype = in_ttype_copy;
+        }
+
+        // The array_op pass leaves a GPU kernel's array operations alone,
+        // because the Metal and CUDA backends lower them directly. An
+        // elemental intrinsic there therefore still has its array
+        // arguments, and a helper instantiated from the element types
+        // would be handed the arrays it was written with.
+        void visit_GpuKernelFunction(const ASR::GpuKernelFunction_t& x) {
+            bool in_gpu_kernel_copy = in_gpu_kernel;
+            in_gpu_kernel = true;
+            ASR::CallReplacerOnExpressionsVisitor<
+                ReplaceIntrinsicFunctionsVisitor>::visit_GpuKernelFunction(x);
+            in_gpu_kernel = in_gpu_kernel_copy;
         }
 
         void call_replacer() {

--- a/src/libasr/pass/openmp.cpp
+++ b/src/libasr/pass/openmp.cpp
@@ -4091,11 +4091,75 @@ class ParallelRegionVisitor :
 
 };
 
+// A procedure whose dummy the pass turned into a pointer, so that the region
+// can reach it through the thread data, no longer takes what its callers pass.
+// Point a pointer at the actual and pass that: both are descriptors, so this
+// only says in ASR what the call already does.
+class RepointCallArguments: public PassUtils::PassVisitor<RepointCallArguments> {
+
+    public:
+
+        RepointCallArguments(Allocator& al_) : PassVisitor(al_, nullptr) {
+            pass_result.reserve(al, 1);
+        }
+
+        void repoint(ASR::symbol_t* name, ASR::call_arg_t* args, size_t n_args,
+                const Location& loc) {
+            ASR::symbol_t* callee = ASRUtils::symbol_get_past_external(name);
+            if( callee == nullptr || !ASR::is_a<ASR::Function_t>(*callee) ||
+                current_scope == nullptr ) {
+                return;
+            }
+            ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(callee);
+            if( func->n_args != n_args ) {
+                return;
+            }
+            ASRUtils::ASRBuilder b(al, loc);
+            for( size_t i = 0; i < n_args; i++ ) {
+                if( args[i].m_value == nullptr ||
+                    !ASR::is_a<ASR::Var_t>(*args[i].m_value) ||
+                    !ASR::is_a<ASR::Var_t>(*func->m_args[i]) ) {
+                    continue;
+                }
+                ASR::ttype_t* formal = ASRUtils::expr_type(func->m_args[i]);
+                ASR::ttype_t* actual = ASRUtils::expr_type(args[i].m_value);
+                if( formal == nullptr || actual == nullptr ||
+                    !ASRUtils::is_pointer(formal) ||
+                    ASRUtils::is_pointer(actual) ||
+                    !ASRUtils::is_array(actual) ) {
+                    continue;
+                }
+                std::string name_ = current_scope->get_unique_name(
+                    "__libasr_omp_arg_" + std::string(ASRUtils::symbol_name(
+                        ASR::down_cast<ASR::Var_t>(args[i].m_value)->m_v)));
+                ASR::expr_t* ptr = b.Variable(current_scope, name_,
+                    ASRUtils::duplicate_type(al, formal),
+                    ASR::intentType::Local);
+                pass_result.push_back(al, ASRUtils::STMT(
+                    ASR::make_Associate_t(al, loc, ptr, args[i].m_value)));
+                args[i].m_value = ptr;
+            }
+        }
+
+        void visit_SubroutineCall(const ASR::SubroutineCall_t& x) {
+            ASR::SubroutineCall_t& xx =
+                const_cast<ASR::SubroutineCall_t&>(x);
+            repoint(xx.m_name, xx.m_args, xx.n_args, x.base.base.loc);
+            if( pass_result.size() > 0 ) {
+                pass_result.push_back(al, ASRUtils::STMT(
+                    (ASR::asr_t*) &xx));
+                remove_original_stmt = true;
+            }
+        }
+};
+
 void pass_replace_openmp(Allocator &al, ASR::TranslationUnit_t &unit,
                             const PassOptions &pass_options) {
     if (pass_options.openmp) {
         ParallelRegionVisitor v(al, pass_options);
         v.visit_TranslationUnit(unit);
+        RepointCallArguments r(al);
+        r.visit_TranslationUnit(unit);
     }
     return;
 }

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -830,12 +830,81 @@ class ReplaceSubroutineCallsWithOptionalArgumentsVisitor : public PassUtils::Pas
         }
 };
 
+// A `procedure(iface)` entity holds a copy of the interface's FunctionType
+// rather than sharing it, so transforming the interface leaves the entity
+// declaring the argument list the procedure no longer has. A call through it
+// is then checked against a signature nothing has.
+class UpdateProcedureEntityTypes:
+    public ASR::BaseWalkVisitor<UpdateProcedureEntityTypes> {
+
+    public:
+
+        Allocator& al;
+        std::map<ASR::symbol_t*, std::vector<int32_t>>& transformed;
+        std::set<ASR::symbol_t*> retyped;
+
+        UpdateProcedureEntityTypes(Allocator& al_,
+            std::map<ASR::symbol_t*, std::vector<int32_t>>& transformed_) :
+            al{al_}, transformed{transformed_} {}
+
+        void visit_Variable(const ASR::Variable_t& x) {
+            ASR::Variable_t& xx = const_cast<ASR::Variable_t&>(x);
+            if( xx.m_type_declaration == nullptr ) {
+                return;
+            }
+            ASR::symbol_t* decl = ASRUtils::symbol_get_past_external(
+                xx.m_type_declaration);
+            if( decl == nullptr || !ASR::is_a<ASR::Function_t>(*decl) ||
+                transformed.find(decl) == transformed.end() ) {
+                return;
+            }
+            if( !ASR::is_a<ASR::FunctionType_t>(
+                    *ASRUtils::type_get_past_pointer(xx.m_type)) ) {
+                return;
+            }
+            ASR::ttype_t* signature = ASR::down_cast<ASR::Function_t>(
+                decl)->m_function_signature;
+            if( ASRUtils::is_pointer(xx.m_type) ) {
+                xx.m_type = ASRUtils::TYPE(ASR::make_Pointer_t(
+                    al, xx.base.base.loc, signature));
+            } else {
+                xx.m_type = signature;
+            }
+            retyped.insert((ASR::symbol_t*) &xx);
+        }
+
+        void visit_Function(const ASR::Function_t& x) {
+            ASR::BaseWalkVisitor<UpdateProcedureEntityTypes>::visit_Function(x);
+            // The signature repeats each dummy's type, so a dummy whose type
+            // just changed leaves the two disagreeing. Only those dummies:
+            // every other argument type belongs to the signature as it is.
+            ASR::FunctionType_t* ft = ASRUtils::get_FunctionType(x);
+            if( ft->n_arg_types != x.n_args ) {
+                return;
+            }
+            for( size_t i = 0; i < x.n_args; i++ ) {
+                if( !ASR::is_a<ASR::Var_t>(*x.m_args[i]) ) {
+                    continue;
+                }
+                ASR::symbol_t* arg = ASR::down_cast<ASR::Var_t>(
+                    x.m_args[i])->m_v;
+                if( arg == nullptr || retyped.find(arg) == retyped.end() ) {
+                    continue;
+                }
+                ft->m_arg_types[i] = ASR::down_cast<ASR::Variable_t>(
+                    arg)->m_type;
+            }
+        }
+};
+
 void pass_transform_optional_argument_functions(
     Allocator &al, ASR::TranslationUnit_t &unit,
     const LCompilers::PassOptions& /*pass_options*/) {
     std::map<ASR::symbol_t*, std::vector<int32_t>> sym2optionalargidx;
     TransformFunctionsWithOptionalArguments v(al, sym2optionalargidx);
     v.visit_TranslationUnit(unit);
+    UpdateProcedureEntityTypes u(al, sym2optionalargidx);
+    u.visit_TranslationUnit(unit);
     ReplaceFunctionCallsWithOptionalArgumentsVisitor w(al, sym2optionalargidx);
     w.visit_TranslationUnit(unit);
     ReplaceSubroutineCallsWithOptionalArgumentsVisitor y(al, sym2optionalargidx);

--- a/tests/asr/asr_generator.py
+++ b/tests/asr/asr_generator.py
@@ -1371,7 +1371,9 @@ def invalid_method_call_family(_rng):
 
 
 def invalid_method_call_rank(_rng):
-    return method_call_unit(array_type(INTEGER, [3]), INTEGER), \
+    # An array actual for a scalar dummy. The other direction is sequence
+    # association, which an explicit-shape dummy allows.
+    return method_call_unit(INTEGER, array_type(INTEGER, [3])), \
         "schema-invalid method call argument rank mismatch"
 
 

--- a/tests/asr/verify/call_scalar_to_assumed_shape.asr
+++ b/tests/asr/verify/call_scalar_to_assumed_shape.asr
@@ -14,8 +14,17 @@
               nil
               nil
               :Default
-              (Integer
-                4
+              (Array
+                (Integer
+                  4
+                )
+                [
+                  (dimension
+                    nil
+                    nil
+                  )
+                ]
+                :DescriptorArray
               )
               nil
               :Source
@@ -36,8 +45,17 @@
         "f"
         (FunctionType
           [
-            (Integer
-              4
+            (Array
+              (Integer
+                4
+              )
+              [
+                (dimension
+                  nil
+                  nil
+                )
+              ]
+              :DescriptorArray
             )
           ]
           nil
@@ -77,29 +95,8 @@
               nil
               nil
               :Default
-              (Array
               (Integer
-              4
-              )
-              [
-              (dimension
-              (IntegerConstant
-              1
-              (Integer
-              4
-              )
-              :Decimal
-              )
-              (IntegerConstant
-              3
-              (Integer
-              4
-              )
-              :Decimal
-              )
-              )
-              ]
-              :FixedSizeArray
+                4
               )
               nil
               :Source

--- a/tests/reference/asr-call_rank_mismatch-ec56b79.json
+++ b/tests/reference/asr-call_rank_mismatch-ec56b79.json
@@ -2,12 +2,12 @@
     "basename": "asr-call_rank_mismatch-ec56b79",
     "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/asr/verify/call_rank_mismatch.asr",
-    "infile_hash": "7ef4aaa5701841f285da361b9a1ed87458cfd44fa9fe8c978720a264",
+    "infile_hash": "51e7566cf1d4ad52349fef56f87faf99ee36a72df453cfaf36203300",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-call_rank_mismatch-ec56b79.stderr",
-    "stderr_hash": "97eb08bd3d34453e283b9f235ac919d5496a3440ceb729a34ada9369",
+    "stderr_hash": "1ff7be63498520065e6de7ce2682c78f0874c89292d7be06b382ea4c",
     "returncode": 2
 }

--- a/tests/reference/asr-call_rank_mismatch-ec56b79.stderr
+++ b/tests/reference/asr-call_rank_mismatch-ec56b79.stderr
@@ -1,5 +1,5 @@
-ASR verify pass error [asr.verify.call.actual_rank_matches_formal]: Actual argument type i32 does not match formal argument rank of type i32[:]
-   --> tests/asr/verify/call_rank_mismatch.asr:149:18
+ASR verify pass error [asr.verify.call.actual_rank_matches_formal]: Actual argument type i32[:] does not match formal argument rank of type i32
+   --> tests/asr/verify/call_rank_mismatch.asr:128:18
     |
-149 |                 (Var
+128 |                 (Var
     |                  ^^^ failed here

--- a/tests/reference/asr-call_scalar_to_assumed_shape-67253a1.json
+++ b/tests/reference/asr-call_scalar_to_assumed_shape-67253a1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-call_scalar_to_assumed_shape-67253a1",
+    "cmd": "lfortran --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/asr/verify/call_scalar_to_assumed_shape.asr",
+    "infile_hash": "a844fa77b9792084598143e8557255edf249797f9b9b3bde41a7a71e",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-call_scalar_to_assumed_shape-67253a1.stderr",
+    "stderr_hash": "895326823a20d4140a6f045be17b5fb47dfcd4aa2de345dfd4951e01",
+    "returncode": 2
+}

--- a/tests/reference/asr-call_scalar_to_assumed_shape-67253a1.stderr
+++ b/tests/reference/asr-call_scalar_to_assumed_shape-67253a1.stderr
@@ -1,0 +1,5 @@
+ASR verify pass error [asr.verify.call.actual_rank_matches_formal]: Actual argument type i32 does not match formal argument rank of type i32[:]
+   --> tests/asr/verify/call_scalar_to_assumed_shape.asr:125:18
+    |
+125 |                 (Var
+    |                  ^^^ failed here

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5357,6 +5357,10 @@ filename = "asr/verify/call_rank_mismatch.asr"
 asr = true
 
 [[test]]
+filename = "asr/verify/call_scalar_to_assumed_shape.asr"
+asr = true
+
+[[test]]
 filename = "asr/verify/call_allocatable_mismatch.asr"
 asr = true
 


### PR DESCRIPTION
Part 6 of 7 splitting #12523, which stays open as the combined branch.

Stack: #12528 → #12529 → **this** → #12531

Rebased onto `main` now that #12525, #12526 and #12527 are merged, so the
diff is down to three commits. #12528 and #12529 are still below it;
**review the last commit only.**

## Summary

The rules that compare an actual argument with the dummy it is passed to ran
only for ASR read from a file. Enforcing them everywhere shows both rules that
were stated too strongly and passes that leave a call disagreeing with the
procedure it calls.

### Rules, corrected against the standard

- an interface declaring no arguments constrains nothing — that is the shape
  `EXTERNAL f` and `procedure(), pointer` produce, and ASR cannot yet tell it
  from a genuinely argumentless interface;
- a `POINTER, INTENT(IN)` dummy also accepts a non-pointer actual that is a
  valid target for it (F2008 12.5.2.7). gfortran and flang both accept it and
  Caffeine relies on it;
- sequence association lets an explicit-shape or assumed-size dummy take an
  array element, which is a scalar (F2008 12.5.2.11); splpak and LAPACK both
  rely on it. An assumed-shape dummy takes its extents from the actual and an
  allocatable or pointer dummy carries the actual's own storage, so neither
  takes an element — new fixture `call_scalar_to_assumed_shape.asr` pins that
  boundary, and `call_rank_mismatch.asr` now takes the direction that stays
  invalid;
- the allocatable, pointer and rank rules describe how an implementation
  receives its arguments, so they apply where the procedure itself is in hand.
  Under `--implicit-interface` the frontend infers an interface from one call
  site rather than reading a declared one, and ASR carries nothing that
  separates the two, so another call site was measured against a guess (LAPACK).
  Separate compilation is unaffected: a module procedure reaches its caller
  with its body.

### Passes

- `transform_optional_argument_functions` replaces an optional dummy with a
  presence flag, rewriting the procedure and the interface it was declared
  from. A `procedure(iface)` entity holds a copy of that interface's
  FunctionType, so the copy was left declaring an argument list the procedure
  no longer has — 4 arguments against 6 in the Caffeine build.
- `openmp` rewrites a dummy into a pointer so the parallel region can reach it
  through the thread data, while callers still pass what the procedure used to
  declare. Point a pointer at the actual and pass that; both are descriptors,
  so this only states in ASR what the call already does.
- `array_op` deliberately leaves a GPU kernel's array operations alone, because
  the Metal and CUDA backends lower them directly. An elemental intrinsic there
  therefore still has its array arguments, and `intrinsic_function` instantiated
  a helper from the element types and handed it those arrays. Leave such an
  intrinsic alone in a kernel, the same way `array_op` does — but only when its
  arguments are still arrays, since the Metal tests rely on scalar-argument
  instantiation.

## Verification

`ctest` 13/13; `./run_tests.py`, `integration_tests -j16`,
`integration_tests -b llvm_omp` (81/81) and `integration_tests -b metal`
(195/195) all pass.

New integration tests `pointer_intent_in_01`, `sequence_assoc_01` and
`separate_compilation_51`; each fails on `main` and passes here.
