### PR TITLE
fix: dropped loops, untyped intrinsics and ** in CUDA do concurrent

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5011,6 +5011,11 @@ RUN(NAME gpu_metal_195 LABELS gfortran llvm metal)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
 RUN(NAME gpu_kernel_source_02 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_03 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_04 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_05 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_06 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_07 LABELS gfortran llvm)
 
 RUN(NAME real128_arith_01 LABELS gfortran llvm)
 RUN(NAME real128_arith_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5010,6 +5010,7 @@ RUN(NAME gpu_metal_194 LABELS gfortran llvm metal)
 RUN(NAME gpu_metal_195 LABELS gfortran llvm metal)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
+RUN(NAME gpu_kernel_source_02 LABELS gfortran llvm)
 
 RUN(NAME real128_arith_01 LABELS gfortran llvm)
 RUN(NAME real128_arith_02 LABELS gfortran llvm)

--- a/integration_tests/gpu_kernel_source_02.f90
+++ b/integration_tests/gpu_kernel_source_02.f90
@@ -1,0 +1,25 @@
+program gpu_kernel_source_02
+! Named constants referenced inside a do concurrent body.
+implicit none
+integer, parameter :: n = 12
+real, parameter :: a = 2.5
+integer, parameter :: tbl(3) = [7, 8, 9]
+real :: x(n), y(n), y_expected(n)
+integer :: i
+
+do i = 1, n
+    x(i) = real(i)
+    y(i) = 0.0
+    y_expected(i) = a * real(i) + real(tbl(mod(i - 1, 3) + 1))
+end do
+
+do concurrent (i = 1:n)
+    y(i) = a * x(i) + real(tbl(mod(i - 1, 3) + 1))
+end do
+
+do i = 1, n
+    if (abs(y(i) - y_expected(i)) > 1e-3) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_kernel_source_03.f90
+++ b/integration_tests/gpu_kernel_source_03.f90
@@ -1,0 +1,34 @@
+program gpu_kernel_source_03
+! A loop nested inside the do concurrent body, and a named coefficient array.
+implicit none
+integer, parameter :: n = 16
+integer, parameter :: nc = 5
+real, parameter :: cs(nc) = [1.0, 0.5, 0.25, 0.125, 0.0625]
+real :: x(n), y(n)
+real :: b0, b1, b2, twox
+integer :: i, j
+
+do i = 1, n
+    x(i) = 0.5
+    y(i) = 0.0
+end do
+
+do concurrent (i = 1:n)
+    b0 = 0.0
+    b1 = 0.0
+    b2 = 0.0
+    twox = 2.0 * x(i)
+    do j = 1, nc
+        b2 = b1
+        b1 = b0
+        b0 = twox*b1 - b2 + cs(nc - j + 1)
+    end do
+    y(i) = 0.5 * (b0 - b2)
+end do
+
+do i = 1, n
+    if (abs(y(i) - 0.46875) > 1e-5) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_kernel_source_04.f90
+++ b/integration_tests/gpu_kernel_source_04.f90
@@ -1,0 +1,24 @@
+program gpu_kernel_source_04
+! Maths intrinsics on reals, which must not reach the backend untyped and
+! bind to the integer overloads.
+implicit none
+integer, parameter :: n = 8
+real :: x(n), y(n), y_expected(n)
+integer :: i
+
+do i = 1, n
+    x(i) = -0.25 * real(i)
+    y(i) = 0.0
+    y_expected(i) = sqrt(abs(x(i))) + exp(x(i))
+end do
+
+do concurrent (i = 1:n)
+    y(i) = sqrt(abs(x(i))) + exp(x(i))
+end do
+
+do i = 1, n
+    if (abs(y(i) - y_expected(i)) > 1e-5) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_kernel_source_05.f90
+++ b/integration_tests/gpu_kernel_source_05.f90
@@ -1,0 +1,23 @@
+program gpu_kernel_source_05
+! The power operator, which used to reach the backend as a literal **.
+implicit none
+integer, parameter :: n = 8
+real :: x(n), y(n), y_expected(n)
+integer :: i
+
+do i = 1, n
+    x(i) = real(i)
+    y(i) = 0.0
+    y_expected(i) = x(i)**2 + x(i)**0.5
+end do
+
+do concurrent (i = 1:n)
+    y(i) = x(i)**2 + x(i)**0.5
+end do
+
+do i = 1, n
+    if (abs(y(i) - y_expected(i)) > 1e-4) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_kernel_source_06.f90
+++ b/integration_tests/gpu_kernel_source_06.f90
@@ -1,0 +1,27 @@
+program gpu_kernel_source_06
+! Rank-2 subscripts, which the kernel has to flatten column-major by hand.
+implicit none
+integer, parameter :: m = 4
+integer, parameter :: nc = 5
+real :: a(m,nc), b(m,nc)
+integer :: i, j
+
+do j = 1, nc
+    do i = 1, m
+        a(i,j) = real(i) + 10.0 * real(j)
+        b(i,j) = 0.0
+    end do
+end do
+
+do concurrent (i = 1:m, j = 1:nc)
+    b(i,j) = 2.0 * a(i,j)
+end do
+
+do j = 1, nc
+    do i = 1, m
+        if (abs(b(i,j) - 2.0 * a(i,j)) > 1e-3) error stop
+    end do
+end do
+
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_kernel_source_07.f90
+++ b/integration_tests/gpu_kernel_source_07.f90
@@ -1,0 +1,25 @@
+program gpu_kernel_source_07
+! real(8) reaches the CUDA backend; only Metal has no double. The constant
+! also pins the literal precision, which six significant figures would miss.
+implicit none
+integer, parameter :: n = 8
+double precision, parameter :: c = 0.28209479177387814d0
+double precision :: x(n), y(n), y_expected(n)
+integer :: i
+
+do i = 1, n
+    x(i) = dble(i)
+    y(i) = 0.0d0
+    y_expected(i) = c * x(i) + 1.0d0/3.0d0
+end do
+
+do concurrent (i = 1:n)
+    y(i) = c * x(i) + 1.0d0/3.0d0
+end do
+
+do i = 1, n
+    if (abs(y(i) - y_expected(i)) > 1d-12) error stop
+end do
+
+print *, "PASSED"
+end program

--- a/src/libasr/codegen/asr_to_cuda.cpp
+++ b/src/libasr/codegen/asr_to_cuda.cpp
@@ -200,6 +200,11 @@ public:
 
     void emit_local_var_decl(ASR::Variable_t *var) {
         ASR::ttype_t *type = var->m_type;
+        // A named constant carries its value in the ASR rather than being
+        // passed in, so it has to be initialised here or the kernel reads
+        // uninitialised memory.
+        bool is_const = var->m_storage == ASR::storage_typeType::Parameter
+            && var->m_value;
         if (is_array_type(type)) {
             // Local arrays in kernels - determine size
             ASR::ttype_t *past_alloc = ASRUtils::type_get_past_allocatable(type);
@@ -213,9 +218,26 @@ public:
                             arr->m_dims[d].m_length)->m_n;
                     }
                 }
