### PR TITLE
simplify: drop the team_type import only if unused

### DIFF
--- a/integration_tests/coarrays_40.f90
+++ b/integration_tests/coarrays_40.f90
@@ -2,12 +2,7 @@ program coarrays_40
   ! Unused team_type variables must not break compilation (issue #12538)
   use iso_fortran_env, only: team_type
   implicit none
-
   type(team_type) :: subteam
   type(team_type) :: default_team
-  integer :: n
-
-  n = num_images()
   form team(1, subteam)
-  if (num_images() /= n) error stop 1
 end program coarrays_40

--- a/src/libasr/pass/coarray.cpp
+++ b/src/libasr/pass/coarray.cpp
@@ -937,25 +937,18 @@ class PRIFInterface {
             return struct_sym;
         }
 
-        // FORM TEAM only names the used entity; unused team_type variables
-        // in the translation unit must be rewritten before the import is dropped.
-        void convert_vars_of_type(ASR::symbol_t *from_def, ASR::symbol_t *to_decl,
-                                  const Location &loc, SymbolTable *symtab) {
+        static bool type_declaration_in_use(ASR::symbol_t *decl, SymbolTable *symtab) {
             for (auto &item : symtab->get_scope()) {
                 ASR::symbol_t *sym = item.second;
-                if (ASR::is_a<ASR::Variable_t>(*sym)) {
-                    ASR::Variable_t *var = ASR::down_cast<ASR::Variable_t>(sym);
-                    if (var->m_type_declaration &&
-                            ASRUtils::symbol_get_past_external(var->m_type_declaration)
-                                == from_def) {
-                        var->m_type_declaration = to_decl;
-                        var->m_type = ASRUtils::make_StructType_t_util(al, loc, to_decl, true);
-                    }
+                if (ASR::is_a<ASR::Variable_t>(*sym) &&
+                        ASR::down_cast<ASR::Variable_t>(sym)->m_type_declaration == decl) {
+                    return true;
                 }
                 if (SymbolTable *child = ASRUtils::symbol_symtab(sym)) {
-                    convert_vars_of_type(from_def, to_decl, loc, child);
+                    if (type_declaration_in_use(decl, child)) return true;
                 }
             }
+            return false;
         }
 
         void convert_team_type(const Location &loc, ASR::expr_t *team) {
@@ -967,15 +960,17 @@ class PRIFInterface {
                 ASR::symbol_t *prif_decl = get_or_create_prif_team_type_struct(loc);
                 if (team_var->m_type_declaration != prif_decl) {
                     ASR::symbol_t *orig_decl = team_var->m_type_declaration;
+                    team_var->m_type_declaration = prif_decl;
+                    team_var->m_type = ASRUtils::make_StructType_t_util(al, loc, prif_decl, true);
                     LCOMPILERS_ASSERT(orig_decl != nullptr);
-                    ASR::symbol_t *orig_def = ASRUtils::symbol_get_past_external(orig_decl);
-                    convert_vars_of_type(orig_def, prif_decl, loc, unit.m_symtab);
-                    // Drop the import, not the type defined in iso_fortran_env.
+                    // Drop the import, not the type defined in iso_fortran_env,
+                    // and only once nothing else still names it.
                     if (ASR::is_a<ASR::ExternalSymbol_t>(*orig_decl)) {
                         SymbolTable *parent_symtab = ASRUtils::symbol_parent_symtab(orig_decl);
                         LCOMPILERS_ASSERT(parent_symtab != nullptr);
                         std::string sym_name = std::string(ASRUtils::symbol_name(orig_decl));
-                        if (parent_symtab->get_symbol(sym_name) == orig_decl) {
+                        if (parent_symtab->get_symbol(sym_name) == orig_decl &&
+                                !type_declaration_in_use(orig_decl, parent_symtab)) {
                             parent_symtab->erase_symbol(sym_name);
                         }
                     }


### PR DESCRIPTION
FORM TEAM already converts the used variable. An unused team_type entity still names the import, so drop it only when nothing else does, instead of rewriting every team_type variable in the translation unit.

Follow-up on #12549.