### PR TITLE
fix: classify BIND(C) character kind in semantics instead of patching codegen

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2036,6 +2036,8 @@ RUN(NAME bindc_52 LABELS gfortran llvm)
 # Extension: BIND(C) character(len>1); GFortran rejects, so llvm only
 RUN(NAME bindc_53 LABELS llvm)
 RUN(NAME bindc_54 LABELS gfortran llvm)
+RUN(NAME bindc_55 LABELS gfortran llvm)
+RUN(NAME bindc_56 LABELS gfortran llvm)
 RUN(NAME bindc_iso_fb_01 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_01c.c)
 RUN(NAME bindc_iso_fb_02 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_02c.c)
 RUN(NAME bindc_iso_fb_03 LABELS gfortran llvm flang EXTRAFILES bindc_iso_fb_03c.c)

--- a/integration_tests/bindc_55.f90
+++ b/integration_tests/bindc_55.f90
@@ -1,0 +1,49 @@
+! An allocatable character array declared alongside an interface body for a
+! BIND(C) procedure that takes an assumed-size character dummy argument.
+! Regression test: the dummy is a StringArraySinglePointer array, i.e. one flat
+! character buffer, but its element String was left as DescriptorString. The two
+! physical types disagreed, so the backend had to pick a representation on its
+! own and ended up sharing one LLVM array descriptor between this dummy and the
+! allocatable array, whose elements really are string descriptors.
+module bindc_55_mod
+  implicit none
+contains
+  subroutine fill(n, total)
+    integer, intent(in) :: n
+    integer, intent(out) :: total
+    character, allocatable :: buf(:)
+    integer :: k
+    interface
+      subroutine c_take(pattern) bind(c, name="c_take")
+        character :: pattern(*)
+      end subroutine c_take
+    end interface
+    allocate(buf(n))
+    do k = 1, n
+      buf(k) = achar(iachar('a') + k - 1)
+    end do
+    if (buf(1) /= 'a') error stop
+    if (buf(n) /= achar(iachar('a') + n - 1)) error stop
+    total = size(buf)
+    do k = 1, n
+      total = total + iachar(buf(k))
+    end do
+    deallocate(buf)
+  end subroutine fill
+end module bindc_55_mod
+
+program bindc_55
+  use bindc_55_mod
+  implicit none
+  integer :: total
+
+  call fill(3, total)
+  print *, total
+  ! size + iachar('a') + iachar('b') + iachar('c') = 3 + 97 + 98 + 99
+  if (total /= 297) error stop
+
+  call fill(1, total)
+  print *, total
+  ! size + iachar('a') = 1 + 97
+  if (total /= 98) error stop
+end program bindc_55

