### PR TITLE
Add runtime bounds checking for array sections

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3550,6 +3550,10 @@ RUN(NAME array_section_27 LABELS gfortran llvm llvm_single_invocation
     EXTRA_ARGS --separate-compilation)
 RUN(NAME array_section_28 LABELS gfortran llvm)
 RUN(NAME array_section_29 LABELS gfortran llvm)
+RUN(NAME array_section_30 LABELS gfortran llvm)
+RUN(NAME array_section_oob_01 FAIL LABELS gfortran llvm NO_FAST GFORTRAN_ARGS -fcheck=bounds)
+RUN(NAME array_section_oob_02 FAIL LABELS gfortran llvm NO_FAST GFORTRAN_ARGS -fcheck=bounds)
+RUN(NAME array_section_oob_03 FAIL LABELS gfortran llvm NO_FAST GFORTRAN_ARGS -fcheck=bounds)
 
 RUN(NAME nested_vars_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray)
 RUN(NAME nested_vars_02 LABELS gfortran llvm)

--- a/integration_tests/array_section_30.f90
+++ b/integration_tests/array_section_30.f90
@@ -1,0 +1,45 @@
+module array_section_30_mod
+   implicit none
+contains
+   subroutine take(a, expected_n)
+      real, intent(in) :: a(:)
+      integer, intent(in) :: expected_n
+      if (size(a) /= expected_n) error stop
+   end subroutine
+   subroutine asz(y)
+      real, intent(in) :: y(*)
+      if (abs(y(1) - 1.0) > 1e-6) error stop
+      call take(y(1:2), 2)
+   end subroutine
+end module array_section_30_mod
+
+program array_section_30
+   ! In-bounds sections (including empty sections, negative strides and
+   ! non-default lower bounds) must not trip the runtime bounds checker.
+   use array_section_30_mod
+   implicit none
+   real :: x(3), x2(3,3)
+   real, allocatable :: xa(:), xb(:)
+   integer :: i
+   x = 1.0; x2 = 1.0
+   allocate(xa(3)); xa = 1.0
+   allocate(xb(-1:1)); xb = 1.0
+
+   call take(x(1:3), 3)
+   call take(x(:), 3)
+   call take(x(2:), 2)
+   call take(x(:2), 2)
+   call take(x(1:3:2), 2)
+   call take(x(3:1:-1), 3)
+   call take(x(3:2), 0)
+   call take(x(2:3:-1), 0)
+   i = 2
+   call take(x(i:i+1), 2)
+   call take(xa(1:3), 3)
+   call take(xb(-1:1), 3)
+   call take(xb(-1:0), 2)
+   call take(x2(2:3, 2), 2)
+   call take(x2(1:3:2, 3), 2)
+   call asz(x)
+   print *, "ok"
+end program array_section_30

--- a/integration_tests/array_section_oob_01.f90
+++ b/integration_tests/array_section_oob_01.f90
@@ -1,0 +1,9 @@
+program array_section_oob_01
+   ! Reading an array section below the lower bound must abort at runtime.
+   implicit none
+   real :: x(3)
+   integer :: i
+   x = 1.0
+   i = 0
+   print *, x(i:i+1)
+end program array_section_oob_01

--- a/integration_tests/array_section_oob_02.f90
+++ b/integration_tests/array_section_oob_02.f90
@@ -1,0 +1,11 @@
+program array_section_oob_02
+   ! Writing through an out-of-bounds array section must abort at runtime
+   ! instead of silently corrupting memory outside the array.
+   implicit none
+   real :: x(3)
+   integer :: i
+   x = 1.0
+   i = 0
+   x(i:i+1) = 9.0
+   print *, x
+end program array_section_oob_02

--- a/integration_tests/array_section_oob_03.f90
+++ b/integration_tests/array_section_oob_03.f90
@@ -1,0 +1,11 @@
+program array_section_oob_03
+   ! A strided section of an allocatable array that runs outside the
+   ! bounds must abort at runtime.
+   implicit none
+   real, allocatable :: x(:)
+   integer :: i
+   allocate(x(3))
+   x = 1.0
+   i = 0
+   print *, x(i:i+4:2)
+end program array_section_oob_03

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4450,6 +4450,7 @@ public:
             Vec<llvm::Value*> llvm_diminfo;
             llvm_diminfo.reserve(al, 2 * x.n_args + 1);
             bool check_for_bounds = compiler_options.po.bounds_checking;
