### PR TITLE
fix: support labeled END statement targets

### DIFF
--- a/ci/parser.yy.patch
+++ b/ci/parser.yy.patch
@@ -1,8 +1,8 @@
 diff --git a/src/lfortran/parser/parser.yy b/src/lfortran/parser/parser.yy
-index 7acf93adf7..1417518bcd 100644
+index 472b34b278..210669a300 100644
 --- a/src/lfortran/parser/parser.yy
 +++ b/src/lfortran/parser/parser.yy
-@@ -2581,177 +2581,4 @@ id_opt
+@@ -2625,177 +2625,4 @@ id_opt
  
  id
      : TK_NAME { $$ = SYMBOL($1, @$); }

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -625,6 +625,8 @@ RUN(NAME goto_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME goto_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME goto_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME goto_06 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME goto_07 LABELS gfortran llvm)
+RUN(NAME goto_08 LABELS gfortran llvm)
 
 RUN(NAME subroutines_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm mlir fortran)
 RUN(NAME subroutines_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp x86 wasm fortran)

--- a/integration_tests/goto_07.f90
+++ b/integration_tests/goto_07.f90
@@ -1,0 +1,49 @@
+module goto_07_m
+implicit none
+interface
+    module subroutine set_value(i)
+        integer, intent(out) :: i
+    end subroutine set_value
+end interface
+end module goto_07_m
+
+submodule(goto_07_m) goto_07_s
+contains
+module procedure set_value
+i = 4
+goto 40
+i = 0
+40 end procedure set_value
+end submodule goto_07_s
+
+program goto_07
+use goto_07_m, only: set_value
+implicit none
+interface
+    integer function f()
+    end function f
+end interface
+integer :: i
+
+i = 1
+call increment(i)
+if (i /= 2) error stop
+if (f() /= 3) error stop
+call set_value(i)
+if (i /= 4) error stop
+goto 10
+error stop
+10 end program goto_07
+
+subroutine increment(i)
+integer, intent(inout) :: i
+i = i + 1
+goto 20
+error stop
+20 end subroutine increment
+
+integer function f()
+f = 3
+goto 30
+f = 0
+30 end function f

--- a/integration_tests/goto_08.f90
+++ b/integration_tests/goto_08.f90
@@ -1,0 +1,3 @@
+goto 10
+error stop
+10 end

--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -14,7 +14,7 @@ see the documentation in that script for details and motivation.
 %param {LCompilers::LFortran::Parser &p}
 %locations
 %glr-parser
-%expect    213 // shift/reduce conflicts
+%expect    193 // shift/reduce conflicts
 %expect-rr 180 // reduce/reduce conflicts
 
 // Uncomment this to get verbose error messages
@@ -414,17 +414,22 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %type <ast> instantiate_symbol
 %type <ast> enum_decl
 %type <ast> program
-%type <ast> end_program
+%type <end_stmt> end_program
 %type <ast> id_opt
 %type <ast> subroutine
-%type <ast> end_subroutine
+%type <end_stmt> end_subroutine
 %type <ast> procedure
+%type <end_stmt> end_procedure
 %type <ast> sub_or_func
 %type <vec_ast> sub_args
 %type <vec_ast> id_or_star_list
 %type <ast> id_or_star
 %type <ast> function
-%type <ast> end_function
+%type <end_stmt> end_function
+%type <contains_end> program_contains_end
+%type <contains_end> subroutine_contains_end
+%type <contains_end> procedure_contains_end
+%type <contains_end> function_contains_end
 %type <ast> use_statement
 %type <ast> use_statement1
 %type <ast> use_symbol
@@ -537,6 +542,7 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %type <ast> decl_statement
 %type <vec_ast> statements
 %type <vec_ast> decl_statements
+%type <vec_ast> contains_block
 %type <vec_ast> contains_block_opt
 %type <vec_ast> sub_or_func_plus
 %type <vec_ast> sub_or_func_star
@@ -642,6 +648,9 @@ script_unit
     | statement          %dprec 7
     | expr sep           %dprec 8
     | KW_END_PROGRAM sep { $$ = SYMBOL($1, @$); }
+    | TK_LABEL KW_END sep { $$ = LABELED_END($1, $2, @$); }
+    | TK_LABEL KW_END_PROGRAM sep { $$ = LABELED_END($1, $2, @$); }
+    | TK_LABEL KW_ENDPROGRAM sep { $$ = LABELED_END($1, $2, @$); }
     ;
 
 // ----------------------------------------------------------------------------
