### PR TITLE
fix: store COMMON block characters inline instead of via descriptors

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3921,6 +3921,7 @@ RUN(NAME common_38 LABELS gfortran llvm)
 RUN(NAME common_39 LABELS gfortran llvm)
 RUN(NAME common_40 LABELS gfortran llvm)
 RUN(NAME common_41 LABELS gfortran llvm)
+RUN(NAME common_42 LABELS gfortran llvm)
 RUN(NAME common_substring_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME common_substring_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
@@ -4603,6 +4604,8 @@ RUN(NAME separate_compilation_48 LABELS gfortran llvm EXTRAFILES separate_compil
 RUN(NAME separate_compilation_49 LABELS gfortran llvm EXTRAFILES separate_compilation_49a.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_50 LABELS gfortran llvm EXTRAFILES separate_compilation_50a.f90 separate_compilation_50b.f90 EXTRA_ARGS --separate-compilation)
 RUN(NAME separate_compilation_51 LABELS gfortran llvm EXTRAFILES separate_compilation_51a.f90 EXTRA_ARGS --separate-compilation)
+RUN(NAME separate_compilation_52 LABELS gfortran llvm EXTRAFILES separate_compilation_52a.f90 separate_compilation_52b.f90 EXTRA_ARGS --implicit-interface --separate-compilation)
+RUN(NAME separate_compilation_53 LABELS gfortran llvm EXTRAFILES separate_compilation_53a.f90 separate_compilation_53b.f90 EXTRA_ARGS --implicit-interface --separate-compilation)
 
 RUN(NAME no_explicit_return_type_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc
     EXTRA_ARGS --implicit-typing)

--- a/integration_tests/common_42.f90
+++ b/integration_tests/common_42.f90
@@ -1,0 +1,33 @@
+! A COMMON block CHARACTER member is stored inline as a flat byte blob, but a
+! callee taking a string descriptor needs one materialized over those bytes.
+! Passing the member straight through produced a call whose argument type did
+! not match the callee's signature (reduced from LAPACK's srnamc / xerbla).
+program common_42
+    implicit none
+    character(32) :: srnamt
+    character(8) :: tag
+    common /srnamc/ srnamt
+    common /tagc/ tag
+
+    srnamt = "ABCDE"
+    tag = "xy"
+
+    ! intrinsic taking a string descriptor
+    if (len_trim(srnamt) /= 5) error stop "len_trim on common char member"
+    if (trim(srnamt) /= "ABCDE") error stop "trim on common char member"
+    if (index(srnamt, "CD") /= 3) error stop "index on common char member"
+
+    ! user-defined function taking a string
+    if (mylen(srnamt) /= 5) error stop "user function on common char member"
+    if (mylen(tag) /= 2) error stop "user function on second common block"
+
+    print *, len_trim(srnamt), trim(srnamt), mylen(tag)
+
+contains
+
+    integer function mylen(s)
+        character(len=*), intent(in) :: s
+        mylen = len_trim(s)
+    end function mylen
+
+end program common_42

--- a/integration_tests/separate_compilation_52.f90
+++ b/integration_tests/separate_compilation_52.f90
@@ -1,0 +1,4 @@
+program separate_compilation_52
+    implicit none
+    call initialize_common_character_array()
+end program separate_compilation_52

--- a/integration_tests/separate_compilation_52a.f90
+++ b/integration_tests/separate_compilation_52a.f90
@@ -1,0 +1,11 @@
+subroutine initialize_common_character_array()
+    implicit none
+    character(1) :: value
+    character(1) :: initialized(1)
+    common /shared_52/ value(1)
+    common /initialized_52/ initialized
+
+    if (initialized(1) /= "y") error stop "BLOCK DATA initialization was overwritten"
+    value(1) = "x"
+    if (value(1) /= "x") error stop "COMMON character array assignment failed"
+end subroutine initialize_common_character_array

--- a/integration_tests/separate_compilation_52b.f90
+++ b/integration_tests/separate_compilation_52b.f90
@@ -1,0 +1,6 @@
+block data initialize_common_character_data
+    implicit none
+    character(1) :: initialized(1)
+    common /initialized_52/ initialized
+    data initialized /"y"/
+end block data initialize_common_character_data

--- a/integration_tests/separate_compilation_53.f90
+++ b/integration_tests/separate_compilation_53.f90
@@ -1,0 +1,5 @@
+program separate_compilation_53
+    implicit none
+    call set_common_name()
+    call check_common_chars()
+end program separate_compilation_53

--- a/integration_tests/separate_compilation_53a.f90
+++ b/integration_tests/separate_compilation_53a.f90
@@ -1,0 +1,6 @@
+subroutine set_common_name()
+    implicit none
+    character(4) :: name
+    common /nm_53/ name
+    name = "ABCD"
+end subroutine set_common_name

--- a/integration_tests/separate_compilation_53b.f90
+++ b/integration_tests/separate_compilation_53b.f90
@@ -1,0 +1,13 @@
+subroutine check_common_chars()
+    implicit none
+    ! The same 4 bytes of common block /nm_53/ are declared here as an array of
+    ! four single characters (storage association). This only works if the
+    ! common character storage lives inline in the block, shared across the
+    ! separately compiled units, rather than behind a per-unit descriptor.
+    character(1) :: ch(4)
+    common /nm_53/ ch
+    if (ch(1) /= "A") error stop "ch(1)"
+    if (ch(2) /= "B") error stop "ch(2)"
+    if (ch(3) /= "C") error stop "ch(3)"
+    if (ch(4) /= "D") error stop "ch(4)"
+end subroutine check_common_chars

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -4599,7 +4599,7 @@ public:
             ASR::symbol_t* struct_symbol = ASR::down_cast<ASR::symbol_t>(make_Struct_t(
                 al, loc, struct_scope, s2c(al,common_block_name),
                 nullptr,
-                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false, false,
+                nullptr, 0, nullptr, 0, nullptr, 0, ASR::abiType::Source, ASR::accessType::Public, false, false, true,
                 nullptr, 0, nullptr, nullptr, nullptr, 0));
             ASR::ttype_t* struct_type = ASRUtils::make_StructType_t_util(al, loc, struct_symbol, true);
             ASR::Struct_t* struct_ = ASR::down_cast<ASR::Struct_t>(struct_symbol);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1013,6 +1013,35 @@ public:
         return data_and_length;
     }
 