+            bool assumed_size_last_dim = false;
             if( array_t->m_physical_type == ASR::array_physical_typeType::PointerArray ||
                 array_t->m_physical_type == ASR::array_physical_typeType::UnboundedPointerArray ||
                 array_t->m_physical_type == ASR::array_physical_typeType::FixedSizeArray ||
@@ -4480,7 +4481,13 @@ public:
                         llvm::Type* idx_type = arr_descr->get_index_type();
                         unsigned idx_bits = idx_type->getIntegerBitWidth();
                         dim_size = llvm::ConstantInt::get(context, llvm::APInt(idx_bits, 0));
-                        check_for_bounds = false;
+                        if (idim == x.n_args - 1) {
+                            // Assumed-size last dimension: no upper bound is
+                            // known, but the lower bound can still be checked.
+                            assumed_size_last_dim = true;
+                        } else {
+                            check_for_bounds = false;
+                        }
                     }
                     llvm_diminfo.push_back(al, dim_start);
                     llvm_diminfo.push_back(al, dim_size);
@@ -4531,7 +4538,8 @@ public:
                                                     true,
                                                     false,
                                                     llvm_diminfo.p, is_polymorphic, nullptr,
-                                                    false, false, array_name, infile);
+                                                    false, check_for_bounds,
+                                                    assumed_size_last_dim, array_name, infile);
             } else {
                 llvm::Type* type;
                 bool is_fixed_size = (array_t->m_physical_type == ASR::array_physical_typeType::FixedSizeArray ||
@@ -4553,7 +4561,8 @@ public:
                                                     array_t->m_physical_type == ASR::array_physical_typeType::StringArraySinglePointer,
                                                     is_fixed_size, llvm_diminfo.p, is_polymorphic,
                                                     nullptr, false,
-                                                    check_for_bounds, array_name, infile);
+                                                    check_for_bounds, assumed_size_last_dim,
+                                                    array_name, infile);
             }
         }
         if( ASR::is_a<ASR::StructType_t>(*ASRUtils::extract_type(x.m_type)) && !ASRUtils::is_class_type(x.m_type) ) {
@@ -9952,6 +9961,103 @@ public:
             } else {
                 visit_expr_wrapper(array_section->m_args[i].m_right, true);
                 non_sliced_indices.p[i] = tmp;
+            }
+        }
+        if (compiler_options.po.bounds_checking) {
+            std::string array_name;
+            if (ASR::is_a<ASR::Var_t>(*array_section->m_v)) {
+                array_name = ASRUtils::EXPR2VAR(array_section->m_v)->m_name;
+            } else if (ASR::is_a<ASR::StructInstanceMember_t>(*array_section->m_v)) {
+                array_name = ASRUtils::symbol_name(ASRUtils::symbol_get_past_external(
+                    ASR::down_cast<ASR::StructInstanceMember_t>(array_section->m_v)->m_m));
+            } else {
+                array_name = "array";
+            }
+            llvm::Type* idx_type = arr_descr->get_index_type();
+            llvm::Value* zero = llvm::ConstantInt::get(idx_type, 0);
+            llvm::Value* one = llvm::ConstantInt::get(idx_type, 1);
+            bool desc_dims = arr_physical_type == ASR::array_physical_typeType::DescriptorArray;
+            llvm::Value* dim_des_arr = nullptr;
+            if (desc_dims) {
+                dim_des_arr = arr_descr->get_pointer_to_dimension_descriptor_array(
+                    value_desc_type, value_desc);
+            }
+            for (int i = 0; i < value_rank; i++) {
+                llvm::Value* alb = nullptr;
+                llvm::Value* aub = nullptr;
+                if (desc_dims) {
+                    llvm::Value* dim_des_ptr = arr_descr->get_pointer_to_dimension_descriptor(
+                        dim_des_arr, llvm::ConstantInt::get(idx_type, i));
+                    alb = arr_descr->get_lower_bound(dim_des_ptr);
+                    aub = arr_descr->get_upper_bound(dim_des_ptr);
+                } else {
+                    if (m_dims[i].m_start) {
+                        visit_expr_wrapper(m_dims[i].m_start, true);
+                        alb = builder->CreateSExtOrTrunc(tmp, idx_type);
+                    } else {
+                        alb = one;
+                    }
+                    if (m_dims[i].m_length) {
+                        visit_expr_wrapper(m_dims[i].m_length, true);
+                        llvm::Value* len = builder->CreateSExtOrTrunc(tmp, idx_type);
+                        aub = builder->CreateSub(builder->CreateAdd(alb, len), one);
+                    }
+                    // A dimension without a length (assumed-size last
+                    // dimension) has no known upper bound; check only the
+                    // lower bound then.
+                }
+                llvm::Value* dimension = llvm::ConstantInt::get(
+                    llvm::Type::getInt32Ty(context), llvm::APInt(32, i + 1));
+                llvm::Value* bad_idx = nullptr;
+                llvm::Value* fail = nullptr;
+                if (lbs.p[i] != nullptr) {
+                    llvm::Value* start = builder->CreateSExtOrTrunc(lbs.p[i], idx_type);
+                    llvm::Value* end = builder->CreateSExtOrTrunc(ubs.p[i], idx_type);
+                    llvm::Value* step = builder->CreateSExtOrTrunc(ds.p[i], idx_type);
+                    // The section accesses start, start+step, ...,
+                    // start + trip*step where trip = (end-start)/step; an
+                    // empty section accesses nothing, so there is nothing
+                    // to check.
+                    llvm::Value* trip = builder->CreateSDiv(
+                        builder->CreateSub(end, start), step);
+                    llvm::Value* nonempty = builder->CreateICmpSGE(trip, zero);
+                    llvm::Value* last = builder->CreateAdd(start,
+                        builder->CreateMul(trip, step));
+                    llvm::Value* step_pos = builder->CreateICmpSGT(step, zero);
+                    llvm::Value* lo = builder->CreateSelect(step_pos, start, last);
+                    llvm::Value* hi = builder->CreateSelect(step_pos, last, start);
+                    llvm::Value* bad_lo = builder->CreateICmpSLT(lo, alb);
+                    llvm::Value* bad = bad_lo;
+                    if (aub) {
+                        bad = builder->CreateOr(bad, builder->CreateICmpSGT(hi, aub));
+                    }
+                    fail = builder->CreateAnd(nonempty, bad);
+                    bad_idx = builder->CreateSelect(bad_lo, lo, hi);
+                } else {
+                    llvm::Value* idxv = builder->CreateSExtOrTrunc(
+                        non_sliced_indices.p[i], idx_type);
+                    llvm::Value* bad_lo = builder->CreateICmpSLT(idxv, alb);
+                    fail = bad_lo;
+                    if (aub) {
+                        fail = builder->CreateOr(fail, builder->CreateICmpSGT(idxv, aub));
+                    }
+                    bad_idx = idxv;
+                }
+                if (aub) {
+                    llvm_utils->generate_runtime_error(fail,
+                        "Array '%s' index out of bounds. Tried to access index %d of dimension %d, but valid range is %d to %d.",
+                        {LLVMUtils::RuntimeLabel("", {array_section->base.base.loc})},
+                        infile, location_manager,
+                        LCompilers::create_global_string_ptr(context, *module, *builder, array_name),
+                        bad_idx, dimension, alb, aub);
+                } else {
+                    llvm_utils->generate_runtime_error(fail,
+                        "Array '%s' index out of bounds. Tried to access index %d of dimension %d, but it is below the lower bound %d.",
+                        {LLVMUtils::RuntimeLabel("", {array_section->base.base.loc})},
+                        infile, location_manager,
+                        LCompilers::create_global_string_ptr(context, *module, *builder, array_name),
+                        bad_idx, dimension, alb);
+                }
             }
         }
         LCOMPILERS_ASSERT(target_rank > 0);

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -933,7 +933,7 @@ namespace LCompilers {
 
         llvm::Value* SimpleCMODescriptor::cmo_convertor_single_element_data_only(
             llvm::Value** llvm_diminfo, std::vector<llvm::Value*>& m_args,
-            int n_args, bool check_for_bounds,LocationManager& lm, bool is_unbounded_pointer_to_data, std::string array_name, std::string infile, Location loc) {
+            int n_args, bool check_for_bounds,LocationManager& lm, bool is_unbounded_pointer_to_data, bool assumed_size_last_dim, std::string array_name, std::string infile, Location loc) {
             unsigned index_bit_width = index_type->getIntegerBitWidth();
             llvm::Value* prod = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1));
             llvm::Value* idx = llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 0));