@@ -906,15 +915,22 @@ proc_modifier
 
 
 program
-    : KW_PROGRAM id sep decl_statements
-        contains_block_opt end_program sep {
-      LLOC(@$, @6); $$ = PROGRAM($2, TRIVIA($3, $7, @$), $4, $5, $6, @$); }
+    : KW_PROGRAM id sep decl_statements program_contains_end sep {
+      LLOC(@$, @5); $$ = PROGRAM($2, TRIVIA($3, $6, @$), $4, $5, @$); }
+    ;
+
+program_contains_end
+    : end_program { $$ = CONTAINS_END1(p.m_a, $1); }
+    | contains_block end_program { $$ = CONTAINS_END2(p.m_a, $1, $2); }
     ;
 
 end_program
-    : KW_END_PROGRAM id_opt { $$ = $2; }
-    | KW_ENDPROGRAM id_opt { $$ = $2; }
-    | KW_END { $$ = nullptr; }
+    : KW_END_PROGRAM id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_ENDPROGRAM id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_END { $$ = END_STMT(nullptr, 0, @$); }
+    | TK_LABEL KW_END_PROGRAM id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_ENDPROGRAM id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_END { $$ = END_STMT(nullptr, $1, @$); }
     ;
 
 end_module
@@ -936,21 +952,30 @@ end_blockdata
     ;
 
 end_subroutine
-    : KW_END_SUBROUTINE id_opt { $$ = $2; }
-    | KW_ENDSUBROUTINE id_opt { $$ = $2; }
-    | KW_END { $$ = nullptr; }
+    : KW_END_SUBROUTINE id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_ENDSUBROUTINE id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_END { $$ = END_STMT(nullptr, 0, @$); }
+    | TK_LABEL KW_END_SUBROUTINE id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_ENDSUBROUTINE id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_END { $$ = END_STMT(nullptr, $1, @$); }
     ;
 
 end_procedure
-    : KW_END_PROCEDURE id_opt
-    | KW_ENDPROCEDURE id_opt
-    | KW_END
+    : KW_END_PROCEDURE id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_ENDPROCEDURE id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_END { $$ = END_STMT(nullptr, 0, @$); }
+    | TK_LABEL KW_END_PROCEDURE id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_ENDPROCEDURE id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_END { $$ = END_STMT(nullptr, $1, @$); }
     ;
 
 end_function
-    : KW_END_FUNCTION id_opt { $$ = $2; }
-    | KW_ENDFUNCTION id_opt { $$ = $2; }
-    | KW_END { $$ = nullptr; }
+    : KW_END_FUNCTION id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_ENDFUNCTION id_opt { $$ = END_STMT($2, 0, @$); }
+    | KW_END { $$ = END_STMT(nullptr, 0, @$); }
+    | TK_LABEL KW_END_FUNCTION id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_ENDFUNCTION id_opt { $$ = END_STMT($3, $1, @$); }
+    | TK_LABEL KW_END { $$ = END_STMT(nullptr, $1, @$); }
     ;
 
 end_associate
@@ -980,56 +1005,59 @@ end_team
 
 subroutine
     : KW_SUBROUTINE id sub_args bind_opt sep decl_statements
-        contains_block_opt
-        end_subroutine sep {
-            LLOC(@$, @8); $$ = SUBROUTINE($2, $3, $4, TRIVIA($5, $9, @$),
-                $6, $7, $8, @$); }
+        subroutine_contains_end sep {
+            LLOC(@$, @7); $$ = SUBROUTINE($2, $3, $4, TRIVIA($5, $8, @$),
+                $6, $7, @$); }
     | KW_SUBROUTINE id "{" id_list "}" sub_args bind_opt
     sep decl_statements end_subroutine sep {
             LLOC(@$, @10); $$ = TEMPLATED_SUBROUTINE($2, $4, $6, $7,
-                TRIVIA($8, $11, @$), $9, @$); }
+                TRIVIA($8, $11, @$), $9, $10, @$); }
     | fn_mod_plus KW_SUBROUTINE id sub_args bind_opt sep decl_statements
