### PR TITLE
fix: lay out and index inline character array struct members correctly

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2560,6 +2560,7 @@ RUN(NAME derived_types_150 LABELS gfortran llvm) # SEQUENCE char(len>1) inline +
 RUN(NAME derived_types_151 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME derived_types_152 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME derived_types_153 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME derived_types_154 LABELS gfortran llvm)
 RUN(NAME defined_assignment_01 LABELS llvm flang)
 RUN(NAME defined_assignment_free_interface_01 LABELS gfortran llvm flang)
 

--- a/integration_tests/derived_types_154.f90
+++ b/integration_tests/derived_types_154.f90
@@ -1,0 +1,29 @@
+! A character array member of a SEQUENCE (or bind(C)) derived type is stored
+! inline in the struct, as a flat blob of count*len bytes, rather than behind
+! a string descriptor. The blob has to be sized by the element count, and
+! indexing it has to step by the element length.
+program derived_types_154
+    implicit none
+    type :: t
+        sequence
+        character(len=4) :: names(3)
+        integer :: n
+    end type
+    type(t) :: x
+
+    x%names(1) = "abcd"
+    x%names(2) = "efgh"
+    x%names(3) = "ijkl"
+    x%n = 42
+
+    if (x%names(1) /= "abcd") error stop "names(1)"
+    if (x%names(2) /= "efgh") error stop "names(2)"
+    if (x%names(3) /= "ijkl") error stop "names(3)"
+    ! a substring of an inline element must read the same bytes
+    if (x%names(2)(2:3) /= "fg") error stop "names(2)(2:3)"
+    if (x%names(3)(1:1) /= "i") error stop "names(3)(1:1)"
+    ! the member after the blob must not be overlapped by it
+    if (x%n /= 42) error stop "n"
+
+    print *, x%names(1), x%names(2), x%names(3), x%n
+end program derived_types_154

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4355,6 +4355,25 @@ static inline bool is_inline_character_struct_member(
         && ASR::is_a<ASR::String_t>(*type_get_past_array(member_type));
 }
 
+/*
+    Total number of bytes a character member stored inline occupies in the
+    struct: the element length times the kind times the number of elements
+    (1 for a scalar member).
+*/
+static inline int64_t inline_character_storage_size(ASR::ttype_t* member_type) {
+    ASR::String_t* string_type = get_string_type(member_type);
+    int64_t length = 1;
+    if (string_type->m_len) {
+        extract_value(string_type->m_len, length);
+    }
+    if (length < 1) {
+        length = 1;
+    }
+    int64_t count = is_array(member_type)
+        ? get_fixed_size_of_array(member_type) : 1;
+    return length * string_type->m_kind * count;
+}
+
 // Same as above, for an expression that may be a struct member access.
 static inline bool is_inline_character_struct_member(ASR::expr_t* expr) {
     if (!ASR::is_a<ASR::StructInstanceMember_t>(*expr)) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6760,6 +6760,15 @@ public:
                     continue ;
                 }
                 ASR::ttype_t* symbol_type = ASRUtils::symbol_type(sym);
+                // Inline character members (bind(C)/SEQUENCE/COMMON) are stored
+                // as a flat [count*len x i8] blob in place: there is no string
+                // descriptor to allocate or initialize at runtime (scalars and
+                // arrays alike), so skip all per-member setup for them.
+                if (ASR::is_a<ASR::Variable_t>(*sym)
+                        && ASRUtils::is_inline_character_struct_member(
+                            struct_type_t, symbol_type)) {
+                    continue;
+                }
                 int idx = 0;
                 idx = name2memidx[struct_type_name][item.first];
                 llvm::Type* type = name2dertype[struct_type_name];
@@ -12393,12 +12402,9 @@ public:
                 tmp = nullptr;
                 return;
             }
-            // For struct members (especially common blocks), treat as allocatable
-            // so _lfortran_strcpy allocates memory if the pointer is NULL.
-            // Common block structs are initialized with zeroinitializer, so
-            // their string descriptor pointers start as NULL.
-            bool is_dest_allocatable = ASRUtils::is_allocatable(asr_target_type) ||
-                                       ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target);
+            bool is_dest_allocatable = ASRUtils::is_allocatable(asr_target_type)
+                || (ASR::is_a<ASR::StructInstanceMember_t>(*x.m_target)
+                    && !ASRUtils::is_inline_character_struct_member(x.m_target));
             // bind(C) allocatable string dummies have an extra pointer
             // level (string_descriptor** rather than string_descriptor*)
             // due to the BindC ABI. Dereference to string_descriptor*.
@@ -14895,16 +14901,16 @@ public:
 
         /* Visit String + Visit Index */
         llvm::Value *idx {};
-        llvm::Value *str {};
         this->visit_expr_load_wrapper(x.m_idx, LLVM::is_llvm_pointer(*expr_type(x.m_idx)) ? 2 : 1, true);
         idx = tmp;