--- a/integration_tests/bindc_56.f90
+++ b/integration_tests/bindc_56.f90
@@ -1,0 +1,71 @@
+! The BIND(C) character kind must be recognised from the resolved symbol, not
+! from how it is spelled: `C_char` (mixed case) and a renamed import both name
+! the same `c_char` from iso_c_binding, so all three spellings must produce the
+! same interoperable character type. Regression test: only the exact lowercase
+! spelling `c_char` was recognised, so the other two produced a different
+! physical type and the module failed LLVM verification.
+module bindc_56_mod
+  use ISO_C_Binding, only: C_char
+  use iso_c_binding, only: renamed_char => c_char
+  implicit none
+contains
+  subroutine upper_case(n, total)
+    integer, intent(in) :: n
+    integer, intent(out) :: total
+    character(kind=C_char, len=1), allocatable :: buf(:)
+    integer :: k
+    interface
+      subroutine c_upper(pattern) bind(C, name="c_upper")
+        import
+        character(kind=C_char) :: pattern(*)
+      end subroutine c_upper
+    end interface
+    allocate(buf(n))
+    do k = 1, n
+      buf(k) = achar(iachar('A') + k - 1)
+    end do
+    total = 0
+    do k = 1, n
+      total = total + iachar(buf(k))
+    end do
+    deallocate(buf)
+  end subroutine upper_case
+
+  subroutine renamed_kind(n, total)
+    integer, intent(in) :: n
+    integer, intent(out) :: total
+    character(kind=renamed_char, len=1), allocatable :: buf(:)
+    integer :: k
+    interface
+      subroutine c_lower(pattern) bind(C, name="c_lower")
+        import
+        character(kind=renamed_char) :: pattern(*)
+      end subroutine c_lower
+    end interface
+    allocate(buf(n))
+    do k = 1, n
+      buf(k) = achar(iachar('a') + k - 1)
+    end do
+    total = 0
+    do k = 1, n
+      total = total + iachar(buf(k))
+    end do
+    deallocate(buf)
+  end subroutine renamed_kind
+end module bindc_56_mod
+
+program bindc_56
+  use bindc_56_mod
+  implicit none
+  integer :: total
+
+  call upper_case(3, total)
+  print *, total
+  ! iachar('A') + iachar('B') + iachar('C') = 65 + 66 + 67
+  if (total /= 198) error stop
+
+  call renamed_kind(3, total)
+  print *, total
+  ! iachar('a') + iachar('b') + iachar('c') = 97 + 98 + 99
+  if (total /= 294) error stop
+end program bindc_56

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -9986,11 +9986,22 @@ public:
                     nullptr, 0,
                     ASR::array_physical_typeType::AssumedRankArray));
             } else {
-                type = ASRUtils::make_Array_t_util(
-                    al, loc, type, dims.p, dims.size(), abi, is_argument,
+                ASR::array_physical_typeType array_physical_type =
                     dims.size() > 0 && abi == ASR::abiType::BindC && (is_dimension_star || ASRUtils::is_fixed_size_array(dims.p, dims.n)) ? ASR::array_physical_typeType::StringArraySinglePointer :
                                     ASRUtils::is_fixed_size_array(dims.p, dims.n) ? ASR::array_physical_typeType::PointerArray :
-                                    ASR::array_physical_typeType::DescriptorArray,
+                                    ASR::array_physical_typeType::DescriptorArray;
+                // A StringArraySinglePointer array is one flat character
+                // buffer, so its elements are plain C characters rather than
+                // string descriptors. Keep the two physical types consistent
+                // here, where the array one is decided: a mismatched pair
+                // leaves the representation of the array ambiguous, and any
+                // consumer would have to pick a winner on its own.
+                if (array_physical_type == ASR::array_physical_typeType::StringArraySinglePointer) {
+                    str->m_physical_type = ASR::CChar;
+                }
+                type = ASRUtils::make_Array_t_util(
+                    al, loc, type, dims.p, dims.size(), abi, is_argument,
+                    array_physical_type,
                     dims.size() > 0 ? true : false);
             }
 
@@ -20844,6 +20855,29 @@ public:
         visit_NameUtil(x.m_member, x.n_member, x.m_id, x.base.base.loc, x.n_member);
     }
 