-        contains_block_opt
-        end_subroutine sep {
-            LLOC(@$, @9); $$ = SUBROUTINE1($1, $3, $4, $5, TRIVIA($6, $10, @$),
-                $7, $8, $9, @$); }
+        subroutine_contains_end sep {
+            LLOC(@$, @8); $$ = SUBROUTINE1($1, $3, $4, $5, TRIVIA($6, $9, @$),
+                $7, $8, @$); }
     | fn_mod_plus KW_SUBROUTINE id "{" id_list "}" sub_args bind_opt
     sep decl_statements end_subroutine sep {
             LLOC(@$, @11); $$ = TEMPLATED_SUBROUTINE1($1, $3, $5, $7, $8,
-                TRIVIA($9, $12, @$), $10, @$); }
+                TRIVIA($9, $12, @$), $10, $11, @$); }
+    ;
+
+subroutine_contains_end
+    : end_subroutine { $$ = CONTAINS_END1(p.m_a, $1); }
+    | contains_block end_subroutine {
+            $$ = CONTAINS_END2(p.m_a, $1, $2); }
     ;
 
 procedure
     : fn_mod_plus KW_PROCEDURE id sub_args sep decl_statements
-        contains_block_opt
-        end_procedure sep {
-            LLOC(@$, @9); $$ = PROCEDURE($1, $3, $4, TRIVIA($5, $9, @$),
+        procedure_contains_end sep {
+            LLOC(@$, @8); $$ = PROCEDURE($1, $3, $4, TRIVIA($5, $8, @$),
                 $6, $7, @$); }
+    ;
+
+procedure_contains_end
+    : end_procedure { $$ = CONTAINS_END1(p.m_a, $1); }
+    | contains_block end_procedure {
+            $$ = CONTAINS_END2(p.m_a, $1, $2); }
     ;
 
 function
     : KW_FUNCTION id "(" id_list_opt ")"
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @9); $$ = FUNCTION0($2, $4, nullptr, nullptr,
-                TRIVIA($6, $10, @$), $7, $8, $9, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @8); $$ = FUNCTION0($2, $4, nullptr, nullptr,
+                TRIVIA($6, $9, @$), $7, $8, @$); }
     | KW_FUNCTION id "(" id_list_opt ")"
         bind
         result_opt
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @11); $$ = FUNCTION0($2, $4, $7, $6, TRIVIA($8, $12, @$),
-                $9, $10, $11, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @10); $$ = FUNCTION0($2, $4, $7, $6, TRIVIA($8, $11, @$),
+                $9, $10, @$); }
     | KW_FUNCTION id "(" id_list_opt ")"
         result
         bind_opt
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @11); $$ = FUNCTION0($2, $4, $6, $7, TRIVIA($8, $12, @$),
-                $9, $10, $11, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @10); $$ = FUNCTION0($2, $4, $6, $7, TRIVIA($8, $11, @$),
+                $9, $10, @$); }
     | KW_FUNCTION id "{" id_list "}" "(" id_list_opt ")"
         result_opt
         bind_opt
@@ -1038,27 +1066,21 @@ function
             LLOC(@$, @13); $$ = TEMPLATED_FUNCTION0($2, $4, $7, $9, $10,
                 TRIVIA($11, $14, @$), $12, $13, @$); }
     | fn_mod_plus KW_FUNCTION id "(" id_list_opt ")"
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @10); $$ = FUNCTION($1, $3, $5, nullptr, nullptr,
-                TRIVIA($7, $11, @$), $8, $9, $10, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @9); $$ = FUNCTION($1, $3, $5, nullptr, nullptr,
+                TRIVIA($7, $10, @$), $8, $9, @$); }
     | fn_mod_plus KW_FUNCTION id "(" id_list_opt ")"
         bind
         result_opt
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @12); $$ = FUNCTION($1, $3, $5, $8, $7, TRIVIA($9, $13, @$),
-                $10, $11, $12, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @11); $$ = FUNCTION($1, $3, $5, $8, $7,
+                TRIVIA($9, $12, @$), $10, $11, @$); }
     | fn_mod_plus KW_FUNCTION id "(" id_list_opt ")"
         result
         bind_opt