-        this->visit_expr_load_wrapper(x.m_arg, 0, true);
-        str = tmp;
+        // Use the inline-aware accessor so a character member stored inline
+        // (bind(C)/SEQUENCE/COMMON struct member) yields a direct data pointer
+        // instead of being (mis)read as a string descriptor.
+        llvm::Value* str_data /* i8* */ = get_string_data_and_length(x.m_arg).first;
 
         /* Get StringItem */
         llvm::Value *str_item {};
         {
-            llvm::Value* str_data /*  i8*  */ = llvm_utils->get_string_data(ASRUtils::get_string_type(x.m_arg), str);
             llvm::Value* idx_INT64 = llvm_utils->convert_kind(idx, llvm::Type::getInt64Ty(context));
             llvm::Value* idx_zero_based /* 0-based */ = builder->CreateSub(
                                                 idx_INT64,
@@ -14976,11 +14982,6 @@ public:
         LCOMPILERS_ASSERT(ASR::is_a<ASR::IntegerConstant_t>(*x.m_step))
         LCOMPILERS_ASSERT(ASR::down_cast<ASR::IntegerConstant_t>(x.m_step)->m_n == 1 /*Fortran only has step of 1*/)
 
-        /* Evaluate String */
-        llvm::Value *str {};
-        this->visit_expr_load_wrapper(x.m_arg, 0);
-        str = tmp;
-        
         /* Evaluate Start + End */
         llvm::Value *start {};
         llvm::Value *end   {};
@@ -15011,7 +15012,9 @@ public:
         llvm::Value* str_data {}; // Shifted from Original by value = start
         {
             int kind = ASRUtils::get_string_type(x.m_arg)->m_kind;
-            llvm::Value* str_data_orig = llvm_utils->get_string_data(ASRUtils::get_string_type(x.m_arg), str);
+            // Inline-aware: yields a direct data pointer for characters stored
+            // inline in a bind(C)/SEQUENCE/COMMON struct member.
+            llvm::Value* str_data_orig = get_string_data_and_length(x.m_arg).first;
             llvm::Value* start_INT64 = llvm_utils->convert_kind(start, llvm::Type::getInt64Ty(context));
             llvm::Value* start = builder->CreateSub(start_INT64, llvm::ConstantInt::get(context, llvm::APInt(64, 1)));
             
@@ -19529,6 +19532,11 @@ public:
                         elem_ptr = builder->CreateGEP(llvm_arr_type, var_ptr,
                             {llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 0),
                              llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), elem_idx)});