+    // Returns true if the kind expression names `c_char` from the intrinsic
+    // `iso_c_binding` module. The name is resolved through the symbol table, so
+    // any spelling (`C_char`, `C_CHAR`) and a renamed import
+    // (`use iso_c_binding, only: my_char => c_char`) are all recognised.
+    bool is_iso_c_binding_c_char(AST::expr_t* kind_value) {
+        if (!AST::is_a<AST::Name_t>(*kind_value)) {
+            return false;
+        }
+        std::string name = to_lower(AST::down_cast<AST::Name_t>(kind_value)->m_id);
+        ASR::symbol_t* kind_sym = current_scope->resolve_symbol(name);
+        if (!kind_sym) {
+            return false;
+        }
+        ASR::symbol_t* orig_sym = ASRUtils::symbol_get_past_external(kind_sym);
+        if (!orig_sym || to_lower(ASRUtils::symbol_name(orig_sym)) != "c_char") {
+            return false;
+        }
+        ASR::symbol_t* owner = ASRUtils::get_asr_owner(orig_sym);
+        return owner && ASR::is_a<ASR::Module_t>(*owner) &&
+            startswith(to_lower(ASRUtils::symbol_name(owner)),
+                "lfortran_intrinsic_iso_c_binding");
+    }
+
     void determine_char_len_and_kind(const AST::kind_item_t* len_item, const AST::kind_item_t* kind_item,
     AST::AttrType_t* type, AST::var_sym_t* var_sym, std::string& sym, ASR::String_t* str, bool is_argument, ASR::abiType abi) {
         // Handle kind: set CChar for bind(C) character(c_char) arguments
@@ -20861,8 +20895,7 @@ public:
             }
         }
         if (kind_item && kind_item->m_value) {
-            if (AST::is_a<AST::Name_t>(*kind_item->m_value) && 
-                std::string(AST::down_cast<AST::Name_t>(kind_item->m_value)->m_id) == "c_char") {
+            if (is_iso_c_binding_c_char(kind_item->m_value)) {
                 if ((is_argument || is_return_var) && abi == ASR::BindC) {
                     str->m_physical_type = ASR::CChar;
                 } else {


### PR DESCRIPTION
## Summary

Fixes #12571 — **alternative to #12573**, fixing the same bug in semantics instead of in codegen. See the comparison below; only one of the two should be merged.

The reported crash:

```
code generation error: asr_to_llvm: module failed verification. Error:
Stored value type does not match pointer operand type!
  store %string_descriptor* %arr_desc_str_desc, i8*** %3
 i8**
```

The BIND(C) dummy ended up with an ASR type that contradicts itself — `Array(String(…, DescriptorString), StringArraySinglePointer)`. `DescriptorString` says the elements are `%string_descriptor`; `StringArraySinglePointer` says the whole array is one flat `i8*`. The backend resolved the contradiction on its own at `llvm_utils.cpp:900` ("`// Treat it as a DescriptorArray`", element type `i8*`), while the descriptor cache key still said `strdesc` — so the dummy and a genuine allocatable string array shared one LLVM descriptor struct and the wrong pointer type got stored.

Two independent semantic bugs produced that contradictory type.

### 1. The BIND(C) character kind was matched by spelling

`ast_common_visitor.h` string-compared the source identifier against `"c_char"`. Fortran is case insensitive and the kind can be imported under another name, so these three semantically identical declarations produced two different ASR types:

| Declaration | Before | After |
| --- | --- | --- |
| `character(kind=c_char)` | `CChar` | `CChar` |
| `character(kind=C_char)` | `DescriptorString` | `CChar` |
| `use iso_c_binding, only: my_char => c_char` … `character(kind=my_char)` | `DescriptorString` | `CChar` |

**The issue's own code uses capital `C_char`** — that is exactly why it hit this. Now the name is resolved through the symbol table and checked to be `c_char` from the intrinsic `iso_c_binding` module, which also satisfies the "use enums or structured types, not string comparisons" rule in `AGENTS.md`.

### 2. The element `String` was not kept consistent with the array

A `StringArraySinglePointer` array is one flat character buffer, so its elements are plain C characters. The element `String` kept whatever physical type it already had. It is now set where the array physical type is decided, so the pair cannot disagree.

This part also covers a plain `character :: pattern(*)` dummy, which has no `c_char` spelling to resolve but is interoperable all the same (the default character kind *is* `c_char`).

## Scope

Semantics only. No backend change — with the ASR consistent, the existing descriptor cache key is already unambiguous.

An earlier attempt classified by ABI + kind + length inside `determine_char_len_and_kind` instead. That regressed `string_29`, which has an assumed-shape `character(len=1), intent(in) :: s(:)` dummy in a BIND(C) function: assumed-shape arrays are not interoperable and legitimately keep descriptors, so an ABI-based rule marked them wrong. Deriving the string physical type from the array physical type — at the one site where the latter is computed — avoids re-deriving that condition and gets the case right by construction.

## Verification

Two integration tests, both `LABELS gfortran llvm`, both confirmed to **fail on main** with the codegen error and pass here, with output matching GFortran and Flang:

- `bindc_55` — plain `character` assumed-size dummy alongside an allocatable character array.
- `bindc_56` — the same shape via mixed-case `C_char` and via a renamed import, covering both spellings the old check missed.

```
$ cd integration_tests && ./run_tests.py -j16 &> log
100% tests passed, 0 tests failed out of 3891

$ ./run_tests.py &> log
TESTS PASSED
```

No reference outputs needed updating.

## Comparison with #12573

| | #12573 (codegen) | this PR (semantics) |
| --- | --- | --- |
| Layer | `llvm_array_utils.cpp` descriptor cache | AST→ASR |
| Fixes the issue's code | yes | yes |
| Fixes plain `character` in BIND(C) | yes | yes |
| Fixes the `C_char` / renamed-import misclassification | no — ASR stays wrong | yes |
| Contradictory ASR still constructible | yes | no, for this path |
| Tests | `bindc_55` | `bindc_55`, `bindc_56` |

`AGENTS.md` says the backend "must never infer or fix types — it should only lower what ASR gives it. If codegen needs a type workaround, the bug is upstream." That points at this PR. #12573 remains useful as a backstop, but if it lands it would be better reduced to an assertion on the cache invariant rather than a silent repair.
