### PR TITLE
fix: allow real kind 10 in ASR verification

### DIFF
--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -2624,8 +2624,8 @@ public:
     void visit_Real(const Real_t &x) {
         if (diagnostics.has_error()) return;
         require_id(
-            x.m_kind == 4 || x.m_kind == 8 || x.m_kind == 16 ||
-                x.m_kind >= 1000,
+            x.m_kind == 4 || x.m_kind == 8 || x.m_kind == 10 ||
+                x.m_kind == 16 || x.m_kind >= 1000,
             "asr.verify.type.real_kind_supported",
             "Real kind " + std::to_string(x.m_kind) +
                 " is not supported");


### PR DESCRIPTION
## Summary

CI on main failed after merging #12502 because `c_long_double` is now `real(kind=10)`, but ASR verification still rejected Real kind 10.

Example:

```
ASR verify pass error [asr.verify.type.real_kind_supported]: Real kind 10 is not supported
 --> integration_tests/test_c_long_double.f90:8:10
8 |          real(c_long_double), value :: a, b
```

This updates `visit_Real` to accept kind 10, matching the kinds the rest of the compiler already implements for `c_long_double`.

Fixes the regression from https://github.com/lfortran/lfortran/actions/runs/32389361496.

## Scope

- `src/libasr/asr_verify.cpp`: allow Real kind 10 (alongside 4, 8, and 16).

No test changes: `test_c_long_double` and `test_c_long_double_01` already exist from #12502.

## Verification

- Rebuilt the in-tree LLVM Debug compiler.
- `lfortran integration_tests/test_c_long_double.f90 integration_tests/test_c_long_double_c.c` compiles and prints `PASS`.
- `lfortran integration_tests/test_c_long_double_01.f90` compiles and prints `PASS`.

Without this change those programs fail in the ASR verifier before codegen.

## Rationale

#12502 added kind 10 for `c_long_double` (LLVM `x86_fp80` / platform `long double`). The kind check in `asr_verify.cpp` (from #12453) was never updated, so valid ASR from that feature is rejected. The verifier should allow every kind the frontend and backends already support.