### PR TITLE
fix: convert unused team_type variables in the coarray pass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4795,6 +4795,7 @@ RUN(NAME coarrays_36 EXTRA_ARGS --coarray=true)
 RUN(NAME coarrays_37 EXTRA_ARGS --coarray=true)
 RUN(NAME coarrays_38 EXTRA_ARGS --coarray=true)
 RUN(NAME coarrays_39 EXTRA_ARGS --coarray=true NUM_IMAGES=6)
+RUN(NAME coarrays_40 EXTRA_ARGS --coarray=true)
 
 RUN(NAME gpu_metal_01 LABELS gfortran llvm metal)
 RUN(NAME gpu_metal_02 LABELS gfortran llvm metal)

--- a/integration_tests/coarrays_40.f90
+++ b/integration_tests/coarrays_40.f90
@@ -1,0 +1,13 @@
+program coarrays_40
+  ! Unused team_type variables must not break compilation (issue #12538)
+  use iso_fortran_env, only: team_type
+  implicit none
+
+  type(team_type) :: subteam
+  type(team_type) :: default_team
+  integer :: n
+
+  n = num_images()
+  form team(1, subteam)
+  if (num_images() /= n) error stop 1
+end program coarrays_40

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -937,6 +937,27 @@ class PRIFInterface {
             return struct_sym;
         }
 
+        // FORM TEAM only names the used entity; unused team_type variables
+        // in the translation unit must be rewritten before the import is dropped.
+        void convert_vars_of_type(ASR::symbol_t *from_def, ASR::symbol_t *to_decl,
+                                  const Location &loc, SymbolTable *symtab) {
+            for (auto &item : symtab->get_scope()) {
+                ASR::symbol_t *sym = item.second;
+                if (ASR::is_a<ASR::Variable_t>(*sym)) {
+                    ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(sym);
+                    if (var->m_type_declaration &&
+                            ASRUtils::symbol_get_past_external(var->m_type_declaration)
+                                == from_def) {
+                        var->m_type_declaration = to_decl;
+                        var->m_type = ASRUtils::make_StructType_t_util(al, loc, to_decl, true);
+                    }
+                }
+                if (SymbolTable *child = ASRUtils::symbol_symtab(sym)) {
+                    convert_vars_of_type(from_def, to_decl, loc, child);
+                }
+            }
+        }
+
         void convert_team_type(const Location &loc, ASR::expr_t *team) {
             if (team && ASR::is_a<ASR::Var_t>(*team)) {
                 ASR::symbol_t *team_sym = ASR::down_cast<ASR::Var_t>(team)->m_v;
@@ -946,14 +967,17 @@ class PRIFInterface {
                 ASR::symbol_t *prif_decl = get_or_create_prif_team_type_struct(loc);
                 if (team_var->m_type_declaration != prif_decl) {
                     ASR::symbol_t *orig_decl = team_var->m_type_declaration;
-                    team_var->m_type_declaration = prif_decl;
-                    team_var->m_type = ASRUtils::make_StructType_t_util(al, loc, prif_decl, true);
                     LCOMPILERS_ASSERT(orig_decl != nullptr);
-                    SymbolTable *parent_symtab = ASRUtils::symbol_parent_symtab(orig_decl);
-                    LCOMPILERS_ASSERT(parent_symtab != nullptr);
-                    std::string sym_name = std::string(ASRUtils::symbol_name(orig_decl));
-                    if (parent_symtab->get_symbol(sym_name)) {
-                        parent_symtab->erase_symbol(sym_name);
+                    ASR::symbol_t *orig_def = ASRUtils::symbol_get_past_external(orig_decl);
+                    convert_vars_of_type(orig_def, prif_decl, loc, unit.m_symtab);
+                    // Drop the import, not the type defined in iso_fortran_env.
+                    if (ASR::is_a<ASR::ExternalSymbol_t>(*orig_decl)) {
+                        SymbolTable *parent_symtab = ASRUtils::symbol_parent_symtab(orig_decl);
+                        LCOMPILERS_ASSERT(parent_symtab != nullptr);
+                        std::string sym_name = std::string(ASRUtils::symbol_name(orig_decl));
+                        if (parent_symtab->get_symbol(sym_name) == orig_decl) {
+                            parent_symtab->erase_symbol(sym_name);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
FORM TEAM only rewrote the used team_type entity, then dropped the import. Unused team_type variables still named that declaration, so ASR verify failed. Convert every remaining team_type variable before dropping the import.

Fixes #12538