+    /*
+        A character member stored inline in a struct (bind(C)/SEQUENCE/COMMON)
+        is a flat [count*len x i8] blob, but any callee taking a
+        DescriptorString expects a %string_descriptor*. Materialize a temporary
+        descriptor over the blob so the call matches the callee's signature and
+        the callee sees the right data pointer and length. Returns `value`
+        unchanged when it is not such a member.
+
+        Only scalar members are wrapped: a whole inline character *array*
+        member is passed as an array, not as one string descriptor.
+    */
+    llvm::Value* inline_char_member_as_string_descriptor(ASR::expr_t* arg,
+            llvm::Value* value, std::string name) {
+        if (!ASRUtils::is_string_only(expr_type(arg))
+                || ASRUtils::get_string_type(expr_type(arg))->m_physical_type
+                    != ASR::DescriptorString
+                || !ASRUtils::is_inline_character_struct_member(arg)) {
+            return value;
+        }
+        int64_t len = 1;
+        ASR::String_t* str_type = ASRUtils::get_string_type(expr_type(arg));
+        if (str_type->m_len) {
+            ASRUtils::extract_value(str_type->m_len, len);
+        }
+        if (len < 1) len = 1;
+        return llvm_utils->create_string_descriptor(
+            builder->CreateBitCast(value, character_type),
+            llvm::ConstantInt::get(context, llvm::APInt(64, len)), name);
+    }
 
 
 
@@ -5386,6 +5415,18 @@ public:
             ASR::expr_t *value = x.m_args[i].m_value;
             llvm::Constant* initializer = nullptr;
             llvm::Type* type = nullptr;