-        sep decl_statements
-        contains_block_opt
-        end_function sep {
-            LLOC(@$, @12); $$ = FUNCTION($1, $3, $5, $7, $8, TRIVIA($9, $13, @$),
-                $10, $11, $12, @$); }
+        sep decl_statements function_contains_end sep {
+            LLOC(@$, @11); $$ = FUNCTION($1, $3, $5, $7, $8,
+                TRIVIA($9, $12, @$), $10, $11, @$); }
     | fn_mod_plus KW_FUNCTION id "{" id_list "}" "(" id_list_opt ")"
         result_opt
         bind_opt
@@ -1066,6 +1088,12 @@ function
         end_function sep {
             LLOC(@$, @14); $$ = TEMPLATED_FUNCTION($1, $3, $5, $8, $10, $11,
                 TRIVIA($12, $15, @$), $13, $14, @$); }
+    ;
+
+function_contains_end
+    : end_function { $$ = CONTAINS_END1(p.m_a, $1); }
+    | contains_block end_function {
+            $$ = CONTAINS_END2(p.m_a, $1, $2); }
     ;
 
 fn_mod_plus
@@ -1084,9 +1112,13 @@ fn_mod
     ;
 
 contains_block_opt
+    : contains_block
+    | %empty { LIST_NEW($$); }
+    ;
+
+contains_block
     : KW_CONTAINS sep sub_or_func_plus { $$ = $3; }
     | KW_CONTAINS sep { LIST_NEW($$); }
-    | %empty { LIST_NEW($$); }
     ;
 
 sub_or_func_star

--- a/src/lfortran/parser/parser_stype.h
+++ b/src/lfortran/parser/parser_stype.h
@@ -50,12 +50,25 @@ struct StrPrefix {
     Str* str_kind;  // Pointer to kind string allocated in Arena, or nullptr
 };
 