+                    } else if (ASRUtils::is_inline_character_struct_member(val_expr)) {
+                        elem_ptr = llvm_utils->get_inline_string_element(
+                            ASRUtils::get_string_type(val_type), var_ptr,
+                            llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), elem_idx),
+                            "inline_read_elem");
                     } else if (ASR::is_a<ASR::String_t>(*val_type)) {
                         ASR::String_t* str_type = ASRUtils::get_string_type(val_type);
                         elem_ptr = llvm_utils->get_string_element_in_array(

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -997,6 +997,9 @@ namespace LCompilers {
                     ASR::String_t* string_type = ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(asr_type));
                     if (string_type->m_physical_type == ASR::string_physical_typeType::CChar) {
                         tmp = llvm_utils->create_ptr_gep2(llvm::Type::getInt8Ty(context), array, idx);
+                    } else if (ASRUtils::is_inline_character_struct_member(expr)) {
+                        tmp = llvm_utils->get_inline_string_element(
+                            string_type, array, idx, "inline_arr_element");
                     } else {
                         tmp = llvm_utils->get_string_element_in_array(string_type, array, idx);
                     }

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -500,19 +500,15 @@ namespace LCompilers {
                 std::string member_name = der_type->m_members[i];
                 ASR::Variable_t* member = ASR::down_cast<ASR::Variable_t>(der_type->m_symtab->get_symbol(member_name));
                 llvm::Type* llvm_mem_type;
-                // bind(C)/SEQUENCE: non-pointer, non-allocatable character maps to inline [len x i8]
+                // bind(C)/SEQUENCE: non-pointer, non-allocatable character maps
+                // to an inline [count*len*kind x i8] byte blob
                 ASR::ttype_t* mem_type = member->m_type;
                 if (ASRUtils::is_inline_character_struct_member(
                         der_type, mem_type)) {
-                    ASR::String_t* s = ASR::down_cast<ASR::String_t>(
-                        ASRUtils::type_get_past_array(mem_type));
-                    int64_t slen = 1;
-                    if (s->m_len) {
-                        ASRUtils::extract_value(s->m_len, slen);
-                    }
-                    if (slen < 1) slen = 1;
+                    int64_t inline_bytes =
+                        ASRUtils::inline_character_storage_size(mem_type);
                     llvm_mem_type = llvm::ArrayType::get(
-                        llvm::Type::getInt8Ty(context), (uint64_t)slen);
+                        llvm::Type::getInt8Ty(context), (uint64_t)inline_bytes);
                 } else {
                     llvm_mem_type = get_type_from_ttype_t_util(ASRUtils::EXPR(ASR::make_Var_t(
                         al, member->base.base.loc, &member->base)), member->m_type, module, member->m_abi);
@@ -2470,6 +2466,25 @@ namespace LCompilers {
     llvm::Value* LLVMUtils::get_string_element_in_array(ASR::String_t* str_type, llvm::Value* data, llvm::Value* arr_idx){
         llvm::Value* desired_ptr = get_string_element_in_array_(str_type, data, arr_idx);
         return create_string_descriptor(desired_ptr, get_string_length(str_type, data), "arr_element");
+    }
+
+    llvm::Value* LLVMUtils::get_inline_string_element(ASR::String_t* str_type,
+            llvm::Value* blob_ptr, llvm::Value* idx, std::string name){
+        int64_t len = 1;
+        if (str_type->m_len) {
+            ASRUtils::extract_value(str_type->m_len, len);
+        }
+        llvm::Value* elem_bytes = llvm::ConstantInt::get(
+            llvm::Type::getInt64Ty(context), len * str_type->m_kind);
+        llvm::Value* off = builder->CreateMul(
+            convert_kind(idx, llvm::Type::getInt64Ty(context)), elem_bytes);
+        // blob_ptr points at the inline [count*len x i8] blob; view it as a
+        // flat i8 buffer before indexing to the element.
+        llvm::Value* bytes = builder->CreateBitCast(blob_ptr, character_type);
+        llvm::Value* elem_ptr = create_ptr_gep2(
+            llvm::Type::getInt8Ty(context), bytes, off);
+        return create_string_descriptor(elem_ptr,
+            llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), len), name);
     }
 
 

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -586,6 +586,15 @@ class ASRToLLVMVisitor;
             llvm::Value* get_string_element_in_array(ASR::String_t* str_type, llvm::Value* array_ptr/*PointerArray*/, llvm::Value* arr_idx);
 
             /*
+                Gets an element of a character array stored inline as a flat
+                [count*len x i8] blob (bind(C)/SEQUENCE/COMMON struct member):
+                element data = blob + idx*len*kind, wrapped in a string view
+                descriptor for downstream use.
+            */
+            llvm::Value* get_inline_string_element(ASR::String_t* str_type,
+                llvm::Value* blob_ptr, llvm::Value* idx, std::string name = "");
+
+            /*
                 Corresponds to the process of allocating a string.
                 e.g. --> `allocate(character(10) :: str)`
                 - If deferred length, Use desired amount passed by user.

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "de311aa380839952e5ded165a614b82c4d039916441a92d67725169a",
+    "stdout_hash": "e30242de2cfaa19c608b10d30ed29307c906d00c33b52ec6480e6365",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -41,28 +41,30 @@ loop.head:                                        ; preds = %ifcont, %then
   %5 = load i32, i32* %result, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %7 = load i8*, i8** %6, align 8
-  %8 = sext i32 %5 to i64
-  %9 = sub i64 %8, 1
-  %10 = getelementptr i8, i8* %7, i64 %9
-  %11 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  store i8* %10, i8** %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
-  store i64 1, i64* %12, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %9 = load i64, i64* %8, align 8
+  %10 = sext i32 %5 to i64
+  %11 = sub i64 %10, 1
+  %12 = getelementptr i8, i8* %7, i64 %11
   %13 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  %16 = load i8, i8* %14, align 1
-  %17 = load i8, i8* %15, align 1
-  %18 = icmp eq i8 %16, %17
-  br i1 %18, label %loop.body, label %loop.end
+  store i8* %12, i8** %13, align 8
+  %14 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
+  store i64 1, i64* %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
+  %16 = load i8*, i8** %15, align 8
+  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
+  %18 = load i8, i8* %16, align 1
+  %19 = load i8, i8* %17, align 1
+  %20 = icmp eq i8 %18, %19
+  br i1 %20, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %19 = load i32, i32* %result, align 4
-  %20 = sub i32 %19, 1
-  store i32 %20, i32* %result, align 4
   %21 = load i32, i32* %result, align 4
-  %22 = icmp eq i32 %21, 0
-  br i1 %22, label %then1, label %else
+  %22 = sub i32 %21, 1
+  store i32 %22, i32* %result, align 4
+  %23 = load i32, i32* %result, align 4
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %then1, label %else
 
 then1:                                            ; preds = %loop.body
   br label %loop.end
@@ -89,8 +91,8 @@ return:                                           ; preds = %ifcont3
   br label %FINALIZE_SYMTABLE__lcompilers_len_trim_str
 
 FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
-  %23 = load i32, i32* %result, align 4
-  ret i32 %23
+  %25 = load i32, i32* %result, align 4
+  ret i32 %25
 }
 
 define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
@@ -114,18 +116,20 @@ define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* 
   %12 = select i1 %11, i64 0, i64 %10
   %13 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %14 = load i8*, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %16 = load i64, i64* %15, align 8
   %StrSliceGEP = getelementptr i8, i8* %14, i64 0
-  %15 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %12, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 0
-  %18 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 1
-  %19 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %17, i64* %18, i8 0, i8 0, i8* %20, i64 %22, i32 1)
+  %17 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  store i8* %StrSliceGEP, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %12, i64* %18, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %22 = load i8*, i8** %21, align 8
+  %23 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %24 = load i64, i64* %23, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %19, i64* %20, i8 0, i8 0, i8* %22, i64 %24, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-read_83-d6544e3.json
+++ b/tests/reference/llvm-read_83-d6544e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-read_83-d6544e3.stdout",
-    "stdout_hash": "15b652bb65d19aca27313753debd97e8016edf9f02aab7eb79b394e9",
+    "stdout_hash": "50e4a978360e18e839444c169abe611a719f2e379b892cf70282b2e7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-read_83-d6544e3.stdout
+++ b/tests/reference/llvm-read_83-d6544e3.stdout
@@ -123,28 +123,30 @@ loop.head:                                        ; preds = %ifcont, %then
   %5 = load i32, i32* %result, align 4
   %6 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %7 = load i8*, i8** %6, align 8
-  %8 = sext i32 %5 to i64
-  %9 = sub i64 %8, 1
-  %10 = getelementptr i8, i8* %7, i64 %9
-  %11 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  store i8* %10, i8** %11, align 8
-  %12 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
-  store i64 1, i64* %12, align 8
+  %8 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %9 = load i64, i64* %8, align 8
+  %10 = sext i32 %5 to i64
+  %11 = sub i64 %10, 1
+  %12 = getelementptr i8, i8* %7, i64 %11
   %13 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
-  %14 = load i8*, i8** %13, align 8
-  %15 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  %16 = load i8, i8* %14, align 1
-  %17 = load i8, i8* %15, align 1
-  %18 = icmp eq i8 %16, %17
-  br i1 %18, label %loop.body, label %loop.end
+  store i8* %12, i8** %13, align 8
+  %14 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 1
+  store i64 1, i64* %14, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %StringItem, i32 0, i32 0
+  %16 = load i8*, i8** %15, align 8
+  %17 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
+  %18 = load i8, i8* %16, align 1
+  %19 = load i8, i8* %17, align 1
+  %20 = icmp eq i8 %18, %19
+  br i1 %20, label %loop.body, label %loop.end
 
 loop.body:                                        ; preds = %loop.head
-  %19 = load i32, i32* %result, align 4
-  %20 = sub i32 %19, 1
-  store i32 %20, i32* %result, align 4
   %21 = load i32, i32* %result, align 4
-  %22 = icmp eq i32 %21, 0
-  br i1 %22, label %then1, label %else
+  %22 = sub i32 %21, 1
+  store i32 %22, i32* %result, align 4
+  %23 = load i32, i32* %result, align 4
+  %24 = icmp eq i32 %23, 0
+  br i1 %24, label %then1, label %else
 
 then1:                                            ; preds = %loop.body
   br label %loop.end
@@ -171,8 +173,8 @@ return:                                           ; preds = %ifcont3
   br label %FINALIZE_SYMTABLE__lcompilers_len_trim_str
 
 FINALIZE_SYMTABLE__lcompilers_len_trim_str:       ; preds = %return
-  %23 = load i32, i32* %result, align 4
-  ret i32 %23
+  %25 = load i32, i32* %result, align 4
+  ret i32 %25
 }
 
 define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* %result) {
@@ -196,18 +198,20 @@ define void @_lcompilers_trim_str(%string_descriptor* %str, %string_descriptor* 
   %12 = select i1 %11, i64 0, i64 %10
   %13 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %14 = load i8*, i8** %13, align 8
+  %15 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %16 = load i64, i64* %15, align 8
   %StrSliceGEP = getelementptr i8, i8* %14, i64 0
-  %15 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %15, align 8
-  %16 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %12, i64* %16, align 8
-  %17 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 0
-  %18 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 1
-  %19 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %20 = load i8*, i8** %19, align 8
-  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %22 = load i64, i64* %21, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %17, i64* %18, i8 0, i8 0, i8* %20, i64 %22, i32 1)
+  %17 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  store i8* %StrSliceGEP, i8** %17, align 8
+  %18 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %12, i64* %18, align 8
+  %19 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 0
+  %20 = getelementptr %string_descriptor, %string_descriptor* %str_desc_local, i32 0, i32 1
+  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %22 = load i8*, i8** %21, align 8
+  %23 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %24 = load i64, i64* %23, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %19, i64* %20, i8 0, i8 0, i8* %22, i64 %24, i32 1)
   br label %return
 
 return:                                           ; preds = %.entry

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "a35884a9d02713f3221183ee155eedacf29970c0b241d35773b05995",
+    "stdout_hash": "efcc078a3a240a65fee0d8732188b533dd291afd65fc921731822f2d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -74,45 +74,49 @@ ifcont:                                           ; preds = %else, %then
   %18 = select i1 %17, i64 0, i64 %16
   %19 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
   %20 = load i8*, i8** %19, align 8
+  %21 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
   %StrSliceGEP = getelementptr i8, i8* %20, i64 0
-  %21 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %21, align 8
-  %22 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %18, i64* %22, align 8
   %23 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  store i8* %StrSliceGEP, i8** %23, align 8
   %24 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %25 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 0
-  %26 = load i8*, i8** %25, align 8
-  %27 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 1
-  %28 = load i64, i64* %27, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %23, i64* %24, i8 0, i8 0, i8* %26, i64 %28, i32 1)
-  %29 = load i32, i32* %s1_len, align 4
-  %30 = add i32 %29, 1
-  %31 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
-  %32 = load i64, i64* %31, align 8
-  %33 = trunc i64 %32 to i32
-  %34 = sext i32 %30 to i64
-  %35 = sext i32 %33 to i64
-  %36 = sub i64 %35, %34
-  %37 = add i64 %36, 1
-  %38 = icmp slt i64 %37, 0
-  %39 = select i1 %38, i64 0, i64 %37
-  %40 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
-  %41 = load i8*, i8** %40, align 8
-  %42 = sext i32 %30 to i64
-  %43 = sub i64 %42, 1
-  %StrSliceGEP1 = getelementptr i8, i8* %41, i64 %43
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  store i8* %StrSliceGEP1, i8** %44, align 8
-  %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  store i64 %39, i64* %45, align 8
-  %46 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
-  %48 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 0
-  %49 = load i8*, i8** %48, align 8
-  %50 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 1
-  %51 = load i64, i64* %50, align 8
-  call void @_lfortran_strcpy_alloc(i8* %0, i8** %46, i64* %47, i8 0, i8 0, i8* %49, i64 %51, i32 1)
+  store i64 %18, i64* %24, align 8
+  %25 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %26 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %27 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 0
+  %28 = load i8*, i8** %27, align 8
+  %29 = getelementptr %string_descriptor, %string_descriptor* %s1, i32 0, i32 1
+  %30 = load i64, i64* %29, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %25, i64* %26, i8 0, i8 0, i8* %28, i64 %30, i32 1)
+  %31 = load i32, i32* %s1_len, align 4
+  %32 = add i32 %31, 1
+  %33 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %34 = load i64, i64* %33, align 8
+  %35 = trunc i64 %34 to i32
+  %36 = sext i32 %32 to i64
+  %37 = sext i32 %35 to i64
+  %38 = sub i64 %37, %36
+  %39 = add i64 %38, 1
+  %40 = icmp slt i64 %39, 0
+  %41 = select i1 %40, i64 0, i64 %39
+  %42 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 0
+  %43 = load i8*, i8** %42, align 8
+  %44 = getelementptr %string_descriptor, %string_descriptor* %concat_result, i32 0, i32 1
+  %45 = load i64, i64* %44, align 8
+  %46 = sext i32 %32 to i64
+  %47 = sub i64 %46, 1
+  %StrSliceGEP1 = getelementptr i8, i8* %43, i64 %47
+  %48 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
+  store i8* %StrSliceGEP1, i8** %48, align 8
+  %49 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
+  store i64 %41, i64* %49, align 8
+  %50 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 0
+  %51 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView2, i32 0, i32 1
+  %52 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 0
+  %53 = load i8*, i8** %52, align 8
+  %54 = getelementptr %string_descriptor, %string_descriptor* %s2, i32 0, i32 1
+  %55 = load i64, i64* %54, align 8
+  call void @_lfortran_strcpy_alloc(i8* %0, i8** %50, i64* %51, i8 0, i8 0, i8* %53, i64 %55, i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "2ef42d973a53bdb53be49e9d010bd271b8a78d3703992d11b5573ba4",
+    "stdout_hash": "7b9804001528885fed4ea38be93fb05ea7a6c4229c4e51ca15803d5d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -97,41 +97,45 @@ loop.body2:                                       ; preds = %loop.head1
   %38 = select i1 %37, i64 0, i64 %36
   %39 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %40 = load i8*, i8** %39, align 8
-  %41 = sext i32 %31 to i64
-  %42 = sub i64 %41, 1
-  %StrSliceGEP = getelementptr i8, i8* %40, i64 %42
-  %43 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %38, i64* %44, align 8
+  %41 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %42 = load i64, i64* %41, align 8
+  %43 = sext i32 %31 to i64
+  %44 = sub i64 %43, 1
+  %StrSliceGEP = getelementptr i8, i8* %40, i64 %44
   %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
-  %49 = load i32, i32* %j, align 4
-  %50 = load i32, i32* %j, align 4
-  %51 = sext i32 %49 to i64
-  %52 = sext i32 %50 to i64
-  %53 = sub i64 %52, %51
-  %54 = add i64 %53, 1
-  %55 = icmp slt i64 %54, 0
-  %56 = select i1 %55, i64 0, i64 %54
-  %57 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
-  %58 = load i8*, i8** %57, align 8
-  %59 = sext i32 %49 to i64
-  %60 = sub i64 %59, 1
-  %StrSliceGEP3 = getelementptr i8, i8* %58, i64 %60
-  %61 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  store i8* %StrSliceGEP3, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  store i64 %56, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
-  %67 = call i32 @str_compare(i8* %46, i64 %48, i8* %64, i64 %66)
-  %68 = icmp ne i32 %67, 0
-  br i1 %68, label %then5, label %else6
+  store i8* %StrSliceGEP, i8** %45, align 8
+  %46 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %38, i64* %46, align 8
+  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %48 = load i8*, i8** %47, align 8
+  %49 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %50 = load i64, i64* %49, align 8
+  %51 = load i32, i32* %j, align 4
+  %52 = load i32, i32* %j, align 4
+  %53 = sext i32 %51 to i64
+  %54 = sext i32 %52 to i64
+  %55 = sub i64 %54, %53
+  %56 = add i64 %55, 1
+  %57 = icmp slt i64 %56, 0
+  %58 = select i1 %57, i64 0, i64 %56
+  %59 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
+  %60 = load i8*, i8** %59, align 8
+  %61 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
+  %62 = load i64, i64* %61, align 8
+  %63 = sext i32 %51 to i64
+  %64 = sub i64 %63, 1
+  %StrSliceGEP3 = getelementptr i8, i8* %60, i64 %64
+  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
+  store i8* %StrSliceGEP3, i8** %65, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
+  store i64 %58, i64* %66, align 8
+  %67 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
+  %68 = load i8*, i8** %67, align 8
+  %69 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
+  %70 = load i64, i64* %69, align 8
+  %71 = call i32 @str_compare(i8* %48, i64 %50, i8* %68, i64 %70)
+  %72 = icmp ne i32 %71, 0
+  br i1 %72, label %then5, label %else6
 
 then5:                                            ; preds = %loop.body2
   store i32 0, i32* %found, align 4
@@ -141,24 +145,24 @@ else6:                                            ; preds = %loop.body2
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %69 = load i32, i32* %j, align 4
-  %70 = add i32 %69, 1
-  store i32 %70, i32* %j, align 4
-  %71 = load i32, i32* %k, align 4
-  %72 = add i32 %71, 1
-  store i32 %72, i32* %k, align 4
+  %73 = load i32, i32* %j, align 4
+  %74 = add i32 %73, 1
+  store i32 %74, i32* %j, align 4
+  %75 = load i32, i32* %k, align 4
+  %76 = add i32 %75, 1
+  store i32 %76, i32* %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %73 = load i32, i32* %found, align 4
-  %74 = icmp eq i32 %73, 1
-  br i1 %74, label %then8, label %else9
+  %77 = load i32, i32* %found, align 4
+  %78 = icmp eq i32 %77, 1
+  br i1 %78, label %then8, label %else9
 
 then8:                                            ; preds = %loop.end
-  %75 = load i32, i32* %i, align 4
-  store i32 %75, i32* %_lcompilers_index_str, align 4
-  %76 = load i32, i32* %back, align 4
-  store i32 %76, i32* %found, align 4
+  %79 = load i32, i32* %i, align 4
+  store i32 %79, i32* %_lcompilers_index_str, align 4
+  %80 = load i32, i32* %back, align 4
+  store i32 %80, i32* %found, align 4
   br label %ifcont10
 
 else9:                                            ; preds = %loop.end
@@ -166,9 +170,9 @@ else9:                                            ; preds = %loop.end
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %77 = load i32, i32* %i, align 4
-  %78 = add i32 %77, 1
-  store i32 %78, i32* %i, align 4
+  %81 = load i32, i32* %i, align 4
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %i, align 4
   br label %loop.head
 
 loop.end11:                                       ; preds = %loop.head
@@ -178,8 +182,8 @@ return:                                           ; preds = %loop.end11
   br label %FINALIZE_SYMTABLE__lcompilers_index_str
 
 FINALIZE_SYMTABLE__lcompilers_index_str:          ; preds = %return
-  %79 = load i32, i32* %_lcompilers_index_str, align 4
-  ret i32 %79
+  %83 = load i32, i32* %_lcompilers_index_str, align 4
+  ret i32 %83
 }
 
 define i32 @_lcompilers_index_str1(%string_descriptor* %str, %string_descriptor* %substr, i32* %back, i32* %kind) {
@@ -261,41 +265,45 @@ loop.body2:                                       ; preds = %loop.head1
   %38 = select i1 %37, i64 0, i64 %36
   %39 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 0
   %40 = load i8*, i8** %39, align 8
-  %41 = sext i32 %31 to i64
-  %42 = sub i64 %41, 1
-  %StrSliceGEP = getelementptr i8, i8* %40, i64 %42
-  %43 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  store i8* %StrSliceGEP, i8** %43, align 8
-  %44 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  store i64 %38, i64* %44, align 8
+  %41 = getelementptr %string_descriptor, %string_descriptor* %str, i32 0, i32 1
+  %42 = load i64, i64* %41, align 8
+  %43 = sext i32 %31 to i64
+  %44 = sub i64 %43, 1
+  %StrSliceGEP = getelementptr i8, i8* %40, i64 %44
   %45 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
-  %46 = load i8*, i8** %45, align 8
-  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
-  %48 = load i64, i64* %47, align 8
-  %49 = load i32, i32* %j, align 4
-  %50 = load i32, i32* %j, align 4
-  %51 = sext i32 %49 to i64
-  %52 = sext i32 %50 to i64
-  %53 = sub i64 %52, %51
-  %54 = add i64 %53, 1
-  %55 = icmp slt i64 %54, 0
-  %56 = select i1 %55, i64 0, i64 %54
-  %57 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
-  %58 = load i8*, i8** %57, align 8
-  %59 = sext i32 %49 to i64
-  %60 = sub i64 %59, 1
-  %StrSliceGEP3 = getelementptr i8, i8* %58, i64 %60
-  %61 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  store i8* %StrSliceGEP3, i8** %61, align 8
-  %62 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  store i64 %56, i64* %62, align 8
-  %63 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
-  %64 = load i8*, i8** %63, align 8
-  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
-  %66 = load i64, i64* %65, align 8
-  %67 = call i32 @str_compare(i8* %46, i64 %48, i8* %64, i64 %66)
-  %68 = icmp ne i32 %67, 0
-  br i1 %68, label %then5, label %else6
+  store i8* %StrSliceGEP, i8** %45, align 8
+  %46 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  store i64 %38, i64* %46, align 8
+  %47 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 0
+  %48 = load i8*, i8** %47, align 8
+  %49 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView, i32 0, i32 1
+  %50 = load i64, i64* %49, align 8
+  %51 = load i32, i32* %j, align 4
+  %52 = load i32, i32* %j, align 4
+  %53 = sext i32 %51 to i64
+  %54 = sext i32 %52 to i64
+  %55 = sub i64 %54, %53
+  %56 = add i64 %55, 1
+  %57 = icmp slt i64 %56, 0
+  %58 = select i1 %57, i64 0, i64 %56
+  %59 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 0
+  %60 = load i8*, i8** %59, align 8
+  %61 = getelementptr %string_descriptor, %string_descriptor* %substr, i32 0, i32 1
+  %62 = load i64, i64* %61, align 8
+  %63 = sext i32 %51 to i64
+  %64 = sub i64 %63, 1
+  %StrSliceGEP3 = getelementptr i8, i8* %60, i64 %64
+  %65 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
+  store i8* %StrSliceGEP3, i8** %65, align 8
+  %66 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
+  store i64 %58, i64* %66, align 8
+  %67 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 0
+  %68 = load i8*, i8** %67, align 8
+  %69 = getelementptr %string_descriptor, %string_descriptor* %StrSlice_StrView4, i32 0, i32 1
+  %70 = load i64, i64* %69, align 8
+  %71 = call i32 @str_compare(i8* %48, i64 %50, i8* %68, i64 %70)
+  %72 = icmp ne i32 %71, 0
+  br i1 %72, label %then5, label %else6
 
 then5:                                            ; preds = %loop.body2
   store i32 0, i32* %found, align 4
@@ -305,24 +313,24 @@ else6:                                            ; preds = %loop.body2
   br label %ifcont7
 
 ifcont7:                                          ; preds = %else6, %then5
-  %69 = load i32, i32* %j, align 4
-  %70 = add i32 %69, 1
-  store i32 %70, i32* %j, align 4
-  %71 = load i32, i32* %k, align 4
-  %72 = add i32 %71, 1
-  store i32 %72, i32* %k, align 4
+  %73 = load i32, i32* %j, align 4
+  %74 = add i32 %73, 1
+  store i32 %74, i32* %j, align 4
+  %75 = load i32, i32* %k, align 4
+  %76 = add i32 %75, 1
+  store i32 %76, i32* %k, align 4
   br label %loop.head1
 
 loop.end:                                         ; preds = %loop.head1
-  %73 = load i32, i32* %found, align 4
-  %74 = icmp eq i32 %73, 1
-  br i1 %74, label %then8, label %else9
+  %77 = load i32, i32* %found, align 4
+  %78 = icmp eq i32 %77, 1
+  br i1 %78, label %then8, label %else9
 
 then8:                                            ; preds = %loop.end
-  %75 = load i32, i32* %i, align 4
-  store i32 %75, i32* %_lcompilers_index_str1, align 4
-  %76 = load i32, i32* %back, align 4
-  store i32 %76, i32* %found, align 4
+  %79 = load i32, i32* %i, align 4
+  store i32 %79, i32* %_lcompilers_index_str1, align 4
+  %80 = load i32, i32* %back, align 4
+  store i32 %80, i32* %found, align 4
   br label %ifcont10
 
 else9:                                            ; preds = %loop.end
@@ -330,9 +338,9 @@ else9:                                            ; preds = %loop.end
   br label %ifcont10
 
 ifcont10:                                         ; preds = %else9, %then8
-  %77 = load i32, i32* %i, align 4
-  %78 = add i32 %77, 1
-  store i32 %78, i32* %i, align 4
+  %81 = load i32, i32* %i, align 4
+  %82 = add i32 %81, 1
+  store i32 %82, i32* %i, align 4
   br label %loop.head
 
 loop.end11:                                       ; preds = %loop.head
@@ -342,8 +350,8 @@ return:                                           ; preds = %loop.end11
   br label %FINALIZE_SYMTABLE__lcompilers_index_str1
 
 FINALIZE_SYMTABLE__lcompilers_index_str1:         ; preds = %return
-  %79 = load i32, i32* %_lcompilers_index_str1, align 4
-  ret i32 %79
+  %83 = load i32, i32* %_lcompilers_index_str1, align 4
+  ret i32 %83
 }
 
 declare i32 @str_compare(i8*, i64, i8*, i64)


### PR DESCRIPTION
> Rebased onto `main` (71f604b2a) now that #12552 has merged. This PR is a single
> commit and its diff no longer carries #12552's refactor. Merge before #12554.

## Summary

A non-pointer, non-allocatable character member of a bind(C)/SEQUENCE struct is
stored inline in the struct rather than behind a string descriptor, but the
layout only ever reserved one element's worth of bytes: `getStructType` sized the
member as `[len x i8]` and ignored the element count, so an array member
overlapped the members that follow it. The accessors matched that assumption —
indexing, substring and formatted read all went through the descriptor-only
paths — so a program that used such a member crashed:

```fortran
type :: t
    sequence
    character(len=4) :: names(3)
    integer :: n
end type
type(t) :: x
x%names(1) = "abcd"     ! Segmentation fault
```

## Scope

- `src/libasr/asr_utils.h`: add `ASRUtils::inline_character_storage_size`
  (`count * len * kind`).
- `src/libasr/codegen/llvm_utils.cpp`: size the inline member as
  `[count*len*kind x i8]`; add `LLVMUtils::get_inline_string_element`, which
  offsets into the blob by `idx*len*kind` and wraps the element in a string view
  descriptor.
- `src/libasr/codegen/llvm_array_utils.cpp`, `src/libasr/codegen/asr_to_llvm.cpp`:
  use it from `get_single_element` and from the formatted-read element path;
  route `visit_StringItem` and the string-section helper through the inline-aware
  `get_string_data_and_length`; skip descriptor setup for inline members in
  `allocate_array_members_of_struct` (arrays as well as scalars); and stop
  treating an inline member as an allocatable assignment destination — there is
  no data pointer for `_lfortran_strcpy` to allocate.
- Reference outputs updated for the four tests whose LLVM lowering changes
  (`derived_types_32`, `read_83`, `string_03`, `string_11`).

## Verification

New integration test `derived_types_154` (labels `gfortran llvm`). It segfaults
at runtime before this change and passes after; gfortran agrees.

The four `llvm-*` reference outputs were regenerated locally against
**llvmdev 11.1.0**, matching the LLVM version CI's ubuntu reference job uses.
That toolchain was validated first by running the full reference suite on
unmodified `main`, which passed — so it reproduces CI's reference outputs
byte-for-byte. `derived_types_32` and `read_83` needed regenerating after the
rebase because main's 10db928bf touched the same string lowering; `string_03`
and `string_11` were already correct.

Local runs on this branch:

- `./run_tests.py` under LLVM 11 — TESTS PASSED
- integration suites were run on the #12554 tip, which contains this commit:
  `-b llvm` 3874 passed / 0 failed, `-b gfortran` 3936 passed / 0 failed

## Rationale

Extracted from #12309, where this was a prerequisite for storing COMMON block
characters inline. It is a bug in its own right for bind(C)/SEQUENCE types, with
no COMMON involved, so it is reviewable and testable on its own.

Second of the three PRs split out of #12309: #12552 (merged) → **this PR** →
#12554.