@@ -958,7 +958,21 @@ namespace LCompilers {
                     }
                     dim_size = builder->CreateSExtOrTrunc(dim_size, index_type);
                     r1 += 2;
-                    if( check_for_bounds ) {
+                    if( check_for_bounds && assumed_size_last_dim && r == n_args - 1 ) {
+                        // Only the lower bound of an assumed-size dimension
+                        // is known; its upper bound cannot be checked.
+                        llvm::Value* dimension = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, r + 1));
+                        llvm::Value* lbound_check = builder->CreateICmpSLT(req_idx, lval);
+                        llvm_utils->generate_runtime_error(lbound_check,
+                                                "Runtime error: Array '%s' index out of bounds. Tried to access index %d of dimension %d, but it is below the lower bound %d.",
+                                                        {LLVMUtils::RuntimeLabel("", {loc})},
+                                                        infile,
+                                                        lm,
+                                                        LCompilers::create_global_string_ptr(context, *builder->GetInsertBlock()->getParent()->getParent(), *builder, array_name),
+                                                        req_idx,
+                                                        dimension,
+                                                        lval);
+                    } else if( check_for_bounds ) {
                         llvm::Value* dimension = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), llvm::APInt(32, r + 1));
                         llvm::Value* ubound = builder->CreateSub(builder->CreateAdd(lval, dim_size),
                                 llvm::ConstantInt::get(context, llvm::APInt(index_bit_width, 1)));
