### PR TITLE
refactor: centralize inline character struct member detection

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4302,6 +4302,46 @@ static inline ASR::String_t* get_string_type(ASR::expr_t* s){
 }
 
 /*
+    A character member of a bind(C) or SEQUENCE struct is laid out inline in
+    the struct (a flat byte blob at a fixed offset) instead of behind a string
+    descriptor, so that the struct matches the C/Fortran storage layout.
+    Pointer and allocatable members keep their descriptor.
+*/
+static inline bool is_inline_character_struct_member(
+        ASR::Struct_t* struct_type, ASR::ttype_t* member_type) {
+    return (struct_type->m_abi == ASR::abiType::BindC
+            || struct_type->m_is_sequence)
+        && !ASR::is_a<ASR::Pointer_t>(*member_type)
+        && !ASR::is_a<ASR::Allocatable_t>(*member_type)
+        && ASR::is_a<ASR::String_t>(*type_get_past_array(member_type));
+}
+
+// Same as above, for an expression that may be a struct member access.
+static inline bool is_inline_character_struct_member(ASR::expr_t* expr) {
+    if (!ASR::is_a<ASR::StructInstanceMember_t>(*expr)) {
+        return false;
+    }
+    ASR::StructInstanceMember_t* sim =
+        ASR::down_cast<ASR::StructInstanceMember_t>(expr);
+    ASR::symbol_t* member_sym = symbol_get_past_external(sim->m_m);
+    if (!ASR::is_a<ASR::Variable_t>(*member_sym)) {
+        return false;
+    }
+    ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(member_sym);
+    if (!member_var->m_parent_symtab
+            || !member_var->m_parent_symtab->asr_owner) {
+        return false;
+    }
+    ASR::symbol_t* struct_sym = symbol_get_past_external(
+        ASR::down_cast<ASR::symbol_t>(member_var->m_parent_symtab->asr_owner));
+    if (!ASR::is_a<ASR::Struct_t>(*struct_sym)) {
+        return false;
+    }
+    return is_inline_character_struct_member(
+        ASR::down_cast<ASR::Struct_t>(struct_sym), sim->m_type);
+}
+
+/*
     Checks if type is a string.
     If array of strings, Returns false.
 */

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -949,35 +949,15 @@ public:
             ASRUtils::extract_type(expr_type(str_expr)));
         this->visit_expr_load_wrapper(str_expr, 0);
 
-        // For bind(C)/SEQUENCE struct character members, the LLVM type is
-        // [len x i8]* even though the ASR physical type says DescriptorString.
-        ASR::string_physical_typeType phys_type = str->m_physical_type;
         int64_t bindc_inline_len = 0;
-        if (phys_type == ASR::DescriptorString && tmp->getType()->isPointerTy()) {
-            // Check if this is a non-pointer character member of a bind(C)/SEQUENCE struct
-            if (ASR::is_a<ASR::StructInstanceMember_t>(*str_expr)) {
-                ASR::StructInstanceMember_t* sim =
-                    ASR::down_cast<ASR::StructInstanceMember_t>(str_expr);
-                ASR::symbol_t* member_sym = ASRUtils::symbol_get_past_external(sim->m_m);
-                ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(member_sym);
-                ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(
-                    member_var->m_parent_symtab->asr_owner);
-                struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
-                if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
-                    (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC ||
-                     ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence)) {
-                    ASR::ttype_t* mem_type = sim->m_type;
-                    if (!ASR::is_a<ASR::Pointer_t>(*mem_type) &&
-                        !ASR::is_a<ASR::Allocatable_t>(*mem_type)) {
-                        phys_type = ASR::CChar;
-                        bindc_inline_len = 1;
-                        if (str->m_len) {
-                            ASRUtils::extract_value(str->m_len, bindc_inline_len);
-                        }
-                        if (bindc_inline_len < 1) bindc_inline_len = 1;
-                    }
-                }
+        if (str->m_physical_type == ASR::DescriptorString
+                && tmp->getType()->isPointerTy()
+                && ASRUtils::is_inline_character_struct_member(str_expr)) {
+            bindc_inline_len = 1;
+            if (str->m_len) {
+                ASRUtils::extract_value(str->m_len, bindc_inline_len);
             }
+            if (bindc_inline_len < 1) bindc_inline_len = 1;
         }
 
         std::pair<llvm::Value*, llvm::Value*> data_and_length;
@@ -989,7 +969,7 @@ public:
                 context, llvm::APInt(64, bindc_inline_len));
             return data_and_length;
         }
