### PR TITLE
Write and read kind 4 character values as UTF-8

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4777,6 +4777,10 @@ RUN(NAME merge_str_01 LABELS gfortran llvm)
 RUN(NAME io_direct_slash LABELS gfortran llvm)
 RUN(NAME achar_kind_01 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_01 LABELS gfortran llvm)
+RUN(NAME char4_string_intrinsics_02 LABELS gfortran llvm)
+# GFortran treats each source byte of a kind 4 literal as one character,
+# LFortran (like LLVM Flang) decodes the UTF-8 source into code points.
+RUN(NAME char4_string_literal_01 LABELS llvm)
 
 #test for coarray
 RUN(NAME coarray_01 LABELS gfortran GFORTRAN_ARGS -fcoarray=single)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4777,6 +4777,8 @@ RUN(NAME merge_str_01 LABELS gfortran llvm)
 RUN(NAME io_direct_slash LABELS gfortran llvm)
 RUN(NAME achar_kind_01 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_01 LABELS gfortran llvm)
+RUN(NAME char4_io_01 LABELS gfortran llvm)
+RUN(NAME char4_io_02 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_02 LABELS gfortran llvm)
 # GFortran treats each source byte of a kind 4 literal as one character,
 # LFortran (like LLVM Flang) decodes the UTF-8 source into code points.

--- a/integration_tests/char4_io_01.f90
+++ b/integration_tests/char4_io_01.f90
@@ -1,0 +1,73 @@
+program char4_io_01
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+4F60 and U+597D: three UTF-8 bytes each, so a byte oriented write
+    ! would truncate or mangle them.
+    character(kind=ucs4, len=1), parameter :: ni = char(int(z'4F60'), ucs4)
+    character(kind=ucs4, len=1), parameter :: hao = char(int(z'597D'), ucs4)
+    character(kind=ucs4, len=6) :: greeting
+    character(len=80) :: record
+    integer :: u
+
+    greeting = ucs4_"ab" // ni // hao
+
+    ! Write the value out with ENCODING='UTF-8', then read the file back as
+    ! default characters so the exact bytes can be checked.
+    open(newunit=u, file="char4_io_01_data.txt", status="replace", &
+         encoding="UTF-8", action="write")
+    write(u, '(a)') greeting
+    write(u, '("<",a,">")') trim(greeting)
+    write(u, *) greeting
+    close(u)
+
+    open(newunit=u, file="char4_io_01_data.txt", status="old", action="read")
+
+    ! 'a' with no width writes all six characters: a, b, then the two
+    ! ideographs as three bytes each, then two trailing blanks.
+    read(u, '(a)') record
+    call check_utf8(record, 1, "plain a")
+
+    ! trim() drops the two blanks, so only four characters are written.
+    read(u, '(a)') record
+    if (record(1:1) /= "<") error stop 10
+    call check_utf8(record, 2, "trimmed a")
+    if (record(10:10) /= ">") error stop 11
+
+    ! List directed output writes the same bytes.
+    read(u, '(a)') record
+    call check_utf8(record, 1 + count_leading_blanks(record), "list directed")
+
+    close(u, status="delete")
+
+    print *, "ok"
+
+contains
+
+    integer function count_leading_blanks(s) result(n)
+        character(len=*), intent(in) :: s
+        n = 0
+        do while (n < len(s))
+            if (s(n + 1 : n + 1) /= " ") exit
+            n = n + 1
+        end do
+    end function
+
+    ! Checks that `s`, starting at `start`, holds the UTF-8 bytes of
+    ! "ab" // U+4F60 // U+597D.
+    subroutine check_utf8(s, start, what)
+        character(len=*), intent(in) :: s
+        integer, intent(in) :: start
+        character(len=*), intent(in) :: what
+        integer :: expected(8), i, got
+        ! 'a', 'b', E4 BD A0, E5 A5 BD
+        expected = [97, 98, 228, 189, 160, 229, 165, 189]
+        do i = 1, 8
+            got = ichar(s(start + i - 1 : start + i - 1))
+            if (got /= expected(i)) then
+                print *, "byte", i, "of", what, "is", got, "expected", expected(i)
+                error stop 1
+            end if
+        end do
+    end subroutine
+
+end program

--- a/integration_tests/char4_io_02.f90
+++ b/integration_tests/char4_io_02.f90
@@ -1,0 +1,51 @@
+program char4_io_02
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+5E74, U+6708 and U+65E5: the Japanese year, month and day characters.
+    character(kind=ucs4, len=1), parameter :: nen = char(int(z'5e74'), ucs4)
+    character(kind=ucs4, len=1), parameter :: gatsu = char(int(z'6708'), ucs4)
+    character(kind=ucs4, len=1), parameter :: nichi = char(int(z'65e5'), ucs4)
+    character(kind=ucs4, len=40) :: line
+    character(kind=ucs4, len=:), allocatable :: grown
+    integer :: u
+
+    ! An internal WRITE into a kind 4 variable must store code units, so the
+    ! result can be measured and indexed as characters afterwards.
+    write(line, '(i0,a,i0,a,i0,a)') 2026, nen, 8, gatsu, 24, nichi
+    if (len_trim(line) /= 10) error stop 1
+    if (line(1:4) /= ucs4_"2026") error stop 2
+    if (ichar(line(5:5), kind=4) /= int(z'5e74')) error stop 3
+    if (line(6:6) /= ucs4_"8") error stop 4
+    if (ichar(line(7:7), kind=4) /= int(z'6708')) error stop 5
+    if (line(8:9) /= ucs4_"24") error stop 6
+    if (ichar(line(10:10), kind=4) /= int(z'65e5')) error stop 7
+
+    ! The same for a shorter record: the tail must be blank padded in
+    ! characters, not in bytes.
+    write(line, '(a,a,a)') nen, gatsu, nichi
+    if (len_trim(line) /= 3) error stop 8
+    if (ichar(line(2:2), kind=4) /= int(z'6708')) error stop 9
+
+    grown = repeat(nichi, 3)
+    if (len(grown) /= 3) error stop 10
+
+    ! Round trip through a UTF-8 file: what is written as code units comes
+    ! back as code units.
+    open(newunit=u, file="char4_io_02_data.txt", status="replace", &
+         encoding="UTF-8", action="write")
+    write(u, '(a)') nen // gatsu // nichi
+    close(u)
+
+    line = ucs4_" "
+    open(newunit=u, file="char4_io_02_data.txt", status="old", &
+         encoding="UTF-8", action="read")
+    read(u, '(a)') line
+    close(u, status="delete")
+
+    if (len_trim(line) /= 3) error stop 11
+    if (ichar(line(1:1), kind=4) /= int(z'5e74')) error stop 12
+    if (ichar(line(2:2), kind=4) /= int(z'6708')) error stop 13
+    if (ichar(line(3:3), kind=4) /= int(z'65e5')) error stop 14
+
+    print *, "ok"
+end program