+struct EndStmt {
+    AST::ast_t *name;
+    int64_t label;
+    Location loc;
+};
+
+struct ContainsEnd {
+    Vec<AST::ast_t*> contains;
+    EndStmt end;
+};
+
 union YYSTYPE {
     int64_t n;
     Str string;
 
     IntSuffix int_suffix;
     StrPrefix str_prefix;
+    EndStmt end_stmt;
+    ContainsEnd *contains_end;
 
     AST::ast_t* ast;
     Vec<AST::ast_t*> vec_ast;

--- a/src/lfortran/parser/semantics.h
+++ b/src/lfortran/parser/semantics.h
@@ -28,6 +28,8 @@ using LCompilers::LFortran::FnArg;
 using LCompilers::LFortran::CoarrayArg;
 using LCompilers::LFortran::VarType;
 using LCompilers::LFortran::ArgStarKw;
+using LCompilers::LFortran::EndStmt;
+using LCompilers::LFortran::ContainsEnd;
 
 
 static inline expr_t* EXPR(const ast_t *f)
@@ -1702,12 +1704,58 @@ Vec<ast_t*> empty_sync(Allocator &al) {
 #define EVENT_WAIT_KW_ARG(id, e, l) make_AttrEventWaitKwArg_t(p.m_a, l, \
         name2char(id), EXPR(e))
 
+void append_labeled_end(Allocator &al, Vec<ast_t*> &decl_stmts,
+        int64_t end_label, const Location &end_loc) {
+    if (end_label == 0) return;
+    // A labeled END is a branch target immediately before implicit termination.
+    decl_stmts.push_back(al, make_Continue_t(
+        al, end_loc, end_label, nullptr));
+}
+
+// The END statement of a program unit: the name it optionally repeats, and
+// the label it optionally carries.
+EndStmt END_STMT(ast_t *name, int64_t label, const Location &loc) {
+    return {name, label, loc};
+}
+
+// A program unit's contains block together with its END statement. The two
+// are parsed as one symbol so that a label on the END does not have to be
+// distinguished from a label starting a statement in the contains block.
+// CONTAINS_END1 is the unit with no contains block, CONTAINS_END2 the one
+// that has it.
+ContainsEnd* CONTAINS_END1(Allocator &al, EndStmt end) {
+    ContainsEnd *result = al.make_new<ContainsEnd>();
+    result->contains.reserve(al, 0);
+    result->end = end;
+    return result;
+}
+
+ContainsEnd* CONTAINS_END2(Allocator &al, Vec<ast_t*> contains, EndStmt end) {
+    ContainsEnd *result = al.make_new<ContainsEnd>();
+    result->contains = contains;
+    result->end = end;
+    return result;
+}
+
+// A program unit's contains block and END statement reach these macros as one
+// value. Reading them here keeps their layout out of the grammar actions. The
+// field names live in these accessors rather than in the program-unit macros,
+// where a parameter of the same name would capture them.
+#define CE_CONTAINS(ce) ((ce)->contains)
+#define CE_END(ce) ((ce)->end)
+#define END_NAME(e) ((e).name)
+#define END_LABEL(e) ((e).label)
+#define END_LOC(e) ((e).loc)
+#define END_NAME_LOC(e) (END_NAME(e) ? &(END_NAME(e)->loc) : nullptr)
+
 ast_t* SUBROUTINE2(Allocator &al, const Location &l, char* a_name,
         arg_t* a_args, size_t n_args, decl_attribute_t** a_attributes,
         size_t n_attributes, bind_t* a_bind, trivia_t* a_trivia,
         Vec<ast_t*> decl_stmts, program_unit_t** a_contains, size_t n_contains,
         char** a_temp_args, size_t n_temp_args, Location* a_start_name,
-        Location* a_end_name, LCompilers::diag::Diagnostics &diag) {
+        Location* a_end_name, int64_t end_label, const Location &end_loc,
+        LCompilers::diag::Diagnostics &diag) {
+    append_labeled_end(al, decl_stmts, end_label, end_loc);
     check_decl_order(decl_stmts, DeclContext::Subprogram, diag);
     return make_Subroutine_t(al, l, a_name, a_args, n_args,
         a_attributes, n_attributes, a_bind, a_trivia,
@@ -1720,7 +1768,9 @@ ast_t* PROCEDURE2(Allocator &al, const Location &l, char* a_name,
         arg_t* a_args, size_t n_args, decl_attribute_t** a_attributes,
         size_t n_attributes, trivia_t* a_trivia, Vec<ast_t*> decl_stmts,
         program_unit_t** a_contains, size_t n_contains,
+        int64_t end_label, const Location &end_loc,
         LCompilers::diag::Diagnostics &diag) {
+    append_labeled_end(al, decl_stmts, end_label, end_loc);
     check_decl_order(decl_stmts, DeclContext::Subprogram, diag);
     return make_Procedure_t(al, l, a_name, a_args, n_args,
         a_attributes, n_attributes, a_trivia,
@@ -1728,9 +1778,10 @@ ast_t* PROCEDURE2(Allocator &al, const Location &l, char* a_name,
         a_contains, n_contains);
 }
 
-#define SUBROUTINE(name, args, bind, trivia, decl_stmts, contains, name_opt, l) \
+#define SUBROUTINE(name, args, bind, trivia, decl_stmts, ce, l) \
     SUBROUTINE2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "subroutine", p.diag), \
+        /*name*/ name2char_with_check(name, END_NAME(CE_END(ce)), l, "subroutine", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, args), \
         /*n_args*/ args.size(), \
         /*m_attributes*/ nullptr, \
@@ -1738,15 +1789,17 @@ ast_t* PROCEDURE2(Allocator &al, const Location &l, char* a_name,
         /*bind*/ bind_opt(bind), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), \
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
         /*temp_args*/ nullptr, \
         /*n_temp_args*/ 0, \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
-#define SUBROUTINE1(fn_mod, name, args, bind, trivia, decl_stmts, contains, \
-        name_opt, l) SUBROUTINE2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "subroutine", p.diag), \
+        /*end_name*/ END_NAME_LOC(CE_END(ce)), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
+#define SUBROUTINE1(fn_mod, name, args, bind, trivia, decl_stmts, ce, l) \
+    SUBROUTINE2(p.m_a, l, \
+        /*name*/ name2char_with_check(name, END_NAME(CE_END(ce)), l, "subroutine", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, args), \
         /*n_args*/ args.size(), \
         /*m_attributes*/ VEC_CAST(fn_mod, decl_attribute), \
@@ -1754,13 +1807,14 @@ ast_t* PROCEDURE2(Allocator &al, const Location &l, char* a_name,
         /*bind*/ bind_opt(bind), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), \
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
         /*temp_args*/ nullptr, \
         /*n_temp_args*/ 0, \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
-#define PROCEDURE(fn_mod, name, args, trivia, decl_stmts, contains, l) \
+        /*end_name*/ END_NAME_LOC(CE_END(ce)), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
+#define PROCEDURE(fn_mod, name, args, trivia, decl_stmts, ce, l) \
     PROCEDURE2(p.m_a, l, \
         /*name*/ name2char(name), \
         /*args*/ ARGS(p.m_a, args), \
@@ -1769,8 +1823,9 @@ ast_t* PROCEDURE2(Allocator &al, const Location &l, char* a_name,
         /*n_attributes*/ fn_mod.size(), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), p.diag)
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
 
 char *str_or_null(Allocator &al, const LCompilers::Str &s) {
     if (s.size() == 0) {
@@ -1786,7 +1841,9 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         trivia_t* a_trivia, Vec<ast_t*> decl_stmts,
         program_unit_t** a_contains, size_t n_contains,
         char** a_temp_args, size_t n_temp_args, Location* a_start_name,
-        Location* a_end_name, LCompilers::diag::Diagnostics &diag) {
+        Location* a_end_name, int64_t end_label, const Location &end_loc,
+        LCompilers::diag::Diagnostics &diag) {
+    append_labeled_end(al, decl_stmts, end_label, end_loc);
     check_decl_order(decl_stmts, DeclContext::Subprogram, diag);
     return make_Function_t(al, l, a_name, a_args, n_args,
         a_attributes, n_attributes, a_return_var, a_bind, a_trivia,
@@ -1796,8 +1853,9 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
 }
 
 #define FUNCTION(fn_type, name, args, return_var, bind, trivia, decl_stmts, \
-        contains, name_opt, l) FUNCTION2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "function", p.diag), \
+        ce, l) FUNCTION2(p.m_a, l, \
+        /*name*/ name2char_with_check(name, END_NAME(CE_END(ce)), l, "function", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, args), \
         /*n_args*/ args.size(), \
         /*m_attributes*/ VEC_CAST(fn_type, decl_attribute), \
@@ -1806,15 +1864,17 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*bind*/ bind_opt(bind), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), \
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
         /*temp_args*/ nullptr, \
         /*n_temp_args*/ 0, \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
-#define FUNCTION0(name, args, return_var, bind, trivia, decl_stmts, contains, \
-        name_opt, l) FUNCTION2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "function", p.diag), \
+        /*end_name*/ END_NAME_LOC(CE_END(ce)), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
+#define FUNCTION0(name, args, return_var, bind, trivia, decl_stmts, ce, l) \
+    FUNCTION2(p.m_a, l, \
+        /*name*/ name2char_with_check(name, END_NAME(CE_END(ce)), l, "function", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, args), \
         /*n_args*/ args.size(), \
         /*m_attributes*/ nullptr, \
@@ -1823,16 +1883,19 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*bind*/ bind_opt(bind), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), \
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
         /*temp_args*/ nullptr, \
         /*n_temp_args*/ 0, \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