+                if (is_const && ASR::is_a<ASR::ArrayConstant_t>(*var->m_value)) {
+                    ASR::ArrayConstant_t *ac = ASR::down_cast<ASR::ArrayConstant_t>(
+                        var->m_value);
+                    src << get_indent() << "const " << cuda_type(arr->m_type) << " "
+                        << var->m_name << "[" << total << "] = {";
+                    for (int64_t i = 0; i < total; i++) {
+                        if (i > 0) src << ", ";
+                        src << ASRUtils::fetch_ArrayConstant_value(ac, i);
+                    }
+                    src << "};\n";
+                    return;
+                }
                 src << get_indent() << cuda_type(arr->m_type) << " "
                     << var->m_name << "[" << total << "];\n";
             }
+        } else if (is_const) {
+            src << get_indent() << "const " << cuda_type(type) << " "
+                << var->m_name << " = ";
+            visit_expr(var->m_value);
+            src << ";\n";
         } else {
             src << get_indent() << cuda_type(type) << " " << var->m_name << ";\n";
         }

--- a/src/libasr/codegen/asr_to_cuda.cpp
+++ b/src/libasr/codegen/asr_to_cuda.cpp
@@ -9,6 +9,7 @@
 #include <libasr/pass/intrinsic_function_registry.h>
 
 #include <sstream>
+#include <iomanip>
 #include <map>
 #include <set>
 #include <vector>
@@ -86,6 +87,40 @@ public:
             case ASR::cmpopType::GtE: return ">=";
         }
         return "?";