@@ -987,12 +1001,12 @@ namespace LCompilers {
             std::vector<llvm::Value*>& m_args, int n_args, ASR::ttype_t* asr_type, ASR::expr_t* expr, LocationManager& lm,
             ASR::symbol_t* const variable_type_decl, bool data_only,
             bool is_fixed_size, llvm::Value** llvm_diminfo, bool polymorphic,
-            llvm::Type* polymorphic_type, bool is_unbounded_pointer_to_data, bool check_for_bounds, std::string array_name, std::string infile) {
+            llvm::Type* polymorphic_type, bool is_unbounded_pointer_to_data, bool check_for_bounds, bool assumed_size_last_dim, std::string array_name, std::string infile) {
             llvm::Value* tmp = nullptr;
             llvm::Value* idx = nullptr;
             if( data_only || is_fixed_size ) {
                 LCOMPILERS_ASSERT(llvm_diminfo);
-                idx = cmo_convertor_single_element_data_only(llvm_diminfo, m_args, n_args, check_for_bounds, lm, is_unbounded_pointer_to_data, array_name, infile, expr->base.loc);
+                idx = cmo_convertor_single_element_data_only(llvm_diminfo, m_args, n_args, check_for_bounds, lm, is_unbounded_pointer_to_data, assumed_size_last_dim, array_name, infile, expr->base.loc);
                 if(ASRUtils::is_character(*asr_type)){// Special handling for array of strings.
                     ASR::String_t* string_type = ASR::down_cast<ASR::String_t>(ASRUtils::extract_type(asr_type));
                     if (string_type->m_physical_type == ASR::string_physical_typeType::CChar) {

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -305,7 +305,7 @@ namespace LCompilers {
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
                     bool polymorphic=false, llvm::Type* polymorphic_type=nullptr,
-                    bool is_unbounded_pointer_to_data = false, bool check_for_bounds = false, std::string array_name = "", std::string infile = "") = 0;
+                    bool is_unbounded_pointer_to_data = false, bool check_for_bounds = false, bool assumed_size_last_dim = false, std::string array_name = "", std::string infile = "") = 0;
 
                 virtual
                 llvm::Value* get_is_allocated_flag(llvm::Value* array, ASR::expr_t* array_exp) = 0;
@@ -436,7 +436,7 @@ namespace LCompilers {
 
                 llvm::Value* cmo_convertor_single_element_data_only(
                     llvm::Value** llvm_diminfo, std::vector<llvm::Value*>& m_args,
-                    int n_args, bool check_for_bounds, LocationManager& lm, bool is_unbounded_pointer_to_data = false, std::string array_name = "", std::string infile = "", Location loc = {0, 0});
+                    int n_args, bool check_for_bounds, LocationManager& lm, bool is_unbounded_pointer_to_data = false, bool assumed_size_last_dim = false, std::string array_name = "", std::string infile = "", Location loc = {0, 0});
 
             public:
 
@@ -586,7 +586,7 @@ namespace LCompilers {
                     bool data_only=false, bool is_fixed_size=false,
                     llvm::Value** llvm_diminfo=nullptr,
                     bool polymorphic=false, llvm::Type* polymorphic_type=nullptr,
-                    bool is_unbounded_pointer_to_data = false, bool check_for_bounds = false, std::string array_name = "", std::string infile = "");
+                    bool is_unbounded_pointer_to_data = false, bool check_for_bounds = false, bool assumed_size_last_dim = false, std::string array_name = "", std::string infile = "");
 
                 virtual
                 llvm::Value* get_is_allocated_flag(llvm::Value* array, ASR::expr_t* array_exp);


### PR DESCRIPTION
## Summary

With `--bounds-checking`, out-of-bounds **array sections** (e.g. `x(i:i+1)` with `i = 0`) were not caught at runtime: reads returned garbage and writes silently corrupted memory outside the array. Only scalar element accesses were checked. This PR extends the runtime bounds checker in the LLVM backend to cover array sections.

In `visit_ArraySection` lowering (`asr_to_llvm.cpp`), when `--bounds-checking` is enabled, each dimension of the section is now validated before the section descriptor is built:

- For a sliced dimension `start:end:step`, the trip count `(end - start) / step` is computed first; an **empty section** accesses no elements, so nothing is checked for it (matching Fortran semantics where e.g. `x(3:2)` is legal). For a non-empty section, the smallest and largest accessed indices (which depend on the sign of `step`) are checked against the array's bounds — note the last accessed element is `start + trip*step`, not `end`.
- For a non-sliced index in a partially-sliced access like `x2(2:3, 2)`, the scalar index is checked directly.
- Bounds come from the runtime descriptor for `DescriptorArray`s, and from the compile-time/ASR dimension info otherwise.

Additionally, arrays whose **last dimension is assumed-size** (`y(*)`) previously had bounds checking disabled entirely for element accesses. A new `assumed_size_last_dim` flag threads through `cmo_convertor_single_element_data_only` so that all other dimensions remain fully checked and the assumed-size dimension still gets a **lower-bound** check (only its upper bound is unknowable).

The runtime error messages follow the existing element-access checker's format, including source location, array name, the offending index, dimension, and the valid range (or lower bound only, for an assumed-size dimension).

## Scope

- `src/libasr/codegen/asr_to_llvm.cpp`: section bounds checks in `visit_ArraySection` lowering; detect assumed-size last dimension and pass it (plus `check_for_bounds`) into `resolve_array_dataonly`.
- `src/libasr/codegen/llvm_array_utils.{h,cpp}`: new `assumed_size_last_dim` parameter for `get_single_element` / `cmo_convertor_single_element_data_only`; lower-bound-only check for the assumed-size dimension.
- LLVM backend only; no changes to semantics or ASR. Checks are emitted only under `--bounds-checking`, so default builds are unaffected.

## Rationale

Bounds checking that covers `x(i)` but not `x(i:i+1)` gives a false sense of safety — section writes are exactly the case where silent memory corruption is hardest to debug. The checks live in codegen next to the existing element-access checker and reuse its runtime-error machinery, so both paths report errors consistently.