-        switch (phys_type)
+        switch (str->m_physical_type)
         {
             case ASR::DescriptorString:{
                 if (!tmp->getType()->isPointerTy()) {
@@ -6905,13 +6885,9 @@ public:
                 }  else if(ASRUtils::is_string_only(symbol_type) && !is_intent_out) {
                     // Skip string descriptor setup for bind(C)/SEQUENCE struct
                     // non-pointer character members (inline [len x i8]).
-                    bool is_bindc = (struct_type_t->m_abi == ASR::abiType::BindC) ||
-                                    struct_type_t->m_is_sequence;
                     ASR::Variable_t* v_sym = ASR::down_cast<ASR::Variable_t>(sym);
-                    bool is_direct_char = is_bindc &&
-                        !ASR::is_a<ASR::Pointer_t>(*v_sym->m_type) &&
-                        !ASR::is_a<ASR::Allocatable_t>(*v_sym->m_type);
-                    if (!is_direct_char) {
+                    if (!ASRUtils::is_inline_character_struct_member(
+                            struct_type_t, v_sym->m_type)) {
                         setup_string(ptr_member, symbol_type);
                         // `=> null()` on a character pointer component is not a string
                         // value to copy; setup_string already left the descriptor in the
@@ -12272,23 +12248,8 @@ public:
         }
         if ( ASRUtils::is_string_only(ASRUtils::expr_type(x.m_value)) &&
              ASR::is_a<ASR::String_t>(*ASRUtils::extract_type(asr_target_type))) {
-            // Check if target is a character member of a bind(C)/SEQUENCE struct
-            bool is_bindc_char_member = false;
-            if (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target)) {
-                ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(x.m_target);
-                ASR::symbol_t* member_sym = ASRUtils::symbol_get_past_external(sim->m_m);
-                ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(member_sym);
-                ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(
-                    member_var->m_parent_symtab->asr_owner);
-                struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
-                if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
-                    (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi == ASR::abiType::BindC ||
-                     ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence)) {
-                    ASR::ttype_t* mem_type = sim->m_type;
-                    is_bindc_char_member = !ASR::is_a<ASR::Pointer_t>(*mem_type) &&
-                        !ASR::is_a<ASR::Allocatable_t>(*mem_type);
-                }
-            }
+            bool is_bindc_char_member =
+                ASRUtils::is_inline_character_struct_member(x.m_target);
             bool is_cchar_array_item = false;
             if (ASR::is_a<ASR::ArrayItem_t>(*x.m_target)) {
                 ASR::ttype_t* target_item_type = ASRUtils::extract_type(ASRUtils::expr_type(x.m_target));
@@ -27648,40 +27609,20 @@ public:
                 if (ASRUtils::is_character(*expr_type(x.m_args[i])) &&
                     ASRUtils::get_string_type(expr_type(x.m_args[i]))->m_physical_type
                         == ASR::DescriptorString &&
-                    ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i])) {
+                    ASRUtils::is_inline_character_struct_member(x.m_args[i])) {
                     ASR::StructInstanceMember_t* sim = ASR::down_cast<
                         ASR::StructInstanceMember_t>(x.m_args[i]);
-                    ASR::symbol_t* member_sym = ASRUtils::symbol_get_past_external(sim->m_m);
-                    ASR::Variable_t* member_var = ASR::down_cast<ASR::Variable_t>(member_sym);
-                    ASR::symbol_t* struct_sym = ASR::down_cast<ASR::symbol_t>(
-                        member_var->m_parent_symtab->asr_owner);
-                    struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
-                    if (ASR::is_a<ASR::Struct_t>(*struct_sym) &&
-                        (ASR::down_cast<ASR::Struct_t>(struct_sym)->m_abi
-                            == ASR::abiType::BindC ||
-                         ASR::down_cast<ASR::Struct_t>(struct_sym)->m_is_sequence) &&
-                        !ASR::is_a<ASR::Pointer_t>(*sim->m_type) &&
-                        !ASR::is_a<ASR::Allocatable_t>(*sim->m_type)) {
-                        ASR::String_t* str_ty = ASR::down_cast<ASR::String_t>(
-                            ASRUtils::extract_type(sim->m_type));
-                        int64_t slen = 1;
-                        if (str_ty->m_len) {
-                            ASRUtils::extract_value(str_ty->m_len, slen);
-                        }
-                        if (slen < 1) slen = 1;
-                        llvm::Value* desc = builder->CreateAlloca(
-                            llvm_utils->string_descriptor);
-                        llvm::Value* data_field = llvm_utils->create_gep2(
-                            llvm_utils->string_descriptor, desc, 0);
-                        llvm::Value* len_field = llvm_utils->create_gep2(
-                            llvm_utils->string_descriptor, desc, 1);
-                        llvm::Value* data_ptr = builder->CreateBitCast(
-                            tmp, llvm::Type::getInt8Ty(context)->getPointerTo());
-                        builder->CreateStore(data_ptr, data_field);
-                        builder->CreateStore(llvm::ConstantInt::get(
-                            context, llvm::APInt(64, slen)), len_field);
-                        tmp = desc;
+                    ASR::String_t* str_ty = ASR::down_cast<ASR::String_t>(
+                        ASRUtils::extract_type(sim->m_type));
+                    int64_t slen = 1;
+                    if (str_ty->m_len) {
+                        ASRUtils::extract_value(str_ty->m_len, slen);
                     }
+                    if (slen < 1) slen = 1;
+                    tmp = llvm_utils->create_string_descriptor(
+                        builder->CreateBitCast(tmp, character_type),
+                        llvm::ConstantInt::get(context, llvm::APInt(64, slen)),
+                        "inline_fmt_arg");
                 }
                 args.push_back(tmp);
                 ptr_loads = ptr_load_copy;

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -496,18 +496,14 @@ namespace LCompilers {
                 member_idx += 1;
             }
             Allocator al(1024);
-            bool is_bindc = (der_type->m_abi == ASR::abiType::BindC) || der_type->m_is_sequence;
             for( size_t i = 0; i < der_type->n_members; i++ ) {
                 std::string member_name = der_type->m_members[i];
                 ASR::Variable_t* member = ASR::down_cast<ASR::Variable_t>(der_type->m_symtab->get_symbol(member_name));
                 llvm::Type* llvm_mem_type;
                 // bind(C)/SEQUENCE: non-pointer, non-allocatable character maps to inline [len x i8]
                 ASR::ttype_t* mem_type = member->m_type;
-                bool is_direct_char = is_bindc &&
-                    !ASR::is_a<ASR::Pointer_t>(*mem_type) &&
-                    !ASR::is_a<ASR::Allocatable_t>(*mem_type) &&
-                    ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_array(mem_type));
-                if (is_direct_char) {
+                if (ASRUtils::is_inline_character_struct_member(
+                        der_type, mem_type)) {
                     ASR::String_t* s = ASR::down_cast<ASR::String_t>(
                         ASRUtils::type_get_past_array(mem_type));
                     int64_t slen = 1;
@@ -10770,12 +10766,8 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
                     llvm::Type *mem_type = llvm_utils->get_type_from_ttype_t_util(ASRUtils::get_expr_from_sym(al, mem_sym),
                         ASRUtils::symbol_type(mem_sym), module);
                     ASR::ttype_t* member_type = ASRUtils::symbol_type(mem_sym);
-                    bool is_inline_char = (struct_sym->m_abi == ASR::abiType::BindC ||
-                            struct_sym->m_is_sequence) &&
-                        !ASR::is_a<ASR::Pointer_t>(*member_type) &&
-                        !ASR::is_a<ASR::Allocatable_t>(*member_type) &&
-                        ASR::is_a<ASR::String_t>(*ASRUtils::type_get_past_array(member_type));
-                    if (is_inline_char) {
+                    if (ASRUtils::is_inline_character_struct_member(
+                            struct_sym, member_type)) {
                         llvm::Type* inline_type = llvm_utils->name2dertype[
                             der_type_name]->getElementType(mem_idx);
                         if (src_member->getType()->isPointerTy()) {


### PR DESCRIPTION
## Summary

bind(C) and SEQUENCE derived types lay their non-pointer, non-allocatable
character members out inline in the struct (a flat byte blob at a fixed offset)
instead of behind a string descriptor, so that the struct matches the C/Fortran
storage layout. That condition was hand-rolled in six places across
`asr_to_llvm.cpp` and `llvm_utils.cpp`, each one respelling the same walk from a
`StructInstanceMember` to its owning `Struct`.

This PR is pure refactoring: no behavior change, no new tests.

## Scope

- `src/libasr/asr_utils.h`: add `ASRUtils::is_inline_character_struct_member`
  with two overloads — one taking a `Struct_t` plus a member type, one taking a
  member-access expression.
- `src/libasr/codegen/asr_to_llvm.cpp`, `src/libasr/codegen/llvm_utils.cpp`:
  call it from all six sites (`getStructType`,
  `handle_global_nonallocatable_stringArray`, `get_string_data_and_length`,
  `allocate_array_members_of_struct`, `visit_Assignment`, and the string-format
  argument path).

Two dead/duplicated bits fall out while collapsing the copies:

- `get_string_data_and_length` assigned `phys_type = CChar` for the inline case
  and then returned before the switch that reads it — dropped.
- the string-format path built a string descriptor by hand; it now reuses the
  existing `LLVMUtils::create_string_descriptor`.

## Verification

Local runs on this branch:

- `./run_tests.py --no-llvm` — TESTS PASSED
- `integration_tests/run_tests.py -b llvm` — 100% passed, 0 failed out of 3860
- `integration_tests/run_tests.py -b gfortran` — 100% passed, 0 failed out of 3922
- reference outputs for the tests that touch this code (`common2`, `common_03`
  … `common_13`, `derived_types_32`, `read_83`, `string_03`, `string_11`) are
  byte-identical to the ones produced by `main` with the same compiler — as
  expected for a no-op refactor, and no reference file needed updating.

## Rationale

Extracted from #12309, which added a seventh copy of this predicate. Pulling the
dedup out first keeps the behavior changes that follow readable; per `AGENTS.md`,
refactoring is not mixed with bug fixes.

This is the first of three stacked PRs extracted from the inline-COMMON part of
#12309:

1. **this PR** — the shared helper (no behavior change)
2. #12553 — fix inline character *array* members (bind(C)/SEQUENCE)
3. #12554 — store COMMON block characters inline