+    }
+
+    std::string math_fn(const std::string &dbl_name, ASR::ttype_t *type) {
+        ASR::ttype_t *t = ASRUtils::type_get_past_array(
+            ASRUtils::type_get_past_allocatable(type));
+        if (ASR::is_a<ASR::Real_t>(*t) &&
+                ASR::down_cast<ASR::Real_t>(t)->m_kind == 8) {
+            return dbl_name;
+        }
+        return dbl_name + "f";
+    }
+
+    bool is_real_expr(ASR::ttype_t *type) {
+        return ASR::is_a<ASR::Real_t>(*ASRUtils::type_get_past_array(
+            ASRUtils::type_get_past_allocatable(type)));
+    }
+
+    std::string real_literal(double v, int kind) {
+        std::ostringstream o;
+        o << std::setprecision(kind == 8 ? 17 : 9) << v;
+        std::string lit = o.str();
+        if (lit.find_first_of(".eE") == std::string::npos) lit += ".0";
+        return (kind == 8) ? lit : lit + "f";
+    }
+
+    void emit_call(const std::string &fn, ASR::expr_t *a,
+            ASR::expr_t *b = nullptr) {
+        src << fn << "(";
+        visit_expr(a);
+        if (b) {
+            src << ", ";
+            visit_expr(b);
+        }
+        src << ")";
     }
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &tu) {
@@ -285,43 +320,124 @@ public:
                 src << get_indent() << "return;\n";
                 break;
             }
-            default:
+            case ASR::stmtType::WhileLoop: {
+                ASR::WhileLoop_t *wl = ASR::down_cast<ASR::WhileLoop_t>(stmt);
+                src << get_indent() << "while (";
+                visit_expr(wl->m_test);
+                src << ") {\n";
+                indent_level++;
+                for (size_t i = 0; i < wl->n_body; i++) {
+                    visit_stmt(wl->m_body[i]);
+                }
+                indent_level--;
+                src << get_indent() << "}\n";
                 break;
+            }
+            case ASR::stmtType::DoLoop: {
+                emit_do_loop(ASR::down_cast<ASR::DoLoop_t>(stmt));
+                break;
+            }
+            case ASR::stmtType::Exit: {
+                if (ASR::down_cast<ASR::Exit_t>(stmt)->m_stmt_name) {
+                    throw CodeGenError("CUDA codegen: a named EXIT in a GPU "
+                        "kernel is not supported");
+                }
+                src << get_indent() << "break;\n";
+                break;
+            }
+            case ASR::stmtType::Cycle: {
+                if (ASR::down_cast<ASR::Cycle_t>(stmt)->m_stmt_name) {
+                    throw CodeGenError("CUDA codegen: a named CYCLE in a GPU "
+                        "kernel is not supported");
+                }
+                src << get_indent() << "continue;\n";
+                break;
+            }
+            default:
+                throw CodeGenError("CUDA codegen: unsupported statement type "
+                    + std::to_string(stmt->type) + " in a GPU kernel");
         }
