### PR TITLE
fix: tokenize named DO WHILE in fixed form

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -470,6 +470,7 @@ RUN(NAME fixed_form_io_keyword_02 LABELS gfortran llvm EXTRA_ARGS --fixed-form G
 RUN(NAME fixed_form_goto LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_stmt_func_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_do_name_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --use-loop-variable-after-loop GFORTRAN_ARGS -ffixed-form)
+RUN(NAME fixed_form_do_while_name_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_where_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_module_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form GFORTRAN_ARGS -ffixed-form)
 RUN(NAME fixed_form_common_01 LABELS gfortran llvm EXTRA_ARGS --fixed-form --implicit-typing GFORTRAN_ARGS -ffixed-form)

--- a/integration_tests/fixed_form_do_while_name_01.f90
+++ b/integration_tests/fixed_form_do_while_name_01.f90
@@ -1,0 +1,8 @@
+      PROGRAM FIXED_FORM_DO_WHILE_NAME_01
+      INTEGER K
+      K = 1
+      L: DO WHILE (K .LE. 2)
+        K = K + 1
+      END DO L
+      IF (K .NE. 3) ERROR STOP 1
+      END

--- a/src/lfortran/parser/fixedform_tokenizer.cpp
+++ b/src/lfortran/parser/fixedform_tokenizer.cpp
@@ -1144,6 +1144,13 @@ struct FixedFormRecursiveDescent {
     bool lex_body_statement(unsigned char *&cur, bool continue_compilation = false) {
         int64_t l = eat_label(cur);
         unsigned char *do_pos = nullptr;
+        if (is_named_do_while(cur, do_pos)) {
+            t.cur = cur;
+            tokenize_until(do_pos);
+            cur = do_pos;
+            lex_dowhile(cur);
+            return true;
+        }
         if (is_named_do_loop(cur, do_pos)) {
             t.cur = cur;
             tokenize_until(do_pos);
@@ -1553,6 +1560,15 @@ struct FixedFormRecursiveDescent {
         return true;
     }
 
+    bool is_named_do_while(unsigned char *cur, unsigned char *&do_pos) {
+        unsigned char *tmp = cur;
+        if (!try_name(tmp)) return false;
+        if (!try_next(tmp, ":")) return false;
+        if (!next_is(tmp, "dowhile(")) return false;
+        do_pos = tmp;
+        return true;
+    }
+
     bool label_last(int64_t label) {
         if (do_labels.size() > 0) {
             if (do_labels[do_labels.size()-1] == label) {
@@ -1680,7 +1696,8 @@ struct FixedFormRecursiveDescent {
         push_token_advance(cur, "do");
         push_token_advance(cur, "while");
         tokenize_line(cur); // tokenize rest of line where `do while` starts
-        while (!next_is(cur, "enddo\n")) {
+        // Named ENDDO ("END DO L") prescans to "enddol", not "enddo\n".
+        while (!next_is(cur, "enddo")) {
             lex_body_statement(cur);
         }
         push_token_advance(cur, "enddo");


### PR DESCRIPTION
Recognize a construct name before DO WHILE and accept a named END DO, which prescanning concatenates (END DO L -> enddol).