+            ASR::symbol_t* member_sym = i < struct_->n_members
+                ? struct_->m_symtab->get_symbol(struct_->m_members[i]) : nullptr;
+            if (member_sym && ASR::is_a<ASR::Variable_t>(*member_sym)) {
+                ASR::ttype_t* member_type =
+                    ASR::down_cast<ASR::Variable_t>(member_sym)->m_type;
+                if (ASRUtils::is_inline_character_struct_member(
+                        struct_, member_type)) {
+                    // Inline character member: flat [count*len x i8] byte blob.
+                    elements.push_back(get_inline_char_member_constant(member_type, value));
+                    continue;
+                }
+            }
             if (value == nullptr) {
                 auto member2sym = struct_->m_symtab->get_scope();
                 LCOMPILERS_ASSERT(member2sym[struct_->m_members[i]]->type == ASR::symbolType::Variable);
@@ -6510,6 +6551,7 @@ public:
             allocate_array_members_of_struct(ASR::down_cast<ASR::Struct_t>(st.first),
                 st.second, ASRUtils::symbol_type(st.first), false, false);
         }
+        allocatable_struct_array_members_details.clear();
         declare_vars(x);
         for(variable_inital_value var_to_initalize : variable_inital_value_vec){
             set_VariableInital_value(var_to_initalize.v, var_to_initalize.target_var);
@@ -7142,6 +7184,40 @@ public:
         class2vtab[struct_type_][symtab].push_back(vtab_obj);
     }
 
+    // Build the [count*len*kind x i8] byte constant for a character member that
+    // is stored inline (bind(C)/SEQUENCE/COMMON struct). The bytes come from the
+    // member's DATA value (StringConstant for a scalar, ArrayConstant's flat data
+    // buffer for an array); any remainder is space-padded (Fortran blank fill).
+    llvm::Constant* get_inline_char_member_constant(ASR::ttype_t* member_type,
+            ASR::expr_t* value_expr) {
+        int64_t total = ASRUtils::inline_character_storage_size(member_type);
+        llvm::ArrayType* blob_type = llvm::ArrayType::get(
+            llvm::Type::getInt8Ty(context), (uint64_t)total);
+        std::string bytes;
+        ASR::expr_t* value = value_expr ? ASRUtils::expr_value(value_expr) : nullptr;
+        if (value && ASR::is_a<ASR::StringConstant_t>(*value)) {
+            ASR::StringConstant_t* sc = ASR::down_cast<ASR::StringConstant_t>(value);
+            int64_t sc_len = 1;
+            ASRUtils::extract_value(ASRUtils::get_string_type(sc->m_type)->m_len, sc_len);
+            bytes.assign(sc->m_s, (size_t)sc_len);
+        } else if (value && ASR::is_a<ASR::ArrayConstant_t>(*value)) {
+            ASR::ArrayConstant_t* ac = ASR::down_cast<ASR::ArrayConstant_t>(value);
+            bytes.assign((char*)ac->m_data, (size_t)ac->m_n_data);
+        } else {
+            // No initializer: emit an all-zero aggregate so the enclosing global
+            // stays an all-zero tentative definition and keeps CommonLinkage
+            // (which merges the member's storage across separate TUs).
+            return llvm::ConstantAggregateZero::get(blob_type);
+        }
+        // Blank-pad a DATA-initialized member (Fortran blank fill).
+        if ((int64_t)bytes.size() < total) {
+            bytes.append((size_t)(total - bytes.size()), ' ');
+        } else if ((int64_t)bytes.size() > total) {
+            bytes.resize((size_t)total);
+        }
+        return llvm::ConstantDataArray::getString(context, bytes, false);
+    }
+
     void get_type_default_field_values(ASR::symbol_t* struct_sym,
             std::vector<llvm::Constant*>& field_values, ASR::symbol_t* orig_struct_sym) {
         struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
@@ -7161,7 +7237,12 @@ public:
             if (!sym || !ASR::is_a<ASR::Variable_t>(*sym))
                 continue;
             ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-            if (var->m_value != nullptr) {
+            if (ASRUtils::is_inline_character_struct_member(
+                    struct_t, var->m_type)) {
+                // Inline character member is a flat [count*len x i8] byte blob;
+                // build a matching byte constant (space-padded) from its DATA value.
+                field_values.push_back(get_inline_char_member_constant(var->m_type, var->m_value));
+            } else if (var->m_value != nullptr) {
                 llvm::Constant* c = create_llvm_constant_from_asr_expr(var->m_value, var->m_type,
                     orig_struct_sym);
                 field_values.push_back(c);
@@ -24089,6 +24170,10 @@ public:
                     al, orig_arg->base.base.loc, &orig_arg->base)), orig_arg->m_type, module.get());
                     tmp = llvm_utils->CreateLoad2(el_type->getPointerTo(), tmp);
                 }