--- a/integration_tests/char4_string_intrinsics_02.f90
+++ b/integration_tests/char4_string_intrinsics_02.f90
@@ -1,0 +1,87 @@
+program char4_string_intrinsics_02
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+4F60 and U+597D, two CJK ideographs outside the ASCII range
+    character(kind=ucs4, len=1), parameter :: ni = char(int(z'4F60'), ucs4)
+    character(kind=ucs4, len=1), parameter :: hao = char(int(z'597D'), ucs4)
+    character(kind=ucs4, len=6) :: padded
+    character(kind=ucs4, len=4) :: leading
+    character(kind=ucs4, len=3) :: a, b
+    character(kind=ucs4, len=:), allocatable :: joined
+    integer :: code
+
+    ! Every character intrinsic must return a result of the same character
+    ! kind as its argument, not the default kind.
+    if (kind(trim(padded)) /= 4) error stop 1
+    if (kind(adjustl(leading)) /= 4) error stop 2
+    if (kind(adjustr(padded)) /= 4) error stop 3
+    if (kind(repeat(a, 2)) /= 4) error stop 4
+    if (kind(a // b) /= 4) error stop 5
+    if (kind(new_line(a)) /= 4) error stop 6
+    if (kind(char(65, ucs4)) /= 4) error stop 7
+    if (kind(achar(65, ucs4)) /= 4) error stop 8
+
+    ! char() with a non-constant code point and a constant kind must still
+    ! build a four byte character.
+    code = int(z'4F60')
+    if (ichar(char(code, ucs4), kind=4) /= int(z'4F60')) error stop 9
+    if (ichar(achar(code, ucs4), kind=4) /= int(z'4F60')) error stop 10
+
+    ! trim/adjustl/adjustr must count and compare whole characters, so a
+    ! trailing blank of kind 4 is one character wide, not one byte.
+    padded = ni // hao // ucs4_"    "
+    if (len_trim(padded) /= 2) error stop 11
+    if (len(trim(padded)) /= 2) error stop 12
+    if (trim(padded) /= ni // hao) error stop 13
+
+    leading = ucs4_"  " // ni // hao
+    if (len_trim(adjustl(leading)) /= 2) error stop 14
+    if (adjustl(leading) /= ni // hao // ucs4_"  ") error stop 15
+    if (adjustr(ni // hao // ucs4_"  ") /= ucs4_"  " // ni // hao) error stop 16
+
+    ! Concatenation of two run time values keeps the kind and the length.
+    a = ni // hao // ucs4_"!"
+    b = ucs4_"abc"
+    joined = a // b
+    if (len(joined) /= 6) error stop 17
+    if (kind(joined) /= 4) error stop 18
+    if (ichar(joined(1:1), kind=4) /= int(z'4F60')) error stop 19
+    if (ichar(joined(2:2), kind=4) /= int(z'597D')) error stop 20
+    if (joined(4:6) /= ucs4_"abc") error stop 21
+
+    if (repeat(ni, 3) /= ni // ni // ni) error stop 22
+    if (len(repeat(ni, 3)) /= 3) error stop 23
+
+    ! index/scan/verify report character positions, not byte offsets.
+    if (index(padded, hao) /= 2) error stop 24
+    if (scan(padded, hao) /= 2) error stop 25
+    if (verify(padded, ni // hao // ucs4_" ") /= 0) error stop 26
+    if (index(padded, ni // hao) /= 1) error stop 27
+
+    call check_folded()
+
+    print *, "ok"
+
+contains
+
+    ! The same properties, but computed at compile time: constant folding must
+    ! use the same character counts as the generated code.
+    subroutine check_folded()
+        character(kind=ucs4, len=6), parameter :: cpadded = ni // hao // ucs4_"    "
+        character(kind=ucs4, len=4), parameter :: clead = ucs4_"  " // ni // hao
+        if (len(cpadded) /= 6) error stop 31
+        if (len_trim(cpadded) /= 2) error stop 32
+        if (len(trim(cpadded)) /= 2) error stop 33
+        if (trim(cpadded) /= ni // hao) error stop 34
+        if (ichar(ni, kind=4) /= int(z'4F60')) error stop 35
+        if (len(ni // hao) /= 2) error stop 36
+        if (len_trim(adjustl(clead)) /= 2) error stop 37
+        if (adjustl(clead) /= ni // hao // ucs4_"  ") error stop 38
+        if (adjustr(cpadded) /= ucs4_"    " // ni // hao) error stop 39
+        if (len(repeat(ni, 3)) /= 3) error stop 40
+        if (index(cpadded, hao) /= 2) error stop 41
+        if (scan(cpadded, hao) /= 2) error stop 42
+        if (verify(cpadded, ni // hao // ucs4_" ") /= 0) error stop 43
+    end subroutine
+
+end program

--- a/integration_tests/char4_string_literal_01.f90
+++ b/integration_tests/char4_string_literal_01.f90
@@ -1,0 +1,21 @@
+program char4_string_literal_01
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! A kind 4 literal written directly in the (UTF-8) source is decoded into
+    ! code points, so its length is a count of characters. This matches LLVM
+    ! Flang; GFortran instead treats each source byte as one character, so this
+    ! test is not run against GFortran.
+    character(kind=ucs4, len=*), parameter :: greeting = ucs4_"你好"
+    character(kind=ucs4, len=:), allocatable :: copy
+
+    if (len(greeting) /= 2) error stop 1
+    if (ichar(greeting(1:1), kind=4) /= int(z'4F60')) error stop 2
+    if (ichar(greeting(2:2), kind=4) /= int(z'597D')) error stop 3
+    if (greeting /= char(int(z'4F60'), ucs4) // char(int(z'597D'), ucs4)) error stop 4
+
+    copy = greeting
+    if (len(copy) /= 2) error stop 5
+    if (len_trim(greeting // ucs4_"  ") /= 2) error stop 6
+
+    print *, "ok"
+end program

--- a/integration_tests/print_12.f90
+++ b/integration_tests/print_12.f90
@@ -3,10 +3,34 @@ program print_12
     implicit none
 
     integer, parameter :: ucs4 = selected_char_kind('ISO_10646')
+    character(kind=ucs4, len=:), allocatable :: greeting
+    character(len=80) :: record
+    integer :: u, i
+    ! "Hello = Ni Hao = " followed by the UTF-8 bytes of U+4F60 and U+597D
+    integer, parameter :: tail(6) = [228, 189, 160, 229, 165, 189]
 
     if (ucs4 /= 4) error stop
 
-    open(output_unit, encoding='UTF-8')
-    print *, ucs4_'Hello = Ni Hao = ' // &
+    greeting = ucs4_'Hello = Ni Hao = ' // &
          char(int(z'4F60'), ucs4) // char(int(z'597D'), ucs4)
+    if (len(greeting) /= 19) error stop 1
+
+    open(output_unit, encoding='UTF-8')
+    print *, greeting
+
+    ! Write the same value to a file and read it back as default characters,
+    ! so the bytes that reach the stream can be checked.
+    open(newunit=u, file='print_12_data.txt', status='replace', &
+         encoding='UTF-8', action='write')
+    write(u, '(a)') greeting
+    close(u)
+
+    open(newunit=u, file='print_12_data.txt', status='old', action='read')
+    read(u, '(a)') record
+    close(u, status='delete')
+
+    if (record(1:17) /= 'Hello = Ni Hao = ') error stop 2
+    do i = 1, 6
+        if (ichar(record(17 + i : 17 + i)) /= tail(i)) error stop 3
+    end do
 end program print_12

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -918,6 +918,18 @@ inline static void set_intrinsic_return_kind(Allocator& al, const Location& loc,
     }
 }
 
+inline static std::string cmpop_to_str(ASR::cmpopType op) {
+    switch (op) {
+        case (ASR::cmpopType::Eq): return "==";
+        case (ASR::cmpopType::NotEq): return "/=";
+        case (ASR::cmpopType::Lt): return "<";
+        case (ASR::cmpopType::LtE): return "<=";
+        case (ASR::cmpopType::Gt): return ">";
+        case (ASR::cmpopType::GtE): return ">=";
+        default: return "";
+    }
+}
+
 inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
                                    ASR::expr_t *&left, ASR::expr_t *&right,
                                    ASR::asr_t *&asr, std::string& intrinsic_op_name,
@@ -1072,6 +1084,20 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
     }
 
     if( overloaded == nullptr ) {
+        if (ASRUtils::is_character(*left_type2) && ASRUtils::is_character(*right_type2)) {
+            int64_t left_kind = ASRUtils::extract_kind_from_ttype_t(left_type2);
+            int64_t right_kind = ASRUtils::extract_kind_from_ttype_t(right_type2);
+            if (left_kind != right_kind) {
+                diag.add(diag::Diagnostic(
+                    "operands of comparison operator '" + cmpop_to_str(asr_op) +
+                    "' must be character with the same kind, found character(" +
+                    std::to_string(left_kind) + ") and character(" +
+                    std::to_string(right_kind) + ")",
+                    Level::Error, Stage::Semantic, {
+                    diag::Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
+        }
         if (!ASRUtils::check_equal_type(ASRUtils::expr_type(left),
                                     ASRUtils::expr_type(right), left, right)) {
             diag.add(diag::Diagnostic(
@@ -19541,6 +19567,16 @@ public:
 
         if( ASR::is_a<ASR::String_t>(*left_type) &&
             ASR::is_a<ASR::String_t>(*right_type) ) { // CreateIntrinisc `stringConcat`
+            int64_t left_kind = ASR::down_cast<ASR::String_t>(left_type)->m_kind;
+            int64_t right_kind = ASR::down_cast<ASR::String_t>(right_type)->m_kind;
+            if (left_kind != right_kind) {
+                diag.add(Diagnostic(
+                    "operands of // must be character with the same kind, "
+                    "found character(" + std::to_string(left_kind) + ") and character("
+                    + std::to_string(right_kind) + ")",
+                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
             Vec<ASR::expr_t*> v; v.reserve(al, 1);
             v.push_back(al, left);
             v.push_back(al, right);
@@ -19767,6 +19803,12 @@ public:
                     throw SemanticAbort();
                 }
             }
+        }
+        if (!ASRUtils::is_supported_character_kind(kind)) {
+            diag.add(Diagnostic("kind " + std::to_string(kind) +
+                " is not supported for character, only 1 and 4 are",
+                Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            throw SemanticAbort();
         }
         if (kind > 1) {
             s_len = (int)utf8_codepoint_count(x.m_s);
@@ -20928,6 +20970,14 @@ public:
                 this->visit_expr(*kind_item->m_value);
                 ASR::expr_t* kind_expr = ASRUtils::EXPR(tmp);
                 str->m_kind = ASRUtils::extract_kind<SemanticAbort>(kind_expr, kind_item->loc, diag);
+                if (!ASRUtils::is_supported_character_kind(str->m_kind)) {
+                    diag.add(diag::Diagnostic(
+                        "kind " + std::to_string(str->m_kind) +
+                        " is not supported for character, only 1 and 4 are",
+                        Level::Error, Stage::Semantic, {
+                        diag::Label("", {kind_item->loc})}));
+                    throw SemanticAbort();
+                }
                 str->m_physical_type = ASR::DescriptorString;
             }
         } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -422,11 +422,15 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc, x.m_s, x.m_type));
     }
 
+    // Substring bounds are character positions. For kind > 1 the value holds
+    // UTF-8, so one character can span several bytes and the value has to be
+    // sliced character by character.
     void visit_StringSection(const ASR::StringSection_t &x) {
         this->visit_expr(*x.m_arg);
-        char* str_val = ASR::down_cast<ASR::StringConstant_t>(value)->m_s;
-        std::string str(str_val);
-        int start = 1, end = (int)str.size();
+        ASR::StringConstant_t* str_const = ASR::down_cast<ASR::StringConstant_t>(value);
+        std::vector<std::string> characters = ASRUtils::string_value_characters(
+            str_const->m_s, ASRUtils::extract_kind_from_ttype_t(str_const->m_type));
+        int start = 1, end = (int)characters.size();
         if (x.m_start) {
             this->visit_expr(*x.m_start);
             start = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
@@ -435,18 +439,22 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
             this->visit_expr(*x.m_end);
             end = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
         }
-        int len = end - start + 1;
-        std::string result = len > 0 ? str.substr(start - 1, len) : "";
+        std::string result;
+        for (int i = start; i <= end && i <= (int)characters.size(); i++) {
+            result += characters[i - 1];
+        }
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc,
             s2c(al, result), x.m_type));
     }
 
     void visit_StringItem(const ASR::StringItem_t &x) {
         this->visit_expr(*x.m_arg);
-        char* str_val = ASR::down_cast<ASR::StringConstant_t>(value)->m_s;
+        ASR::StringConstant_t* str_const = ASR::down_cast<ASR::StringConstant_t>(value);
+        std::vector<std::string> characters = ASRUtils::string_value_characters(
+            str_const->m_s, ASRUtils::extract_kind_from_ttype_t(str_const->m_type));
         this->visit_expr(*x.m_idx);
         int idx = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
-        std::string result(1, str_val[idx - 1]);
+        std::string result = characters[idx - 1];
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc,
             s2c(al, result), x.m_type));
     }
@@ -10910,8 +10918,17 @@ public:
                     if( end == -1 && !flag ) {
                         end = str_length;
                     } else {
+                        // Substring bounds are character positions. For kind > 1
+                        // the value holds UTF-8, so slice whole characters.
+                        std::vector<std::string> characters =
+                            ASRUtils::string_value_characters(m_str->m_s, s_type->m_kind);
+                        // An initializer shorter than the declared length is
+                        // blank padded, so the value has `str_length` characters.
+                        characters.resize(str_length, " ");
+                        int64_t sliced_len = 0;
                         for( int i = start - 1; i < end; i += step ) {
-                            sliced_str.push_back(m_str->m_s[i]);
+                            sliced_str += characters[i];
+                            sliced_len++;
                         }
                         Str l_str;
                         l_str.from_str(al, sliced_str);
@@ -10919,7 +10936,7 @@ public:
                             ASRUtils::TYPE(ASR::make_String_t(al, loc, ASRUtils::extract_kind_from_ttype_t(root_v_type), 
                                 ASRUtils::EXPR(
                                     ASR::make_IntegerConstant_t(
-                                        al, loc, sliced_str.size(),
+                                        al, loc, sliced_len,
                                         ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind))
                                     )
                                 ),
@@ -19700,6 +19717,9 @@ public:
     void visit_String(const AST::String_t &x) {
         int s_len = strlen(x.m_s);
         int kind = 1;
+        // `s_len` is fixed up below once `kind` is known: a kind > 1 literal
+        // holds UTF-8 in ASR, so its Fortran length is the number of code
+        // points, not the number of bytes.
         if (x.m_kind) {
             kind = std::atoi(x.m_kind);
             if (kind == 0) {
@@ -19747,6 +19767,9 @@ public:
                     throw SemanticAbort();
                 }
             }
+        }
+        if (kind > 1) {
+            s_len = (int)utf8_codepoint_count(x.m_s);
         }
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_String_t(al, x.base.base.loc, kind, 
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, s_len,

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -376,8 +376,17 @@ class ASRBuilder {
         return EXPR(ASR::make_StringSection_t(al, loc, s, start, end, i32(1), string_type, nullptr));
     }
 
+    // A single character of `x` has the same character kind as `x` itself.
     inline ASR::expr_t* StringItem(ASR::expr_t* x, ASR::expr_t* idx) {
-        return EXPR(ASR::make_StringItem_t(al, loc, x, idx, character(1), nullptr));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x));
+        return EXPR(ASR::make_StringItem_t(al, loc, x, idx,
+            String(i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind), nullptr));
+    }
+
+    // A blank of the given character kind, for padding and trimming.
+    inline ASR::expr_t* StringBlank(int char_kind) {
+        return StringConstant(" ",
+            String(i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind));
     }
 
     inline ASR::expr_t* StringConstant(std::string s, ASR::ttype_t* type) {

--- a/src/libasr/asr_text.cpp
+++ b/src/libasr/asr_text.cpp
@@ -19,51 +19,11 @@
 #include <libasr/asr_text_parser.h>
 #include <libasr/asr_text_visitor.h>
 #include <libasr/asr_utils.h>
+#include <libasr/string_utils.h>
 
 namespace LCompilers {
 
 namespace {
-
-// Returns true if `value` is well-formed UTF-8: the encoding the text format
-// is defined in. Overlong forms, surrogates and out-of-range code points are
-// rejected, so a value that survives this check can be written as a string.
-bool is_valid_utf8(const char *value, size_t size) {
-    size_t i = 0;
-    while (i < size) {
-        const unsigned char c = static_cast<unsigned char>(value[i]);
-        size_t length;
-        uint32_t code_point;
-        if (c < 0x80) {
-            i++;
-            continue;
-        } else if ((c & 0xe0) == 0xc0) {
-            length = 2;
-            code_point = c & 0x1f;
-        } else if ((c & 0xf0) == 0xe0) {
-            length = 3;
-            code_point = c & 0x0f;
-        } else if ((c & 0xf8) == 0xf0) {
-            length = 4;
-            code_point = c & 0x07;
-        } else {
-            return false;
-        }
-        if (i + length > size) return false;
-        for (size_t k = 1; k < length; k++) {
-            const unsigned char cont =
-                static_cast<unsigned char>(value[i + k]);
-            if ((cont & 0xc0) != 0x80) return false;
-            code_point = (code_point << 6) | (cont & 0x3f);
-        }
-        if (length == 2 && code_point < 0x80) return false;
-        if (length == 3 && code_point < 0x800) return false;
-        if (length == 4 && code_point < 0x10000) return false;
-        if (code_point > 0x10ffff) return false;
-        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
-        i += length;
-    }
-    return true;
-}
 
 std::string byte_hex(const uint8_t *bytes, size_t size) {
     static const char digits[] = "0123456789abcdef";
@@ -129,7 +89,7 @@ class ASRTextWriter
     // byte into a two byte character. Such values are written as #asr/bytes
     // instead, which keeps the document valid UTF-8 and byte exact.
     void write_escaped_string(const char *value, size_t size) {
-        if (!is_valid_utf8(value, size)) {
+        if (!LCompilers::is_valid_utf8(value, size)) {
             write_bytes(value, size);
             return;
         }

--- a/src/libasr/asr_text_parser.cpp
+++ b/src/libasr/asr_text_parser.cpp
@@ -8,6 +8,7 @@
 #include <set>
 
 #include <libasr/asr_text_parser.h>
+#include <libasr/string_utils.h>
 
 namespace LCompilers::ASRText {
 
@@ -49,59 +50,6 @@ bool is_token_terminator(unsigned char c) {
 
 bool is_ascii_digit(unsigned char c) {
     return c >= '0' && c <= '9';
-}
-
-// Appends the UTF-8 encoding of a BMP code point that is not a surrogate.
-void append_utf8(std::string &out, uint32_t cp) {
-    if (cp <= 0x7F) {
-        out += static_cast<char>(cp);
-    } else if (cp <= 0x7FF) {
-        out += static_cast<char>(0xC0 | (cp >> 6));
-        out += static_cast<char>(0x80 | (cp & 0x3F));
-    } else {
-        out += static_cast<char>(0xE0 | (cp >> 12));
-        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-        out += static_cast<char>(0x80 | (cp & 0x3F));
-    }
-}
-
-bool is_well_formed_utf8(const std::string &text) {
-    size_t i = 0;
-    const size_t size = text.size();
-    while (i < size) {
-        const unsigned char c = static_cast<unsigned char>(text[i]);
-        size_t length;
-        uint32_t code_point;
-        if (c < 0x80) {
-            i++;
-            continue;
-        } else if ((c & 0xe0) == 0xc0) {
-            length = 2;
-            code_point = c & 0x1f;
-        } else if ((c & 0xf0) == 0xe0) {
-            length = 3;
-            code_point = c & 0x0f;
-        } else if ((c & 0xf8) == 0xf0) {
-            length = 4;
-            code_point = c & 0x07;
-        } else {
-            return false;
-        }
-        if (i + length > size) return false;
-        for (size_t k = 1; k < length; k++) {
-            const unsigned char cont =
-                static_cast<unsigned char>(text[i + k]);
-            if ((cont & 0xc0) != 0x80) return false;
-            code_point = (code_point << 6) | (cont & 0x3f);
-        }
-        if (length == 2 && code_point < 0x80) return false;
-        if (length == 3 && code_point < 0x800) return false;
-        if (length == 4 && code_point < 0x10000) return false;
-        if (code_point > 0x10ffff) return false;
-        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
-        i += length;
-    }
-    return true;
 }
 
 bool hex_digit_value(char c, int &value) {
@@ -498,7 +446,7 @@ private:
                                     span_loc(esc_start, pos - 1),
                                     "surrogate escapes are not valid UTF-8");
                         }
-                        append_utf8(buffer, cp);
+                        utf8_encode_codepoint(buffer, cp);
                         break;
                     }
                     default:
@@ -512,7 +460,7 @@ private:
             }
         }
         Location loc = span_loc(start, pos - 1);
-        if (!is_well_formed_utf8(buffer)) {
+        if (!is_valid_utf8(buffer)) {
             return fail("string literal is not well-formed UTF-8",
                     loc, "invalid UTF-8 in this string");
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3149,6 +3149,13 @@ static inline int64_t string_first_code_point(ASR::StringConstant_t* s) {
     return (int64_t)code_points[0];
 }
 
+// The character kinds the compiler supports: 1 (one byte per character,
+// ASCII / the default kind) and 4 (four bytes per character, ISO 10646 /
+// UCS-4). This matches GFortran; LLVM Flang additionally supports 2 (UCS-2).
+static inline bool is_supported_character_kind(int64_t kind) {
+    return kind == 1 || kind == 4;
+}
+
 static inline bool is_complex(ASR::ttype_t &x) {
     return ASR::is_a<ASR::Complex_t>(
         *type_get_past_array(

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3121,6 +3121,34 @@ static inline bool is_character(ASR::ttype_t &x) {
                 type_get_past_pointer(&x))));
 }
 
+// The Fortran characters of a compile time string value: one entry per
+// character. A kind 1 value stores one byte per character, while a kind > 1
+// value stores UTF-8 in `StringConstant::m_s`, so one entry can span several
+// bytes.
+static inline std::vector<std::string> string_value_characters(
+        const char* s, int64_t kind) {
+    std::string str(s);
+    if (kind == 1) {
+        std::vector<std::string> characters;
+        characters.reserve(str.size());
+        for (char c : str) characters.push_back(std::string(1, c));
+        return characters;
+    }
+    return utf8_split(str);
+}
+
+// The Unicode code point of the first character of a compile time string
+// value, i.e. the result of ICHAR/IACHAR applied to it. A kind 1 value yields
+// the byte, a kind > 1 value the code point its UTF-8 encodes.
+static inline int64_t string_first_code_point(ASR::StringConstant_t* s) {
+    int64_t kind = extract_kind_from_ttype_t(s->m_type);
+    if (s->m_s[0] == '\0') return 0;
+    if (kind == 1) return (int64_t)(unsigned char)s->m_s[0];
+    std::vector<uint32_t> code_points = utf8_decode(std::string(s->m_s));
+    LCOMPILERS_ASSERT(code_points.size() >= 1);
+    return (int64_t)code_points[0];
+}
+
 static inline bool is_complex(ASR::ttype_t &x) {
     return ASR::is_a<ASR::Complex_t>(
         *type_get_past_array(

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -2937,6 +2937,9 @@ public:
     }
 
     void visit_String(const String_t &x){
+/*Check the character kind*/
+        require(ASRUtils::is_supported_character_kind(x.m_kind),
+            "String kind must be 1 or 4, found " + std::to_string(x.m_kind));
 /*General Check on the length*/ 
         if(x.m_len){
             require(ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18990,16 +18990,25 @@ public:
         constexpr int32_t kInt64 = 3;
         constexpr int32_t kFloat = 4;
         constexpr int32_t kDouble = 5;
+        constexpr int32_t kWideChar = 8;
 
         // Scalar arg: prepend is_descriptor_array=0 before type_code
         llvm::Value* is_descriptor_array_false = llvm::ConstantInt::get(context, llvm::APInt(32, 0));
         if (ASR::is_a<ASR::String_t>(*val_type)) {
+            // A destination of character kind > 1 uses its own type code and
+            // carries the kind, so the runtime knows the field has to be
+            // decoded into code units.
+            int64_t char_kind = ASR::down_cast<ASR::String_t>(val_type)->m_kind;
             args.push_back(is_descriptor_array_false);
-            args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, kChar)));
+            args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32,
+                char_kind > 1 ? kWideChar : kChar)));
             auto [str_data, str_len] = llvm_utils->get_string_length_data(
                 ASRUtils::get_string_type(val_type), elem_ptr, true);
             args.push_back(str_data);
             args.push_back(str_len);
+            if (char_kind > 1) {
+                args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, char_kind)));
+            }
         } else if (ASR::is_a<ASR::Logical_t>(*val_type)) {
             args.push_back(is_descriptor_array_false);
             args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, kLogical)));
@@ -21028,7 +21037,8 @@ public:
                     end_data = LCompilers::create_global_string_ptr(context, *module, *builder, "\n");
                     end_len = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
                 }
-                printf(context, *module, *builder, { fmt_ptr, str_data, str_len, end_data, end_len });
+                llvm::Value* str_kind = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
+                printf(context, *module, *builder, { fmt_ptr, str_data, str_len, str_kind, end_data, end_len });
             } else if (x.n_values == 1){
                 handle_print(x.m_values[0], x.m_end);
             } else {
@@ -21058,6 +21068,7 @@ public:
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_allocatable
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_deferred
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_array_unit
+            args_type.push_back(llvm::Type::getInt32Ty(context)); // char_kind
             args_type.push_back(llvm::Type::getInt64Ty(context)); // array_size
             args_type.push_back(llvm::Type::getInt64Ty(context)->getPointerTo()); //len
             args_type.push_back(llvm::Type::getInt32Ty(context)->getPointerTo()); //iostat
@@ -21432,14 +21443,25 @@ public:
                 }
                 continue;
             }
+            ASR::ttype_t *t = ASRUtils::extract_type(ASRUtils::expr_type(m_values[i]));
+            bool value_is_wide_char = x.m_is_formatted && ASRUtils::is_character(*t) &&
+                ASRUtils::extract_kind_from_ttype_t(t) > 1;
             compute_fmt_specifier_and_arg(fmt, args, m_values[i],
                 x.base.base.loc); // return of visited expression `m_values[i]` stored in `tmp`
+            if (value_is_wide_char) {
+                // `%S` takes (data, character count, character kind): the
+                // runtime transcodes the code units to UTF-8 on the way out.
+                fmt.back() = "%S";
+            }
 
             // Push the length of the string to args
-            ASR::ttype_t *t = ASRUtils::extract_type(ASRUtils::expr_type(m_values[i]));
             if (x.m_is_formatted && ASRUtils::is_character(*t)) {
                 llvm::Value *str_len = llvm_utils->get_string_length(ASRUtils::get_string_type(t), tmp);
                 args.push_back(str_len);
+                if (value_is_wide_char) {
+                    args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32,
+                        ASRUtils::extract_kind_from_ttype_t(t))));
+                }
             }
         }
         if (!x.m_is_formatted) {  // give -1 argument for end of arguments
@@ -21474,9 +21496,15 @@ public:
                 ASRUtils::is_deferredLength_string(ASRUtils::expr_type(x.m_unit))));
             llvm::Value* is_array_unit = llvm::ConstantInt::get(context, llvm::APInt(8,
                 is_string_array_unit));
+            // The internal file's character kind: the formatted record is
+            // produced as UTF-8 bytes, so a kind 4 target needs it decoded
+            // back into code units.
+            llvm::Value* char_kind = llvm::ConstantInt::get(context, llvm::APInt(32,
+                ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_unit))));
             printf_args.push_back(is_allocatable);
             printf_args.push_back(is_deferred);
             printf_args.push_back(is_array_unit);
+            printf_args.push_back(char_kind);
             printf_args.push_back(string_array_size);
             printf_args.push_back(string_len);
         }
@@ -21519,7 +21547,7 @@ public:
         ( ) --> Struct
         I   --> Integer
         R   --> Real
-        S-PhysicalType-len? --> Character [S-DESC-10, S-CCHAR-1, S-DESC]
+        S-PhysicalType-K<kind>-len? --> Character [S-DESC-K1-10, S-CCHAR-K1-1, S-DESC-K4]
         L   --> Logical
         { } --> Struct for COMPLEX
         The serialization corresponds to how these arguments are represented in LLVM backend;
@@ -21546,6 +21574,10 @@ public:
             if(str_type->m_physical_type == ASR::DescriptorString) res += "DESC";
             else if(str_type->m_physical_type == ASR::CChar) res +="CCHAR";
             else throw LCompilersException("Unhandled string physical type");
+            // The character kind tells the runtime how many bytes one character
+            // occupies, so that it can transcode a kind 4 value to UTF-8 and
+            // count field widths in characters rather than bytes.
+            res += "-K" + std::to_string(str_type->m_kind);
             int len;
             if(ASRUtils::extract_value(str_type->m_len, len)){res += "-" + std::to_string(len);}
         } else if (ASR::is_a<ASR::Complex_t>(*type)){
@@ -21753,11 +21785,17 @@ public:
         }
 
         std::string fmt_str;
+        // The character kind of the value being written. `main_len` counts
+        // characters, so the runtime needs the kind to know how many bytes
+        // that is and whether to transcode to UTF-8 on the way out.
+        llvm::Value* main_kind = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
 
         if (ASRUtils::is_character(*t)) {
             // --- String path ---
             std::tie(main_data, main_len) = get_string_data_and_length(arg);
             main_len = builder->CreateTrunc(main_len, llvm::Type::getInt32Ty(context));
+            main_kind = llvm::ConstantInt::get(context, llvm::APInt(32,
+                ASRUtils::extract_kind_from_ttype_t(ASRUtils::extract_type(t))));
             fmt_str = "%s";
         } else {
             // --- Non-string path ---
@@ -21780,7 +21818,7 @@ public:
         }
         fmt_str += "%s";
         llvm::Value* fmt_ptr = LCompilers::create_global_string_ptr(context, *module, *builder, fmt_str);
-        printf(context, *module, *builder, { fmt_ptr, main_data, main_len, end_data, end_len });
+        printf(context, *module, *builder, { fmt_ptr, main_data, main_len, main_kind, end_data, end_len });
         llvm_utils->stringFormat_return.free();
     }
 

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2,6 +2,7 @@
 #include <libasr/codegen/llvm_utils.h>
 #include <libasr/codegen/llvm_array_utils.h>
 #include <libasr/asr_utils.h>
+#include <libasr/string_utils.h>
 #include <libasr/codegen/llvm_compat.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -2901,49 +2902,6 @@ namespace LCompilers {
             throw LCompilersException("Unhandled case");
         }
     }
-    /*
-     * Decodes a UTF-8 encoded string into a sequence of Unicode codepoints,
-     * then serializes each codepoint into `kind`-width little-endian bytes.
-     *   kind=2 -> 2 bytes per codepoint (UCS-2 / UTF-16 code unit)
-     *   kind=4 -> 4 bytes per codepoint (UCS-4 / UTF-32)
-     */
-    static std::vector<uint8_t> utf8_to_unicode_bytes(const std::string& str, int kind) {
-        std::vector<uint32_t> codepoints;
-        size_t i = 0;
-        while (i < str.length()) {
-            uint32_t codepoint = 0;
-            unsigned char c = str[i];
-            if (c <= 0x7F) {
-                codepoint = c;
-                i += 1;
-            } else if ((c & 0xE0) == 0xC0) {
-                LCOMPILERS_ASSERT(i + 1 < str.length());
-                codepoint = ((c & 0x1F) << 6) | (str[i + 1] & 0x3F);
-                i += 2;
-            } else if ((c & 0xF0) == 0xE0) {
-                LCOMPILERS_ASSERT(i + 2 < str.length());
-                codepoint = ((c & 0x0F) << 12) | ((str[i + 1] & 0x3F) << 6) | (str[i + 2] & 0x3F);
-                i += 3;
-            } else if ((c & 0xF8) == 0xF0) {
-                LCOMPILERS_ASSERT(i + 3 < str.length());
-                codepoint = ((c & 0x07) << 18) | ((str[i + 1] & 0x3F) << 12) | ((str[i + 2] & 0x3F) << 6) | (str[i + 3] & 0x3F);
-                i += 4;
-            } else {
-                LCOMPILERS_ASSERT(false); // Invalid UTF-8 lead byte
-            }
-            codepoints.push_back(codepoint);
-        }
-        // Serialize codepoints into kind-width little-endian bytes
-        std::vector<uint8_t> bytes(codepoints.size() * kind);
-        for (size_t idx = 0; idx < codepoints.size(); ++idx) {
-            uint32_t cp = codepoints[idx];
-            for (int b = 0; b < kind; ++b) {
-                bytes[idx * kind + b] = (cp >> (8 * b)) & 0xFF;
-            }
-        }
-        return bytes;
-    }
-
     llvm::Value* LLVMUtils::declare_global_string(
         ASR::String_t* str, std::string initial_data, bool is_const, std::string name,
         llvm::GlobalValue::LinkageTypes linkage,
@@ -2990,7 +2948,7 @@ namespace LCompilers {
                         initial_data_padded.resize(len, ' ');
                         const_data_as_array = llvm::ConstantDataArray::getString(context, initial_data_padded, false);
                     } else if (kind == 2 || kind == 4) {
-                        std::vector<uint8_t> bytes = utf8_to_unicode_bytes(initial_data_padded, kind);
+                        std::vector<uint8_t> bytes = LCompilers::utf8_to_unicode_bytes(initial_data_padded, kind);
                         size_t orig_count = bytes.size() / kind;
                         bytes.resize(len * kind, 0x00);
                         // Pad remaining slots with space character (0x20)

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -113,6 +113,7 @@ class ASRToLLVMVisitor;
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // format
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // str
                     llvm::Type::getInt32Ty(context),                               // str_len
+                    llvm::Type::getInt32Ty(context),                               // str_kind
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // end
                     llvm::Type::getInt32Ty(context)                                // end_len
                 },

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5947,6 +5947,9 @@ namespace StringConcat {
             require_impl(   is_character(*arg0) && is_character(*arg1),
                             "Unexpected arg types. StringConcat expects (char, char)",
                             loc, diag);
+            require_impl(   extract_kind_from_ttype_t(arg0) == extract_kind_from_ttype_t(arg1),
+                            "StringConcat expects both operands to have the same character kind",
+                            loc, diag);
         } else {
             require_impl(   false,
                             "Unexpected number of args, StringConcat takes 2 arguments, found "+ std::to_string(n_args),

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5758,24 +5758,31 @@ namespace Adjustl {
 
     static ASR::expr_t *eval_Adjustl(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
         size_t first_non_space = 0;
-        while (first_non_space < len && std::isspace(str[first_non_space])) {
+        while (first_non_space < characters.size() &&
+                characters[first_non_space] == " ") {
             first_non_space++;
         }
-        std::string res(len, ' ');
-        char* result = s2c(al, res);
-        std::strncpy(result, str + first_non_space, len - first_non_space);
-        return make_ConstantWithType(make_StringConstant_t, result, t1, loc);
+        std::string res;
+        for (size_t i = first_non_space; i < characters.size(); i++) {
+            res += characters[i];
+        }
+        res.append(first_non_space, ' ');
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Adjustl(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_adjustl_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_adjustl_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
             ASR::string_length_kindType::ExpressionLength,
             ASR::string_physical_typeType::DescriptorString));
         auto result = declare("result", return_type, ReturnVar);
@@ -5802,12 +5809,12 @@ namespace Adjustl {
                 end if
             end function
         */
-        body.push_back(al, b.Assignment(result, b.StringConstant(" ", character(1))));
+        body.push_back(al, b.Assignment(result, b.StringBlank(char_kind)));
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.While(b.LtE(itr, b.StringLen(args[0])), {
             b.If(b.Eq(ASRUtils::EXPR(ASR::make_Ichar_t(al, loc,
                 ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,  nullptr, 
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,  nullptr, 
                     ASR::string_length_kindType::AssumedLength,
                     ASR::string_physical_typeType::DescriptorString)), nullptr)), int32, nullptr)),
                 b.Ichar(" ", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 
@@ -5841,31 +5848,31 @@ namespace Adjustr {
 
     static ASR::expr_t *eval_Adjustr(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
-        int last_non_space = len - 1;
-        while (last_non_space >= 0 && std::isspace(str[last_non_space])) {
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        int last_non_space = (int)characters.size() - 1;
+        while (last_non_space >= 0 && characters[last_non_space] == " ") {
             last_non_space--;
         }
-        std::string res(len, ' ');
-        char* result = s2c(al, res);
-        if (last_non_space != -1) {
-            int tmp = len - 1 - last_non_space;
-            for (int i = 0; i <= last_non_space; i++) {
-                result[i + tmp] = str[i];
-            }
+        std::string res(characters.size() - (last_non_space + 1), ' ');
+        for (int i = 0; i <= last_non_space; i++) {
+            res += characters[i];
         }
-        return make_ConstantWithType(make_StringConstant_t, result, t1, loc);
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Adjustr(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_adjustr_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_adjustr_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,
             nullptr, ASR::string_length_kindType::AssumedLength,
              ASR::string_physical_typeType::DescriptorString)));
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, 
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, 
             EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::DescriptorString));
@@ -5894,12 +5901,12 @@ namespace Adjustr {
             end function
         */
 
-        body.push_back(al, b.Assignment(result, b.StringConstant(" ", character(1))));
+        body.push_back(al, b.Assignment(result, b.StringBlank(char_kind)));
         body.push_back(al, b.Assignment(itr, b.StringLen(args[0])));
         body.push_back(al, b.While(b.GtE(itr, b.i32(1)), {
             b.If(b.Eq(ASRUtils::EXPR(ASR::make_Ichar_t(al, loc,
                 ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr,
                     ASR::string_length_kindType::AssumedLength,
                     ASR::string_physical_typeType::DescriptorString)), nullptr)), int32, nullptr)),
                 b.Ichar(" ", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 
@@ -5970,8 +5977,8 @@ namespace StringConcat {
         extract_value_(s1_value, s1_char);
 
         // For kind=1, logical length == physical byte length (safe for null bytes).
-        // For kind>1, logical length != physical bytes (UTF-8 multi-byte encoding),
-        // so we must use strlen to get the actual byte count.
+        // For kind>1, m_s holds UTF-8 while m_len counts characters, so the
+        // number of bytes to copy is strlen, not m_len.
         int64_t s0_len, s1_len;
         extract_value_(expr_value(s0_type->m_len), s0_len);
         extract_value_(expr_value(s1_type->m_len), s1_len);
@@ -5996,6 +6003,9 @@ namespace StringConcat {
 
         ASR::expr_t* value {};
         ASR::ttype_t* return_type {};
+        // Both operands are guaranteed to have the same character kind by the
+        // frontend, and the result carries that kind through.
+        int char_kind = get_string_type(args[0])->m_kind;
         if(all_args_evaluated(m_args)){
             // When args have compile-time values, evaluate and get length from value types
             ASRBuilder b(al, loc);
@@ -6010,13 +6020,11 @@ namespace StringConcat {
                 int64_t s0_len, s1_len;
                 extract_value(expr_value(s0_type->m_len), s0_len);
                 extract_value(expr_value(s1_type->m_len), s1_len);
-                // For kind>1, logical length != physical bytes (UTF-8 encoding),
-                // so use strlen. For kind=1, logical == physical (null-safe).
-                char* s0_char {}; extract_value_(s0_value, s0_char);
-                char* s1_char {}; extract_value_(s1_value, s1_char);
-                int64_t phys_s0 = (s0_type->m_kind > 1 && s0_char) ? (int64_t)strlen(s0_char) : s0_len;
-                int64_t phys_s1 = (s1_type->m_kind > 1 && s1_char) ? (int64_t)strlen(s1_char) : s1_len;
-                return_type = b.String(b.i64(phys_s0 + phys_s1), ASR::ExpressionLength);
+                // Lengths are character counts, so they add directly. For
+                // kind > 1 the number of *bytes* to copy differs, and
+                // eval_StringConcat works that out from the values themselves.
+                return_type = b.String(b.i64(s0_len + s1_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
                 value = eval_StringConcat(al, loc, return_type, args, diag);
             } else {
                 // Array parameter: evaluate element-by-element into an ArrayConstant.
@@ -6080,12 +6088,14 @@ namespace StringConcat {
                     Vec<ASR::expr_t*> elem_args; elem_args.reserve(al, 2);
                     elem_args.push_back(al, arg0_is_array ? left_elem : right_elem);
                     elem_args.push_back(al, arg0_is_array ? right_elem : left_elem);
-                    ASR::ttype_t* res_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength);
+                    ASR::ttype_t* res_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength,
+                        ASR::DescriptorString, char_kind);
                     ASR::StringConstant_t* res_i = ASR::down_cast<ASR::StringConstant_t>(
                         eval_StringConcat(al, loc, res_type, elem_args, diag));
                     memcpy(result_buf + i * result_elem_len, res_i->m_s, result_elem_len);
                 }
-                return_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength);
+                return_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
                 ASR::Array_t* arr_t = ASR::down_cast<ASR::Array_t>(
                     ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(arr_arg)));
                 ASR::ttype_t* result_arr_type = ASRUtils::TYPE(ASR::make_Array_t(
@@ -6103,9 +6113,11 @@ namespace StringConcat {
                 int64_t s1_len, s2_len;
                 extract_value(s1->m_len, s1_len);
                 extract_value(s2->m_len, s2_len);
-                return_type = b.String(b.i64(s1_len + s2_len), ASR::ExpressionLength);
+                return_type = b.String(b.i64(s1_len + s2_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
             } else {
-                return_type = b.allocatable(b.String(nullptr, ASR::DeferredLength));
+                return_type = b.allocatable(b.String(nullptr, ASR::DeferredLength,
+                    ASR::DescriptorString, char_kind));
             }
         }
 
@@ -6162,7 +6174,9 @@ namespace StringConcat {
     inline ASR::expr_t* instantiate_StringConcat(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t* /*return_type*/,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/){
-        char intrinsic_fn_name[] = "_lcompilers_stringconcat";
+        int char_kind = ASR::down_cast<ASR::String_t>(
+            ASRUtils::extract_type(arg_types[0]))->m_kind;
+        std::string intrinsic_fn_name = "_lcompilers_stringconcat_" + std::to_string(char_kind);
         declare_basic_variables(intrinsic_fn_name)
 
         // Compute argument lengths safely, avoiding circular references for
@@ -6185,14 +6199,14 @@ namespace StringConcat {
         }
 
         /* Function signature: (s1, s2, s1_len, s2_len) -> concat_result */
-        fill_func_arg("s1", b.String(nullptr, ASR::AssumedLength))
-        fill_func_arg("s2", b.String(nullptr, ASR::AssumedLength))
+        fill_func_arg("s1", b.String(nullptr, ASR::AssumedLength, ASR::DescriptorString, char_kind))
+        fill_func_arg("s2", b.String(nullptr, ASR::AssumedLength, ASR::DescriptorString, char_kind))
         fill_func_arg("s1_len", int32)
         fill_func_arg("s2_len", int32)
 
         ASR::expr_t* ret_var = declare(
             "concat_result",
-            b.allocatable(b.String(nullptr, ASR::DeferredLength)),
+            b.allocatable(b.String(nullptr, ASR::DeferredLength, ASR::DescriptorString, char_kind)),
             ReturnVar);
 
         body.push_back(al, b.Allocate(ret_var, nullptr, 0, b.Add(args[2], args[3])));
@@ -6219,10 +6233,12 @@ namespace StringLenTrim {
 
     static ASR::expr_t *eval_StringLenTrim(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
-        for (int i = len - 1; i >= 0; i--) {
-            if (!std::isspace(str[i])) {
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        for (int i = (int)characters.size() - 1; i >= 0; i--) {
+            if (characters[i] != " ") {
                 return make_ConstantWithType(make_IntegerConstant_t, i + 1, t1, loc);
             }
         }
@@ -6252,7 +6268,7 @@ namespace StringLenTrim {
 
         body.push_back(al, b.Assignment(result, b.i2i_t(b.StringLen(args[0]), return_type)));
         body.push_back(al, b.If(b.NotEq(result, b.i_t(0, return_type)), {
-            b.While(b.Eq(b.StringItem(args[0], result), b.StringConstant(" ", character(1))), {
+            b.While(b.Eq(b.StringItem(args[0], result), b.StringBlank(char_kind)), {
                 b.Assignment(result, b.Sub(result, b.i_t(1, return_type))),
                 b.If(b.Eq(result, b.i_t(0, return_type)), {
                     b.Exit()
@@ -6275,22 +6291,19 @@ namespace StringTrim {
 
     static ASR::expr_t *eval_StringTrim(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        // Trim trailing spaces (in place)
-        size_t len = strlen(str);
-        if (len > 0) {
-            char* endptr = str + len - 1;
-            while (endptr >= str && std::isspace(*endptr)) {
-                *endptr = '\0';
-                --endptr;
-            }
-        }
-
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
         int char_kind = ASRUtils::extract_kind_from_ttype_t(t1);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        size_t trimmed = characters.size();
+        while (trimmed > 0 && characters[trimmed - 1] == " ") trimmed--;
+        std::string res;
+        for (size_t i = 0; i < trimmed; i++) res += characters[i];
+
         ASR::ttype_t* str_type = ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,
-            make_ConstantWithType(make_IntegerConstant_t, strlen(str), int32, loc), 
+            make_ConstantWithType(make_IntegerConstant_t, trimmed, int32, loc), 
             ASR::ExpressionLength, ASR::string_physical_typeType::DescriptorString));
-        return make_ConstantWithType(make_StringConstant_t, str, str_type, loc);
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), str_type, loc);
     }
 
     static inline ASR::expr_t* instantiate_StringTrim(Allocator &al, const Location &loc,
@@ -6329,10 +6342,8 @@ namespace Ichar {
 
     static ASR::expr_t *eval_Ichar(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        LCOMPILERS_ASSERT(str[0] == '\0' || std::strlen(str) == 1);
-        char first_char = str[0];
-        int result = (int)first_char;
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t result = string_first_code_point(arg);
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
@@ -6401,11 +6412,15 @@ namespace Char {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
 
-        declare_basic_variables("_lcompilers_char_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(return_type);
+        declare_basic_variables("_lcompilers_char_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
 
         /* Declare Arguments + Return Variable */
         fill_func_arg("i", arg_types[0]);
-        auto result = declare("result", character(1), ReturnVar);
+        auto result = declare("result",
+            b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+            ReturnVar);
 
         /* Body */
         /*
@@ -6466,7 +6481,9 @@ namespace Achar {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
 
-        declare_basic_variables("_lcompilers_achar_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(return_type);
+        declare_basic_variables("_lcompilers_achar_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
 
         ASR::expr_t* result;
         ASR::ttype_t* call_return_type = return_type;
@@ -6476,10 +6493,13 @@ namespace Achar {
 
             ASR::expr_t* n = b.ArraySize(args[0], b.i32(1), int32);
             ASR::ttype_t* result_str_type = b.String(n,
-                ASR::string_length_kindType::ExpressionLength);
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::DescriptorString, char_kind);
             result = declare("result", result_str_type, ReturnVar);
             auto j = declare("j", int32, Local);
-            auto tmp_char = declare("tmp_char", character(1), Local);
+            auto tmp_char = declare("tmp_char",
+                b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+                Local);
 
             body.push_back(al, b.DoLoop(j, b.i32(1), n, {
                 b.Assignment(tmp_char, b.BitCast(
@@ -6490,10 +6510,13 @@ namespace Achar {
             ASR::expr_t* n_caller = b.ArraySize(
                 new_args[0].m_value, b.i32(1), int32);
             call_return_type = b.String(n_caller,
-                ASR::string_length_kindType::ExpressionLength);
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::DescriptorString, char_kind);
         } else {
             fill_func_arg("i", arg_types[0]);
-            result = declare("result", character(1), ReturnVar);
+            result = declare("result",
+                b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+                ReturnVar);
             body.push_back(al, b.Assignment(result, b.BitCast(args[0], result)));
         }
 
@@ -6510,10 +6533,8 @@ namespace Iachar {
 
     static ASR::expr_t *eval_Iachar(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        LCOMPILERS_ASSERT(str[0] == '\0' || std::strlen(str) == 1);
-        unsigned char first_char = (unsigned char)str[0];
-        int result = (int)first_char;
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t result = string_first_code_point(arg);
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
@@ -6521,14 +6542,16 @@ namespace Iachar {
     static inline ASR::expr_t* instantiate_Iachar(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_iachar_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_iachar_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
             ASRUtils::EXPR(ASR::make_Iachar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-            ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+            ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr,
                 ASR::string_length_kindType::AssumedLength,
                 ASR::string_physical_typeType::DescriptorString)),
             nullptr)), int32, nullptr)), return_type)));
@@ -6680,14 +6703,14 @@ namespace Repeat {
         ASRUtils::ASRBuilder b(al, loc);
         char* str = ASR::down_cast<ASR::StringConstant_t>(expr_value(args[0]))->m_s;
         int64_t n = ASR::down_cast<ASR::IntegerConstant_t>(expr_value(args[1]))->m_n;
-        size_t len = std::strlen(str);
-        size_t new_len = len*n;
-        char* result = new char[new_len+1];
-        for (size_t i=0; i<new_len; i++) {
-            result[i] = str[i%len];
-        }
-        result[new_len] = '\0';
         int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
+        // The result length is a character count, so repeat whole characters
+        // rather than bytes.
+        size_t len = ASRUtils::string_value_characters(str, char_kind).size();
+        size_t new_len = len*n;
+        std::string repeated;
+        for (int64_t i = 0; i < n; i++) repeated += str;
+        char* result = s2c(al, repeated);
         ASR::ttype_t *return_type = b.String(
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, new_len,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
@@ -6814,21 +6837,32 @@ namespace StringContainsSet {
 
     static ASR::expr_t *eval_StringContainsSet(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* set_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        size_t len = std::strlen(string);
+        // Positions count characters, so for kind > 1 walk code points rather
+        // than the bytes of the UTF-8 encoding.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> set =
+            ASRUtils::string_value_characters(set_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        // VERIFY reports the first character that is *not* in the set.
+        auto is_match = [&](size_t idx) {
+            return std::find(set.begin(), set.end(), string[idx]) == set.end();
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[len-i-1]) == nullptr) {
+                if (is_match(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[i]) == nullptr) {
+                if (is_match(i)) {
                     result = i+1;
                     break;
                 }
@@ -6840,9 +6874,11 @@ namespace StringContainsSet {
     static inline ASR::expr_t* instantiate_StringContainsSet(Allocator &al, const Location &loc,
             SymbolTable* scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_verify_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_verify_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         fill_func_arg("back", ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
         fill_func_arg("kind", int32);
         auto result = declare(fn_name, return_type, ReturnVar);
@@ -6945,21 +6981,32 @@ namespace StringFindSet {
 
     static ASR::expr_t *eval_StringFindSet(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* set_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        size_t len = std::strlen(string);
+        // Positions count characters, so for kind > 1 walk code points rather
+        // than the bytes of the UTF-8 encoding.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> set =
+            ASRUtils::string_value_characters(set_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        // SCAN reports the first character that is in the set.
+        auto is_match = [&](size_t idx) {
+            return std::find(set.begin(), set.end(), string[idx]) != set.end();
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[len-i-1]) != nullptr) {
+                if (is_match(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[i]) != nullptr) {
+                if (is_match(i)) {
                     result = i+1;
                     break;
                 }
@@ -6971,9 +7018,11 @@ namespace StringFindSet {
     static inline ASR::expr_t* instantiate_StringFindSet(Allocator &al, const Location &loc,
             SymbolTable* scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_scan_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_scan_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         fill_func_arg("back", ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
         fill_func_arg("kind", int32);
         auto result = declare(fn_name, return_type, ReturnVar);
@@ -7067,22 +7116,37 @@ namespace SubstrIndex {
 
     static ASR::expr_t *eval_SubstrIndex(Allocator &al, const Location &loc,
             ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* substring = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* substring_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
         int64_t kind = ASR::down_cast<ASR::IntegerConstant_t>(args[3])->m_n;
-        size_t len = std::strlen(string);
+        // INDEX counts characters, so walk the values character by character
+        // rather than byte by byte: for kind > 1 one character can span
+        // several UTF-8 bytes.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> substring =
+            ASRUtils::string_value_characters(substring_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        auto matches_at = [&](size_t start) {
+            if (start + substring.size() > string.size()) return false;
+            for (size_t k = 0; k < substring.size(); k++) {
+                if (string[start + k] != substring[k]) return false;
+            }
+            return true;
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strncmp(string+len-i-1, substring, std::strlen(substring)) == 0) {
+                if (matches_at(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strncmp(string+i, substring, std::strlen(substring)) == 0) {
+                if (matches_at(i)) {
                     result = i+1;
                     break;
                 }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -614,11 +614,120 @@ LFORTRAN_API int _lfortran_random_int(int lower, int upper)
     return randint;
 }
 
-LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, const fchar* end, uint32_t end_len)
+// Appends the UTF-8 encoding of one code point to `out`, returning how many
+// bytes it wrote. `out` must have room for 4 bytes.
+static int utf8_encode_code_point(char* out, uint32_t cp)
+{
+    if (cp <= 0x7f) {
+        out[0] = (char)cp;
+        return 1;
+    } else if (cp <= 0x7ff) {
+        out[0] = (char)(0xc0 | (cp >> 6));
+        out[1] = (char)(0x80 | (cp & 0x3f));
+        return 2;
+    } else if (cp <= 0xffff) {
+        out[0] = (char)(0xe0 | (cp >> 12));
+        out[1] = (char)(0x80 | ((cp >> 6) & 0x3f));
+        out[2] = (char)(0x80 | (cp & 0x3f));
+        return 3;
+    }
+    out[0] = (char)(0xf0 | (cp >> 18));
+    out[1] = (char)(0x80 | ((cp >> 12) & 0x3f));
+    out[2] = (char)(0x80 | ((cp >> 6) & 0x3f));
+    out[3] = (char)(0x80 | (cp & 0x3f));
+    return 4;
+}
+
+// Number of bytes the UTF-8 sequence starting with `c` occupies, or 0 if `c`
+// is not a lead byte.
+static int utf8_sequence_length(unsigned char c)
+{
+    if (c < 0x80) return 1;
+    if ((c & 0xe0) == 0xc0) return 2;
+    if ((c & 0xf0) == 0xe0) return 3;
+    if ((c & 0xf8) == 0xf0) return 4;
+    return 0;
+}
+
+/*
+ * A character value of kind > 1 is held in memory as `count` little-endian
+ * code units of `kind` bytes each (kind 4 is UCS-4). Files and the terminal
+ * are byte streams, so such a value is written out as UTF-8. This matches LLVM
+ * Flang, which transcodes kind 4 output regardless of the unit's ENCODING=.
+ *
+ * Returns a newly allocated buffer and stores its length in `*out_len`. The
+ * caller frees it with internal_free.
+ */
+char* _lfortran_unicode_to_utf8(const char* data, int64_t count, int32_t kind,
+        int64_t* out_len)
+{
+    char* out = (char*)internal_malloc((size_t)(count * 4 + 1));
+    int64_t pos = 0;
+    for (int64_t i = 0; i < count; i++) {
+        uint32_t cp = 0;
+        for (int32_t b = 0; b < kind; b++) {
+            cp |= ((uint32_t)(unsigned char)data[i * kind + b]) << (8 * b);
+        }
+        pos += utf8_encode_code_point(out + pos, cp);
+    }
+    out[pos] = '\0';
+    *out_len = pos;
+    return out;
+}
+
+/*
+ * The inverse: decodes at most `count` characters of UTF-8 from `data` into
+ * `kind`-wide little-endian code units written to `dest`, blank padding any
+ * remaining characters. Returns the number of characters decoded.
+ */
+int64_t _lfortran_utf8_to_unicode(const char* data, int64_t data_len,
+        char* dest, int64_t count, int32_t kind)
+{
+    int64_t i = 0, written = 0;
+    while (i < data_len && written < count) {
+        int length = utf8_sequence_length((unsigned char)data[i]);
+        uint32_t cp;
+        if (length == 0 || i + length > data_len) {
+            // Not well-formed; pass the byte through so we always make progress
+            cp = (unsigned char)data[i];
+            length = 1;
+        } else if (length == 1) {
+            cp = (unsigned char)data[i];
+        } else {
+            static const uint32_t lead_mask[5] = {0, 0, 0x1f, 0x0f, 0x07};
+            cp = (unsigned char)data[i] & lead_mask[length];
+            for (int k = 1; k < length; k++) {
+                cp = (cp << 6) | ((unsigned char)data[i + k] & 0x3f);
+            }
+        }
+        for (int32_t b = 0; b < kind; b++) {
+            dest[written * kind + b] = (char)((cp >> (8 * b)) & 0xff);
+        }
+        written++;
+        i += length;
+    }
+    for (int64_t j = written; j < count; j++) {
+        dest[j * kind] = ' ';
+        for (int32_t b = 1; b < kind; b++) dest[j * kind + b] = 0;
+    }
+    return written;
+}
+
+LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, int32_t str_kind, const fchar* end, uint32_t end_len)
 {
     if (str == NULL) {
         str = (fchar*)" "; // dummy output
         str_len = 1; // length of dummy output
+        str_kind = 1;
+    }
+    // `str_len` counts characters. A kind > 1 value is code units in memory and
+    // is written out as UTF-8.
+    char* encoded = NULL;
+    if (str_kind > 1) {
+        int64_t encoded_len;
+        encoded = _lfortran_unicode_to_utf8((const char*)str, str_len, str_kind, &encoded_len);
+        str = (const fchar*)encoded;
+        str_len = (uint32_t)encoded_len;
     }
     // Detect "\b" to raise error (only if still null-terminated)
     if (str_len > 0 && ((char*)str)[0] == '\b') {
@@ -633,6 +742,7 @@ LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_
     fwrite((char*)str, sizeof(char), str_len, stdout);
     fwrite((char*)end, sizeof(char), end_len, stdout);
     fflush(stdout);
+    internal_free(encoded);
 }
 
 char* substring(const char* str, int start, int end) {
@@ -2421,6 +2531,7 @@ typedef struct serialization_info{
         void* current_arg; // holds pointer to the arg being printed (Scalar or Vector) 
         bool is_complex;
         int64_t current_string_len; // Holds string length 'If Exist'
+        int32_t current_string_kind; // Bytes per character of the string arg
     } current_arg_info;
     struct runtime_sizes_lengths{ // Passed array sizes or string legnths.
         int64_t* ptr;
@@ -2439,6 +2550,22 @@ int64_t transform_string_size_into_int(struct serialization_info* s_info){
         array_size = array_size * 10 + (s_info->serialization_string[s_info->current_stop++] - '0');
     }
     return array_size;
+}
+
+// Reads the `-K<kind>` part that follows the string physical type. The kind is
+// the number of bytes one character occupies: 1 for ASCII/default, 4 for
+// ISO 10646 (UCS-4).
+void set_string_kind(Serialization_Info* s_info){
+    if(s_info->serialization_string[s_info->current_stop] != '-' ||
+       s_info->serialization_string[s_info->current_stop + 1] != 'K') {
+        fprintf(stderr, "RunTime - compiler internal error"
+            " : Missing character kind in string serialization --> %s\n",
+                s_info->serialization_string);
+        exit(1);
+    }
+    s_info->current_stop += 2;
+    s_info->current_arg_info.current_string_kind =
+        (int32_t)transform_string_size_into_int(s_info);
 }
 
 // Sets `current_string_length` either from the serialization string or passed run-time length
@@ -2641,6 +2768,7 @@ void set_current_PrimitiveType(Serialization_Info* s_info){
     }
     case 'S':{
         Primitive_Types str_phys_type = get_string_primitive_type(s_info);
+        set_string_kind(s_info);
         set_string_length(s_info);
         *PrimitiveType = str_phys_type;
         break;
@@ -2954,6 +3082,17 @@ int64_t print_into_string(Serialization_Info* s_info,  char* result){
             char* char_ptr = *(char**)arg;
                 if(char_ptr == NULL){
                     sprintf(result, "%s", " ");
+                } else if(s_info->current_arg_info.current_string_kind > 1){
+                    // A kind > 1 value is code units in memory; write it out
+                    // as UTF-8.
+                    int64_t encoded_len;
+                    char* encoded = _lfortran_unicode_to_utf8(char_ptr,
+                        s_info->current_arg_info.current_string_len,
+                        s_info->current_arg_info.current_string_kind, &encoded_len);
+                    memcpy(result, encoded, encoded_len);
+                    *(result + encoded_len) = '\0';
+                    internal_free(encoded);
+                    return encoded_len;
                 } else {
                     memcpy(result,
                         char_ptr,
@@ -3049,7 +3188,9 @@ void default_formatting(lfortran_allocator_t* al, char** result, int64_t *result
         int size_to_allocate;
         if(curr_is_char &&
             *(char**)s_info->current_arg_info.current_arg != NULL){
+            // A kind > 1 character can take up to 4 bytes once encoded as UTF-8.
             size_to_allocate = (s_info->current_arg_info.current_string_len
+                                    * (s_info->current_arg_info.current_string_kind > 1 ? 4 : 1)
                                  + default_spacing_len + 1) * sizeof(char);
         } else {
             size_to_allocate = (60 + default_spacing_len) * sizeof(char);
@@ -3143,6 +3284,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
     s_info.current_arg_info.args = &args;
     s_info.current_element_type = NONE_TYPE;
     s_info.current_arg_info.is_complex = false;
+    s_info.current_arg_info.current_string_kind = 1;
     s_info.array_sizes.current_index = 0;
     s_info.string_lengths.current_index = 0;
     s_info.just_peeked = false;
@@ -3514,26 +3656,49 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
                     }
                     char* arg = *(char**)s_info.current_arg_info.current_arg;
                     if (arg == NULL) continue;
+                    // `current_string_len` counts characters. A kind 1 value is
+                    // already a byte string; a kind > 1 value is transcoded to
+                    // UTF-8 here, and the field width below stays a character
+                    // count, as the standard requires.
+                    int32_t char_kind = s_info.current_arg_info.current_string_kind;
+                    int64_t src_len = s_info.current_arg_info.current_string_len;
+                    char* encoded = NULL;
+                    int64_t arg_bytes = src_len;
+                    if (char_kind > 1) {
+                        encoded = _lfortran_unicode_to_utf8(arg, src_len, char_kind, &arg_bytes);
+                        arg = encoded;
+                    }
                     if (strlen(value) == 1) {
                         // Simple 'A' format - use full string length, preserve embedded nulls
-                        result = write_to_result_at_pos(al, result, &result_extent, result_len, arg, s_info.current_arg_info.current_string_len);
-                        result_len += s_info.current_arg_info.current_string_len;
+                        result = write_to_result_at_pos(al, result, &result_extent, result_len, arg, arg_bytes);
+                        result_len += arg_bytes;
                     } else {
                         // 'Aw' format with width: right-justify if width > len, truncate leading part if width < len.
                         int64_t width = atoi(value + 1);
-                        if (width <= 0) continue;
-                        int64_t src_len = s_info.current_arg_info.current_string_len;
-                        int64_t copy_len = (width < src_len) ? width : src_len;
+                        if (width <= 0) { internal_free(encoded); continue; }
+                        int64_t copy_chars = (width < src_len) ? width : src_len;
                         int64_t pad_len = (width > src_len) ? (width - src_len) : 0;
-                        char *field = (char*)internal_malloc((size_t)width);
+                        // Truncation is by characters, so re-encode just the
+                        // part that is kept.
+                        int64_t copy_bytes = copy_chars;
+                        char* truncated = NULL;
+                        if (char_kind > 1) {
+                            truncated = _lfortran_unicode_to_utf8(
+                                *(char**)s_info.current_arg_info.current_arg,
+                                copy_chars, char_kind, &copy_bytes);
+                        }
+                        int64_t field_len = pad_len + copy_bytes;
+                        char *field = (char*)internal_malloc((size_t)field_len);
                         if (pad_len > 0) {
                             memset(field, ' ', (size_t)pad_len);
                         }
-                        memcpy(field + pad_len, arg, (size_t)copy_len);
-                        result = write_to_result_at_pos(al, result, &result_extent, result_len, field, width);
-                        result_len += width;
+                        memcpy(field + pad_len, truncated ? truncated : arg, (size_t)copy_bytes);
+                        result = write_to_result_at_pos(al, result, &result_extent, result_len, field, field_len);
+                        result_len += field_len;
                         internal_free(field);
+                        internal_free(truncated);
                     }
+                    internal_free(encoded);
                 } else if (tolower(value[0]) == 'i') {
                     // Integer Editing ( I[w[.m]] )
                     char* temp_buf = (char*)internal_malloc(1); temp_buf[0] = '\0';
@@ -10349,6 +10514,7 @@ typedef struct {
     long record_length;     // length of current record in characters
     int access_id;          // 0=sequential, 1=stream, 2=direct
     int32_t record_len;     // record length for direct access
+    int encoding_mode;      // 0=unknown, 1=UTF-8, 2=default
 } InputSource;
 
 // Shared buffer parsing functions for formatted reads
@@ -10542,6 +10708,24 @@ static void parse_logical_from_buffer(char* buffer, int field_len,
     }
 }
 
+// A destination of character kind > 1 holds `kind`-wide code units. With
+// ENCODING='UTF-8' the field is decoded from UTF-8; otherwise each byte of the
+// field is one character, as both GFortran and LLVM Flang do.
+static void parse_wide_character_from_buffer(char* buffer, int field_len,
+        char* str_data, int64_t str_len, int32_t char_kind, int encoding_mode)
+{
+    if (encoding_mode == 1) {
+        _lfortran_utf8_to_unicode(buffer, field_len, str_data, str_len, char_kind);
+        return;
+    }
+    for (int64_t i = 0; i < str_len; i++) {
+        uint32_t cp = (i < field_len) ? (uint32_t)(unsigned char)buffer[i] : (uint32_t)' ';
+        for (int32_t b = 0; b < char_kind; b++) {
+            str_data[i * char_kind + b] = (char)((cp >> (8 * b)) & 0xff);
+        }
+    }
+}
+
 static void parse_character_from_buffer(char* buffer, int field_len,
         char* str_data, int64_t str_len, int width)
 {
@@ -10714,9 +10898,14 @@ static bool handle_read_A(InputSource *inputSource, va_list *args, int width, bo
     // TODO: Add support for read into descriptor-arrays for character reads
     (void)is_descriptor_array;
     int32_t type_code = va_arg(*args, int32_t);
-    (void)type_code;
     char** str_data_ptr = va_arg(*args, char**);
     int64_t str_len = va_arg(*args, int64_t);
+    // Type code 8 marks a destination of character kind > 1; it carries the
+    // kind after the length.
+    int32_t char_kind = 1;
+    if (type_code == 8) {
+        char_kind = va_arg(*args, int32_t);
+    }
     (*arg_idx)++;
 
     char* str_data = str_data_ptr ? *str_data_ptr : NULL;
@@ -10735,7 +10924,12 @@ static bool handle_read_A(InputSource *inputSource, va_list *args, int width, bo
         return false;
     }
 
-    parse_character_from_buffer(buffer, field_len, str_data, str_len, read_width);
+    if (char_kind > 1) {
+        parse_wide_character_from_buffer(buffer, field_len, str_data, str_len,
+            char_kind, inputSource->encoding_mode);
+    } else {
+        parse_character_from_buffer(buffer, field_len, str_data, str_len, read_width);
+    }
 
     internal_free(buffer);
     return true;
@@ -11374,16 +11568,19 @@ LFORTRAN_API void _lfortran_formatted_read(
     int pad_mode;
     inputSource.access_id = 0;
     inputSource.record_len = 0;
+    inputSource.encoding_mode = 0;
 
     if (unit_num != -1) {
         int access_id = 0;
         int32_t unit_recl = 0;
         bool read_access = true;
+        int encoding_mode = 0;
         inputSource.inputMethod = INPUT_FILE;
         inputSource.file = get_file_pointer_from_unit(unit_num, &unit_file_bin,
-            &access_id, &read_access, NULL, NULL, &blank_zero, &unit_recl, NULL, NULL, NULL, NULL, &pad_mode);
+            &access_id, &read_access, NULL, NULL, &blank_zero, &unit_recl, NULL, NULL, &encoding_mode, NULL, &pad_mode);
         inputSource.access_id = access_id;
         inputSource.record_len = unit_recl;
+        inputSource.encoding_mode = encoding_mode;
         if (!inputSource.file) {
             if (iostat) { *iostat = 1; return; }
             printf("No file found with given unit\n");
@@ -12068,6 +12265,14 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
         va_start(args, format_len);
         char* str = va_arg(args, char*);
         int64_t str_len = va_arg(args, int64_t);
+        // `%S` marks a value of character kind > 1: it carries a kind after the
+        // length, and its code units are written out as UTF-8.
+        char* wide_encoded = NULL;
+        if (format_data[1] == 'S') {
+            int32_t str_kind = va_arg(args, int32_t);
+            wide_encoded = _lfortran_unicode_to_utf8(str, str_len, str_kind, &str_len);
+            str = wide_encoded;
+        }
 
         // Detect "\b" to raise error
         if(str_len > 0 && str[0] == '\b'){
@@ -12090,7 +12295,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 
         char* end = NULL;
         int64_t end_len = 0;
-        if(strcmp(format_data, "%s%s") == 0){
+        if(strcmp(format_data + 2, "%s") == 0){
             end = va_arg(args, char*);
             end_len = va_arg(args, int64_t);
         } else if (strcmp(format_data, "%s") != 0){
@@ -12164,6 +12369,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 
 
         if(iostat != NULL) *iostat = 0;
+        internal_free(wide_encoded);
         va_end(args);
     }
     // Only truncate actual files, not stdout/stderr
@@ -12175,7 +12381,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 }
 
 LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_holder, bool is_allocatable, bool is_deferred,
-    bool is_array_unit, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
+    bool is_array_unit, int32_t char_kind, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
     int64_t format_len, ...) {
     va_list args;
     va_start(args, format_len);
@@ -12234,11 +12440,17 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
                 while (end < str_len && str[end] != '\n') {
                     end++;
                 }
-                _lfortran_copy_str_and_pad(
-                    (*str_holder) + rec * (*len),
-                    *len,
-                    str + start,
-                    end - start, 1);
+                if (char_kind > 1) {
+                    // The record is UTF-8; the target holds code units.
+                    _lfortran_utf8_to_unicode(str + start, end - start,
+                        (*str_holder) + rec * (*len) * char_kind, *len, char_kind);
+                } else {
+                    _lfortran_copy_str_and_pad(
+                        (*str_holder) + rec * (*len),
+                        *len,
+                        str + start,
+                        end - start, 1);
+                }
                 rec++;
                 if (end >= str_len) {
                     break;
@@ -12248,9 +12460,25 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
 
             // Remaining records (beyond the output list) are left
             // unchanged, per the Fortran standard.
+        } else if (char_kind > 1) {
+            _lfortran_utf8_to_unicode(str, str_len, *str_holder, *len, char_kind);
         } else {
             _lfortran_copy_str_and_pad(*str_holder, *len, str, str_len, 1);
         }
+    } else if (char_kind > 1) {
+        // A deferred length kind 4 target takes one character per code point
+        // of the record.
+        int64_t char_count = 0;
+        for (int64_t i = 0; i < str_len; ) {
+            int seq = utf8_sequence_length((unsigned char)str[i]);
+            i += (seq == 0 || i + seq > str_len) ? 1 : seq;
+            char_count++;
+        }
+        char* decoded = (char*)internal_malloc((size_t)(char_count * char_kind + 1));
+        _lfortran_utf8_to_unicode(str, str_len, decoded, char_count, char_kind);
+        _lfortran_strcpy_alloc(al, str_holder, len, is_allocatable, is_deferred,
+            decoded, char_count, char_kind);
+        internal_free(decoded);
     } else {
         _lfortran_strcpy_alloc(al, str_holder, len, is_allocatable, is_deferred, str, str_len, 1);
     }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -108,7 +108,7 @@ LFORTRAN_API int _lfortran_init_random_seed(unsigned seed);
 LFORTRAN_API double _lfortran_random();
 LFORTRAN_API int _lfortran_randrange(int lower, int upper);
 LFORTRAN_API int _lfortran_random_int(int lower, int upper);
-LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, const fchar* end, uint32_t end_len);
+LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, int32_t str_kind, const fchar* end, uint32_t end_len);
 LFORTRAN_API char* _lcompilers_snprintf_alloc(lfortran_allocator_t* al, const char* format, ...);
 LFORTRAN_API void _lcompilers_print_error(const char* format, ...);
 LFORTRAN_API void _lfortran_complex_add_32(struct _lfortran_complex_32* a,
@@ -355,7 +355,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
 LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_size, int32_t unit_num, int32_t *iostat);
 LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_holder, bool is_allocatable, bool is_deferred,
-        bool is_array_unit, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
+        bool is_array_unit, int32_t char_kind, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
         int64_t format_len, ...);
 LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const char* format_data, int64_t format_len, ...);
 LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child);

--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -302,4 +302,156 @@ void rtrim(std::string& str) {
     str.erase(std::find_if_not(str.rbegin(), str.rend(), ::isspace).base(), str.end());
 }
 
+// UTF-8 helpers ------------------------------------------------------------
+
+namespace {
+
+// Length in bytes of the UTF-8 sequence a lead byte starts, or 0 if `c` is not
+// a valid lead byte.
+size_t utf8_sequence_length(unsigned char c) {
+    if (c < 0x80) return 1;
+    if ((c & 0xe0) == 0xc0) return 2;
+    if ((c & 0xf0) == 0xe0) return 3;
+    if ((c & 0xf8) == 0xf0) return 4;
+    return 0;
+}
+
+// The code point bits a lead byte contributes.
+uint32_t utf8_lead_bits(unsigned char c, size_t length) {
+    switch (length) {
+        case 1: return c;
+        case 2: return c & 0x1f;
+        case 3: return c & 0x0f;
+        default: return c & 0x07;
+    }
+}
+
+} // anonymous namespace
+
+bool is_valid_utf8(const char *value, size_t size) {
+    size_t i = 0;
+    while (i < size) {
+        const unsigned char c = static_cast<unsigned char>(value[i]);
+        const size_t length = utf8_sequence_length(c);
+        if (length == 0) return false;
+        if (length == 1) {
+            i++;
+            continue;
+        }
+        if (i + length > size) return false;
+        uint32_t code_point = utf8_lead_bits(c, length);
+        for (size_t k = 1; k < length; k++) {
+            const unsigned char cont =
+                static_cast<unsigned char>(value[i + k]);
+            if ((cont & 0xc0) != 0x80) return false;
+            code_point = (code_point << 6) | (cont & 0x3f);
+        }
+        if (length == 2 && code_point < 0x80) return false;
+        if (length == 3 && code_point < 0x800) return false;
+        if (length == 4 && code_point < 0x10000) return false;
+        if (code_point > 0x10ffff) return false;
+        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
+        i += length;
+    }
+    return true;
+}
+
+bool is_valid_utf8(const std::string &value) {
+    return is_valid_utf8(value.data(), value.size());
+}
+
+std::vector<uint32_t> utf8_decode(const std::string &s) {
+    std::vector<uint32_t> code_points;
+    size_t i = 0;
+    while (i < s.size()) {
+        const unsigned char c = static_cast<unsigned char>(s[i]);
+        size_t length = utf8_sequence_length(c);
+        if (length == 0 || i + length > s.size()) {
+            // Not well-formed: pass the byte through so callers that did not
+            // validate still make progress instead of running off the end.
+            code_points.push_back(c);
+            i++;
+            continue;
+        }
+        uint32_t code_point = utf8_lead_bits(c, length);
+        for (size_t k = 1; k < length; k++) {
+            code_point = (code_point << 6) |
+                (static_cast<unsigned char>(s[i + k]) & 0x3f);
+        }
+        code_points.push_back(code_point);
+        i += length;
+    }
+    return code_points;
+}
+
+size_t utf8_codepoint_count(const std::string &s) {
+    size_t count = 0;
+    size_t i = 0;
+    while (i < s.size()) {
+        const size_t length =
+            utf8_sequence_length(static_cast<unsigned char>(s[i]));
+        i += (length == 0 || i + length > s.size()) ? 1 : length;
+        count++;
+    }
+    return count;
+}
+
+size_t utf8_codepoint_count(const char *s) {
+    return utf8_codepoint_count(std::string(s));
+}
+
+void utf8_encode_codepoint(std::string &out, uint32_t code_point) {
+    if (code_point <= 0x7f) {
+        out += static_cast<char>(code_point);
+    } else if (code_point <= 0x7ff) {
+        out += static_cast<char>(0xc0 | (code_point >> 6));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    } else if (code_point <= 0xffff) {
+        out += static_cast<char>(0xe0 | (code_point >> 12));
+        out += static_cast<char>(0x80 | ((code_point >> 6) & 0x3f));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    } else {
+        out += static_cast<char>(0xf0 | (code_point >> 18));
+        out += static_cast<char>(0x80 | ((code_point >> 12) & 0x3f));
+        out += static_cast<char>(0x80 | ((code_point >> 6) & 0x3f));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    }
+}
+
+std::vector<uint8_t> utf8_to_unicode_bytes(const std::string &s, int kind) {
+    std::vector<uint32_t> code_points = utf8_decode(s);
+    std::vector<uint8_t> bytes(code_points.size() * kind);
+    for (size_t idx = 0; idx < code_points.size(); idx++) {
+        const uint32_t cp = code_points[idx];
+        for (int b = 0; b < kind; b++) {
+            bytes[idx * kind + b] = (cp >> (8 * b)) & 0xff;
+        }
+    }
+    return bytes;
+}
+
+std::vector<std::string> utf8_split(const std::string &s) {
+    std::vector<std::string> characters;
+    size_t i = 0;
+    while (i < s.size()) {
+        size_t length = utf8_sequence_length(static_cast<unsigned char>(s[i]));
+        if (length == 0 || i + length > s.size()) length = 1;
+        characters.push_back(s.substr(i, length));
+        i += length;
+    }
+    return characters;
+}
+
+std::string unicode_bytes_to_utf8(const uint8_t *bytes, size_t count, int kind) {
+    std::string out;
+    for (size_t idx = 0; idx < count; idx++) {
+        uint32_t cp = 0;
+        for (int b = 0; b < kind; b++) {
+            cp |= static_cast<uint32_t>(bytes[idx * kind + b]) << (8 * b);
+        }
+        utf8_encode_codepoint(out, cp);
+    }
+    return out;
+}
+
 } // namespace LCompilers

--- a/src/libasr/string_utils.h
+++ b/src/libasr/string_utils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cctype>
 
 #include <libasr/alloc.h>
@@ -53,6 +54,44 @@ char* str_unescape_fortran(Allocator &al, LCompilers::Str &s, char ch);
 
 bool str_compare(const unsigned char *pos, std::string s);
 void rtrim(std::string& str);
+
+// UTF-8 helpers ------------------------------------------------------------
+//
+// A CHARACTER value of kind > 1 is stored in ASR as UTF-8 in
+// `StringConstant::m_s` (a `char*` cannot carry the embedded null bytes that
+// raw UCS-4 would produce), while its ASR length is a count of characters.
+// These helpers convert between the two.
+
+// Returns true if `value` is well-formed UTF-8. Overlong forms, surrogates and
+// out-of-range code points are rejected.
+bool is_valid_utf8(const char *value, size_t size);
+bool is_valid_utf8(const std::string &value);
+
+// Decodes well-formed UTF-8 into code points. The input must already have
+// passed `is_valid_utf8`.
+std::vector<uint32_t> utf8_decode(const std::string &s);
+
+// Number of Unicode code points in `s`, i.e. the Fortran length of the value
+// `s` encodes. Malformed trailing bytes count as one character each, so this
+// never reads past the end of `s`.
+size_t utf8_codepoint_count(const std::string &s);
+size_t utf8_codepoint_count(const char *s);
+
+// Appends the UTF-8 encoding of a single code point to `out`.
+void utf8_encode_codepoint(std::string &out, uint32_t code_point);
+
+// Decodes UTF-8 and serialises each code point as `kind` little-endian bytes:
+// kind 2 gives UCS-2, kind 4 gives UCS-4. This is the in-memory form the
+// backends use.
+std::vector<uint8_t> utf8_to_unicode_bytes(const std::string &s, int kind);
+
+// The inverse of `utf8_to_unicode_bytes`: reads `count` code points of `kind`
+// little-endian bytes each and returns their UTF-8 encoding.
+std::string unicode_bytes_to_utf8(const uint8_t *bytes, size_t count, int kind);
+
+// Splits UTF-8 into one string per code point. Malformed trailing bytes are
+// returned as single byte entries rather than dropped.
+std::vector<std::string> utf8_split(const std::string &s);
 
 } // namespace LCompilers
 

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -966,6 +966,40 @@ program continue_compilation_1
         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
         print *, values(1)
     end subroutine
+
+    subroutine character_kind_mixing_concat()
+        implicit none
+        character(kind=4, len=3) :: wide
+        character(len=3) :: narrow
+        wide = 4_"abc"
+        narrow = "xyz"
+        print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
+    end subroutine
+
+    subroutine character_kind_mixing_compare()
+        implicit none
+        character(kind=4, len=3) :: wide
+        character(len=3) :: narrow
+        wide = 4_"abc"
+        narrow = "xyz"
+        if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+    end subroutine
+
+    subroutine character_literal_kind_not_supported()
+        implicit none
+        character(len=4) :: s
+        s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+    end subroutine
+
+    ! Keep the unsupported character kind declarations last: a rejected
+    ! declaration makes the symbol table visitor skip the program units that
+    ! follow it, which would hide the errors expected above.
+    subroutine character_kind_not_supported()
+        implicit none
+        character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+        character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+        character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+    end subroutine
 end program
 
 ! A syntax error inside a module makes the parser skip the erroneous

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "84a3b6397734cd4055d21571c3d7b837479ef9b1ec58586c59a46ee1",
+    "infile_hash": "225aedafcfbdd579cc77da7548f73331b6b9411119af8b5db5b1df07",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "76a6b2de5561abe4df3a75104301de648e3e07007d977c9759a59ff3",
+    "stderr_hash": "21c248cf709e49318348b5fa37b69129e90c49925faa086b22c099fb",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,10 +11,10 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-   --> tests/errors/continue_compilation_1.f90:978:7
-    |
-978 |       foo    end type t_recovery
-    |       ^^^ 
+    --> tests/errors/continue_compilation_1.f90:1012:7
+     |
+1012 |       foo    end type t_recovery
+     |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
   --> tests/errors/continue_compilation_1.f90:53:5 - 57:24
@@ -544,6 +544,24 @@ semantic error: equivalence between a common block variable and this array eleme
 949 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
+semantic error: kind 2 is not supported for character, only 1 and 4 are
+   --> tests/errors/continue_compilation_1.f90:999:19
+    |
+999 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+    |                   ^^^^^^ 
+
+semantic error: kind 3 is not supported for character, only 1 and 4 are
+    --> tests/errors/continue_compilation_1.f90:1000:19
+     |
+1000 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+     |                   ^^^^^^ 
+
+semantic error: kind 8 is not supported for character, only 1 and 4 are
+    --> tests/errors/continue_compilation_1.f90:1001:19
+     |
+1001 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+     |                   ^^^^^^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |
@@ -551,10 +569,10 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-   --> tests/errors/continue_compilation_1.f90:981:7
-    |
-981 |       class(t_recovery), intent(in) :: self
-    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    --> tests/errors/continue_compilation_1.f90:1015:7
+     |
+1015 |       class(t_recovery), intent(in) :: self
+     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared
  --> tests/errors/continue_compilation_1.f90:1:2
@@ -1883,3 +1901,21 @@ semantic error: The implied do loop variable 'r_idx' must be a scalar integer, n
     |
 966 |         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: operands of // must be character with the same kind, found character(4) and character(1)
+   --> tests/errors/continue_compilation_1.f90:976:18
+    |
+976 |         print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
+    |                  ^^^^^^^^^^^^^^ 
+
+semantic error: operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+   --> tests/errors/continue_compilation_1.f90:985:13
+    |
+985 |         if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+    |             ^^^^^^^^^^^^^^ 
+
+semantic error: kind 3 is not supported for character, only 1 and 4 are
+   --> tests/errors/continue_compilation_1.f90:991:13
+    |
+991 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+    |             ^^^^^^^ 


### PR DESCRIPTION
Fixes [#12574](https://github.com/lfortran/lfortran/issues/12574).

Third of a short series. **Depends on [#12581](https://github.com/lfortran/lfortran/pull/12581) and [#12582](https://github.com/lfortran/lfortran/pull/12582)** — they are the parent commits, so only the third commit (`404e9345`) belongs to this PR.

## Summary

A kind 4 `CHARACTER` value is held in memory as four-byte code units, but every output path treated the descriptor's *character* count as a *byte* count. So `write (*,*) trim(hello_world)` emitted the first byte of the record and stopped at the first embedded null — the `H` in the issue report. Internal `WRITE` into a kind 4 variable stored kind 1 bytes, and a formatted `READ` copied raw bytes into code units.

The issue's program, before and after, alongside the reference compilers:

```
main:      H
           2026t8^H24M-oM-?M-=

branch:    Hello World and Ni Hao -- M-dM-=M- M-eM-%M-=
           2026M-eM-9M-48M-fM-^\M-^H25M-fM-^WM-%

gfortran:  Hello World and Ni Hao -- M-dM-=M- M-eM-%M-=
           2026M-eM-9M-48M-fM-^\M-^H25M-fM-^WM-%
```

Byte-identical to GFortran 13 (and to LLVM Flang 18).

## Scope

**The character kind reaches the runtime.** `SerializeType` emits it as `S-DESC-K<kind>`, alongside the kind every other type already carried (`I4`, `R8`, `L32`) — strings were the only type whose kind was dropped. The format engine transcodes a kind 4 argument to UTF-8 when it consumes it, and counts `Aw` field widths in characters, as the standard requires.

Widths are counted in characters rather than copied from GFortran here: GFortran's `Aw` for kind 4 is demonstrably wrong (`a10` on a six-character value emits ten blanks, `a3` and `a2` both emit all six characters), so it is not a usable oracle for that one case. The new tests only assert behaviour all three compilers agree on.

**The two fast paths that bypass the format engine** for a lone character value carry the kind too: `_lfortran_printf` takes it as a parameter, and `_lfortran_file_write` learns `%S`, which reads a kind after the length. Without this, `print *, s` and `write(*,*) s` still wrote raw code units.

**Internal writes.** `_lfortran_string_write` takes the internal file's character kind and decodes the record back into code units for a kind 4 target, blank-padding in characters. It also drops a `sprintf("%.*s")` staging step that truncated the record at the first null.

**Reads.** A destination of kind > 1 uses read type code 8 and carries its kind. The field is decoded from UTF-8 when the connection has `ENCODING='UTF-8'`, and otherwise one byte becomes one character — `InputSource` gains the connection's `encoding_mode` for this. Both reference compilers agree exactly here, with and without the specifier.

**`ENCODING=` on output follows Flang**, per the design decision in the plan: kind 4 output is transcoded to UTF-8 regardless of the unit's encoding. GFortran instead substitutes `?` on a non-UTF-8 unit. Following Flang keeps the write path free of any per-unit encoding lookup and still gives the issue's program the output it expects. `ENCODING=` was already parsed, validated and stored per unit (`unit_to_file[].encoding`); before this PR its only consumer was `INQUIRE`, and it now also drives decoding on input.

## Tests

All self-checking with `error stop`, labelled `gfortran llvm`, and passing on GFortran 13, LLVM Flang 18 and this branch.

Integration tests can't compare stdout — the runner only checks the exit status — so byte-exactness is verified by writing to a scratch file with `encoding='UTF-8'`, reopening it as default `character`, and checking the bytes with `ichar`.

- `char4_io_01.f90` — `'(a)'`, `'("<",a,">")'` and list-directed output of a kind 4 value, each checked against the expected UTF-8 bytes.
- `char4_io_02.f90` — the issue's internal-write case (`write(line,'(i0,a,i0,a,i0,a)') 2026, nen, …`) checked character by character, blank padding of a short record, and a write/read round trip through a UTF-8 file.
- `print_12.f90` already exercised this path but asserted nothing, so it passed on `main` while printing garbage. It now checks the length and the bytes that reach the stream.

## Verification

```
./run_tests.py --no-llvm --skip-run-with-dbg    # TESTS PASSED
cd integration_tests && ./run_tests.py -b llvm -j4       # pass
cd integration_tests && ./run_tests.py -b gfortran -j4   # pass
```

`--no-llvm --skip-run-with-dbg` only because this sandbox has LLVM 18 (the `llvm-*.stdout` references are LLVM 11) and no runtime-stacktrace build; both are covered by CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sa9WpeKxiSd3kV1VKZXCUd)_