### PR TITLE
fix: cast select rank selector in arithmetic expressions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1027,6 +1027,7 @@ RUN(NAME select_rank_37 LABELS gfortran llvm)
 RUN(NAME select_rank_38 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME select_rank_39 LABELS gfortran llvm)
 RUN(NAME select_rank_40 LABELS gfortran llvm)
+RUN(NAME select_rank_41 LABELS gfortran llvm)
 
 RUN(NAME global_allocatable_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME global_allocatable_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/select_rank_41.f90
+++ b/integration_tests/select_rank_41.f90
@@ -1,0 +1,87 @@
+module select_rank_41_mod
+
+   implicit none
+
+contains
+
+   ! Arithmetic and relational expressions involving the selector of an
+   ! enclosing `select rank` block, including nested `select rank` blocks.
+   function add_reduce(a, b) result(res)
+      real(8), intent(in) :: a(..)
+      real(8), intent(in) :: b(..)
+      real(8) :: res
+      res = -1.d0
+      select rank(a)
+         rank(1)
+            select rank(b)
+               rank(1)
+                  res = sum(a + b)
+            end select
+         rank(2)
+            select rank(b)
+               rank(2)
+                  res = sum(a + b)
+            end select
+      end select
+   end function add_reduce
+
+   function neg_sum(a) result(res)
+      real(8), intent(in) :: a(..)
+      real(8) :: res
+      res = -1.d0
+      select rank(a)
+         rank(1)
+            res = sum(-a)
+         rank(2)
+            res = sum(-a)
+      end select
+   end function neg_sum
+
+   ! A `rank(0)` selector is a scalar, so it takes part in scalar arithmetic.
+   function twice(a) result(res)
+      real(8), intent(in) :: a(..)
+      real(8) :: res
+      res = -1.d0
+      select rank(a)
+         rank(0)
+            res = a + a
+      end select
+   end function twice
+
+   function count_above(a, x) result(res)
+      real(8), intent(in) :: a(..)
+      real(8), intent(in) :: x
+      integer :: res
+      res = -1
+      select rank(a)
+         rank(1)
+            res = count(a + a > x)
+      end select
+   end function count_above
+
+end module select_rank_41_mod
+
+program select_rank_41
+
+   use select_rank_41_mod
+   implicit none
+
+   real(8) :: a(4), b(4)
+   real(8) :: c(2,2), d(2,2)
+   real(8) :: e(4)
+
+   a = 1.d0; b = 2.d0
+   c = 1.d0; d = 2.d0
+   e = [1.d0, 2.d0, 3.d0, 4.d0]
+
+   if (abs(add_reduce(a, b) - 12.d0) > 1.d-12) error stop
+   if (abs(add_reduce(c, d) - 12.d0) > 1.d-12) error stop
+
+   if (abs(neg_sum(a) + 4.d0) > 1.d-12) error stop
+   if (abs(neg_sum(c) + 4.d0) > 1.d-12) error stop
+
+   if (abs(twice(3.d0) - 6.d0) > 1.d-12) error stop
+
+   if (count_above(e, 4.d0) /= 2) error stop
+
+end program select_rank_41

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -18992,9 +18992,11 @@ public:
             throw SemanticAbort();
         }
         this->visit_expr(*x.m_left);
-        ASR::expr_t *left = ASRUtils::EXPR(tmp);
+        ASR::expr_t *left = cast_assumed_rank_selector(ASRUtils::EXPR(tmp));
         this->visit_expr(*x.m_right);
