### PR TITLE
fix: ICE on EQUIVALENCE between two COMMON block variables

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7098,6 +7098,20 @@ public:
                                         bool eq1_is_common = ASR::is_a<ASR::StructInstanceMember_t>(*asr_eq1);
                                         bool eq2_is_common = ASR::is_a<ASR::StructInstanceMember_t>(*asr_eq2);
 
+                                        if (eq1_is_common && eq2_is_common) {
+                                            ASR::symbol_t* member = ASRUtils::symbol_get_past_external(
+                                                ASR::down_cast<ASR::StructInstanceMember_t>(asr_eq2)->m_m);
+                                            ASR::symbol_t* common_block = ASR::down_cast<ASR::symbol_t>(
+                                                ASRUtils::symbol_parent_symtab(member)->asr_owner);
+                                            diag.add(diag::Diagnostic(
+                                                "equivalence for '" + std::string(ASRUtils::symbol_name(member))
+                                                + "' conflicts with the ordering of COMMON block '"
+                                                + ASRUtils::symbol_name(common_block) + "'",
+                                                diag::Level::Error, diag::Stage::Semantic, {
+                                                    diag::Label("", {asr_eq1->base.loc, asr_eq2->base.loc})}));
+                                            throw SemanticAbort();
+                                        }
+
                                         ASR::expr_t* source_expr;
                                         ASR::expr_t* pointer_expr;
                                         ASR::Variable_t* pointer_var;

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -7099,16 +7099,27 @@ public:
                                         bool eq2_is_common = ASR::is_a<ASR::StructInstanceMember_t>(*asr_eq2);
 
                                         if (eq1_is_common && eq2_is_common) {
-                                            ASR::symbol_t* member = ASRUtils::symbol_get_past_external(
+                                            ASR::symbol_t* member1 = ASRUtils::symbol_get_past_external(
+                                                ASR::down_cast<ASR::StructInstanceMember_t>(asr_eq1)->m_m);
+                                            ASR::symbol_t* member2 = ASRUtils::symbol_get_past_external(
                                                 ASR::down_cast<ASR::StructInstanceMember_t>(asr_eq2)->m_m);
                                             ASR::symbol_t* common_block = ASR::down_cast<ASR::symbol_t>(
-                                                ASRUtils::symbol_parent_symtab(member)->asr_owner);
+                                                ASRUtils::symbol_parent_symtab(member2)->asr_owner);
+                                            std::string explanation =
+                                                "\n\n'" + std::string(ASRUtils::symbol_name(member1))
+                                                + "' and '" + ASRUtils::symbol_name(member2)
+                                                + "' are both declared in COMMON block '"
+                                                + ASRUtils::symbol_name(common_block) + "'. "
+                                                + "The COMMON statement already places them at fixed positions "
+                                                + "in memory. EQUIVALENCE is not allowed to override that layout."
+                                                + "\n\nHint: you may EQUIVALENCE a non-COMMON variable to a COMMON "
+                                                + "variable (this extends the common block), but never two "
+                                                + "variables that are already in a COMMON block.";
                                             diag.add(diag::Diagnostic(
-                                                "equivalence for '" + std::string(ASRUtils::symbol_name(member))
-                                                + "' conflicts with the ordering of COMMON block '"
-                                                + ASRUtils::symbol_name(common_block) + "'",
+                                                "cannot make two COMMON variables share the same storage",
                                                 diag::Level::Error, diag::Stage::Semantic, {
-                                                    diag::Label("", {asr_eq1->base.loc, asr_eq2->base.loc})}));
+                                                    diag::Label(explanation,
+                                                        {asr_eq1->base.loc, asr_eq2->base.loc})}));
                                             throw SemanticAbort();
                                         }
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -966,6 +966,12 @@ program continue_compilation_1
         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
         print *, values(1)
     end subroutine
+
+    subroutine equivalence_common_1()
+        real :: a, b
+        common /c1/ a, b
+        equivalence (a, b)
+    end subroutine
 end program
 
 ! A syntax error inside a module makes the parser skip the erroneous

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "cfd37b383e6f5875fdce5a86041d9f20e41f0c5b9de2628146db3f56",
+    "infile_hash": "b6d7714c8175608f98b1022fdd90c300a7f850c4d0d960d1beb0765c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "2745da5982ca014957f4ed3795ea6c781ead17bb69870d980b248180",
+    "stderr_hash": "33cc245d2556844d3e50324b5afaef18797e31025c11b9713a39c895",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "33cc245d2556844d3e50324b5afaef18797e31025c11b9713a39c895",
+    "stderr_hash": "70e622591603f8d69e8e5ff35d18303acffc630219b2ebe3b67f3526",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -538,11 +538,15 @@ semantic error: equivalence between a common block variable and this array eleme
 949 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
-semantic error: equivalence for 'b' conflicts with the ordering of COMMON block 'c1'
+semantic error: cannot make two COMMON variables share the same storage
    --> tests/errors/continue_compilation_1.f90:973:22
     |
 973 |         equivalence (a, b)
     |                      ^  ^ 
+
+'a' and 'b' are both declared in COMMON block 'c1'. The COMMON statement already places them at fixed positions in memory. EQUIVALENCE is not allowed to override that layout.
+
+Hint: you may EQUIVALENCE a non-COMMON variable to a COMMON variable (this extends the common block), but never two variables that are already in a COMMON block.
 
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,9 +11,9 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-   --> tests/errors/continue_compilation_1.f90:978:7
+   --> tests/errors/continue_compilation_1.f90:984:7
     |
-978 |       foo    end type t_recovery
+984 |       foo    end type t_recovery
     |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
@@ -538,6 +538,12 @@ semantic error: equivalence between a common block variable and this array eleme
 949 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
+semantic error: equivalence for 'b' conflicts with the ordering of COMMON block 'c1'
+   --> tests/errors/continue_compilation_1.f90:973:22
+    |
+973 |         equivalence (a, b)
+    |                      ^  ^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |
@@ -545,9 +551,9 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-   --> tests/errors/continue_compilation_1.f90:981:7
+   --> tests/errors/continue_compilation_1.f90:987:7
     |
-981 |       class(t_recovery), intent(in) :: self
+987 |       class(t_recovery), intent(in) :: self
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared


### PR DESCRIPTION
Fixes #12524