### PR TITLE
fix: point COMMON block char substring StringItem at struct member

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3915,6 +3915,7 @@ RUN(NAME common_39 LABELS gfortran llvm)
 RUN(NAME common_40 LABELS gfortran llvm)
 RUN(NAME common_41 LABELS gfortran llvm)
 RUN(NAME common_substring_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME common_substring_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME statement_01 LABELS llvm gfortran llvmImplicit)
 RUN(NAME statement_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/common_substring_02.f90
+++ b/integration_tests/common_substring_02.f90
@@ -1,0 +1,20 @@
+! Reproducer: COMMON block CHARACTER substring using the same variable for
+! both bounds, e.g. ISPARS(K:K), collapses to a StringItem which must still
+! point to the COMMON struct member (reduced from XFOIL src/xfoil.f).
+program common_substring_02
+    implicit none
+    character(len=80) :: ispars
+    integer :: k
+    common /cc01/ ispars
+
+    ispars = "ABCDE"
+    k = 3
+
+    ! ispars(k:k) with identical bounds becomes a single-character StringItem
+    if (ispars(k:k) /= "C") error stop "single-char substring mismatch"
+
+    k = 1
+    if (ispars(k:k) /= "A") error stop "single-char substring mismatch 2"
+
+    print *, "PASS: common_substring_02"
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -10960,8 +10960,10 @@ public:
                         ASRUtils::TYPE(ASR::make_Integer_t(al, type->base.loc, 4)))),
                         ASR::string_length_kindType::ExpressionLength,
                     ASR::string_physical_typeType::DescriptorString));
+                // Replace COMMON block variable with struct member
+                ASR::expr_t* string_var = replace_with_common_block_variables(v_Var);
                 return ASR::make_StringItem_t(al, loc,
-                    v_Var, args.p[0].m_right, char_type, arr_ref_val);
+                    string_var, args.p[0].m_right, char_type, arr_ref_val);
             } else if ( ASRUtils::is_character(*root_v_type) &&
                         ASRUtils::is_array(root_v_type) &&
                         n_subargs > 0) {


### PR DESCRIPTION
## Summary

A single-character substring of a COMMON block `CHARACTER` variable — e.g.
`ISPARS(K:K)`, where both bounds are the same expression — collapses to a
`StringItem` in the semantic phase. Unlike the neighbouring substring and array
paths, the `StringItem` was built over the bare variable instead of over the
COMMON block struct member, so the reference did not resolve to the shared
common storage and the program failed to compile.

## Scope

`src/lfortran/semantics/ast_common_visitor.h`: route the `StringItem` base
expression through `replace_with_common_block_variables`, the helper the
surrounding cases already use.

## Verification

New integration test `common_substring_02` (labels `gfortran llvm llvm_wasm
llvm_wasm_emcc`), reduced from XFOIL's `src/xfoil.f`. It fails to compile
before this change and passes after; gfortran agrees.

Local runs on this branch:

- `./run_tests.py --no-llvm` — TESTS PASSED
- `integration_tests/run_tests.py -b llvm` — 100% passed, 0 failed out of 3861
- `integration_tests/run_tests.py -b gfortran` — 100% passed, 0 failed out of 3923

## Rationale

Extracted from #12309. This is a one-line semantic fix, independent of the
other COMMON changes in that PR.