+        /*end_name*/ END_NAME_LOC(CE_END(ce)), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
 
 #define TEMPLATED_FUNCTION(fn_type, name, temp_args, fn_args, return_var, \
-        bind, trivia, decl_stmts, name_opt, l) FUNCTION2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "function", p.diag), \
+        bind, trivia, decl_stmts, end, l) \
+    FUNCTION2(p.m_a, l, \
+        /*name*/ name2char_with_check(name, END_NAME(end), l, "function", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, fn_args), \
         /*n_args*/ fn_args.size(), \
         /*m_attributes*/ VEC_CAST(fn_type, decl_attribute), \
@@ -1846,10 +1909,13 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*temp_args*/ REDUCE_ARGS(p.m_a, temp_args), \
         /*n_temp_args*/ temp_args.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
+        /*end_name*/ END_NAME_LOC(end), \
+        END_LABEL(end), END_LOC(end), p.diag)
 #define TEMPLATED_FUNCTION0(name, temp_args, fn_args, return_var, bind, \
-        trivia, decl_stmts, name_opt, l) FUNCTION2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "function", p.diag), \
+        trivia, decl_stmts, end, l) \
+    FUNCTION2(p.m_a, l, \
+        /*name*/ name2char_with_check(name, END_NAME(end), l, "function", \
+            p.diag), \
         /*args*/ ARGS(p.m_a, fn_args), \
         /*n_args*/ fn_args.size(), \
         /*m_attributes*/ nullptr, \
@@ -1863,9 +1929,10 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*temp_args*/ REDUCE_ARGS(p.m_a, temp_args), \
         /*n_temp_args*/ temp_args.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name_opt->loc), p.diag)