-        ASR::expr_t *right = ASRUtils::EXPR(tmp);
+        ASR::expr_t *right = cast_assumed_rank_selector(ASRUtils::EXPR(tmp));
+        ensure_not_assumed_rank(left, "Arithmetic", x.base.base.loc);
+        ensure_not_assumed_rank(right, "Arithmetic", x.base.base.loc);
         visit_BinOp2(al, x, left, right, tmp, binop2str[x.m_op], current_scope);
 
         if (ASR::is_a<ASR::IntegerBinOp_t>(*ASRUtils::EXPR(tmp))) {
@@ -19605,33 +19607,63 @@ public:
 
     void visit_UnaryOp(const AST::UnaryOp_t &x) {
         this->visit_expr(*x.m_operand);
-        ASR::expr_t *operand = ASRUtils::EXPR(tmp);
+        ASR::expr_t *operand = cast_assumed_rank_selector(ASRUtils::EXPR(tmp));
+        ensure_not_assumed_rank(operand, "Arithmetic", x.base.base.loc);
         CommonVisitorMethods::visit_UnaryOp(al, x, operand, tmp,
             current_scope, current_function_dependencies,
             current_module_dependencies, diag);
     }
 
+    // Inside a `select rank` block the selector is known to have a specific
+    // rank, so a reference to it takes part in expressions as a descriptor
+    // array of that rank rather than as an assumed rank array. `expr` is
+    // returned unchanged when it does not reference such a selector.
+    ASR::expr_t* cast_assumed_rank_selector(ASR::expr_t* expr) {
+        if (!ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(expr)) ||
+                !ASR::is_a<ASR::Var_t>(*expr)) {
+            return expr;
+        }
+        std::string array_name = ASRUtils::symbol_name(
+            ASR::down_cast<ASR::Var_t>(expr)->m_v);
+        auto it = assumed_rank_arrays.find(array_name);
+        if (it == assumed_rank_arrays.end()) {
+            return expr;
+        }
+        // `create_array_type_with_empty_dims` returns the element type itself
+        // for `rank(0)`, i.e. a scalar selector.
+        ASR::ttype_t* desc_type = ASRUtils::create_array_type_with_empty_dims(al,
+            it->second, ASRUtils::extract_type(ASRUtils::expr_type(expr)));
+        return ASRUtils::EXPR(ASRUtils::make_ArrayPhysicalCast_t_util(al,
+            expr->base.loc, expr, ASR::array_physical_typeType::AssumedRankArray,
+            ASR::array_physical_typeType::DescriptorArray, desc_type, nullptr));
+    }
+
+    // An assumed rank array that is not the selector of an enclosing
+    // `select rank` block has no known rank, so it cannot take part in an
+    // operation. `op_kind` names the kind of operation, e.g. "Comparison".
+    void ensure_not_assumed_rank(ASR::expr_t* expr, const std::string& op_kind,
+            const Location& loc) {
+        if (!ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(expr))) {
+            return;
+        }
+        std::string array_name = "";
+        if (ASR::is_a<ASR::Var_t>(*expr)) {
+            array_name = " ('" + std::string(ASRUtils::symbol_name(
+                ASR::down_cast<ASR::Var_t>(expr)->m_v)) + "')";
+        }
+        diag.add(Diagnostic(op_kind + " operations are not allowed on "
+            "assumed-rank arrays" + array_name,
+            Level::Error, Stage::Semantic, {Label("", {loc})}));
+        throw SemanticAbort();
+    }
+
     void visit_Compare(const AST::Compare_t &x) {
         this->visit_expr(*x.m_left);
-        ASR::expr_t *left = ASRUtils::EXPR(tmp);
+        ASR::expr_t *left = cast_assumed_rank_selector(ASRUtils::EXPR(tmp));
         this->visit_expr(*x.m_right);
-        ASR::expr_t *right = ASRUtils::EXPR(tmp);
-        if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(left))) {
-            std::string array_name = ASRUtils::symbol_name(ASR::down_cast<ASR::Var_t>(left)->m_v);
-            if (assumed_rank_arrays.find(array_name) == assumed_rank_arrays.end()) {
-                diag.add(Diagnostic("Comparison operations are not allowed on assumed-rank arrays ('" + array_name + "')",
-                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
-                throw SemanticAbort();
-            } else {
-                size_t rank = assumed_rank_arrays[array_name];
-                ASR::ttype_t* new_type = ASRUtils::create_array_type_with_empty_dims(al, 
-                    rank, ASRUtils::extract_type(ASRUtils::expr_type(left)));
-                ASR::expr_t* cast_expr = ASRUtils::EXPR(ASRUtils::make_ArrayPhysicalCast_t_util(al,
-                    left->base.loc, left, ASR::array_physical_typeType::AssumedRankArray, 
-                    ASR::array_physical_typeType::DescriptorArray, new_type, nullptr));
-                left = cast_expr;
-            }
-        }
+        ASR::expr_t *right = cast_assumed_rank_selector(ASRUtils::EXPR(tmp));
+        ensure_not_assumed_rank(left, "Comparison", x.base.base.loc);
+        ensure_not_assumed_rank(right, "Comparison", x.base.base.loc);
         CommonVisitorMethods::visit_Compare(al, x, left, right, tmp,
                                             cmpop2str[x.m_op], current_scope,
                                             current_function_dependencies,

--- a/tests/errors/continue_compilation_3.f90
+++ b/tests/errors/continue_compilation_3.f90
@@ -12,7 +12,6 @@ module continue_compilation_3_mod
         procedure, pass(self) :: m => tbp_ptr_dummy_pass_f  ! Warning: passed-object dummy argument that is POINTER is not standard
     end type
 
-
 contains
 
     subroutine check_incompatible_type(i)
@@ -36,6 +35,7 @@ contains
         print *, x(1)
 	    x = [1, 2]
         print *, (x /= [1, 2])
+        print *, x + x
     end subroutine assumed_rank
 
     subroutine ss(x)

--- a/tests/reference/asr-continue_compilation_3-435a232.json
+++ b/tests/reference/asr-continue_compilation_3-435a232.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_3-435a232",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_3.f90",
-    "infile_hash": "b76372c6aa40fad88c233647e41a9e9323162ca1bbe00c14f365d187",
+    "infile_hash": "3a2b553546b9f9793486e124a622d1d6ae7e430b63346af2be4d7761",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_3-435a232.stderr",
-    "stderr_hash": "47bd0e91c3c17c43fbfb2cee6469e919c71587d52e93c9788d0e5ef4",
+    "stderr_hash": "2d2df974daad64f794b46c0f6299c5c6eb8ffc85935ee191493aa46f",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_3-435a232.stderr
+++ b/tests/reference/asr-continue_compilation_3-435a232.stderr
@@ -47,34 +47,40 @@ semantic error: Procedure declarations without an explicit interface (procedure(
    |         ^^^^^^^^^^^ 
 
 semantic error: Assumed-rank arrays are not supported in print statements
-  --> tests/errors/continue_compilation_3.f90:34:18
+  --> tests/errors/continue_compilation_3.f90:33:18
    |
-34 |         print *, x
+33 |         print *, x
    |                  ^ 
 
 semantic error: Assumed rank arrays cannot be used as `source` argument to reshape intrinsic
-  --> tests/errors/continue_compilation_3.f90:35:26
+  --> tests/errors/continue_compilation_3.f90:34:26
    |
-35 |         print *, reshape(x, [size(x)])
+34 |         print *, reshape(x, [size(x)])
    |                          ^ 
 
 semantic error: Assumed-rank array `x` cannot be accessed outside a select rank block
-  --> tests/errors/continue_compilation_3.f90:36:18
+  --> tests/errors/continue_compilation_3.f90:35:18
    |
-36 |         print *, x(1)
+35 |         print *, x(1)
    |                  ^^^^ 
 
 semantic error: Assumed-rank array 'x' must be a dummy argument
-  --> tests/errors/continue_compilation_3.f90:37:6
+  --> tests/errors/continue_compilation_3.f90:36:6
    |
-37 |      x = [1, 2]
+36 |      x = [1, 2]
    |      ^ 
 
 semantic error: Comparison operations are not allowed on assumed-rank arrays ('x')
-  --> tests/errors/continue_compilation_3.f90:38:19
+  --> tests/errors/continue_compilation_3.f90:37:19
    |
-38 |         print *, (x /= [1, 2])
+37 |         print *, (x /= [1, 2])
    |                   ^^^^^^^^^^^ 
+
+semantic error: Arithmetic operations are not allowed on assumed-rank arrays ('x')
+  --> tests/errors/continue_compilation_3.f90:38:18
+   |
+38 |         print *, x + x
+   |                  ^^^^^ 
 
 semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
   --> tests/errors/continue_compilation_3.f90:77:26


### PR DESCRIPTION
## Summary

Fixes #12577.

Inside a `select rank` block the selector has a known rank, and LFortran models this by inserting an `ArrayPhysicalCast` from `AssumedRankArray` to `DescriptorArray` at each point of use. That cast was inserted in several contexts (assignment RHS, `allocate(source=)`, actual arguments, `reshape`, comparison LHS, ...) but **not** for the operands of arithmetic operators. So `a + a` was built with an assumed-rank operand and came out with rank 0, which then either produced a bogus "Incompatible ranks 1 and 0 in assignment" or, when passed to an intrinsic, hit an unguarded `down_cast<Var_t>` and aborted:

```
LCOMPILERS_ASSERT failed: src/libasr/asr.h
function down_cast(), line number 41 at is_a<T>(*f)
```

MRE:

```fortran
program p
   real(8) :: a(4)
   a = 1.d0
   print *, f(a)
contains
   function f(a) result(res)
      real(8), intent(in) :: a(..)
      real(8) :: res
      res = 0
      select rank(a)
      rank(1)
         res = sum(a + a)      ! <-- assertion failure
      end select
   end function
end program
```

A related hole: arithmetic on an assumed-rank dummy *outside* any `select rank` block crashed the same way instead of reporting an error.

## Scope

`src/lfortran/semantics/ast_common_visitor.h` only. Two helpers in `CommonVisitor`, applied in `visit_BinOp`, `visit_UnaryOp` and `visit_Compare`:

- `cast_assumed_rank_selector()` — inserts the descriptor cast when the operand references the selector of an enclosing `select rank` block. For `rank(0)` it yields the scalar element type, matching what the assignment path already does.
- `ensure_not_assumed_rank()` — emits a clean semantic error otherwise, replacing the crash.

`visit_Compare` previously had this logic inline for the left operand only, with the same unguarded `down_cast`; it now uses the helpers and covers both operands. Its existing diagnostic wording is preserved.

The fix stays in AST->ASR semantics; no backend changes.

## Verification

New integration test `integration_tests/select_rank_41.f90` (labels `gfortran llvm`), covering nested `select rank` arithmetic (the issue's reproducer), unary minus on a selector, `rank(0)` scalar arithmetic, and a relational expression on a selector.

Test fails on `main`:

```
$ lfortran integration_tests/select_rank_41.f90
  File "src/lfortran/semantics/ast_common_visitor.h", line 13585
    if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(temp))) {
  File "src/libasr/asr.h", line 41
    LCOMPILERS_ASSERT(is_a<T>(*f));
AssertFailed: is_a<T>(*f)
```

Passes on this branch, and with `gfortran`.

The issue's original program now runs and matches gfortran:

```
$ lfortran Current.f90 -o Current && ./Current
   12.000000000000000
   12.000000000000000
```

New error path covered in `tests/errors/continue_compilation_3.f90` (one line added, one blank line removed per that file's line-stability convention), reference updated:

```
semantic error: Arithmetic operations are not allowed on assumed-rank arrays ('x')
```

Suites:

- `./run_tests.py` -> `TESTS PASSED`
- `cd integration_tests && ./run_tests.py -j16` -> `100% tests passed, 0 tests failed out of 3892`
- `./run_tests.py -b gfortran` -> `select_rank_41` builds and links; one pre-existing unrelated failure (`pdt_16.f90`, parameterized derived types rejected by the local gfortran)

## Rationale

Type and rank decisions belong in AST->ASR, with explicit `ArrayPhysicalCast` nodes in ASR. This change puts the arithmetic-operator case on the same footing as the contexts that already handled it, and turns the remaining unhandled case from an assertion failure into a diagnostic.