### PR TITLE
CI: Update Caffeine snapshot and activate integration testing

### DIFF
--- a/ci/test_third_party_codes.sh
+++ b/ci/test_third_party_codes.sh
@@ -154,15 +154,19 @@ time_section "🧪 Testing caffeine" '
   # inject ISO_Fortran_binding.h into the C include path
   export CPPFLAGS="-I$(lfortran --print-c-include-dir)"
 
-  # Release 0.8.0
-  git checkout 0.8.0
-  assert_git_commit 9a4a818d9617bc88890a9fdc9fd6e66959c7fad0
+  # checkout a snapshot more recent than the current release
+  git checkout 341a507bfd61c464fe6db4b8185520e6461e5a9b
 
   # Now build and test caffeine with LFortran
   export GASNET_CONFIGURE_ARGS="--enable-rpath --enable-debug" 
   ./install.sh --yes --prefix=$PWD/inst --verbose
+
+  # Execute Caffeine unit tests
   export CAF_IMAGES=4
   ./run-fpm.sh test --verbose 
+
+  # Execute Caffeine end-to-end test (exercises LFortran+PRIF integration)
+  ./run-fpm.sh run --verbose
 
   print_success "Done with caffeine"
   cd ..


### PR DESCRIPTION
Caffeine includes an end-to-end test that exercises the LFortran+PRIF integration.

Activate this test within LFortran's Exhaustive third-party test of Caffeine, to help ensure we detect any potential regressions in LFortran's coarray pass that manages the PRIF integration.