+        /*end_name*/ END_NAME_LOC(end), \
+        END_LABEL(end), END_LOC(end), p.diag)
 #define TEMPLATED_SUBROUTINE(name, temp_args, fn_args, bind, trivia, \
-        decl_stmts, l) SUBROUTINE2(p.m_a, l, \
+        decl_stmts, end, l) SUBROUTINE2(p.m_a, l, \
         /*name*/ name2char(name), \
         /*args*/ ARGS(p.m_a, fn_args), \
         /*n_args*/ fn_args.size(), \
@@ -1879,9 +1946,9 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*temp_args*/ REDUCE_ARGS(p.m_a, temp_args), \
         /*n_temp_args*/ temp_args.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name->loc), p.diag)
+        /*end_name*/ &(name->loc), END_LABEL(end), END_LOC(end), p.diag)
 #define TEMPLATED_SUBROUTINE1(fn_type, name, temp_args, fn_args, bind, \
-        trivia, decl_stmts, l) SUBROUTINE2(p.m_a, l, \
+        trivia, decl_stmts, end, l) SUBROUTINE2(p.m_a, l, \
         /*name*/ name2char(name), \
         /*args*/ ARGS(p.m_a, fn_args), \
         /*n_args*/ fn_args.size(), \
@@ -1895,13 +1962,15 @@ ast_t* FUNCTION2(Allocator &al, const Location &l, char* a_name,
         /*temp_args*/ REDUCE_ARGS(p.m_a, temp_args), \
         /*n_temp_args*/ temp_args.size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ &(name->loc), p.diag)
+        /*end_name*/ &(name->loc), END_LABEL(end), END_LOC(end), p.diag)
 
 ast_t* PROGRAM2(Allocator &al, const Location &a_loc, char* a_name,
         trivia_t* a_trivia, Vec<ast_t*> decl_stmts, program_unit_t** a_contains,
         size_t n_contains, Location *start_name, Location *end_name,
+        int64_t end_label, const Location &end_loc,
         LCompilers::diag::Diagnostics &diag) {
 
+append_labeled_end(al, decl_stmts, end_label, end_loc);
 check_decl_order(decl_stmts, DeclContext::Program, diag);
 
 return make_Program_t(al, a_loc,
@@ -1917,16 +1986,22 @@ return make_Program_t(al, a_loc,
 }
 
 
-#define PROGRAM(name, trivia, decl_stmts, contains, name_opt, l) \
+#define PROGRAM(name, trivia, decl_stmts, ce, l) \
     PROGRAM2(p.m_a, l, \
-        /*name*/ name2char_with_check(name, name_opt, l, "program", p.diag), \
+        /*name*/ name2char_with_check(name, END_NAME(CE_END(ce)), l, "program", \
+            p.diag), \
         trivia_cast(trivia), \
         decl_stmts, \
-        /*contains*/ CONTAINS(contains), \
-        /*n_contains*/ contains.size(), \
+        /*contains*/ CONTAINS(CE_CONTAINS(ce)), \
+        /*n_contains*/ CE_CONTAINS(ce).size(), \
         /*start_name*/ &(name->loc), \
-        /*end_name*/ (name_opt) ? &((name_opt)->loc) : nullptr, p.diag)
+        /*end_name*/ END_NAME_LOC(CE_END(ce)), \
+        END_LABEL(CE_END(ce)), END_LOC(CE_END(ce)), p.diag)
 #define RESULT(x) p.result.push_back(p.m_a, x)
+// A labeled END terminating an implicit main program. The label is a branch
+// target immediately before termination, and the END still ends the unit.
+#define LABELED_END(label, end_kw, l) \
+    (RESULT(make_Continue_t(p.m_a, l, label, nullptr)), SYMBOL(end_kw, l))
 
 #define STMT_NAME(id_first, id_last, stmt) \
         stmt; \


### PR DESCRIPTION
Fortran allows executable END PROGRAM, END SUBROUTINE, END FUNCTION, and END PROCEDURE statements to carry labels and serve as branch targets. LFortran rejected labels before these terminators, causing valid GOTO statements to fail during parsing.

Parse and preserve END labels, then lower them to terminal branch targets immediately before implicit program-unit termination. Handle both explicit program units and implicit main programs without introducing grammar conflicts, and add integration coverage for each executable END form.

Fixes #12516.