+                // An inline character member is a raw byte blob; a callee taking
+                // a string descriptor needs one materialized over it.
+                tmp = inline_char_member_as_string_descriptor(
+                    x.m_args[i].m_value, tmp, "inline_call_arg");
                 llvm::Value *value = tmp;
                 if (orig_arg_intent == ASR::intentType::In ||
                     orig_arg_intent == ASR::intentType::InOut ||
@@ -27714,26 +27799,8 @@ public:
                     builder->CreateStore(tmp, tmp_ptr);
                     tmp = tmp_ptr;
                 }
-                // bind(C)/SEQUENCE inline char member: tmp is [len x i8]* but
-                // format expects string_descriptor*. Materialize a temp descriptor.
-                if (ASRUtils::is_character(*expr_type(x.m_args[i])) &&
-                    ASRUtils::get_string_type(expr_type(x.m_args[i]))->m_physical_type
-                        == ASR::DescriptorString &&
-                    ASRUtils::is_inline_character_struct_member(x.m_args[i])) {
-                    ASR::StructInstanceMember_t* sim = ASR::down_cast<
-                        ASR::StructInstanceMember_t>(x.m_args[i]);
-                    ASR::String_t* str_ty = ASR::down_cast<ASR::String_t>(
-                        ASRUtils::extract_type(sim->m_type));
-                    int64_t slen = 1;
-                    if (str_ty->m_len) {
-                        ASRUtils::extract_value(str_ty->m_len, slen);
-                    }
-                    if (slen < 1) slen = 1;
-                    tmp = llvm_utils->create_string_descriptor(
-                        builder->CreateBitCast(tmp, character_type),
-                        llvm::ConstantInt::get(context, llvm::APInt(64, slen)),
-                        "inline_fmt_arg");
-                }
+                tmp = inline_char_member_as_string_descriptor(
+                    x.m_args[i], tmp, "inline_fmt_arg");
                 args.push_back(tmp);
                 ptr_loads = ptr_load_copy;
             }

--- a/tests/reference/asr-common2-64c97b2.json
+++ b/tests/reference/asr-common2-64c97b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common2-64c97b2.stdout",
-    "stdout_hash": "f8e6da2b31930be5798ce4f2989d7b2f4b623b60e67a2ef3270da4e9",
+    "stdout_hash": "cb0149df29eea76cfa48b39725bd59b7855f2f37bc75adb61cd16373",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common2-64c97b2.stdout
+++ b/tests/reference/asr-common2-64c97b2.stdout
@@ -132,7 +132,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -249,7 +249,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -366,7 +366,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -458,7 +458,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -575,7 +575,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_03-9052466.json
+++ b/tests/reference/asr-common_03-9052466.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_03-9052466.stdout",
-    "stdout_hash": "67283774b977377290af5f4ddc994228e201dda03f3a6a8b9ec0e1d3",
+    "stdout_hash": "328f0f66d9c1ac50766100b3a7f30285fc390de3c8574aad67e148f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_03-9052466.stdout
+++ b/tests/reference/asr-common_03-9052466.stdout
@@ -231,7 +231,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -348,7 +348,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -515,7 +515,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -667,7 +667,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_04-b603709.json
+++ b/tests/reference/asr-common_04-b603709.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_04-b603709.stdout",
-    "stdout_hash": "58ec4c736cc0845c4e14c2f028c380e8a98dc2029477828d687ceba5",
+    "stdout_hash": "342d81914309d8c73b1fa7182cb3a808ce3e913c431d5b66060d1c0b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_04-b603709.stdout
+++ b/tests/reference/asr-common_04-b603709.stdout
@@ -106,7 +106,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_05-f767179.json
+++ b/tests/reference/asr-common_05-f767179.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_05-f767179.stdout",
-    "stdout_hash": "af57fbdd125e390f28b4368e800843071aa04e7570840ab48ac34dfa",
+    "stdout_hash": "3c719ac1b287344c6d8a3cf306d281cd10201b38337415c70c6e0808",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_05-f767179.stdout
+++ b/tests/reference/asr-common_05-f767179.stdout
@@ -106,7 +106,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_06-4a72d58.json
+++ b/tests/reference/asr-common_06-4a72d58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_06-4a72d58.stdout",
-    "stdout_hash": "7c53b371e75414ef248b6aeb9078d7f3d96869c6ac6748b630b8f815",
+    "stdout_hash": "419a0ed16e2345ab89515daa1099665565153384e12419a819e66d77",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_06-4a72d58.stdout
+++ b/tests/reference/asr-common_06-4a72d58.stdout
@@ -73,7 +73,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()