+    }
+
+    void emit_do_loop(ASR::DoLoop_t *dl) {
+        ASR::do_loop_head_t &h = dl->m_head;
+        if (!h.m_v || !h.m_start || !h.m_end) {
+            throw CodeGenError("CUDA codegen: do loop with an incomplete head");
+        }
+        const char *cmp = "<=";
+        if (h.m_increment) {
+            ASR::expr_t *step = ASRUtils::expr_value(h.m_increment);
+            int64_t n = 0;
+            if (!step || !ASRUtils::extract_value(step, n)) {
+                throw CodeGenError("CUDA codegen: do loop with a non-constant "
+                    "stride is not supported");
+            }
+            if (n == 0) {
+                throw CodeGenError("CUDA codegen: do loop with a zero stride");
+            }
+            if (n < 0) cmp = ">=";
+        }
+        std::string v(ASRUtils::symbol_name(
+            ASR::down_cast<ASR::Var_t>(h.m_v)->m_v));
+        src << get_indent() << "for (" << v << " = ";
+        visit_expr(h.m_start);
+        src << "; " << v << " " << cmp << " ";
+        visit_expr(h.m_end);
+        src << "; " << v << " += ";
+        if (h.m_increment) {
+            visit_expr(h.m_increment);
+        } else {
+            src << "1";
+        }
+        src << ") {\n";
+        indent_level++;
+        for (size_t i = 0; i < dl->n_body; i++) {
+            visit_stmt(dl->m_body[i]);
+        }
+        indent_level--;
+        src << get_indent() << "}\n";
     }
 
     void emit_intrinsic(ASR::IntrinsicElementalFunction_t *f) {
         using IEF = ASRUtils::IntrinsicElementalFunctions;
         int64_t id = f->m_intrinsic_id;
+        if (f->n_args == 0) {
+            throw CodeGenError("CUDA codegen: intrinsic "
+                + ASRUtils::get_intrinsic_name(id) + " has no arguments");
+        }
+        ASR::ttype_t *at = ASRUtils::expr_type(f->m_args[0]);
+        bool real_arg = is_real_expr(at);
 
-        if (id == static_cast<int64_t>(IEF::Sqrt)) {
-            src << "sqrt(";
-            visit_expr(f->m_args[0]);
-            src << ")";
-        } else if (id == static_cast<int64_t>(IEF::Abs)) {
-            src << "abs(";
-            visit_expr(f->m_args[0]);
-            src << ")";
-        } else if (id == static_cast<int64_t>(IEF::Sin)) {
-            src << "sin(";
-            visit_expr(f->m_args[0]);
-            src << ")";
-        } else if (id == static_cast<int64_t>(IEF::Cos)) {
-            src << "cos(";
-            visit_expr(f->m_args[0]);
-            src << ")";
-        } else if (id == static_cast<int64_t>(IEF::Exp)) {
-            src << "exp(";
-            visit_expr(f->m_args[0]);
-            src << ")";
-        } else if (id == static_cast<int64_t>(IEF::Mod)) {
-            ASR::ttype_t *type = ASRUtils::expr_type(f->m_args[0]);
-            if (type->type == ASR::ttypeType::Real) {
-                src << "fmod(";
-                visit_expr(f->m_args[0]);
-                src << ", ";
-                visit_expr(f->m_args[1]);
+        static const struct { IEF id; const char *fn; } unary[] = {
+            {IEF::Sqrt, "sqrt"},  {IEF::Sin, "sin"},   {IEF::Cos, "cos"},
+            {IEF::Tan, "tan"},    {IEF::Exp, "exp"},   {IEF::Log, "log"},
+            {IEF::Log10, "log10"},{IEF::Tanh, "tanh"}, {IEF::Aint, "trunc"},
+            {IEF::Anint, "round"},
+        };
+        for (auto &u : unary) {
+            if (id == static_cast<int64_t>(u.id)) {
+                emit_call(math_fn(u.fn, at), f->m_args[0]);
+                return;
+            }
+        }
+
+        static const struct { IEF id; const char *fn; } to_int[] = {
+            {IEF::Floor, "floor"}, {IEF::Ceiling, "ceil"}, {IEF::Nint, "round"},
+        };
+        for (auto &t : to_int) {
+            if (id == static_cast<int64_t>(t.id)) {
+                src << "((" << cuda_type(f->m_type) << ")";
+                emit_call(math_fn(t.fn, at), f->m_args[0]);
                 src << ")";
+                return;
+            }
+        }
+
+        if (id == static_cast<int64_t>(IEF::Abs)) {
+            emit_call(real_arg ? math_fn("fabs", at) : "abs", f->m_args[0]);
+        } else if (id == static_cast<int64_t>(IEF::Mod)) {
+            if (real_arg) {
+                emit_call(math_fn("fmod", at), f->m_args[0], f->m_args[1]);
             } else {
                 src << "(";
                 visit_expr(f->m_args[0]);
@@ -330,25 +446,72 @@ public:
                 src << ")";
             }
         } else if (id == static_cast<int64_t>(IEF::Min)) {
-            src << "min(";
-            visit_expr(f->m_args[0]);
-            src << ", ";
-            visit_expr(f->m_args[1]);
-            src << ")";
+            emit_call(real_arg ? math_fn("fmin", at) : "min",
+                f->m_args[0], f->m_args[1]);
         } else if (id == static_cast<int64_t>(IEF::Max)) {
-            src << "max(";
-            visit_expr(f->m_args[0]);
-            src << ", ";
-            visit_expr(f->m_args[1]);
-            src << ")";
+            emit_call(real_arg ? math_fn("fmax", at) : "max",
+                f->m_args[0], f->m_args[1]);
+        } else if (id == static_cast<int64_t>(IEF::Sign)) {
+            if (!real_arg) {
+                throw CodeGenError("CUDA codegen: integer SIGN in a GPU kernel "
+                    "is not supported");
+            }
+            emit_call(math_fn("copysign", at), f->m_args[0], f->m_args[1]);
         } else if (id == static_cast<int64_t>(IEF::Real)) {
-            src << "((float)(";
+            src << "((" << cuda_type(f->m_type) << ")";
             visit_expr(f->m_args[0]);
-            src << "))";
-        } else {
-            src << "/* unsupported intrinsic " << id << " */(";
-            if (f->n_args > 0) visit_expr(f->m_args[0]);
             src << ")";
+        } else {
+            throw CodeGenError("CUDA codegen: intrinsic "
+                + ASRUtils::get_intrinsic_name(id)
+                + " is not supported in a GPU kernel");
+        }
+    }
+
+    void emit_array_offset(ASR::ArrayItem_t *ai) {
+        if (ai->n_args == 0) {
+            throw CodeGenError("CUDA codegen: array reference with no "
+                "subscripts");
+        }
+        ASR::ttype_t *t = ASRUtils::type_get_past_allocatable(
+            ASRUtils::expr_type(ai->m_v));
+        ASR::dimension_t *dims = nullptr;
+        size_t n_dims = 0;
+        if (ASR::is_a<ASR::Array_t>(*t)) {
+            ASR::Array_t *arr = ASR::down_cast<ASR::Array_t>(t);
+            dims = arr->m_dims;
+            n_dims = arr->n_dims;
+        }
+        if (ai->n_args > 1 && n_dims < ai->n_args) {
+            throw CodeGenError("CUDA codegen: cannot flatten a rank-"
+                + std::to_string(ai->n_args) + " array reference whose "
+                "extents are not in the ASR");
+        }
+        for (size_t d = 0; d < ai->n_args; d++) {
+            if (!ai->m_args[d].m_right) {
+                throw CodeGenError("CUDA codegen: array section in a GPU "
+                    "kernel is not supported");
+            }
+            if (d > 0) src << " + ";
+            src << "(";
+            visit_expr(ai->m_args[d].m_right);
+            src << " - ";
+            if (d < n_dims && dims[d].m_start) {
+                visit_expr(dims[d].m_start);
+            } else {
+                src << "1";
+            }
+            src << ")";
+            for (size_t e = 0; e < d; e++) {
+                if (!dims[e].m_length) {
+                    throw CodeGenError("CUDA codegen: dimension "
+                        + std::to_string(e + 1) + " of an array in a GPU "
+                        "kernel has no known extent");
+                }
+                src << " * (";
+                visit_expr(dims[e].m_length);
+                src << ")";
+            }
         }
     }
 
@@ -368,7 +531,8 @@ public:
             case ASR::exprType::RealConstant: {
                 ASR::RealConstant_t *c =
                     ASR::down_cast<ASR::RealConstant_t>(expr);
-                src << c->m_r;
+                src << real_literal(c->m_r,
+                    ASRUtils::extract_kind_from_ttype_t(c->m_type));
                 break;
             }
             case ASR::exprType::LogicalConstant: {
@@ -380,6 +544,10 @@ public:
             case ASR::exprType::IntegerBinOp: {
                 ASR::IntegerBinOp_t *op =
                     ASR::down_cast<ASR::IntegerBinOp_t>(expr);
+                if (op->m_op == ASR::binopType::Pow) {
+                    throw CodeGenError("CUDA codegen: integer ** in a GPU "
+                        "kernel is not supported");
+                }
                 src << "(";
                 visit_expr(op->m_left);
                 src << " " << binop_str(op->m_op) << " ";
@@ -390,6 +558,20 @@ public:
             case ASR::exprType::RealBinOp: {
                 ASR::RealBinOp_t *op =
                     ASR::down_cast<ASR::RealBinOp_t>(expr);
+                if (op->m_op == ASR::binopType::Pow) {
+                    src << math_fn("pow", op->m_type) << "(";
+                    visit_expr(op->m_left);
+                    src << ", ";
+                    if (is_real_expr(ASRUtils::expr_type(op->m_right))) {
+                        visit_expr(op->m_right);
+                    } else {
+                        src << "((" << cuda_type(op->m_type) << ")";
+                        visit_expr(op->m_right);
+                        src << ")";
+                    }
+                    src << ")";
+                    break;
+                }
                 src << "(";
                 visit_expr(op->m_left);
                 src << " " << binop_str(op->m_op) << " ";
@@ -444,12 +626,7 @@ public:
                 ASR::ArrayItem_t *ai = ASR::down_cast<ASR::ArrayItem_t>(expr);
                 visit_expr(ai->m_v);
                 src << "[";
-                if (ai->n_args == 1 && ai->m_args[0].m_right) {
-                    // Fortran 1-based → C 0-based
-                    src << "(";
-                    visit_expr(ai->m_args[0].m_right);
-                    src << " - 1)";
-                }
+                emit_array_offset(ai);
                 src << "]";
                 break;
             }
@@ -467,9 +644,7 @@ public:
             }
             case ASR::exprType::RealSqrt: {
                 ASR::RealSqrt_t *rs = ASR::down_cast<ASR::RealSqrt_t>(expr);
-                src << "sqrt(";
-                visit_expr(rs->m_arg);
-                src << ")";
+                emit_call(math_fn("sqrt", rs->m_type), rs->m_arg);
                 break;
             }
             case ASR::exprType::IntrinsicElementalFunction: {
@@ -497,27 +672,28 @@ public:
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
                 } else if (fn_name.find("_lcompilers_sqrt_") == 0) {
-                    src << "sqrt(";
+                    src << math_fn("sqrt", fc->m_type) << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
                 } else if (fn_name.find("_lcompilers_abs_") == 0) {
-                    src << "abs(";
+                    src << (is_real_expr(fc->m_type)
+                        ? math_fn("fabs", fc->m_type) : "abs") << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
                 } else if (fn_name.find("_lcompilers_sin_") == 0) {
-                    src << "sin(";
+                    src << math_fn("sin", fc->m_type) << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
                 } else if (fn_name.find("_lcompilers_cos_") == 0) {
-                    src << "cos(";
+                    src << math_fn("cos", fc->m_type) << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
                 } else if (fn_name.find("_lcompilers_exp_") == 0) {
-                    src << "exp(";
+                    src << math_fn("exp", fc->m_type) << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ")";
@@ -525,7 +701,7 @@ public:
                            fn_name.find("_lcompilers_optimization_mod_") == 0) {
                     ASR::ttype_t *type = fc->m_type;
                     if (type && type->type == ASR::ttypeType::Real) {
-                        src << "fmod(";
+                        src << math_fn("fmod", type) << "(";
                         if (fc->n_args > 0 && fc->m_args[0].m_value)
                             visit_expr(fc->m_args[0].m_value);
                         src << ", ";
@@ -543,7 +719,8 @@ public:
                     }
                 } else if (fn_name.find("_lcompilers_min_") == 0 ||
                            fn_name.find("_lcompilers_min0_") == 0) {
-                    src << "min(";
+                    src << (is_real_expr(fc->m_type)
+                        ? math_fn("fmin", fc->m_type) : "min") << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ", ";
@@ -552,7 +729,8 @@ public:
                     src << ")";
                 } else if (fn_name.find("_lcompilers_max_") == 0 ||
                            fn_name.find("_lcompilers_max0_") == 0) {
-                    src << "max(";
+                    src << (is_real_expr(fc->m_type)
+                        ? math_fn("fmax", fc->m_type) : "max") << "(";
                     if (fc->n_args > 0 && fc->m_args[0].m_value)
                         visit_expr(fc->m_args[0].m_value);
                     src << ", ";

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -4667,14 +4667,15 @@ public:
             }
         }
 
-        // Skip loops containing real(8)/integer(8) types — Metal has no double/int64 support
-        for (auto &sym : involved_syms) {
-            ASR::ttype_t *t = sym.second.first;
-            ASR::ttype_t *base_t = ASRUtils::type_get_past_array(t);
-            if (base_t->type == ASR::ttypeType::Real &&
-                ASR::down_cast<ASR::Real_t>(base_t)->m_kind == 8) return;
-            if (base_t->type == ASR::ttypeType::Integer &&
-                ASR::down_cast<ASR::Integer_t>(base_t)->m_kind == 8) return;
+        if (pass_options.gpu_offload_metal) {
+            for (auto &sym : involved_syms) {
+                ASR::ttype_t *t = sym.second.first;
+                ASR::ttype_t *base_t = ASRUtils::type_get_past_array(t);
+                if (base_t->type == ASR::ttypeType::Real &&
+                    ASR::down_cast<ASR::Real_t>(base_t)->m_kind == 8) return;
+                if (base_t->type == ASR::ttypeType::Integer &&
+                    ASR::down_cast<ASR::Integer_t>(base_t)->m_kind == 8) return;
+            }
         }
 
         // Collect loop variable names

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout",
-    "stdout_hash": "23456068e44521a0c0fd08d8486077797fe5a1e3d51e10c6005821a7",
+    "stdout_hash": "02c6aa383d827b0ca75d4ae7bf2e5b57107f76bad6d3b4dc37c9b1ed",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_01-0428e9e.stdout
@@ -3,7 +3,7 @@
 extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, float a, int __loop_end_0) {
     int __flat_idx;
     int i;
-    int n;
+    const int n = 1000;
     if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
         return;
     }

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout",
-    "stdout_hash": "535d5951f4095808940595624eb79919086a61cdea62e2e976a155af",
+    "stdout_hash": "15700323e27c6945e7daf3b38717ee2f2fe59d56aae2b5da35b55c34",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_02.f90",
+    "infile_hash": "96ecdbc2fea10f324f919623ea8fcbfa81f59c6bd22e124a42eda710",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout",
+    "stdout_hash": "535d5951f4095808940595624eb79919086a61cdea62e2e976a155af",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout
@@ -2,7 +2,7 @@
 
 extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, int __loop_end_0) {
     int __flat_idx;
-    const float a = 2.5;
+    const float a = 2.5f;
     int i;
     const int n = 12;
     const int tbl[3] = {7, 8, 9};

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_02-50a3dd7.stdout
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, int __loop_end_0) {
+    int __flat_idx;
+    const float a = 2.5;
+    int i;
+    const int n = 12;
+    const int tbl[3] = {7, 8, 9};
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    y[(i - 1)] = ((a * x[(i - 1)]) + ((float)tbl[(((((i - 1)) % (3)) + 1) - 1)]));
+}
+

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_03-049e8d1.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_03-049e8d1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_03-049e8d1",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_03.f90",
+    "infile_hash": "aef20c6b0649cecf1487b4b15733bcc5be7e2e89e402c04f14a55363",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_03-049e8d1.stdout",
+    "stdout_hash": "3272708c0bf523e5ecd6a5022b46a0b5e5760a06a18a443e61bf481d",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_03-049e8d1.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_03-049e8d1.stdout
@@ -1,0 +1,34 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, int __loop_end_0) {
+    int __do_loop_end;
+    int __flat_idx;
+    float b0;
+    float b1;
+    float b2;
+    const float cs[5] = {1.00000000e+00, 5.00000000e-01, 2.50000000e-01, 1.25000000e-01, 6.25000000e-02};
+    int i;
+    int j;
+    const int n = 16;
+    const int nc = 5;
+    float twox;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    b0 = 0.0f;
+    b1 = 0.0f;
+    b2 = 0.0f;
+    twox = (2.0f * x[(i - 1)]);
+    __do_loop_end = nc;
+    j = (1 - 1);
+    while (((j + 1) <= __do_loop_end)) {
+        j = (j + 1);
+        b2 = b1;
+        b1 = b0;
+        b0 = (((twox * b1) - b2) + cs[(((nc - j) + 1) - 1)]);
+    }
+    y[(i - 1)] = (0.5f * (b0 - b2));
+}
+

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_04-6974c93.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_04-6974c93.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_04-6974c93",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_04.f90",
+    "infile_hash": "8b2a144f3ee9b3235b39fbb48f2c499a2465e4c160f3001a380fb1ef",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_04-6974c93.stdout",
+    "stdout_hash": "3a259da7570a2f656e1d1d42eb5aa557cbe4bf8625773936005d5b71",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_04-6974c93.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_04-6974c93.stdout
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, int __loop_end_0) {
+    int __flat_idx;
+    int i;
+    const int n = 8;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    y[(i - 1)] = (sqrtf(fabsf(x[(i - 1)])) + expf(x[(i - 1)]));
+}
+

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_05.f90",
+    "infile_hash": "e4d8532df0868da342434bd41eef73b156248a83e820b71caa5898d3",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a.stdout",
+    "stdout_hash": "f88fdeaba48371df1985910cb7ef399f03b8e5e6c2fc83ddcb582d7e",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_05-7a49d7a.stdout
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *x, float *y, int __loop_end_0) {
+    int __flat_idx;
+    int i;
+    const int n = 8;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    y[(i - 1)] = (powf(x[(i - 1)], ((float)2)) + powf(x[(i - 1)], 0.5f));
+}
+

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_06.f90",
+    "infile_hash": "9837c8c3564d653eeb6a0bd53af35b1a99996897de38ad8a0f7eb4d5",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed.stdout",
+    "stdout_hash": "b0a9634a11c4148f1f8287f0c18031641c24fb84edf4896591a4a95c",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_06-e2e24ed.stdout
@@ -1,0 +1,18 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(float *a, float *b, int __loop_end_0, int __loop_end_1) {
+    int __flat_idx;
+    int i;
+    int j;
+    const int m = 4;
+    const int nc = 5;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= (((__loop_end_0 - 1) + 1) * ((__loop_end_1 - 1) + 1)))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = ((__flat_idx - ((__flat_idx / ((__loop_end_0 - 1) + 1)) * ((__loop_end_0 - 1) + 1))) + 1);
+    __flat_idx = (__flat_idx / ((__loop_end_0 - 1) + 1));
+    j = (__flat_idx + 1);
+    b[(i - 1) + (j - 1) * (4)] = (2.0f * a[(i - 1) + (j - 1) * (4)]);
+}
+

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_07-85c87ca.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_07-85c87ca.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_kernel_source_07-85c87ca",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_kernel_source_07.f90",
+    "infile_hash": "519024a113bdd0a7e44a4af497f3fd980afae4adc1b894686edc23c9",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_kernel_source_07-85c87ca.stdout",
+    "stdout_hash": "6b40ca303866806b2960bf1fcb808e99aa87d5436362a1af118242db",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_kernel_source_07-85c87ca.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_kernel_source_07-85c87ca.stdout
@@ -1,0 +1,15 @@
+#include <stdint.h>
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(double *x, double *y, int __loop_end_0) {
+    int __flat_idx;
+    const double c = 0.28209479177387814;
+    int i;
+    const int n = 8;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    y[(i - 1)] = ((c * x[(i - 1)]) + (1.0 / 3.0));
+}
+

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4159,6 +4159,26 @@ filename = "../integration_tests/gpu_kernel_source_02.f90"
 gpu_cuda_kernel = true
 
 [[test]]
