### PR TITLE
fix: treat `/` inside parentheses in fixed-form COMMON as division

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -472,6 +472,7 @@ RUN(NAME fixed_form_stmt_func_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GF
 RUN(NAME fixed_form_do_name_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --use-loop-variable-after-loop GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_where_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_module_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_common_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --implicit-typing GFORTRAN_ARGS -ffixed-form)
 RUN(NAME print_arr_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran mlir)
 RUN(NAME print_arr_08 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/fixed_form_common_01.f90
+++ b/integration_tests/fixed_form_common_01.f90
@@ -1,0 +1,9 @@
+      PROGRAM FIXED_FORM_COMMON_01
+      COMMON /C/ A(20/4)
+      A(1) = 2.5
+      A(5) = 3.5
+      IF (SIZE(A) /= 5) ERROR STOP
+      IF (ABS(A(1) - 2.5) > 1.0E-6) ERROR STOP
+      IF (ABS(A(5) - 3.5) > 1.0E-6) ERROR STOP
+      PRINT *, A(1), A(5)
+      END

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1077,8 +1077,16 @@ struct FixedFormRecursiveDescent {
     void lex_common_block_part(unsigned char *&cur) {
         // tokenize / block_1 / a, b
         bool first_slash = true;
+        int paren_depth = 0;
         while(!next_is_eol(cur)) {
-            if (*(cur+1) == '/' && !first_slash) {
+            if (*cur == '(') {
+                paren_depth++;
+            } else if (*cur == ')') {
+                if (paren_depth > 0) paren_depth--;
+            }
+            // A '/' inside parentheses is a division operator (e.g. in an
+            // array dimension like A(20/4)), not a common block delimiter.
+            if (paren_depth == 0 && *(cur+1) == '/' && !first_slash) {
                 if (*cur != ',') {
                     cur+=1;
                 }
@@ -1087,7 +1095,7 @@ struct FixedFormRecursiveDescent {
                 tokenize_until(end);
                 t.cur = cur;
                 break;
-            } else if (*(cur+1) == '/') {
+            } else if (paren_depth == 0 && *(cur+1) == '/') {
                 first_slash = false;
             }
             cur++;


### PR DESCRIPTION
## Summary

In fixed form, the COMMON statement tokenizer treated every `/` as a common
block delimiter. A `/` inside parentheses is a division operator, so a
declaration such as

```fortran
      COMMON /C/ A(20/4)
```

was mis-tokenized and failed to compile.

## Scope

`src/lfortran/parser/fixedform_tokenizer.cpp`: track parenthesis depth in
`lex_common_block_part` and only treat `/` at depth 0 as a delimiter.

## Verification

New integration test `fixed_form_common_01` (labels `gfortran llvm`), which
fails to compile before this change (syntax error) and compiles and runs after
it; gfortran agrees.

Local runs on this branch:

- `./run_tests.py --no-llvm` — TESTS PASSED
- `integration_tests/run_tests.py -b llvm` — 100% passed, 0 failed out of 3861
- `integration_tests/run_tests.py -b gfortran` — 100% passed, 0 failed out of 3923

## Rationale

Extracted from #12309, which bundled several unrelated COMMON fixes. This one
is parser-only and independent of the rest, so it can be reviewed and merged on
its own.
