### PR TITLE
fix: distinct LLVM descriptor types for character arrays with different element types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2036,6 +2036,7 @@ RUN(NAME bindc_52 LABELS gfortran llvm)
 # Extension: BIND(C) character(len>1); GFortran rejects, so llvm only
 RUN(NAME bindc_53 LABELS llvm)
 RUN(NAME bindc_54 LABELS gfortran llvm)
+RUN(NAME bindc_55 LABELS gfortran llvm)
 RUN(NAME bindc_iso_fb_01 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_01c.c)
 RUN(NAME bindc_iso_fb_02 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_02c.c)
 RUN(NAME bindc_iso_fb_03 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_03c.c)

--- a/integration_tests/bindc_55.f90
+++ b/integration_tests/bindc_55.f90
@@ -1,0 +1,49 @@
+! An allocatable character array declared alongside an interface body for a
+! BIND(C) procedure that takes an assumed-size character dummy argument.
+! Regression test: both arrays encode to the ASR type code "str" with rank 1,
+! but the allocatable one has %string_descriptor elements while the BIND(C) one
+! has i8* elements. LFortran cached a single LLVM array descriptor struct for
+! both, so it stored a %string_descriptor* into an i8** field and the generated
+! module failed LLVM verification.
+module bindc_55_mod
+  implicit none
+contains
+  subroutine fill(n, total)
+    integer, intent(in) :: n
+    integer, intent(out) :: total
+    character, allocatable :: buf(:)
+    integer :: k
+    interface
+      subroutine c_take(pattern) bind(c, name="c_take")
+        character :: pattern(*)
+      end subroutine c_take
+    end interface
+    allocate(buf(n))
+    do k = 1, n
+      buf(k) = achar(iachar('a') + k - 1)
+    end do
+    if (buf(1) /= 'a') error stop
+    if (buf(n) /= achar(iachar('a') + n - 1)) error stop
+    total = size(buf)
+    do k = 1, n
+      total = total + iachar(buf(k))
+    end do
+    deallocate(buf)
+  end subroutine fill
+end module bindc_55_mod
+
+program bindc_55
+  use bindc_55_mod
+  implicit none
+  integer :: total
+
+  call fill(3, total)
+  print *, total
+  ! size + iachar('a') + iachar('b') + iachar('c') = 3 + 97 + 98 + 99
+  if (total /= 297) error stop
+
+  call fill(1, total)
+  print *, total
+  ! size + iachar('a') = 1 + 97
+  if (total /= 98) error stop
+end program bindc_55

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -228,6 +228,20 @@ namespace LCompilers {
                 }
             }
             array_key += "." + std::to_string(n_dims);
+            // The descriptor layout is fully determined by the element type and
+            // the rank, but two ASR types can share a type code and still lower
+            // to different element types. A `DescriptorArray` of strings has
+            // `%string_descriptor` elements, while a bind(C)
+            // `StringArraySinglePointer` of strings has `i8*` elements, and both
+            // encode as "strdesc". Disambiguate by the element type so such
+            // arrays never share a descriptor struct.
+            auto cached = tkr2array.find(array_key);
+            if( cached != tkr2array.end() && cached->second.second != el_type ) {
+                std::string el_type_str;
+                llvm::raw_string_ostream el_type_os(el_type_str);
+                el_type->print(el_type_os);
+                array_key += "." + el_type_os.str();
+            }
             if( tkr2array.find(array_key) != tkr2array.end() ) {
                 if( get_pointer ) {
                     return tkr2array[array_key].first->getPointerTo();


### PR DESCRIPTION
## Summary

Fixes #12571.

A procedure that declares both an allocatable `character` array and an interface body for a `BIND(C)` procedure with an assumed-size `character` dummy failed LLVM verification:

```
code generation error: asr_to_llvm: module failed verification. Error:
Stored value type does not match pointer operand type!
  store %string_descriptor* %arr_desc_str_desc, i8*** %3
 i8**
```

`SimpleCMODescriptor::get_array_type` caches one LLVM descriptor struct per key built from the ASR type code plus the rank. Both arrays encode to `strdesc` with rank 1, so they shared a cache entry — but their element types differ:

| ASR type | element LLVM type |
| --- | --- |
| `Array(String … DescriptorString) DescriptorArray` | `%string_descriptor` |
| `Array(String … DescriptorString) StringArraySinglePointer` | `i8*` |

Whichever array was lowered first fixed the struct layout, and the second one then stored a pointer of the wrong type into the descriptor's data field. This is why the bug was so order-sensitive: anything that happened to lower the string-descriptor array first (a `use iso_c_binding`, an executable statement, a `print`) filled the cache in the other order and the failure disappeared.

## Scope

The descriptor layout is a function of the element type and the rank, so when a cached entry is found whose element type does not match, key the new entry by element type as well:

```cpp
auto cached = tkr2array.find(array_key);
if( cached != tkr2array.end() && cached->second.second != el_type ) {
    std::string el_type_str;
    llvm::raw_string_ostream el_type_os(el_type_str);
    el_type->print(el_type_os);
    array_key += "." + el_type_os.str();
}
```

This only ever *splits* entries whose element types genuinely differ. Entries whose element types already agree keep sharing a struct, so existing codegen is unchanged — borne out by the reference suite needing zero updates.

## Verification

`integration_tests/bindc_55.f90`, registered with `LABELS gfortran llvm`:

- **Fails on main** with the `Stored value type does not match pointer operand type!` codegen error (verified by stashing the fix and rebuilding).
- **Passes on this branch**, and produces identical output under GFortran and Flang.

```
$ cd integration_tests && ./run_tests.py -j16 &> log
100% tests passed, 0 tests failed out of 3890

$ ./run_tests.py &> log
TESTS PASSED
```

No reference outputs needed updating.

## Rationale

The test uses plain `character` rather than `character(kind=c_char)`. The `c_char` spelling — which is what the original M_regex code uses — pulls in `use iso_c_binding`, and that alone reorders the cache filling enough to hide the bug, so a `c_char` version would not fail on main and would not be a regression test.

One adjacent issue is left alone here, as a separate bug: `lfortran -c` on the module alone exits 0 and writes an object file even when the IR fails verification, because the verifier only runs on the full-compile path.