+filename = "../integration_tests/gpu_kernel_source_03.f90"
+gpu_cuda_kernel = true
+
+[[test]]
+filename = "../integration_tests/gpu_kernel_source_04.f90"
+gpu_cuda_kernel = true
+
+[[test]]
+filename = "../integration_tests/gpu_kernel_source_05.f90"
+gpu_cuda_kernel = true
+
+[[test]]
+filename = "../integration_tests/gpu_kernel_source_06.f90"
+gpu_cuda_kernel = true
+
+[[test]]
+filename = "../integration_tests/gpu_kernel_source_07.f90"
+gpu_cuda_kernel = true
+
+[[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true
 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4155,6 +4155,10 @@ filename = "../integration_tests/gpu_kernel_source_01.f90"
 gpu_cuda_kernel = true
 
 [[test]]
+filename = "../integration_tests/gpu_kernel_source_02.f90"
+gpu_cuda_kernel = true
+
+[[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true
 


### PR DESCRIPTION
Six fixes to the CUDA `do concurrent` path, found pushing Fortran kernels through my compiler. Four were silent wrong answers rather than errors: a loop nested inside the `do concurrent` was dropped entirely, real literals lost precision and their decimal point so `1.0/3.0` became integer `0`, `real(8)` loops were never offloaded because of a restriction that only applies to Metal, and `abs`/`exp`/`sqrt` came out untyped. The other two were hard errors, `**` reaching the backend as a literal `**` and `a(i,j)` as `a[]`. The unsupported-statement and unsupported-intrinsic paths used to fall through quietly, which is how the dropped loop went unnoticed, so both raise a `CodeGenError` now.

Fixes #12369. The reproducer there gives 12 for x=3.0 now, where it gave 0.