### PR TITLE
refactor: remove the ASR verify option that split the rules in two

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -813,7 +813,6 @@ int verify_asr_input(const std::string &infile,
     LCompilers::ASRVerifyOptions verify_options;
     verify_options.check_external = true;
     verify_options.require_main_program = true;
-    verify_options.check_standalone_rules = true;
     bool verified = LCompilers::asr_verify(
         *result.result, verify_options, diagnostics);
     std::cerr << diagnostics.render(lm, compiler_options);

--- a/src/lfortran/pipeline.cpp
+++ b/src/lfortran/pipeline.cpp
@@ -28,9 +28,6 @@ Result<ASR::TranslationUnit_t*> load_input_asr(
     ASRVerifyOptions verify_options;
     verify_options.check_external = true;
     verify_options.require_main_program = require_main_program;
-    // Standalone ASR has no pass in flight, so the rules that only
-    // hold for a complete program apply.
-    verify_options.check_standalone_rules = from_asr;
     if (!asr_verify(*result.result, verify_options, diagnostics)) {
         return Error();
     }

--- a/src/libasr/asr_verify.h
+++ b/src/libasr/asr_verify.h
@@ -6,12 +6,10 @@
 namespace LCompilers {
 
     struct ASRVerifyOptions {
+        // Whether ExternalSymbol targets may be followed. Off while a
+        // modfile is being deserialized, where they are not yet resolved.
         bool check_external = true;
         bool require_main_program = false;
-        // Rules that hold for a complete program as the frontend produces it,
-        // but not for the intermediate states an ASR pass moves through.
-        // Enabled for standalone ASR, which has no pass in flight.
-        bool check_standalone_rules = false;
     };
 
     // Verifies that ASR is correctly constructed and contains valid Fortran


### PR DESCRIPTION
Last of the 7 parts splitting #12523, and now the only one left: everything
below it is merged, so this is down to a single commit.

## Summary

`ASRVerifyOptions::check_standalone_rules` gated rules so they ran only for ASR
read from a file — never for ASR the frontend built or a pass rewrote. Every
rule added since the flag appeared was therefore dead in the compiler itself.

With the rules corrected and their producers fixed by #12526, #12527, #12528,
#12529 and #12530, nothing reads the option any more, so it goes.
`check_external` stays: a modfile being deserialized genuinely has no
ExternalSymbol targets to follow yet.

ASR verify is now identical wherever it runs.

Fixes #12513.

## Verification

Rebased onto `main` after #12530 merged. `ctest` 13/13, `./run_tests.py`
passes, `integration_tests -j16` passes.

#12523 stays open as the combined branch and can be closed once this lands.