--- a/tests/reference/asr-common_13-fa7cbf0.json
+++ b/tests/reference/asr-common_13-fa7cbf0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-common_13-fa7cbf0.stdout",
-    "stdout_hash": "66868ae4b5235632e5d965f21ae5be68cfbf89db76df599171fcfc42",
+    "stdout_hash": "0372ddf71af93c36cf835e06fea4d97ff9436eae7f8ef23a8105c006",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-common_13-fa7cbf0.stdout
+++ b/tests/reference/asr-common_13-fa7cbf0.stdout
@@ -219,7 +219,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()
@@ -374,7 +374,7 @@
                                     Public
                                     .false.
                                     .false.
-                                    .false.
+                                    .true.
                                     []
                                     ()
                                     ()


### PR DESCRIPTION
> **Stacked on #12553**, rebased onto `main` (71f604b2a) now that #12552 has
> merged. The diff below contains #12553's commit as well. **The change to review
> here is the second commit, `fix: store COMMON block characters inline instead of
> via descriptors`.** Merge after #12553.

## Summary

A Fortran COMMON block is contiguous, storage-associated memory: every entity
must live inline at a fixed byte offset so that separately compiled units can
overlay the same bytes. LFortran modelled a COMMON `CHARACTER` member as a string
descriptor `{i8*, i64}`, which stores a *pointer* in the block rather than the
bytes. The storage was therefore neither shared nor initializable across
translation units, and a program reading a COMMON character initialized by a
`BLOCK DATA` in another unit died at runtime:

```
LFORTRAN ERROR: Runtime Error : Non-allocatable string isn't allocated.
```

This PR lays COMMON character members out inline, matching gfortran and flang.

## Scope

- `src/lfortran/semantics/ast_common_visitor.h`: create the synthetic COMMON
  struct with `is_sequence=true`, so its character members go through the inline
  layout that bind(C)/SEQUENCE structs already use.
- `src/libasr/codegen/asr_to_llvm.cpp`:
  - `visit_StructConstant` and `get_type_default_field_values` emit a flat byte
    constant for an inline character member (`get_inline_char_member_constant`):
    zero-filled when uninitialized, so the enclosing global stays an all-zero
    tentative definition and `CommonLinkage` still merges it across units, and
    blank-padded (Fortran blank fill) when it has a `DATA` value.
  - `allocate_array_members_of_struct` clears
    `allocatable_struct_array_members_details` after draining it, so descriptor
    members recorded for one function are not re-initialized in the next.
- Reference outputs updated for the ASR change (`common2`, `common_03` …
  `common_13`).

## Verification

Two new integration tests (labels `gfortran llvm`):

- `separate_compilation_52` — a COMMON character array initialized by a
  `BLOCK DATA` in a separately compiled unit. Fails before this change with the
  runtime error above; passes after.
- `separate_compilation_53` — `character(4)` written in one unit and read back as
  four `character(1)` elements in another, pinning down the storage association
  the descriptor model could not express.

Local runs on this branch:

- `./run_tests.py` under **llvmdev 11.1.0** (the version CI's ubuntu reference
  job uses) — TESTS PASSED
- `integration_tests/run_tests.py -b llvm` — 3874 passed, 0 failed
- `integration_tests/run_tests.py -b gfortran` — 3936 passed, 0 failed

## Rationale

Extracted from #12309. The original branch first added a runtime workaround for
this (a `CommonLinkage` side buffer per member plus a run-once global
constructor, `__lfortran_init_common_blocks`, to patch each descriptor's data
pointer) and then deleted it again in favour of the inline layout. Only the
inline layout is kept here, so this diff carries no added-then-removed code.

Third of the three PRs split out of #12309: #12552 (merged) → #12553 →
**this PR**.
